### PR TITLE
docs: add root README.md and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# @vllnt/ui Monorepo
+
+React component library monorepo. Radix UI primitives + Tailwind CSS + CVA variants.
+
+## Package Map
+
+| Package | Path | Published |
+|---------|------|-----------|
+| `@vllnt/ui` | `packages/ui` | GitHub Packages |
+| `@vllnt/eslint` | `packages/eslint-config` | workspace only |
+| `@vllnt/typescript` | `packages/tsconfig` | workspace only |
+| `@vllnt/ui-registry` | `apps/registry` | deployed (Next.js) |
+
+## Tech Stack
+
+- React 19, Radix UI primitives, Tailwind CSS 3, CVA, tailwind-merge
+- Build: tsup (library), Next.js (registry app)
+- Test: Vitest (unit), Playwright CT (visual/component)
+- Lint: ESLint 9 flat config
+- TypeScript strict mode
+- Monorepo: pnpm workspaces + Turborepo
+
+## Package Manager
+
+pnpm (lockfile: `pnpm-lock.yaml`)
+
+## Commands
+
+All from root via `turbo`:
+
+| Command | Scope |
+|---------|-------|
+| `pnpm build` | All packages |
+| `pnpm lint` | All packages |
+| `pnpm lint:fix` | All packages |
+| `pnpm test` | All packages (watch) |
+| `pnpm test:once` | All packages (single run) |
+| `pnpm clean` | All packages |
+| `pnpm check:circular` | Circular import detection |
+
+Package-scoped (from `packages/ui`):
+
+| Command | What |
+|---------|------|
+| `pnpm test:coverage` | Vitest with coverage |
+| `pnpm test:visual` | Playwright CT snapshots |
+| `pnpm test:visual:update` | Update visual snapshots |
+| `pnpm test:generate` | Generate test stubs |
+
+## Component Conventions
+
+File structure per component:
+
+```
+src/components/{name}/
+  {name}.tsx           # Implementation
+  {name}.test.tsx      # Vitest unit test
+  {name}.visual.tsx    # Playwright CT story
+  index.ts             # Barrel export
+```
+
+- One component per directory under `src/components/`
+- Barrel exports in `src/index.ts`
+- shadcn-style patterns (forwardRef, cn(), Slot support)
+
+## Coding Patterns
+
+- `cn()` from `src/lib/utils.ts` — merges clsx + tailwind-merge
+- CVA for variant definitions (`class-variance-authority`)
+- Radix primitives for accessible behavior (dialog, dropdown, etc.)
+- `React.forwardRef` + `React.ComponentPropsWithoutRef` on all components
+- CSS variables for theming (`--primary`, `--background`, etc.) in `styles.css`
+
+## Testing
+
+- **Unit**: Vitest + Testing Library (`*.test.tsx`)
+- **Visual**: Playwright CT (`*.visual.tsx`) — component-level snapshot tests
+- Run unit: `pnpm test:once` (root) or `pnpm -F @vllnt/ui test:once`
+- Run visual: `pnpm -F @vllnt/ui test:visual`
+
+## Publishing
+
+- GitHub Packages registry (`npm.pkg.github.com`)
+- Tag-triggered CI: push `v*` tag -> `.github/workflows/publish.yml`
+- Provenance attestation enabled
+
+## Conventions
+
+- ESLint flat config only (no `.eslintrc`)
+- TypeScript strict mode via `@vllnt/typescript`
+- No `eslint-disable` comments
+- No `any`, `as` assertions, or `@ts-ignore`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# @vllnt/ui
+
+React component library built on Radix UI primitives + Tailwind CSS. Published as `@vllnt/ui` on GitHub Packages.
+
+## Monorepo Structure
+
+| Package | Path | Description |
+|---------|------|-------------|
+| `@vllnt/ui` | `packages/ui` | Component library (published) |
+| `@vllnt/eslint` | `packages/eslint-config` | Shared ESLint flat config |
+| `@vllnt/typescript` | `packages/tsconfig` | Shared TypeScript configs |
+| `@vllnt/ui-registry` | `apps/registry` | Component registry + docs (Next.js) |
+
+## Quick Start
+
+```bash
+git clone https://github.com/bntvllnt/ui.git
+cd ui
+pnpm install
+pnpm build
+```
+
+## Scripts
+
+All scripts run via [Turborepo](https://turbo.build/repo) from the root:
+
+| Script | Description |
+|--------|-------------|
+| `pnpm dev` | Start dev servers |
+| `pnpm build` | Build all packages |
+| `pnpm lint` | Lint all packages |
+| `pnpm lint:fix` | Lint + auto-fix |
+| `pnpm test` | Run tests (watch) |
+| `pnpm test:once` | Run tests (single run) |
+| `pnpm clean` | Clean build artifacts |
+| `pnpm check:circular` | Detect circular imports |
+
+## Consumer Setup
+
+See [`packages/ui/README.md`](packages/ui/README.md) for installation, Tailwind preset, and usage instructions.
+
+## Publishing
+
+Publishing is automated via GitHub Actions (`.github/workflows/publish.yml`):
+
+1. Bump version in `packages/ui/package.json`
+2. Push a `v*` tag (e.g., `git tag v0.2.0 && git push --tags`)
+3. CI builds, verifies output, and publishes to GitHub Packages with provenance
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary

- Add root `README.md` with monorepo overview, structure table, quick start, scripts, and publishing workflow
- Add root `CLAUDE.md` with package map, tech stack, commands, component conventions, coding patterns, and testing instructions

## Test plan

- [x] Verify file content matches sibling `CLAUDE.md` style (`packages/eslint-config`, `packages/tsconfig`)
- [ ] Review rendered markdown on GitHub