### PR TITLE
feat(ui): add core data display family

### DIFF
--- a/apps/registry/components/component-preview/component-preview.tsx
+++ b/apps/registry/components/component-preview/component-preview.tsx
@@ -22,6 +22,7 @@ import {
   AspectRatio,
   Avatar,
   AvatarFallback,
+  AvatarGroup,
   AvatarImage,
   Badge,
   Breadcrumb,
@@ -60,6 +61,11 @@ import {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuTrigger,
+  DataList,
+  DataListItem,
+  DataListLabel,
+  DataListValue,
+  DataTable,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -146,6 +152,8 @@ import {
   Skeleton,
   Slider,
   Spinner,
+  StatCard,
+  StatusIndicator,
   Step,
   StepByStep,
   StepNavigation,
@@ -1334,6 +1342,100 @@ function AvatarPreview() {
   );
 }
 
+function AvatarGroupPreview() {
+  return (
+    <AvatarGroup
+      items={[
+        { alt: "Ada Lovelace", fallback: "AL" },
+        { alt: "Grace Hopper", fallback: "GH" },
+        { alt: "Margaret Hamilton", fallback: "MH" },
+        { alt: "Katherine Johnson", fallback: "KJ" },
+      ]}
+      max={3}
+    />
+  );
+}
+
+function DataListPreview() {
+  return (
+    <div className="w-full max-w-2xl">
+      <DataList>
+        <DataListItem>
+          <DataListLabel>Environment</DataListLabel>
+          <DataListValue>Production</DataListValue>
+        </DataListItem>
+        <DataListItem>
+          <DataListLabel>Owner</DataListLabel>
+          <DataListValue>Platform engineering</DataListValue>
+        </DataListItem>
+        <DataListItem>
+          <DataListLabel>Deploy window</DataListLabel>
+          <DataListValue>Tuesday / Thursday · 09:00 UTC</DataListValue>
+        </DataListItem>
+      </DataList>
+    </div>
+  );
+}
+
+function StatusIndicatorPreview() {
+  return (
+    <div className="flex flex-wrap gap-3">
+      <StatusIndicator tone="success">Operational</StatusIndicator>
+      <StatusIndicator tone="warning">Pending</StatusIndicator>
+      <StatusIndicator tone="danger">Incident</StatusIndicator>
+      <StatusIndicator tone="info">Queued</StatusIndicator>
+    </div>
+  );
+}
+
+function StatCardPreview() {
+  return (
+    <div className="w-full max-w-sm">
+      <StatCard
+        change="+8.2%"
+        description="Monthly recurring revenue"
+        label="MRR"
+        meta="vs last month"
+        tone="success"
+        trend="up"
+        value="$42.8k"
+      />
+    </div>
+  );
+}
+
+function DataTablePreview() {
+  return (
+    <div className="w-full max-w-4xl">
+      <DataTable
+        columns={[
+          { accessorKey: "workspace", header: "Workspace" },
+          { accessorKey: "status", header: "Status" },
+          { accessorKey: "seats", header: "Seats" },
+        ]}
+        data={[
+          { seats: 142, status: "active", workspace: "Northstar" },
+          { seats: 28, status: "trial", workspace: "Signal" },
+          { seats: 11, status: "paused", workspace: "Helix" },
+        ]}
+        enableSelection={true}
+        filterableColumns={[
+          {
+            columnId: "status",
+            label: "status",
+            options: [
+              { label: "Active", value: "active" },
+              { label: "Trial", value: "trial" },
+              { label: "Paused", value: "paused" },
+            ],
+          },
+        ]}
+        searchPlaceholder="Search workspaces"
+      />
+    </div>
+  );
+}
+
 function SkeletonPreview() {
   return (
     <div className="flex items-center space-x-4">
@@ -1506,6 +1608,8 @@ export function ComponentPreview({ componentName }: ComponentPreviewProps) {
       return <AspectRatioPreview />;
     case "avatar":
       return <AvatarPreview />;
+    case "avatar-group":
+      return <AvatarGroupPreview />;
     case "badge":
       return <BadgePreview />;
     case "bar-chart":
@@ -1522,6 +1626,10 @@ export function ComponentPreview({ componentName }: ComponentPreviewProps) {
       return <CalendarPreview />;
     case "card":
       return <CardPreview />;
+    case "data-list":
+      return <DataListPreview />;
+    case "data-table":
+      return <DataTablePreview />;
     case "carousel":
       return <CarouselPreview />;
     case "category-filter":
@@ -1644,6 +1752,8 @@ export function ComponentPreview({ componentName }: ComponentPreviewProps) {
       return <SliderPreview />;
     case "spinner":
       return <SpinnerPreview />;
+    case "stat-card":
+      return <StatCardPreview />;
     case "sidebar-provider":
       return <SidebarProviderPreview />;
     case "sidebar-toggle":
@@ -1656,6 +1766,8 @@ export function ComponentPreview({ componentName }: ComponentPreviewProps) {
       return <StepByStepPreview />;
     case "step-navigation":
       return <StepNavigationPreview />;
+    case "status-indicator":
+      return <StatusIndicatorPreview />;
     case "table-of-contents":
       return <TableOfContentsPreview />;
     case "table-of-contents-panel":

--- a/apps/registry/lib/component-metadata.json
+++ b/apps/registry/lib/component-metadata.json
@@ -76,6 +76,23 @@
     ],
     "title": "Avatar"
   },
+  "avatar-group": {
+    "category": "data",
+    "defaultStoryId": "data-avatargroup--default",
+    "description": "Overlapping avatar stack for participants, assignees, and collaborative contexts.",
+    "name": "avatar-group",
+    "stories": [
+      {
+        "id": "data-avatargroup--default",
+        "name": "Default"
+      },
+      {
+        "id": "data-avatargroup--sizes",
+        "name": "Sizes"
+      }
+    ],
+    "title": "Avatar Group"
+  },
   "badge": {
     "category": "core",
     "defaultStoryId": "core-badge--default",
@@ -218,6 +235,36 @@
       }
     ],
     "title": "Card"
+  },
+  "data-list": {
+    "category": "data",
+    "defaultStoryId": "data-datalist--default",
+    "description": "Semantic key-value metadata layout for displaying labels with values.",
+    "name": "data-list",
+    "stories": [
+      {
+        "id": "data-datalist--default",
+        "name": "Default"
+      },
+      {
+        "id": "data-datalist--compact",
+        "name": "Compact"
+      }
+    ],
+    "title": "Data List"
+  },
+  "data-table": {
+    "category": "data",
+    "defaultStoryId": "data-datatable--default",
+    "description": "Enhanced data table with sorting, filtering, selection, and pagination controls.",
+    "name": "data-table",
+    "stories": [
+      {
+        "id": "data-datatable--default",
+        "name": "Default"
+      }
+    ],
+    "title": "Data Table"
   },
   "carousel": {
     "category": "content",
@@ -975,6 +1022,40 @@
       }
     ],
     "title": "Spinner"
+  },
+  "stat-card": {
+    "category": "data",
+    "defaultStoryId": "data-statcard--default",
+    "description": "Headline KPI card for metrics, trends, and supporting context.",
+    "name": "stat-card",
+    "stories": [
+      {
+        "id": "data-statcard--default",
+        "name": "Default"
+      },
+      {
+        "id": "data-statcard--grid",
+        "name": "Grid"
+      }
+    ],
+    "title": "Stat Card"
+  },
+  "status-indicator": {
+    "category": "data",
+    "defaultStoryId": "data-statusindicator--default",
+    "description": "Compact status label with tone, variant, and activity dot options.",
+    "name": "status-indicator",
+    "stories": [
+      {
+        "id": "data-statusindicator--default",
+        "name": "Default"
+      },
+      {
+        "id": "data-statusindicator--variants",
+        "name": "Variants"
+      }
+    ],
+    "title": "Status Indicator"
   },
   "step-by-step": {
     "category": "learning",

--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -94,6 +94,21 @@
       "category": "core"
     },
     {
+      "name": "avatar-group",
+      "type": "registry:component",
+      "title": "Avatar Group",
+      "description": "Overlapping avatar stack for participants, assignees, and collaborative contexts.",
+      "files": [
+        {
+          "path": "registry/default/avatar-group/avatar-group.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data"
+    },
+    {
       "name": "badge",
       "type": "registry:component",
       "title": "Badge",
@@ -212,6 +227,38 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "content"
+    },
+    {
+      "name": "data-list",
+      "type": "registry:component",
+      "title": "Data List",
+      "description": "Semantic key-value metadata layout for displaying labels with values.",
+      "files": [
+        {
+          "path": "registry/default/data-list/data-list.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data"
+    },
+    {
+      "name": "data-table",
+      "type": "registry:component",
+      "title": "Data Table",
+      "description": "Enhanced data table with sorting, filtering, selection, and pagination controls.",
+      "files": [
+        {
+          "path": "registry/default/data-table/data-table.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@tanstack/react-table"
+      ],
+      "category": "data"
     },
     {
       "name": "carousel",
@@ -1084,6 +1131,36 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "utility"
+    },
+    {
+      "name": "stat-card",
+      "type": "registry:component",
+      "title": "Stat Card",
+      "description": "Headline KPI card for metrics, trends, and supporting context.",
+      "files": [
+        {
+          "path": "registry/default/stat-card/stat-card.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data"
+    },
+    {
+      "name": "status-indicator",
+      "type": "registry:component",
+      "title": "Status Indicator",
+      "description": "Compact status label with tone, variant, and activity dot options.",
+      "files": [
+        {
+          "path": "registry/default/status-indicator/status-indicator.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data"
     },
     {
       "name": "step-by-step",

--- a/apps/registry/registry/default/avatar-group/avatar-group.tsx
+++ b/apps/registry/registry/default/avatar-group/avatar-group.tsx
@@ -1,0 +1,1 @@
+export * from '@vllnt/ui'

--- a/apps/registry/registry/default/avatar-group/example.mdx
+++ b/apps/registry/registry/default/avatar-group/example.mdx
@@ -1,0 +1,3 @@
+```tsx
+import { AvatarGroup } from "@vllnt/ui"
+```

--- a/apps/registry/registry/default/avatar-group/header.mdx
+++ b/apps/registry/registry/default/avatar-group/header.mdx
@@ -1,0 +1,3 @@
+# AvatarGroup
+
+Overlapping avatar stack for collaborative contexts, assignees, and participants.

--- a/apps/registry/registry/default/data-list/data-list.tsx
+++ b/apps/registry/registry/default/data-list/data-list.tsx
@@ -1,0 +1,1 @@
+export * from '@vllnt/ui'

--- a/apps/registry/registry/default/data-list/example.mdx
+++ b/apps/registry/registry/default/data-list/example.mdx
@@ -1,0 +1,3 @@
+```tsx
+import { DataList } from "@vllnt/ui"
+```

--- a/apps/registry/registry/default/data-list/header.mdx
+++ b/apps/registry/registry/default/data-list/header.mdx
@@ -1,0 +1,3 @@
+# DataList
+
+Semantic key-value layout for metadata, summaries, and object inspection.

--- a/apps/registry/registry/default/data-table/data-table.tsx
+++ b/apps/registry/registry/default/data-table/data-table.tsx
@@ -1,0 +1,1 @@
+export * from '@vllnt/ui'

--- a/apps/registry/registry/default/data-table/example.mdx
+++ b/apps/registry/registry/default/data-table/example.mdx
@@ -1,0 +1,3 @@
+```tsx
+import { DataTable } from "@vllnt/ui"
+```

--- a/apps/registry/registry/default/data-table/header.mdx
+++ b/apps/registry/registry/default/data-table/header.mdx
@@ -1,0 +1,3 @@
+# DataTable
+
+Enhanced table primitive with built-in sorting, filtering, selection, and pagination controls.

--- a/apps/registry/registry/default/stat-card/example.mdx
+++ b/apps/registry/registry/default/stat-card/example.mdx
@@ -1,0 +1,3 @@
+```tsx
+import { StatCard } from "@vllnt/ui"
+```

--- a/apps/registry/registry/default/stat-card/header.mdx
+++ b/apps/registry/registry/default/stat-card/header.mdx
@@ -1,0 +1,3 @@
+# StatCard
+
+Compact KPI surface for headline metrics, trends, and supporting metadata.

--- a/apps/registry/registry/default/stat-card/stat-card.tsx
+++ b/apps/registry/registry/default/stat-card/stat-card.tsx
@@ -1,0 +1,1 @@
+export * from '@vllnt/ui'

--- a/apps/registry/registry/default/status-indicator/example.mdx
+++ b/apps/registry/registry/default/status-indicator/example.mdx
@@ -1,0 +1,3 @@
+```tsx
+import { StatusIndicator } from "@vllnt/ui"
+```

--- a/apps/registry/registry/default/status-indicator/header.mdx
+++ b/apps/registry/registry/default/status-indicator/header.mdx
@@ -1,0 +1,3 @@
+# StatusIndicator
+
+Reusable state label with tone, variant, and activity dot treatments.

--- a/apps/registry/registry/default/status-indicator/status-indicator.tsx
+++ b/apps/registry/registry/default/status-indicator/status-indicator.tsx
@@ -1,0 +1,1 @@
+export * from '@vllnt/ui'

--- a/packages/ui/eslint.config.js
+++ b/packages/ui/eslint.config.js
@@ -79,6 +79,14 @@ export default [
     },
   },
   {
+    files: ['**/components/data-table/data-table.tsx'],
+    rules: {
+      'max-lines-per-function': 'off',
+      'react-hooks/incompatible-library': 'off',
+      'react/no-unstable-nested-components': 'off',
+    },
+  },
+  {
     files: ['**/components/search-bar/search-bar.tsx'],
     rules: {
       'max-lines-per-function': 'off',

--- a/packages/ui/src/components/avatar-group/avatar-group.stories.tsx
+++ b/packages/ui/src/components/avatar-group/avatar-group.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { AvatarGroup } from "./avatar-group";
+
+const people = [
+  { alt: "Ada Lovelace", fallback: "AL" },
+  { alt: "Grace Hopper", fallback: "GH" },
+  { alt: "Margaret Hamilton", fallback: "MH" },
+  { alt: "Katherine Johnson", fallback: "KJ" },
+  { alt: "Annie Easley", fallback: "AE" },
+];
+
+const meta = {
+  args: {
+    items: people,
+    max: 4,
+  },
+  component: AvatarGroup,
+  title: "Data/AvatarGroup",
+} satisfies Meta<typeof AvatarGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="space-y-4">
+      <AvatarGroup items={people} max={4} size="sm" />
+      <AvatarGroup items={people} max={4} size="md" />
+      <AvatarGroup items={people} max={4} size="lg" />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/avatar-group/avatar-group.test.tsx
+++ b/packages/ui/src/components/avatar-group/avatar-group.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AvatarGroup } from "./avatar-group";
+
+const items = [
+  { alt: "Ada Lovelace", fallback: "AL" },
+  { alt: "Grace Hopper", fallback: "GH" },
+  { alt: "Margaret Hamilton", fallback: "MH" },
+  { alt: "Katherine Johnson", fallback: "KJ" },
+];
+
+describe("AvatarGroup", () => {
+  it("renders visible avatars", () => {
+    render(<AvatarGroup items={items.slice(0, 2)} />);
+
+    expect(screen.getByText("AL")).toBeVisible();
+    expect(screen.getByText("GH")).toBeVisible();
+  });
+
+  it("renders overflow count when max is provided", () => {
+    render(<AvatarGroup items={items} max={3} />);
+
+    expect(screen.getByText("+1")).toBeVisible();
+  });
+
+  it("applies custom class names", () => {
+    const { container } = render(
+      <AvatarGroup className="custom-class" items={items} />,
+    );
+
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+});

--- a/packages/ui/src/components/avatar-group/avatar-group.tsx
+++ b/packages/ui/src/components/avatar-group/avatar-group.tsx
@@ -1,0 +1,99 @@
+import * as React from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../../lib/utils";
+import { Avatar, AvatarFallback, AvatarImage } from "../avatar";
+
+const avatarGroupVariants = cva("flex items-center", {
+  defaultVariants: {
+    size: "md",
+  },
+  variants: {
+    size: {
+      lg: "-space-x-4",
+      md: "-space-x-3",
+      sm: "-space-x-2.5",
+    },
+  },
+});
+
+const avatarItemVariants = cva(
+  "ring-2 ring-background border border-border bg-muted text-muted-foreground",
+  {
+    defaultVariants: {
+      size: "md",
+    },
+    variants: {
+      size: {
+        lg: "h-12 w-12 text-sm",
+        md: "h-10 w-10 text-xs",
+        sm: "h-8 w-8 text-[11px]",
+      },
+    },
+  },
+);
+
+const overflowBadgeVariants = cva(
+  "inline-flex shrink-0 items-center justify-center rounded-full border border-border bg-muted font-medium text-muted-foreground ring-2 ring-background",
+  {
+    defaultVariants: {
+      size: "md",
+    },
+    variants: {
+      size: {
+        lg: "h-12 min-w-12 px-3 text-sm",
+        md: "h-10 min-w-10 px-2.5 text-xs",
+        sm: "h-8 min-w-8 px-2 text-[11px]",
+      },
+    },
+  },
+);
+
+export type AvatarGroupItem = {
+  alt: string;
+  fallback: string;
+  src?: string;
+};
+
+export type AvatarGroupProps = React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof avatarGroupVariants> & {
+    items: AvatarGroupItem[];
+    max?: number;
+    overflowLabel?: (hiddenCount: number) => string;
+  };
+
+const AvatarGroup = React.forwardRef<HTMLDivElement, AvatarGroupProps>(
+  ({ className, items, max, overflowLabel, size, ...props }, reference) => {
+    const visibleItems = max === undefined ? items : items.slice(0, max);
+    const hiddenCount = max === undefined ? 0 : Math.max(items.length - max, 0);
+
+    return (
+      <div
+        className={cn(avatarGroupVariants({ size }), className)}
+        ref={reference}
+        {...props}
+      >
+        {visibleItems.map((item, index) => (
+          <Avatar
+            className={avatarItemVariants({ size })}
+            key={`${item.alt}-${index}`}
+            style={{ zIndex: visibleItems.length - index }}
+          >
+            {item.src ? <AvatarImage alt={item.alt} src={item.src} /> : null}
+            <AvatarFallback>{item.fallback}</AvatarFallback>
+          </Avatar>
+        ))}
+        {hiddenCount > 0 ? (
+          <span className={overflowBadgeVariants({ size })}>
+            {overflowLabel ? overflowLabel(hiddenCount) : `+${hiddenCount}`}
+          </span>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+AvatarGroup.displayName = "AvatarGroup";
+
+export { AvatarGroup, avatarGroupVariants, avatarItemVariants };

--- a/packages/ui/src/components/avatar-group/avatar-group.visual.tsx
+++ b/packages/ui/src/components/avatar-group/avatar-group.visual.tsx
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { AvatarGroup } from "./avatar-group";
+
+test.describe("AvatarGroup Visual", () => {
+  test("default", async ({ mount, page }) => {
+    await mount(
+      <AvatarGroup
+        items={[
+          { alt: "Ada Lovelace", fallback: "AL" },
+          { alt: "Grace Hopper", fallback: "GH" },
+          { alt: "Margaret Hamilton", fallback: "MH" },
+          { alt: "Katherine Johnson", fallback: "KJ" },
+        ]}
+        max={3}
+      />,
+    );
+
+    await expect(page).toHaveScreenshot("avatar-group-default.png");
+  });
+});

--- a/packages/ui/src/components/avatar-group/index.ts
+++ b/packages/ui/src/components/avatar-group/index.ts
@@ -1,0 +1,7 @@
+export {
+  AvatarGroup,
+  type AvatarGroupItem,
+  type AvatarGroupProps,
+  avatarGroupVariants,
+  avatarItemVariants,
+} from "./avatar-group";

--- a/packages/ui/src/components/data-list/data-list.stories.tsx
+++ b/packages/ui/src/components/data-list/data-list.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { DataList, DataListItem, DataListLabel, DataListValue } from "./data-list";
+
+const meta = {
+  component: DataList,
+  title: "Data/DataList",
+} satisfies Meta<typeof DataList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <DataList>
+      <DataListItem>
+        <DataListLabel>Environment</DataListLabel>
+        <DataListValue>Production</DataListValue>
+      </DataListItem>
+      <DataListItem>
+        <DataListLabel>Owner</DataListLabel>
+        <DataListValue>Platform team</DataListValue>
+      </DataListItem>
+      <DataListItem>
+        <DataListLabel>Rollout</DataListLabel>
+        <DataListValue>25% of traffic</DataListValue>
+      </DataListItem>
+    </DataList>
+  ),
+};
+
+export const Compact: Story = {
+  render: () => (
+    <DataList density="compact">
+      <DataListItem>
+        <DataListLabel>Request ID</DataListLabel>
+        <DataListValue>req_01HZZ1N6M8P8</DataListValue>
+      </DataListItem>
+      <DataListItem>
+        <DataListLabel>Updated</DataListLabel>
+        <DataListValue>2 minutes ago</DataListValue>
+      </DataListItem>
+      <DataListItem>
+        <DataListLabel>Region</DataListLabel>
+        <DataListValue>eu-west-1</DataListValue>
+      </DataListItem>
+    </DataList>
+  ),
+};

--- a/packages/ui/src/components/data-list/data-list.test.tsx
+++ b/packages/ui/src/components/data-list/data-list.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  DataList,
+  DataListItem,
+  DataListLabel,
+  DataListValue,
+} from "./data-list";
+
+describe("DataList", () => {
+  it("renders labels and values semantically", () => {
+    render(
+      <DataList>
+        <DataListItem>
+          <DataListLabel>Environment</DataListLabel>
+          <DataListValue>Production</DataListValue>
+        </DataListItem>
+      </DataList>,
+    );
+
+    expect(screen.getByText("Environment").tagName).toBe("DT");
+    expect(screen.getByText("Production").tagName).toBe("DD");
+  });
+
+  it("inherits compact density from the root", () => {
+    render(
+      <DataList density="compact">
+        <DataListItem>
+          <DataListLabel>Owner</DataListLabel>
+          <DataListValue>Design systems</DataListValue>
+        </DataListItem>
+      </DataList>,
+    );
+
+    expect(screen.getByText("Owner").parentElement).toHaveClass("py-3");
+  });
+
+  it("accepts custom class names", () => {
+    render(
+      <DataList className="custom-class">
+        <DataListItem>
+          <DataListLabel>Region</DataListLabel>
+          <DataListValue>us-east-1</DataListValue>
+        </DataListItem>
+      </DataList>,
+    );
+
+    expect(screen.getByText("Region").closest("dl")).toHaveClass(
+      "custom-class",
+    );
+  });
+});

--- a/packages/ui/src/components/data-list/data-list.tsx
+++ b/packages/ui/src/components/data-list/data-list.tsx
@@ -1,0 +1,128 @@
+import * as React from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../../lib/utils";
+
+const dataListVariants = cva(
+  "grid rounded-xl border bg-card text-card-foreground",
+  {
+    defaultVariants: {
+      density: "default",
+    },
+    variants: {
+      density: {
+        compact: "divide-y",
+        default: "divide-y",
+      },
+    },
+  },
+);
+
+const dataListItemVariants = cva(
+  "grid gap-1 px-4 py-4 sm:grid-cols-[minmax(0,12rem)_1fr] sm:gap-4 sm:px-5",
+  {
+    defaultVariants: {
+      density: "default",
+    },
+    variants: {
+      density: {
+        compact: "py-3",
+        default: "py-4",
+      },
+    },
+  },
+);
+
+type DataListContextValue = {
+  density: NonNullable<VariantProps<typeof dataListVariants>["density"]>;
+};
+
+const DataListContext = React.createContext<DataListContextValue>({
+  density: "default",
+});
+
+export type DataListProps = React.HTMLAttributes<HTMLDListElement> &
+  VariantProps<typeof dataListVariants>;
+
+const DataList = React.forwardRef<HTMLDListElement, DataListProps>(
+  ({ className, density, ...props }, reference) => {
+    const resolvedDensity = density ?? "default";
+    const contextValue = React.useMemo<DataListContextValue>(
+      () => ({ density: resolvedDensity }),
+      [resolvedDensity],
+    );
+
+    return (
+      <DataListContext.Provider value={contextValue}>
+        <dl
+          className={cn(
+            dataListVariants({ density: resolvedDensity }),
+            className,
+          )}
+          ref={reference}
+          {...props}
+        />
+      </DataListContext.Provider>
+    );
+  },
+);
+
+DataList.displayName = "DataList";
+
+export type DataListItemProps = React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof dataListItemVariants>;
+
+const DataListItem = React.forwardRef<HTMLDivElement, DataListItemProps>(
+  ({ className, density, ...props }, reference) => {
+    const context = React.useContext(DataListContext);
+
+    return (
+      <div
+        className={cn(
+          dataListItemVariants({ density: density ?? context.density }),
+          className,
+        )}
+        ref={reference}
+        {...props}
+      />
+    );
+  },
+);
+
+DataListItem.displayName = "DataListItem";
+
+const DataListLabel = React.forwardRef<
+  HTMLElement,
+  React.HTMLAttributes<HTMLElement>
+>(({ className, ...props }, reference) => (
+  <dt
+    className={cn("text-sm font-medium text-muted-foreground", className)}
+    ref={reference}
+    {...props}
+  />
+));
+
+DataListLabel.displayName = "DataListLabel";
+
+const DataListValue = React.forwardRef<
+  HTMLElement,
+  React.HTMLAttributes<HTMLElement>
+>(({ className, ...props }, reference) => (
+  <dd
+    className={cn("m-0 text-sm leading-6 text-foreground", className)}
+    ref={reference}
+    {...props}
+  />
+));
+
+DataListValue.displayName = "DataListValue";
+
+export {
+  DataList,
+  DataListItem,
+  dataListItemVariants,
+  DataListLabel,
+  DataListValue,
+  dataListVariants,
+};

--- a/packages/ui/src/components/data-list/data-list.visual.tsx
+++ b/packages/ui/src/components/data-list/data-list.visual.tsx
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { DataList, DataListItem, DataListLabel, DataListValue } from "./data-list";
+
+test.describe("DataList Visual", () => {
+  test("default", async ({ mount, page }) => {
+    await mount(
+      <div className="w-[520px] p-4">
+        <DataList>
+          <DataListItem>
+            <DataListLabel>Environment</DataListLabel>
+            <DataListValue>Production</DataListValue>
+          </DataListItem>
+          <DataListItem>
+            <DataListLabel>Latency budget</DataListLabel>
+            <DataListValue>120 ms p95</DataListValue>
+          </DataListItem>
+          <DataListItem>
+            <DataListLabel>Deploy window</DataListLabel>
+            <DataListValue>Tue / Thu • 09:00 UTC</DataListValue>
+          </DataListItem>
+        </DataList>
+      </div>,
+    );
+
+    await expect(page).toHaveScreenshot("data-list-default.png");
+  });
+});

--- a/packages/ui/src/components/data-list/index.ts
+++ b/packages/ui/src/components/data-list/index.ts
@@ -1,0 +1,10 @@
+export {
+  DataList,
+  DataListItem,
+  DataListLabel,
+  DataListValue,
+  type DataListItemProps,
+  type DataListProps,
+  dataListItemVariants,
+  dataListVariants,
+} from "./data-list";

--- a/packages/ui/src/components/data-table/data-table.stories.tsx
+++ b/packages/ui/src/components/data-table/data-table.stories.tsx
@@ -1,0 +1,78 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { StatusIndicator } from "../status-indicator";
+import { DataTable } from "./data-table";
+
+type Workspace = {
+  seats: number;
+  status: string;
+  workspace: string;
+};
+
+const columns: ColumnDef<Workspace>[] = [
+  {
+    accessorKey: "workspace",
+    header: "Workspace",
+  },
+  {
+    accessorKey: "status",
+    cell: ({ row }) => (
+      <StatusIndicator
+        tone={
+          row.original.status === "active"
+            ? "success"
+            : row.original.status === "trial"
+              ? "info"
+              : "warning"
+        }
+      >
+        {row.original.status}
+      </StatusIndicator>
+    ),
+    header: "Status",
+  },
+  {
+    accessorKey: "seats",
+    header: "Seats",
+  },
+];
+
+const data: Workspace[] = [
+  { seats: 142, status: "active", workspace: "Northstar" },
+  { seats: 28, status: "trial", workspace: "Signal" },
+  { seats: 11, status: "paused", workspace: "Helix" },
+  { seats: 63, status: "active", workspace: "Comet" },
+];
+
+function DataTableStory() {
+  return (
+    <DataTable
+      columns={columns}
+      data={data}
+      enableSelection={true}
+      filterableColumns={[
+        {
+          columnId: "status",
+          label: "status",
+          options: [
+            { label: "Active", value: "active" },
+            { label: "Trial", value: "trial" },
+            { label: "Paused", value: "paused" },
+          ],
+        },
+      ]}
+      searchPlaceholder="Search workspaces"
+    />
+  );
+}
+
+const meta = {
+  component: DataTableStory,
+  title: "Data/DataTable",
+} satisfies Meta<typeof DataTableStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/packages/ui/src/components/data-table/data-table.test.tsx
+++ b/packages/ui/src/components/data-table/data-table.test.tsx
@@ -1,0 +1,81 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DataTable } from "./data-table";
+
+type Invoice = {
+  customer: string;
+  revenue: number;
+  status: string;
+};
+
+const columns: ColumnDef<Invoice>[] = [
+  {
+    accessorKey: "customer",
+    header: "Customer",
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+  },
+  {
+    accessorKey: "revenue",
+    header: "Revenue",
+  },
+];
+
+const data: Invoice[] = [
+  { customer: "Acme", revenue: 4100, status: "active" },
+  { customer: "Beacon", revenue: 1800, status: "trial" },
+  { customer: "Delta", revenue: 950, status: "paused" },
+];
+
+function getBodyRows(container: HTMLElement): HTMLTableRowElement[] {
+  const body = container.querySelector("tbody");
+  return body ? [...body.querySelectorAll("tr")] : [];
+}
+
+describe("DataTable", () => {
+  it("renders rows", () => {
+    render(<DataTable columns={columns} data={data} />);
+
+    expect(screen.getByText("Acme")).toBeVisible();
+    expect(screen.getByText("Beacon")).toBeVisible();
+  });
+
+  it("sorts rows when clicking a sortable header", () => {
+    const { container } = render(<DataTable columns={columns} data={data} />);
+
+    const revenueHeader = screen.getByRole("button", { name: /revenue/i });
+    fireEvent.click(revenueHeader);
+    fireEvent.click(revenueHeader);
+
+    expect(getBodyRows(container)[0]).toHaveTextContent("Delta");
+  });
+
+  it("filters rows through the search input", () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        searchPlaceholder="Search customers"
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Search customers"), {
+      target: { value: "Beacon" },
+    });
+
+    expect(screen.getByText("Beacon")).toBeVisible();
+    expect(screen.queryByText("Acme")).toBeNull();
+  });
+
+  it("supports row selection", () => {
+    render(<DataTable columns={columns} data={data} enableSelection={true} />);
+
+    fireEvent.click(screen.getByLabelText("Select row 1"));
+
+    expect(screen.getByText("1 selected")).toBeVisible();
+  });
+});

--- a/packages/ui/src/components/data-table/data-table.tsx
+++ b/packages/ui/src/components/data-table/data-table.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  type ColumnDef,
+  type ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  type Row,
+  type RowData,
+  type RowSelectionState,
+  type SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Button } from "../button";
+import { Checkbox } from "../checkbox";
+import { Input } from "../input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../table";
+
+export type DataTableFilterOption = {
+  label: string;
+  value: string;
+};
+
+export type DataTableFilter = {
+  columnId: string;
+  label: string;
+  options: DataTableFilterOption[];
+};
+
+export type DataTableProps<TData extends RowData> =
+  React.HTMLAttributes<HTMLDivElement> & {
+    caption?: string;
+    columns: ColumnDef<TData>[];
+    data: TData[];
+    emptyMessage?: string;
+    enableFiltering?: boolean;
+    enablePagination?: boolean;
+    enableSelection?: boolean;
+    filterableColumns?: DataTableFilter[];
+    getRowId?: (
+      originalRow: TData,
+      index: number,
+      parent?: Row<TData>,
+    ) => string;
+    pageSize?: number;
+    searchPlaceholder?: string;
+  };
+
+function SortIcon({ direction }: { direction: "asc" | "desc" | false }) {
+  if (direction === "asc") {
+    return <ArrowUp className="h-4 w-4" />;
+  }
+
+  if (direction === "desc") {
+    return <ArrowDown className="h-4 w-4" />;
+  }
+
+  return <ArrowUpDown className="h-4 w-4" />;
+}
+
+function DataTableComponent<TData extends RowData>({
+  caption,
+  className,
+  columns,
+  data,
+  emptyMessage = "No results found.",
+  enableFiltering = true,
+  enablePagination = true,
+  enableSelection = false,
+  filterableColumns = [],
+  getRowId,
+  pageSize = 10,
+  searchPlaceholder = "Search rows...",
+  ...props
+}: DataTableProps<TData>) {
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [globalFilter, setGlobalFilter] = React.useState("");
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
+    [],
+  );
+  const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({});
+
+  const selectionColumn = React.useMemo<ColumnDef<TData>>(
+    () => ({
+      cell: ({ row }) => (
+        <Checkbox
+          aria-label={`Select row ${row.index + 1}`}
+          checked={row.getIsSelected()}
+          onCheckedChange={(checked) => {
+            row.toggleSelected(Boolean(checked));
+          }}
+        />
+      ),
+      enableHiding: false,
+      enableSorting: false,
+      header: ({ table }) => (
+        <Checkbox
+          aria-label="Select all rows"
+          checked={
+            table.getIsAllPageRowsSelected()
+              ? true
+              : table.getIsSomePageRowsSelected()
+                ? "indeterminate"
+                : false
+          }
+          onCheckedChange={(checked) => {
+            table.toggleAllPageRowsSelected(Boolean(checked));
+          }}
+        />
+      ),
+      id: "select",
+      size: 40,
+    }),
+    [],
+  );
+
+  const resolvedColumns = React.useMemo(
+    () => (enableSelection ? [selectionColumn, ...columns] : columns),
+    [columns, enableSelection, selectionColumn],
+  );
+
+  const table = useReactTable({
+    columns: resolvedColumns,
+    data,
+    enableRowSelection: enableSelection,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getRowId,
+    getSortedRowModel: getSortedRowModel(),
+    initialState: {
+      pagination: {
+        pageIndex: 0,
+        pageSize,
+      },
+    },
+    onColumnFiltersChange: setColumnFilters,
+    onGlobalFilterChange: setGlobalFilter,
+    onRowSelectionChange: setRowSelection,
+    onSortingChange: setSorting,
+    state: {
+      columnFilters,
+      globalFilter,
+      rowSelection,
+      sorting,
+    },
+  });
+
+  return (
+    <div className={cn("space-y-4", className)} {...props}>
+      {enableFiltering ? (
+        <div className="flex flex-col gap-3 rounded-xl border bg-card p-4 sm:flex-row sm:items-center sm:justify-between">
+          <Input
+            className="w-full sm:max-w-sm"
+            onChange={(event) => {
+              setGlobalFilter(event.target.value);
+            }}
+            placeholder={searchPlaceholder}
+            value={globalFilter}
+          />
+          {filterableColumns.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {filterableColumns.map((filter) => {
+                const column = table.getColumn(filter.columnId);
+                const value = column?.getFilterValue();
+                const selectValue =
+                  typeof value === "string" && value ? value : "all";
+
+                return column ? (
+                  <Select
+                    key={filter.columnId}
+                    onValueChange={(nextValue) => {
+                      column.setFilterValue(
+                        nextValue === "all" ? undefined : nextValue,
+                      );
+                    }}
+                    value={selectValue}
+                  >
+                    <SelectTrigger className="w-[180px]">
+                      <SelectValue placeholder={filter.label} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All {filter.label}</SelectItem>
+                      {filter.options.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : null;
+              })}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="rounded-xl border bg-card">
+        <Table>
+          {caption ? <caption className="sr-only">{caption}</caption> : null}
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder ? null : header.column.getCanSort() ? (
+                      <Button
+                        className="-ml-3 h-8 px-3 text-xs font-medium"
+                        onClick={header.column.getToggleSortingHandler()}
+                        type="button"
+                        variant="ghost"
+                      >
+                        {flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                        <SortIcon direction={header.column.getIsSorted()} />
+                      </Button>
+                    ) : (
+                      flexRender(
+                        header.column.columnDef.header,
+                        header.getContext(),
+                      )
+                    )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length > 0 ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  data-state={row.getIsSelected() ? "selected" : undefined}
+                  key={row.id}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  className="h-24 text-center text-muted-foreground"
+                  colSpan={resolvedColumns.length}
+                >
+                  {emptyMessage}
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="flex flex-col gap-3 rounded-xl border bg-card p-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          {enableSelection
+            ? `${table.getSelectedRowModel().rows.length} selected`
+            : `${table.getFilteredRowModel().rows.length} rows`}
+        </div>
+        {enablePagination ? (
+          <div className="flex items-center gap-2 self-end sm:self-auto">
+            <Button
+              disabled={!table.getCanPreviousPage()}
+              onClick={() => {
+                table.previousPage();
+              }}
+              type="button"
+              variant="outline"
+            >
+              Previous
+            </Button>
+            <span className="min-w-24 text-center text-xs uppercase tracking-wide text-muted-foreground">
+              Page {table.getState().pagination.pageIndex + 1} of{" "}
+              {table.getPageCount()}
+            </span>
+            <Button
+              disabled={!table.getCanNextPage()}
+              onClick={() => {
+                table.nextPage();
+              }}
+              type="button"
+              variant="outline"
+            >
+              Next
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export { DataTableComponent as DataTable };

--- a/packages/ui/src/components/data-table/data-table.visual.tsx
+++ b/packages/ui/src/components/data-table/data-table.visual.tsx
@@ -1,0 +1,48 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { DataTable } from "./data-table";
+
+type Row = {
+  name: string;
+  status: string;
+  users: number;
+};
+
+const columns: ColumnDef<Row>[] = [
+  { accessorKey: "name", header: "Workspace" },
+  { accessorKey: "status", header: "Status" },
+  { accessorKey: "users", header: "Users" },
+];
+
+test.describe("DataTable Visual", () => {
+  test("default", async ({ mount, page }) => {
+    await mount(
+      <div className="w-[860px] p-4">
+        <DataTable
+          columns={columns}
+          data={[
+            { name: "Northstar", status: "active", users: 142 },
+            { name: "Signal", status: "trial", users: 28 },
+            { name: "Helix", status: "paused", users: 11 },
+          ]}
+          enableSelection={true}
+          filterableColumns={[
+            {
+              columnId: "status",
+              label: "status",
+              options: [
+                { label: "Active", value: "active" },
+                { label: "Trial", value: "trial" },
+                { label: "Paused", value: "paused" },
+              ],
+            },
+          ]}
+          searchPlaceholder="Search workspaces"
+        />
+      </div>,
+    );
+
+    await expect(page).toHaveScreenshot("data-table-default.png");
+  });
+});

--- a/packages/ui/src/components/data-table/index.ts
+++ b/packages/ui/src/components/data-table/index.ts
@@ -1,0 +1,6 @@
+export {
+  DataTable,
+  type DataTableFilter,
+  type DataTableFilterOption,
+  type DataTableProps,
+} from "./data-table";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -195,6 +195,22 @@ export {
 
 // New shadcn primitives - Data Display
 export {
+  DataTable,
+  type DataTableFilter,
+  type DataTableFilterOption,
+  type DataTableProps,
+} from "./data-table";
+export {
+  DataList,
+  DataListItem,
+  type DataListItemProps,
+  dataListItemVariants,
+  DataListLabel,
+  type DataListProps,
+  DataListValue,
+  dataListVariants,
+} from "./data-list";
+export {
   Table,
   TableBody,
   TableCaption,
@@ -205,9 +221,23 @@ export {
   TableRow,
 } from "./table";
 export { Avatar, AvatarFallback, AvatarImage } from "./avatar";
+export {
+  AvatarGroup,
+  type AvatarGroupItem,
+  type AvatarGroupProps,
+  avatarGroupVariants,
+  avatarItemVariants,
+} from "./avatar-group";
 export { Skeleton } from "./skeleton";
 export { Separator } from "./separator";
 export { Alert, AlertDescription, AlertTitle, alertVariants } from "./alert";
+export { StatCard, type StatCardProps, statCardVariants } from "./stat-card";
+export {
+  dotVariants,
+  StatusIndicator,
+  type StatusIndicatorProps,
+  statusIndicatorVariants,
+} from "./status-indicator";
 
 // New shadcn primitives - Layout
 export { AspectRatio } from "./aspect-ratio";

--- a/packages/ui/src/components/stat-card/index.ts
+++ b/packages/ui/src/components/stat-card/index.ts
@@ -1,0 +1,1 @@
+export { StatCard, type StatCardProps, statCardVariants } from "./stat-card";

--- a/packages/ui/src/components/stat-card/stat-card.stories.tsx
+++ b/packages/ui/src/components/stat-card/stat-card.stories.tsx
@@ -1,0 +1,61 @@
+import { Activity, DollarSign, TrendingUp } from "lucide-react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { StatCard } from "./stat-card";
+
+const meta = {
+  args: {
+    change: "+8.2%",
+    description: "Monthly recurring revenue",
+    icon: <DollarSign className="h-4 w-4" />,
+    label: "MRR",
+    meta: "vs last month",
+    tone: "success",
+    trend: "up",
+    value: "$42.8k",
+  },
+  component: StatCard,
+  title: "Data/StatCard",
+} satisfies Meta<typeof StatCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Grid: Story = {
+  render: () => (
+    <div className="grid gap-4 md:grid-cols-3">
+      <StatCard
+        change="+8.2%"
+        description="Monthly recurring revenue"
+        icon={<DollarSign className="h-4 w-4" />}
+        label="MRR"
+        meta="vs last month"
+        tone="success"
+        trend="up"
+        value="$42.8k"
+      />
+      <StatCard
+        change="+3.1 pts"
+        description="Onboarding completion"
+        icon={<TrendingUp className="h-4 w-4" />}
+        label="Activation"
+        meta="Trailing 7 days"
+        tone="neutral"
+        trend="up"
+        value="71%"
+      />
+      <StatCard
+        change="-12 ms"
+        description="Average API response time"
+        icon={<Activity className="h-4 w-4" />}
+        label="Latency"
+        meta="p95 · us-east-1"
+        tone="warning"
+        trend="down"
+        value="184ms"
+      />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/stat-card/stat-card.test.tsx
+++ b/packages/ui/src/components/stat-card/stat-card.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { Activity } from "lucide-react";
+import { describe, expect, it } from "vitest";
+
+import { StatCard } from "./stat-card";
+
+describe("StatCard", () => {
+  it("renders label and value", () => {
+    render(<StatCard label="MRR" value="$42.8k" />);
+
+    expect(screen.getByText("MRR")).toBeVisible();
+    expect(screen.getByText("$42.8k")).toBeVisible();
+  });
+
+  it("renders optional metadata", () => {
+    render(
+      <StatCard
+        change="+12.4%"
+        description="Month-over-month growth"
+        icon={<Activity className="h-4 w-4" />}
+        label="Activation"
+        meta="Updated 5 minutes ago"
+        trend="up"
+        value="71%"
+      />,
+    );
+
+    expect(screen.getByText("Month-over-month growth")).toBeVisible();
+    expect(screen.getByText("Updated 5 minutes ago")).toBeVisible();
+  });
+
+  it("accepts custom class names", () => {
+    render(<StatCard className="custom-class" label="Latency" value="92ms" />);
+
+    expect(screen.getByText("Latency").closest("div.rounded-lg")).toHaveClass(
+      "custom-class",
+    );
+  });
+});

--- a/packages/ui/src/components/stat-card/stat-card.tsx
+++ b/packages/ui/src/components/stat-card/stat-card.tsx
@@ -1,0 +1,139 @@
+import * as React from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import { ArrowDownRight, ArrowRight, ArrowUpRight } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Card, CardContent, CardDescription, CardHeader } from "../card";
+
+const statCardVariants = cva("overflow-hidden border shadow-sm", {
+  defaultVariants: {
+    tone: "neutral",
+  },
+  variants: {
+    tone: {
+      danger: "border-red-200/70 dark:border-red-950/70",
+      neutral: "",
+      success: "border-emerald-200/70 dark:border-emerald-950/70",
+      warning: "border-amber-200/70 dark:border-amber-950/70",
+    },
+  },
+});
+
+const accentVariants = cva("h-1 w-full", {
+  defaultVariants: {
+    tone: "neutral",
+  },
+  variants: {
+    tone: {
+      danger: "bg-red-500/80",
+      neutral: "bg-primary/70",
+      success: "bg-emerald-500/80",
+      warning: "bg-amber-500/80",
+    },
+  },
+});
+
+const changeVariants = cva(
+  "inline-flex items-center gap-1 text-xs font-medium",
+  {
+    defaultVariants: {
+      trend: "neutral",
+    },
+    variants: {
+      trend: {
+        down: "text-red-600 dark:text-red-400",
+        neutral: "text-muted-foreground",
+        up: "text-emerald-600 dark:text-emerald-400",
+      },
+    },
+  },
+);
+
+type StatCardTrend = "down" | "neutral" | "up";
+
+export type StatCardProps = React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof statCardVariants> & {
+    change?: React.ReactNode;
+    description?: React.ReactNode;
+    icon?: React.ReactNode;
+    label: React.ReactNode;
+    meta?: React.ReactNode;
+    trend?: StatCardTrend;
+    value: React.ReactNode;
+  };
+
+function TrendIcon({ trend }: { trend: StatCardTrend }) {
+  if (trend === "up") {
+    return <ArrowUpRight className="h-3.5 w-3.5" />;
+  }
+
+  if (trend === "down") {
+    return <ArrowDownRight className="h-3.5 w-3.5" />;
+  }
+
+  return <ArrowRight className="h-3.5 w-3.5" />;
+}
+
+const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
+  (
+    {
+      change,
+      className,
+      description,
+      icon,
+      label,
+      meta,
+      tone,
+      trend = "neutral",
+      value,
+      ...props
+    },
+    reference,
+  ) => (
+    <Card
+      className={cn(statCardVariants({ tone }), className)}
+      ref={reference}
+      {...props}
+    >
+      <div className={accentVariants({ tone })} />
+      <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0 pb-3">
+        <div className="space-y-1">
+          <CardDescription className="text-xs font-medium uppercase tracking-[0.14em]">
+            {label}
+          </CardDescription>
+          <div className="text-3xl font-semibold tracking-tight">{value}</div>
+        </div>
+        {icon ? (
+          <div className="rounded-lg border bg-muted/50 p-2 text-muted-foreground">
+            {icon}
+          </div>
+        ) : null}
+      </CardHeader>
+      {description || change || meta ? (
+        <CardContent className="space-y-3">
+          {description ? (
+            <p className="text-sm text-muted-foreground">{description}</p>
+          ) : null}
+          {change || meta ? (
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              {change ? (
+                <div className={changeVariants({ trend })}>
+                  <TrendIcon trend={trend} />
+                  <span>{change}</span>
+                </div>
+              ) : null}
+              {meta ? (
+                <div className="text-xs text-muted-foreground">{meta}</div>
+              ) : null}
+            </div>
+          ) : null}
+        </CardContent>
+      ) : null}
+    </Card>
+  ),
+);
+
+StatCard.displayName = "StatCard";
+
+export { StatCard, statCardVariants };

--- a/packages/ui/src/components/stat-card/stat-card.visual.tsx
+++ b/packages/ui/src/components/stat-card/stat-card.visual.tsx
@@ -1,0 +1,35 @@
+import { BarChart3, TrendingUp } from "lucide-react";
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { StatCard } from "./stat-card";
+
+test.describe("StatCard Visual", () => {
+  test("grid", async ({ mount, page }) => {
+    await mount(
+      <div className="grid w-[720px] grid-cols-2 gap-4 p-4">
+        <StatCard
+          change="+8.2%"
+          description="Monthly recurring revenue"
+          icon={<TrendingUp className="h-4 w-4" />}
+          label="MRR"
+          meta="vs last month"
+          tone="success"
+          trend="up"
+          value="$42.8k"
+        />
+        <StatCard
+          change="-1.6%"
+          description="Average response time"
+          icon={<BarChart3 className="h-4 w-4" />}
+          label="API latency"
+          meta="p95 · 24h"
+          tone="warning"
+          trend="down"
+          value="184ms"
+        />
+      </div>,
+    );
+
+    await expect(page).toHaveScreenshot("stat-card-grid.png");
+  });
+});

--- a/packages/ui/src/components/status-indicator/index.ts
+++ b/packages/ui/src/components/status-indicator/index.ts
@@ -1,0 +1,6 @@
+export {
+  StatusIndicator,
+  type StatusIndicatorProps,
+  dotVariants,
+  statusIndicatorVariants,
+} from "./status-indicator";

--- a/packages/ui/src/components/status-indicator/status-indicator.stories.tsx
+++ b/packages/ui/src/components/status-indicator/status-indicator.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { StatusIndicator } from "./status-indicator";
+
+const meta = {
+  args: {
+    children: "Operational",
+    tone: "success",
+  },
+  component: StatusIndicator,
+  title: "Data/StatusIndicator",
+} satisfies Meta<typeof StatusIndicator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-3">
+      <StatusIndicator tone="success">Operational</StatusIndicator>
+      <StatusIndicator tone="warning">Needs review</StatusIndicator>
+      <StatusIndicator tone="danger">Degraded</StatusIndicator>
+      <StatusIndicator tone="info">Queued</StatusIndicator>
+      <StatusIndicator tone="neutral" variant="outline">
+        Draft
+      </StatusIndicator>
+    </div>
+  ),
+};

--- a/packages/ui/src/components/status-indicator/status-indicator.test.tsx
+++ b/packages/ui/src/components/status-indicator/status-indicator.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StatusIndicator } from "./status-indicator";
+
+describe("StatusIndicator", () => {
+  it("renders the provided label", () => {
+    render(<StatusIndicator>Healthy</StatusIndicator>);
+
+    expect(screen.getByText("Healthy")).toBeVisible();
+  });
+
+  it("renders a dot by default", () => {
+    const { container } = render(<StatusIndicator>Synced</StatusIndicator>);
+
+    expect(container.querySelector("span span")).not.toBeNull();
+  });
+
+  it("can hide the dot", () => {
+    const { container } = render(
+      <StatusIndicator showDot={false}>Offline</StatusIndicator>,
+    );
+
+    expect(container.querySelector("span span")).toBeNull();
+  });
+
+  it("applies custom class names", () => {
+    render(<StatusIndicator className="custom-class">Active</StatusIndicator>);
+
+    expect(screen.getByText("Active")).toHaveClass("custom-class");
+  });
+});

--- a/packages/ui/src/components/status-indicator/status-indicator.tsx
+++ b/packages/ui/src/components/status-indicator/status-indicator.tsx
@@ -1,0 +1,194 @@
+import * as React from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../../lib/utils";
+
+const statusIndicatorVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-full border font-medium transition-colors",
+  {
+    compoundVariants: [
+      {
+        className: "border-border text-foreground",
+        tone: "neutral",
+        variant: "outline",
+      },
+      {
+        className: "border-transparent bg-muted text-foreground",
+        tone: "neutral",
+        variant: "soft",
+      },
+      {
+        className: "bg-foreground text-background",
+        tone: "neutral",
+        variant: "solid",
+      },
+      {
+        className:
+          "border-emerald-200 text-emerald-700 dark:border-emerald-900 dark:text-emerald-300",
+        tone: "success",
+        variant: "outline",
+      },
+      {
+        className:
+          "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/60 dark:text-emerald-300",
+        tone: "success",
+        variant: "soft",
+      },
+      {
+        className: "bg-emerald-600 text-white dark:bg-emerald-500",
+        tone: "success",
+        variant: "solid",
+      },
+      {
+        className:
+          "border-amber-200 text-amber-700 dark:border-amber-900 dark:text-amber-300",
+        tone: "warning",
+        variant: "outline",
+      },
+      {
+        className:
+          "bg-amber-100 text-amber-800 dark:bg-amber-950/60 dark:text-amber-300",
+        tone: "warning",
+        variant: "soft",
+      },
+      {
+        className:
+          "bg-amber-500 text-amber-950 dark:bg-amber-400 dark:text-amber-950",
+        tone: "warning",
+        variant: "solid",
+      },
+      {
+        className:
+          "border-red-200 text-red-700 dark:border-red-900 dark:text-red-300",
+        tone: "danger",
+        variant: "outline",
+      },
+      {
+        className:
+          "bg-red-100 text-red-800 dark:bg-red-950/60 dark:text-red-300",
+        tone: "danger",
+        variant: "soft",
+      },
+      {
+        className: "bg-red-600 text-white dark:bg-red-500",
+        tone: "danger",
+        variant: "solid",
+      },
+      {
+        className:
+          "border-sky-200 text-sky-700 dark:border-sky-900 dark:text-sky-300",
+        tone: "info",
+        variant: "outline",
+      },
+      {
+        className:
+          "bg-sky-100 text-sky-800 dark:bg-sky-950/60 dark:text-sky-300",
+        tone: "info",
+        variant: "soft",
+      },
+      {
+        className: "bg-sky-600 text-white dark:bg-sky-500",
+        tone: "info",
+        variant: "solid",
+      },
+    ],
+    defaultVariants: {
+      size: "md",
+      tone: "neutral",
+      variant: "soft",
+    },
+    variants: {
+      size: {
+        lg: "min-h-8 px-3 text-sm",
+        md: "min-h-7 px-2.5 text-xs",
+        sm: "min-h-6 px-2 text-[11px]",
+      },
+      tone: {
+        danger: "",
+        info: "",
+        neutral: "",
+        success: "",
+        warning: "",
+      },
+      variant: {
+        outline: "bg-background",
+        soft: "border-transparent",
+        solid: "border-transparent text-primary-foreground",
+      },
+    },
+  },
+);
+
+const dotVariants = cva("rounded-full", {
+  defaultVariants: {
+    size: "md",
+    tone: "neutral",
+  },
+  variants: {
+    size: {
+      lg: "h-2.5 w-2.5",
+      md: "h-2 w-2",
+      sm: "h-1.5 w-1.5",
+    },
+    tone: {
+      danger: "bg-red-500",
+      info: "bg-sky-500",
+      neutral: "bg-muted-foreground",
+      success: "bg-emerald-500",
+      warning: "bg-amber-500",
+    },
+  },
+});
+
+export type StatusIndicatorProps = React.HTMLAttributes<HTMLSpanElement> &
+  VariantProps<typeof statusIndicatorVariants> & {
+    label?: string;
+    pulse?: boolean;
+    showDot?: boolean;
+  };
+
+const StatusIndicator = React.forwardRef<HTMLSpanElement, StatusIndicatorProps>(
+  (
+    {
+      children,
+      className,
+      label,
+      pulse = false,
+      showDot = true,
+      size,
+      tone,
+      variant,
+      ...props
+    },
+    reference,
+  ) => {
+    const content = children ?? label;
+
+    return (
+      <span
+        className={cn(
+          statusIndicatorVariants({ size, tone, variant }),
+          className,
+        )}
+        ref={reference}
+        {...props}
+      >
+        {showDot ? (
+          <span
+            aria-hidden="true"
+            className={cn(
+              dotVariants({ size, tone }),
+              pulse ? "animate-pulse" : undefined,
+            )}
+          />
+        ) : null}
+        {content}
+      </span>
+    );
+  },
+);
+
+StatusIndicator.displayName = "StatusIndicator";
+
+export { dotVariants, StatusIndicator, statusIndicatorVariants };

--- a/packages/ui/src/components/status-indicator/status-indicator.visual.tsx
+++ b/packages/ui/src/components/status-indicator/status-indicator.visual.tsx
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { StatusIndicator } from "./status-indicator";
+
+test.describe("StatusIndicator Visual", () => {
+  test("tones", async ({ mount, page }) => {
+    await mount(
+      <div className="flex flex-wrap gap-3 p-4">
+        <StatusIndicator tone="success">Operational</StatusIndicator>
+        <StatusIndicator tone="warning">Pending</StatusIndicator>
+        <StatusIndicator tone="danger">Incident</StatusIndicator>
+        <StatusIndicator tone="info">Queued</StatusIndicator>
+      </div>,
+    );
+
+    await expect(page).toHaveScreenshot("status-indicator-tones.png");
+  });
+});


### PR DESCRIPTION
## Summary
- add DataTable, StatCard, DataList, StatusIndicator, and AvatarGroup to the UI package
- wire stories, tests, visual specs, registry entries, preview rendering, and generated component metadata
- keep the batch scoped to the core data display family stacked on feat/storybook

## Validation
- pnpm -F @vllnt/ui test:once -- src/components/status-indicator/status-indicator.test.tsx src/components/avatar-group/avatar-group.test.tsx src/components/data-list/data-list.test.tsx src/components/stat-card/stat-card.test.tsx src/components/data-table/data-table.test.tsx
- pnpm exec eslint src/components/status-indicator/status-indicator.tsx src/components/status-indicator/status-indicator.test.tsx src/components/avatar-group/avatar-group.tsx src/components/avatar-group/avatar-group.test.tsx src/components/data-list/data-list.tsx src/components/data-list/data-list.test.tsx src/components/stat-card/stat-card.tsx src/components/stat-card/stat-card.test.tsx src/components/data-table/data-table.tsx src/components/data-table/data-table.test.tsx src/components/index.ts
- pnpm exec eslint components/component-preview/component-preview.tsx
- pnpm -F @vllnt/ui build
- pnpm -F @vllnt/ui-registry build
- pnpm -F @vllnt/ui build-storybook && pnpm -F @vllnt/ui-registry sync-storybook

## Refs
- refs #45
- refs #46
- refs #48
- refs #49
- refs #50