### PR TITLE
feat(ui): add analytics family components

### DIFF
--- a/apps/registry/components/component-preview/component-preview.tsx
+++ b/apps/registry/components/component-preview/component-preview.tsx
@@ -7,6 +7,7 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
+  ActivityLog,
   Alert,
   AlertDescription,
   AlertDialog,
@@ -123,6 +124,7 @@ import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
+  ScopeSelector,
   ScrollArea,
   SearchBar,
   Select,
@@ -178,6 +180,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
   TutorialCard,
+  UsageBreakdown,
   VideoEmbed,
   ViewSwitcher,
 } from "@vllnt/ui";
@@ -705,6 +708,83 @@ function PaginationPreview() {
   return <Pagination baseUrl="/blog" currentPage={3} totalPages={10} />;
 }
 
+function UsageBreakdownPreview() {
+  return (
+    <UsageBreakdown
+      description="Ranked resource consumption across the current workspace."
+      items={[
+        {
+          id: "tokens",
+          label: "Tokens",
+          meta: "LLM",
+          trend: { direction: "up", label: "+14%" },
+          value: 420,
+          valueLabel: "420k",
+        },
+        {
+          id: "storage",
+          label: "Storage",
+          meta: "Vector DB",
+          trend: { direction: "down", label: "-6%" },
+          value: 260,
+          valueLabel: "260 GB",
+        },
+        {
+          id: "events",
+          label: "Events",
+          meta: "Tracking",
+          value: 180,
+          valueLabel: "180k",
+        },
+      ]}
+      title="Usage breakdown"
+    />
+  );
+}
+
+function ActivityLogPreview() {
+  return (
+    <ActivityLog
+      description="Recent analytics changes across your org."
+      items={[
+        {
+          action: "updated",
+          actor: "Alex Morgan",
+          description: "Raised ingestion retention from 30 to 45 days.",
+          id: "1",
+          scope: "Workspace",
+          target: "Analytics policy",
+          timestamp: "2m ago",
+          tone: "success",
+        },
+        {
+          action: "paused",
+          actor: "Riley Chen",
+          description: "Temporarily disabled streaming exports after an alert.",
+          id: "2",
+          scope: "Project",
+          target: "Billing pipeline",
+          timestamp: "11m ago",
+          tone: "warning",
+        },
+        {
+          action: "revoked",
+          actor: "Sam Patel",
+          description:
+            "Removed an expired API credential from production scope.",
+          id: "3",
+          scope: "Environment",
+          target: "Collector token",
+          timestamp: "24m ago",
+          tone: "danger",
+        },
+      ]}
+      pageSize={3}
+      title="Activity log"
+    />
+  );
+}
+
 function SearchBarPreview() {
   return (
     <React.Suspense
@@ -1209,6 +1289,44 @@ function ViewSwitcherPreview() {
   );
 }
 
+function ScopeSelectorPreview() {
+  return (
+    <div className="w-full max-w-sm">
+      <ScopeSelector
+        nodes={[
+          {
+            children: [
+              {
+                children: [
+                  { id: "prod-us", label: "US East" },
+                  { id: "prod-eu", label: "EU West" },
+                ],
+                id: "production",
+                label: "Production",
+              },
+              {
+                children: [{ id: "staging-us", label: "US East" }],
+                id: "staging",
+                label: "Staging",
+              },
+            ],
+            id: "environments",
+            label: "Environments",
+          },
+          {
+            children: [
+              { id: "team-growth", label: "Growth" },
+              { id: "team-data", label: "Data" },
+            ],
+            id: "teams",
+            label: "Teams",
+          },
+        ]}
+      />
+    </div>
+  );
+}
+
 function HoverCardPreview() {
   return (
     <HoverCard>
@@ -1496,6 +1614,8 @@ export function ComponentPreview({ componentName }: ComponentPreviewProps) {
   switch (componentName) {
     case "accordion":
       return <AccordionPreview />;
+    case "activity-log":
+      return <ActivityLogPreview />;
     case "alert":
       return <AlertPreview />;
     case "alert-dialog":
@@ -1628,6 +1748,8 @@ export function ComponentPreview({ componentName }: ComponentPreviewProps) {
       return (
         <SimplePreview description="A command palette style search dialog." />
       );
+    case "scope-selector":
+      return <ScopeSelectorPreview />;
     case "select":
       return <SelectPreview />;
     case "separator":
@@ -1704,6 +1826,8 @@ export function ComponentPreview({ componentName }: ComponentPreviewProps) {
       return (
         <SimplePreview description="MDX components optimized for tutorial content." />
       );
+    case "usage-breakdown":
+      return <UsageBreakdownPreview />;
     case "video-embed":
       return <VideoEmbedPreview />;
     case "view-switcher":

--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -19,6 +19,21 @@
       "category": "content"
     },
     {
+      "name": "activity-log",
+      "type": "registry:component",
+      "title": "Activity Log",
+      "description": "Paginated activity feed for audit history and analytics changes.",
+      "files": [
+        {
+          "path": "registry/default/activity-log/activity-log.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data"
+    },
+    {
       "name": "alert",
       "type": "registry:component",
       "title": "Alert",
@@ -514,6 +529,25 @@
       "category": "data"
     },
     {
+      "name": "horizontal-scroll-row",
+      "type": "registry:component",
+      "title": "Horizontal Scroll Row",
+      "description": "Horizontal scroll container with snap scrolling, chevron navigation, and hidden scrollbar.",
+      "files": [
+        {
+          "path": "registry/default/horizontal-scroll-row/horizontal-scroll-row.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [
+        "button"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "category": "navigation"
+    },
+    {
       "name": "hover-card",
       "type": "registry:component",
       "title": "Hover Card",
@@ -527,21 +561,6 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "overlay"
-    },
-    {
-      "name": "horizontal-scroll-row",
-      "type": "registry:component",
-      "title": "Horizontal Scroll Row",
-      "description": "Horizontal scroll container with snap scrolling, chevron navigation, and hidden scrollbar.",
-      "files": [
-        {
-          "path": "registry/default/horizontal-scroll-row/horizontal-scroll-row.tsx",
-          "type": "registry:component"
-        }
-      ],
-      "registryDependencies": ["button"],
-      "dependencies": ["lucide-react"],
-      "category": "navigation"
     },
     {
       "name": "inline-input",
@@ -872,6 +891,21 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "utility"
+    },
+    {
+      "name": "scope-selector",
+      "type": "registry:component",
+      "title": "Scope Selector",
+      "description": "Multi-level scope picker for nested environments, teams, and targets.",
+      "files": [
+        {
+          "path": "registry/default/scope-selector/scope-selector.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "form"
     },
     {
       "name": "scroll-area",
@@ -1401,6 +1435,21 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "learning"
+    },
+    {
+      "name": "usage-breakdown",
+      "type": "registry:component",
+      "title": "Usage Breakdown",
+      "description": "Ranked resource consumption list with relative share and trend cues.",
+      "files": [
+        {
+          "path": "registry/default/usage-breakdown/usage-breakdown.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data"
     },
     {
       "name": "video-embed",

--- a/apps/registry/registry/default/activity-log/activity-log.tsx
+++ b/apps/registry/registry/default/activity-log/activity-log.tsx
@@ -1,0 +1,6 @@
+export {
+  ActivityLog,
+  type ActivityLogItem,
+  type ActivityLogProps,
+  type ActivityLogTone,
+} from "@vllnt/ui";

--- a/apps/registry/registry/default/activity-log/example.mdx
+++ b/apps/registry/registry/default/activity-log/example.mdx
@@ -1,0 +1,3 @@
+## Example
+
+Use `ActivityLog` when you need a compact feed with status cues, actor context, and built-in pagination controls.

--- a/apps/registry/registry/default/activity-log/header.mdx
+++ b/apps/registry/registry/default/activity-log/header.mdx
@@ -1,0 +1,3 @@
+# ActivityLog
+
+A paginated activity feed for audit trails, review queues, and analytics change history.

--- a/apps/registry/registry/default/scope-selector/example.mdx
+++ b/apps/registry/registry/default/scope-selector/example.mdx
@@ -1,0 +1,3 @@
+## Example
+
+Use `ScopeSelector` to browse hierarchical scopes, search across branches, and select a final target without leaving the current surface.

--- a/apps/registry/registry/default/scope-selector/header.mdx
+++ b/apps/registry/registry/default/scope-selector/header.mdx
@@ -1,0 +1,3 @@
+# ScopeSelector
+
+A multi-level scope picker for choosing nested environments, teams, or deployment targets.

--- a/apps/registry/registry/default/scope-selector/scope-selector.tsx
+++ b/apps/registry/registry/default/scope-selector/scope-selector.tsx
@@ -1,0 +1,6 @@
+export {
+  ScopeSelector,
+  type ScopeSelectorNode,
+  type ScopeSelectorProps,
+  type ScopeSelectorSelection,
+} from "@vllnt/ui";

--- a/apps/registry/registry/default/usage-breakdown/example.mdx
+++ b/apps/registry/registry/default/usage-breakdown/example.mdx
@@ -1,0 +1,3 @@
+## Example
+
+Use `UsageBreakdown` to compare the highest-consuming resources, highlight relative share, and surface trends without changing the surrounding dashboard aesthetic.

--- a/apps/registry/registry/default/usage-breakdown/header.mdx
+++ b/apps/registry/registry/default/usage-breakdown/header.mdx
@@ -1,0 +1,3 @@
+# UsageBreakdown
+
+A ranked resource consumption list for analytics surfaces, billing overviews, or ops dashboards.

--- a/apps/registry/registry/default/usage-breakdown/usage-breakdown.tsx
+++ b/apps/registry/registry/default/usage-breakdown/usage-breakdown.tsx
@@ -1,0 +1,6 @@
+export {
+  UsageBreakdown,
+  type UsageBreakdownItem,
+  type UsageBreakdownProps,
+  type UsageBreakdownTone,
+} from "@vllnt/ui";

--- a/packages/ui/src/components/activity-log/activity-log.stories.tsx
+++ b/packages/ui/src/components/activity-log/activity-log.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ActivityLog } from "./activity-log";
+
+const meta = {
+  args: {
+    description: "Paginated audit history for recent analytics changes.",
+    items: [
+      {
+        action: "updated",
+        actor: "Alex Morgan",
+        description: "Raised ingestion retention from 30 to 45 days.",
+        id: "1",
+        scope: "Workspace",
+        target: "Analytics policy",
+        timestamp: "2m ago",
+        tone: "success",
+      },
+      {
+        action: "paused",
+        actor: "Riley Chen",
+        description: "Temporarily disabled streaming exports after an alert.",
+        id: "2",
+        scope: "Project",
+        target: "Billing pipeline",
+        timestamp: "11m ago",
+        tone: "warning",
+      },
+      {
+        action: "revoked",
+        actor: "Sam Patel",
+        description: "Removed an expired API credential from production scope.",
+        id: "3",
+        scope: "Environment",
+        target: "Collector token",
+        timestamp: "24m ago",
+        tone: "danger",
+      },
+      {
+        action: "reviewed",
+        actor: "Jordan Lee",
+        description: "Confirmed attribution rules for weekend experiment traffic.",
+        id: "4",
+        scope: "Project",
+        target: "Experiment dashboard",
+        timestamp: "46m ago",
+      },
+    ],
+    pageSize: 3,
+    title: "Activity log",
+  },
+  component: ActivityLog,
+  title: "Analytics/ActivityLog",
+} satisfies Meta<typeof ActivityLog>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: {
+    items: [],
+  },
+};

--- a/packages/ui/src/components/activity-log/activity-log.test.tsx
+++ b/packages/ui/src/components/activity-log/activity-log.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ActivityLog } from "./activity-log";
+
+const items = Array.from({ length: 6 }, (_, index) => ({
+  action: "updated",
+  actor: `Operator ${index + 1}`,
+  id: `item-${index + 1}`,
+  scope: index % 2 === 0 ? "Workspace" : "Project",
+  target: `Dataset ${index + 1}`,
+  timestamp: `${index + 1}m ago`,
+}));
+
+describe("ActivityLog", () => {
+  it("renders the first page of activity entries", () => {
+    render(<ActivityLog items={items} pageSize={3} />);
+
+    expect(screen.getByText("Operator 1")).toBeInTheDocument();
+    expect(screen.getByText("Operator 3")).toBeInTheDocument();
+    expect(screen.queryByText("Operator 4")).not.toBeInTheDocument();
+  });
+
+  it("moves to the next page when pagination controls are used", () => {
+    render(<ActivityLog items={items} pageSize={3} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(screen.getByText("Operator 4")).toBeInTheDocument();
+    expect(screen.queryByText("Operator 1")).not.toBeInTheDocument();
+  });
+
+  it("calls onPageChange when a new page is selected", () => {
+    const handlePageChange = vi.fn();
+    render(
+      <ActivityLog
+        items={items}
+        onPageChange={handlePageChange}
+        page={1}
+        pageSize={2}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Go to page 2" }));
+
+    expect(handlePageChange).toHaveBeenCalledWith(2);
+  });
+});

--- a/packages/ui/src/components/activity-log/activity-log.tsx
+++ b/packages/ui/src/components/activity-log/activity-log.tsx
@@ -1,0 +1,355 @@
+import { forwardRef, useMemo, useState } from "react";
+
+import { ArrowRight, ChevronLeft, ChevronRight } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Avatar, AvatarFallback } from "../avatar";
+import { Badge } from "../badge";
+import { Button } from "../button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../card";
+import { ScrollArea } from "../scroll-area";
+import { Separator } from "../separator";
+
+export type ActivityLogTone = "danger" | "default" | "success" | "warning";
+
+export type ActivityLogItem = {
+  action: string;
+  actor: string;
+  description?: string;
+  id: string;
+  scope?: string;
+  target?: string;
+  timestamp: string;
+  tone?: ActivityLogTone;
+};
+
+export type ActivityLogProps = React.ComponentPropsWithoutRef<typeof Card> & {
+  defaultPage?: number;
+  description?: string;
+  emptyMessage?: string;
+  items: ActivityLogItem[];
+  onPageChange?: (page: number) => void;
+  page?: number;
+  pageSize?: number;
+  title?: string;
+};
+
+type ActivityToneConfig = {
+  badgeClassName: string;
+  markerClassName: string;
+};
+
+type ActivityRowProps = {
+  item: ActivityLogItem;
+};
+
+type PaginationControlsProps = {
+  currentPage: number;
+  onPageChange: (page: number) => void;
+  pageNumbers: number[];
+  totalPages: number;
+};
+
+const toneConfig: Record<ActivityLogTone, ActivityToneConfig> = {
+  danger: {
+    badgeClassName:
+      "border-destructive/20 bg-destructive/10 text-destructive dark:text-destructive",
+    markerClassName: "bg-destructive",
+  },
+  default: {
+    badgeClassName: "border-border bg-muted text-muted-foreground",
+    markerClassName: "bg-primary",
+  },
+  success: {
+    badgeClassName:
+      "border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+    markerClassName: "bg-emerald-500",
+  },
+  warning: {
+    badgeClassName:
+      "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+    markerClassName: "bg-amber-500",
+  },
+};
+
+function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .map((segment) => segment[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+function buildPageNumbers(currentPage: number, totalPages: number): number[] {
+  if (totalPages <= 1) return [1];
+
+  const start = Math.max(1, currentPage - 1);
+  const end = Math.min(totalPages, start + 2);
+  const normalizedStart = Math.max(1, end - 2);
+
+  return Array.from(
+    { length: end - normalizedStart + 1 },
+    (_, index) => normalizedStart + index,
+  );
+}
+
+function ActivityLogHeader({
+  currentPage,
+  description,
+  title,
+  totalPages,
+}: {
+  currentPage: number;
+  description?: string;
+  title: string;
+  totalPages: number;
+}) {
+  return (
+    <CardHeader>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <CardTitle>{title}</CardTitle>
+          {description ? (
+            <CardDescription>{description}</CardDescription>
+          ) : null}
+        </div>
+        <Badge className="w-fit" variant="outline">
+          Page {currentPage} of {totalPages}
+        </Badge>
+      </div>
+    </CardHeader>
+  );
+}
+
+function PaginationControls({
+  currentPage,
+  onPageChange,
+  pageNumbers,
+  totalPages,
+}: PaginationControlsProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button
+        disabled={currentPage === 1}
+        onClick={() => {
+          onPageChange(currentPage - 1);
+        }}
+        size="sm"
+        variant="outline"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Previous
+      </Button>
+      {pageNumbers.map((pageNumber) => (
+        <Button
+          aria-label={`Go to page ${pageNumber}`}
+          key={pageNumber}
+          onClick={() => {
+            onPageChange(pageNumber);
+          }}
+          size="sm"
+          variant={pageNumber === currentPage ? "default" : "outline"}
+        >
+          {pageNumber}
+        </Button>
+      ))}
+      <Button
+        disabled={currentPage === totalPages}
+        onClick={() => {
+          onPageChange(currentPage + 1);
+        }}
+        size="sm"
+        variant="outline"
+      >
+        Next
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
+function ActivityRow({ item }: ActivityRowProps) {
+  const palette = toneConfig[item.tone ?? "default"];
+
+  return (
+    <li className="relative pl-12">
+      <span
+        aria-hidden="true"
+        className="absolute bottom-[-1.5rem] left-[18px] top-11 w-px bg-border last:hidden"
+      />
+      <span
+        aria-hidden="true"
+        className={cn(
+          "absolute left-4 top-3 h-3 w-3 rounded-full ring-4 ring-background",
+          palette.markerClassName,
+        )}
+      />
+      <div className="rounded-lg border bg-background/70 p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex min-w-0 items-start gap-3">
+            <Avatar className="h-9 w-9 border bg-muted">
+              <AvatarFallback>{getInitials(item.actor)}</AvatarFallback>
+            </Avatar>
+            <div className="min-w-0 space-y-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-medium text-foreground">
+                  {item.actor}
+                </span>
+                <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="text-sm text-muted-foreground">
+                  {item.action}
+                </span>
+                {item.target ? (
+                  <span className="truncate text-sm font-medium text-foreground">
+                    {item.target}
+                  </span>
+                ) : null}
+              </div>
+              {item.description ? (
+                <p className="text-sm text-muted-foreground">
+                  {item.description}
+                </p>
+              ) : null}
+            </div>
+          </div>
+          <div className="flex shrink-0 flex-wrap items-center gap-2 sm:justify-end">
+            {item.scope ? (
+              <Badge className={palette.badgeClassName} variant="outline">
+                {item.scope}
+              </Badge>
+            ) : null}
+            <span className="text-xs text-muted-foreground">
+              {item.timestamp}
+            </span>
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function ActivityLogBody({
+  currentPage,
+  emptyMessage,
+  items,
+  onPageChange,
+  pageNumbers,
+  pageSize,
+  totalPages,
+}: {
+  currentPage: number;
+  emptyMessage: string;
+  items: ActivityLogItem[];
+  onPageChange: (page: number) => void;
+  pageNumbers: number[];
+  pageSize: number;
+  totalPages: number;
+}) {
+  const visibleItems = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return items.slice(start, start + pageSize);
+  }, [currentPage, items, pageSize]);
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <ScrollArea className="max-h-[26rem] pr-4">
+        <ol className="space-y-4 pb-2">
+          {visibleItems.map((item) => (
+            <ActivityRow item={item} key={item.id} />
+          ))}
+        </ol>
+      </ScrollArea>
+      <Separator />
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-muted-foreground">
+          Showing {(currentPage - 1) * pageSize + 1}
+          {" - "}
+          {(currentPage - 1) * pageSize + visibleItems.length} of {items.length}
+        </p>
+        <PaginationControls
+          currentPage={currentPage}
+          onPageChange={onPageChange}
+          pageNumbers={pageNumbers}
+          totalPages={totalPages}
+        />
+      </div>
+    </>
+  );
+}
+
+const ActivityLog = forwardRef<HTMLDivElement, ActivityLogProps>(
+  (
+    {
+      className,
+      defaultPage = 1,
+      description,
+      emptyMessage = "No activity recorded yet.",
+      items,
+      onPageChange,
+      page,
+      pageSize = 5,
+      title = "Activity log",
+      ...props
+    },
+    ref,
+  ) => {
+    const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+    const [uncontrolledPage, setUncontrolledPage] = useState(defaultPage);
+    const currentPage = Math.min(
+      Math.max(page ?? uncontrolledPage, 1),
+      totalPages,
+    );
+    const pageNumbers = useMemo(
+      () => buildPageNumbers(currentPage, totalPages),
+      [currentPage, totalPages],
+    );
+
+    function handlePageChange(nextPage: number) {
+      if (page === undefined) {
+        setUncontrolledPage(nextPage);
+      }
+      onPageChange?.(nextPage);
+    }
+
+    return (
+      <Card className={cn("w-full", className)} ref={ref} {...props}>
+        <ActivityLogHeader
+          currentPage={currentPage}
+          description={description}
+          title={title}
+          totalPages={totalPages}
+        />
+        <CardContent className="space-y-4">
+          <ActivityLogBody
+            currentPage={currentPage}
+            emptyMessage={emptyMessage}
+            items={items}
+            onPageChange={handlePageChange}
+            pageNumbers={pageNumbers}
+            pageSize={pageSize}
+            totalPages={totalPages}
+          />
+        </CardContent>
+      </Card>
+    );
+  },
+);
+
+ActivityLog.displayName = "ActivityLog";
+
+export { ActivityLog };

--- a/packages/ui/src/components/activity-log/activity-log.visual.tsx
+++ b/packages/ui/src/components/activity-log/activity-log.visual.tsx
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { ActivityLog } from "./activity-log";
+
+test.describe("ActivityLog Visual", () => {
+  test("default", async ({ mount, page }) => {
+    await mount(
+      <div className="w-[780px] p-6">
+        <ActivityLog
+          description="Paginated audit history for recent analytics changes."
+          items={[
+            {
+              action: "updated",
+              actor: "Alex Morgan",
+              description: "Raised ingestion retention from 30 to 45 days.",
+              id: "1",
+              scope: "Workspace",
+              target: "Analytics policy",
+              timestamp: "2m ago",
+              tone: "success",
+            },
+            {
+              action: "paused",
+              actor: "Riley Chen",
+              description: "Temporarily disabled streaming exports after an alert.",
+              id: "2",
+              scope: "Project",
+              target: "Billing pipeline",
+              timestamp: "11m ago",
+              tone: "warning",
+            },
+            {
+              action: "revoked",
+              actor: "Sam Patel",
+              description: "Removed an expired API credential from production scope.",
+              id: "3",
+              scope: "Environment",
+              target: "Collector token",
+              timestamp: "24m ago",
+              tone: "danger",
+            },
+          ]}
+          pageSize={3}
+          title="Activity log"
+        />
+      </div>,
+    );
+
+    await expect(page).toHaveScreenshot("activity-log-default.png");
+  });
+});

--- a/packages/ui/src/components/activity-log/index.ts
+++ b/packages/ui/src/components/activity-log/index.ts
@@ -1,0 +1,6 @@
+export {
+  ActivityLog,
+  type ActivityLogItem,
+  type ActivityLogProps,
+  type ActivityLogTone,
+} from "./activity-log";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -252,10 +252,28 @@ export { SidebarProvider, useSidebar } from "./sidebar-provider";
 export { TableOfContents } from "./table-of-contents";
 
 // Blog components
+export {
+  ActivityLog,
+  type ActivityLogItem,
+  type ActivityLogProps,
+  type ActivityLogTone,
+} from "./activity-log";
 export { BlogCard, ContentCard } from "./blog-card";
 export { CategoryFilter } from "./category-filter";
 export { Pagination, type PaginationProps } from "./pagination";
 export { SearchBar } from "./search-bar";
+export {
+  ScopeSelector,
+  type ScopeSelectorNode,
+  type ScopeSelectorProps,
+  type ScopeSelectorSelection,
+} from "./scope-selector";
+export {
+  UsageBreakdown,
+  type UsageBreakdownItem,
+  type UsageBreakdownProps,
+  type UsageBreakdownTone,
+} from "./usage-breakdown";
 export {
   type PlatformConfig,
   type SharePlatform,

--- a/packages/ui/src/components/scope-selector/index.ts
+++ b/packages/ui/src/components/scope-selector/index.ts
@@ -1,0 +1,6 @@
+export {
+  ScopeSelector,
+  type ScopeSelectorNode,
+  type ScopeSelectorProps,
+  type ScopeSelectorSelection,
+} from "./scope-selector";

--- a/packages/ui/src/components/scope-selector/scope-selector.stories.tsx
+++ b/packages/ui/src/components/scope-selector/scope-selector.stories.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  type ScopeSelectorSelection,
+  ScopeSelector,
+} from "./scope-selector";
+
+function ScopeSelectorStory(args: React.ComponentProps<typeof ScopeSelector>) {
+  const [selection, setSelection] = useState<ScopeSelectorSelection | undefined>();
+
+  return (
+    <div className="w-full max-w-sm space-y-3">
+      <ScopeSelector
+        {...args}
+        onValueChange={(nextSelection) => {
+          setSelection(nextSelection);
+          args.onValueChange?.(nextSelection);
+        }}
+      />
+      <p className="text-sm text-muted-foreground">
+        Selected: {selection?.path.map((node) => node.label).join(" / ") ?? "None"}
+      </p>
+    </div>
+  );
+}
+
+const meta = {
+  args: {
+    nodes: [
+      {
+        children: [
+          {
+            badge: "3 envs",
+            children: [
+              { id: "prod-us", label: "US East" },
+              { id: "prod-eu", label: "EU West" },
+              { id: "prod-apac", label: "APAC" },
+            ],
+            description: "Customer-facing production traffic.",
+            id: "production",
+            label: "Production",
+          },
+          {
+            children: [{ id: "staging-us", label: "US East" }],
+            description: "Pre-release validation and QA.",
+            id: "staging",
+            label: "Staging",
+          },
+        ],
+        id: "environments",
+        label: "Environments",
+      },
+      {
+        children: [
+          { id: "team-growth", label: "Growth" },
+          { id: "team-data", label: "Data" },
+        ],
+        id: "teams",
+        label: "Teams",
+      },
+    ],
+  },
+  component: ScopeSelector,
+  render: ScopeSelectorStory,
+  title: "Analytics/ScopeSelector",
+} satisfies Meta<typeof ScopeSelector>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithDefaultSelection: Story = {
+  args: {
+    defaultValue: "prod-eu",
+  },
+};

--- a/packages/ui/src/components/scope-selector/scope-selector.test.tsx
+++ b/packages/ui/src/components/scope-selector/scope-selector.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ScopeSelector } from "./scope-selector";
+
+const nodes = [
+  {
+    children: [
+      {
+        children: [
+          { id: "prod-us", label: "US East" },
+          { id: "prod-eu", label: "EU West" },
+        ],
+        id: "production",
+        label: "Production",
+      },
+      {
+        children: [{ id: "staging-us", label: "US East" }],
+        id: "staging",
+        label: "Staging",
+      },
+    ],
+    id: "environments",
+    label: "Environments",
+  },
+  {
+    children: [
+      { id: "team-growth", label: "Growth" },
+      { id: "team-data", label: "Data" },
+    ],
+    id: "teams",
+    label: "Teams",
+  },
+];
+
+describe("ScopeSelector", () => {
+  it("renders the placeholder before a scope is selected", () => {
+    render(<ScopeSelector nodes={nodes} placeholder="Pick a scope" />);
+
+    expect(
+      screen.getByRole("button", { name: /pick a scope/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("allows browsing nested scopes and selecting a leaf", () => {
+    const handleValueChange = vi.fn();
+    render(<ScopeSelector nodes={nodes} onValueChange={handleValueChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /select scope/i }));
+    fireEvent.click(screen.getByRole("button", { name: /environments/i }));
+    fireEvent.click(screen.getByRole("button", { name: /production/i }));
+    fireEvent.click(screen.getByRole("button", { name: /eu west/i }));
+
+    expect(handleValueChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        node: expect.objectContaining({ id: "prod-eu", label: "EU West" }),
+      }),
+    );
+    expect(
+      screen.getByRole("button", {
+        name: /environments \/ production \/ eu west/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("filters scopes from search", () => {
+    render(<ScopeSelector nodes={nodes} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /select scope/i }));
+    fireEvent.change(screen.getByPlaceholderText("Search scopes..."), {
+      target: { value: "growth" },
+    });
+
+    expect(screen.getByRole("button", { name: /growth/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /production/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/scope-selector/scope-selector.tsx
+++ b/packages/ui/src/components/scope-selector/scope-selector.tsx
@@ -1,0 +1,497 @@
+"use client";
+
+import { forwardRef, useMemo, useState } from "react";
+
+import { Check, ChevronRight, Search } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Badge } from "../badge";
+import { Button } from "../button";
+import { Input } from "../input";
+import { Popover, PopoverContent, PopoverTrigger } from "../popover";
+import { ScrollArea } from "../scroll-area";
+import { Separator } from "../separator";
+
+export type ScopeSelectorNode = {
+  badge?: string;
+  children?: ScopeSelectorNode[];
+  description?: string;
+  disabled?: boolean;
+  id: string;
+  label: string;
+  selectable?: boolean;
+};
+
+export type ScopeSelectorSelection = {
+  node: ScopeSelectorNode;
+  path: ScopeSelectorNode[];
+};
+
+export type ScopeSelectorProps = {
+  className?: string;
+  defaultValue?: string;
+  disabled?: boolean;
+  emptyMessage?: string;
+  nodes: ScopeSelectorNode[];
+  onValueChange?: (selection: ScopeSelectorSelection) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  value?: string;
+};
+
+type FlattenedScopeNode = {
+  node: ScopeSelectorNode;
+  path: ScopeSelectorNode[];
+};
+
+type ScopeOptionButtonProps = {
+  node: ScopeSelectorNode;
+  onBrowse: (node: ScopeSelectorNode) => void;
+  onSelect: (selection: ScopeSelectorSelection) => void;
+  path: ScopeSelectorNode[];
+  selectedValue?: string;
+  showPathLabel?: boolean;
+};
+
+type ScopePanelProps = {
+  currentPath: ScopeSelectorNode[];
+  emptyMessage: string;
+  nodes: ScopeSelectorNode[];
+  onBrowse: (node: ScopeSelectorNode) => void;
+  onSelect: (selection: ScopeSelectorSelection) => void;
+  query: string;
+  searchResults: FlattenedScopeNode[];
+  selectedValue?: string;
+};
+
+type ScopeSelectorState = {
+  currentLevelNodes: ScopeSelectorNode[];
+  currentPath: ScopeSelectorNode[];
+  currentPathLabel: string;
+  handleBrowse: (node: ScopeSelectorNode) => void;
+  handleOpenChange: (nextOpen: boolean) => void;
+  handleSelect: (selection: ScopeSelectorSelection) => void;
+  open: boolean;
+  query: string;
+  searchResults: FlattenedScopeNode[];
+  selectedPathLabel?: string;
+  selectedSelection?: ScopeSelectorSelection;
+  selectedValue?: string;
+  setCurrentPath: (path: ScopeSelectorNode[]) => void;
+  setQuery: (value: string) => void;
+};
+
+type ScopeSelectorPopoverBodyProps = {
+  emptyMessage: string;
+  searchPlaceholder: string;
+  state: ScopeSelectorState;
+};
+
+function flattenNodes(
+  nodes: ScopeSelectorNode[],
+  parentPath: ScopeSelectorNode[] = [],
+): FlattenedScopeNode[] {
+  return nodes.flatMap((node) => {
+    const path = [...parentPath, node];
+    const current = [{ node, path }];
+    const descendants = node.children ? flattenNodes(node.children, path) : [];
+    return [...current, ...descendants];
+  });
+}
+
+function findSelection(
+  nodes: ScopeSelectorNode[],
+  value?: string,
+): ScopeSelectorSelection | undefined {
+  if (!value) return undefined;
+
+  const flattened = flattenNodes(nodes);
+  const match = flattened.find((entry) => entry.node.id === value);
+  return match ? { node: match.node, path: match.path } : undefined;
+}
+
+function getVisibleNodes(
+  tree: ScopeSelectorNode[],
+  currentPath: ScopeSelectorNode[],
+): ScopeSelectorNode[] {
+  const currentNode = currentPath.at(-1);
+  return currentNode?.children ?? tree;
+}
+
+function isSelectableNode(node: ScopeSelectorNode): boolean {
+  if (node.disabled) return false;
+  if (node.selectable !== undefined) return node.selectable;
+  return !node.children || node.children.length === 0;
+}
+
+function getPathLabel(path: ScopeSelectorNode[]): string {
+  return path.map((node) => node.label).join(" / ");
+}
+
+function filterScopeResults(
+  flattenedNodes: FlattenedScopeNode[],
+  query: string,
+): FlattenedScopeNode[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return [];
+
+  return flattenedNodes.filter(({ node, path }) => {
+    const pathLabel = getPathLabel(path).toLowerCase();
+    const description = node.description?.toLowerCase() ?? "";
+    return (
+      node.label.toLowerCase().includes(normalizedQuery) ||
+      description.includes(normalizedQuery) ||
+      pathLabel.includes(normalizedQuery)
+    );
+  });
+}
+
+function ScopeOptionButton({
+  node,
+  onBrowse,
+  onSelect,
+  path,
+  selectedValue,
+  showPathLabel,
+}: ScopeOptionButtonProps) {
+  const selectable = isSelectableNode(node);
+
+  return (
+    <button
+      className={cn(
+        "flex w-full items-start justify-between rounded-md border px-3 py-3 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
+        selectedValue === node.id && "border-primary bg-accent",
+        node.disabled && "cursor-not-allowed opacity-50",
+      )}
+      disabled={node.disabled}
+      key={node.id}
+      onClick={() => {
+        if (selectable) {
+          onSelect({ node, path });
+          return;
+        }
+        onBrowse(node);
+      }}
+      type="button"
+    >
+      <div className="min-w-0 space-y-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium">{node.label}</span>
+          {node.badge ? <Badge variant="outline">{node.badge}</Badge> : null}
+        </div>
+        {showPathLabel ? (
+          <div className="text-xs text-muted-foreground">
+            {getPathLabel(path)}
+          </div>
+        ) : null}
+        {node.description ? (
+          <p className="text-sm text-muted-foreground">{node.description}</p>
+        ) : null}
+      </div>
+      {selectedValue === node.id ? (
+        <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+      ) : node.children && node.children.length > 0 ? (
+        <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+      ) : null}
+    </button>
+  );
+}
+
+function ScopeSearchResults({
+  onBrowse,
+  onSelect,
+  results,
+  selectedValue,
+}: {
+  onBrowse: (node: ScopeSelectorNode) => void;
+  onSelect: (selection: ScopeSelectorSelection) => void;
+  results: FlattenedScopeNode[];
+  selectedValue?: string;
+}) {
+  return (
+    <div className="space-y-2 px-1 py-1">
+      {results.map(({ node, path }) => (
+        <ScopeOptionButton
+          key={getPathLabel(path)}
+          node={node}
+          onBrowse={onBrowse}
+          onSelect={onSelect}
+          path={path}
+          selectedValue={selectedValue}
+          showPathLabel
+        />
+      ))}
+    </div>
+  );
+}
+
+function ScopeCurrentLevel({
+  currentPath,
+  nodes,
+  onBrowse,
+  onSelect,
+  selectedValue,
+}: {
+  currentPath: ScopeSelectorNode[];
+  nodes: ScopeSelectorNode[];
+  onBrowse: (node: ScopeSelectorNode) => void;
+  onSelect: (selection: ScopeSelectorSelection) => void;
+  selectedValue?: string;
+}) {
+  return (
+    <div className="space-y-2 px-1 py-1">
+      {nodes.map((node) => (
+        <ScopeOptionButton
+          key={node.id}
+          node={node}
+          onBrowse={onBrowse}
+          onSelect={onSelect}
+          path={[...currentPath, node]}
+          selectedValue={selectedValue}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ScopePanel({
+  currentPath,
+  emptyMessage,
+  nodes,
+  onBrowse,
+  onSelect,
+  query,
+  searchResults,
+  selectedValue,
+}: ScopePanelProps) {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  if (normalizedQuery) {
+    if (searchResults.length === 0) {
+      return (
+        <div className="px-3 py-8 text-center text-sm text-muted-foreground">
+          No scopes match your search.
+        </div>
+      );
+    }
+
+    return (
+      <ScopeSearchResults
+        onBrowse={onBrowse}
+        onSelect={onSelect}
+        results={searchResults}
+        selectedValue={selectedValue}
+      />
+    );
+  }
+
+  if (nodes.length === 0) {
+    return (
+      <div className="px-3 py-8 text-center text-sm text-muted-foreground">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return (
+    <ScopeCurrentLevel
+      currentPath={currentPath}
+      nodes={nodes}
+      onBrowse={onBrowse}
+      onSelect={onSelect}
+      selectedValue={selectedValue}
+    />
+  );
+}
+
+function ScopeSelectorBreadcrumb({
+  currentPath,
+  onBack,
+}: {
+  currentPath: ScopeSelectorNode[];
+  onBack: () => void;
+}) {
+  if (currentPath.length === 0) return null;
+
+  return (
+    <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
+      <Button className="h-7 px-2" onClick={onBack} size="sm" variant="ghost">
+        <ChevronRight className="h-3.5 w-3.5 rotate-180" />
+        Back
+      </Button>
+      <span className="truncate">{getPathLabel(currentPath)}</span>
+    </div>
+  );
+}
+
+function ScopeSelectorPopoverBody({
+  emptyMessage,
+  searchPlaceholder,
+  state,
+}: ScopeSelectorPopoverBodyProps) {
+  return (
+    <PopoverContent align="start" className="w-[380px] p-0" sideOffset={8}>
+      <div className="border-b p-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            className="pl-9"
+            onChange={(event) => {
+              state.setQuery(event.target.value);
+            }}
+            placeholder={searchPlaceholder}
+            value={state.query}
+          />
+        </div>
+        {state.query.trim() ? null : (
+          <ScopeSelectorBreadcrumb
+            currentPath={state.currentPath}
+            onBack={() => {
+              state.setCurrentPath(state.currentPath.slice(0, -1));
+            }}
+          />
+        )}
+      </div>
+      <ScrollArea className="max-h-[320px]">
+        <ScopePanel
+          currentPath={state.currentPath}
+          emptyMessage={emptyMessage}
+          nodes={state.currentLevelNodes}
+          onBrowse={state.handleBrowse}
+          onSelect={state.handleSelect}
+          query={state.query}
+          searchResults={state.searchResults}
+          selectedValue={state.selectedValue}
+        />
+      </ScrollArea>
+      {state.selectedSelection ? (
+        <>
+          <Separator />
+          <div className="px-3 py-2 text-xs text-muted-foreground">
+            Selected: {state.selectedPathLabel}
+          </div>
+        </>
+      ) : null}
+    </PopoverContent>
+  );
+}
+
+function useScopeSelectorState({
+  defaultValue,
+  nodes,
+  onValueChange,
+  value,
+}: Pick<
+  ScopeSelectorProps,
+  "defaultValue" | "nodes" | "onValueChange" | "value"
+>): ScopeSelectorState {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue);
+  const [currentPath, setCurrentPath] = useState<ScopeSelectorNode[]>([]);
+  const selectedValue = value ?? uncontrolledValue;
+  const selectedSelection = useMemo(
+    () => findSelection(nodes, selectedValue),
+    [nodes, selectedValue],
+  );
+  const flattenedNodes = useMemo(() => flattenNodes(nodes), [nodes]);
+  const searchResults = useMemo(
+    () => filterScopeResults(flattenedNodes, query),
+    [flattenedNodes, query],
+  );
+  const currentLevelNodes = getVisibleNodes(nodes, currentPath);
+
+  function handleSelect(selection: ScopeSelectorSelection) {
+    if (value === undefined) {
+      setUncontrolledValue(selection.node.id);
+    }
+    setCurrentPath(selection.path.slice(0, -1));
+    setQuery("");
+    setOpen(false);
+    onValueChange?.(selection);
+  }
+
+  function handleBrowse(node: ScopeSelectorNode) {
+    const nextPath = findSelection(nodes, node.id)?.path ?? [];
+    setCurrentPath(nextPath);
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      setCurrentPath(selectedSelection?.path.slice(0, -1) ?? []);
+      return;
+    }
+    setQuery("");
+  }
+
+  return {
+    currentLevelNodes,
+    currentPath,
+    currentPathLabel: getPathLabel(currentPath),
+    handleBrowse,
+    handleOpenChange,
+    handleSelect,
+    open,
+    query,
+    searchResults,
+    selectedPathLabel: selectedSelection
+      ? getPathLabel(selectedSelection.path)
+      : undefined,
+    selectedSelection,
+    selectedValue,
+    setCurrentPath,
+    setQuery,
+  };
+}
+
+const ScopeSelector = forwardRef<HTMLButtonElement, ScopeSelectorProps>(
+  (
+    {
+      className,
+      defaultValue,
+      disabled,
+      emptyMessage = "No scopes available.",
+      nodes,
+      onValueChange,
+      placeholder = "Select scope",
+      searchPlaceholder = "Search scopes...",
+      value,
+    },
+    ref,
+  ) => {
+    const state = useScopeSelectorState({
+      defaultValue,
+      nodes,
+      onValueChange,
+      value,
+    });
+
+    return (
+      <Popover onOpenChange={state.handleOpenChange} open={state.open}>
+        <PopoverTrigger asChild>
+          <Button
+            className={cn("w-full justify-between", className)}
+            disabled={disabled}
+            ref={ref}
+            variant="outline"
+          >
+            <span className="truncate text-left">
+              {state.selectedPathLabel ?? placeholder}
+            </span>
+            <ChevronRight className="h-4 w-4 shrink-0 rotate-90 text-muted-foreground" />
+          </Button>
+        </PopoverTrigger>
+        <ScopeSelectorPopoverBody
+          emptyMessage={emptyMessage}
+          searchPlaceholder={searchPlaceholder}
+          state={state}
+        />
+      </Popover>
+    );
+  },
+);
+
+ScopeSelector.displayName = "ScopeSelector";
+
+export { ScopeSelector };

--- a/packages/ui/src/components/scope-selector/scope-selector.visual.tsx
+++ b/packages/ui/src/components/scope-selector/scope-selector.visual.tsx
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { ScopeSelector } from "./scope-selector";
+
+test.describe("ScopeSelector Visual", () => {
+  test("default", async ({ mount, page }) => {
+    await mount(
+      <div className="w-[420px] p-6">
+        <ScopeSelector
+          nodes={[
+            {
+              children: [
+                {
+                  children: [
+                    { id: "prod-us", label: "US East" },
+                    { id: "prod-eu", label: "EU West" },
+                  ],
+                  id: "production",
+                  label: "Production",
+                },
+                {
+                  children: [{ id: "stage-us", label: "US East" }],
+                  id: "staging",
+                  label: "Staging",
+                },
+              ],
+              id: "environments",
+              label: "Environments",
+            },
+            {
+              children: [
+                { id: "team-growth", label: "Growth" },
+                { id: "team-data", label: "Data" },
+              ],
+              id: "teams",
+              label: "Teams",
+            },
+          ]}
+        />
+      </div>,
+    );
+
+    await expect(page).toHaveScreenshot("scope-selector-default.png");
+  });
+});

--- a/packages/ui/src/components/usage-breakdown/index.ts
+++ b/packages/ui/src/components/usage-breakdown/index.ts
@@ -1,0 +1,6 @@
+export {
+  UsageBreakdown,
+  type UsageBreakdownItem,
+  type UsageBreakdownProps,
+  type UsageBreakdownTone,
+} from "./usage-breakdown";

--- a/packages/ui/src/components/usage-breakdown/usage-breakdown.stories.tsx
+++ b/packages/ui/src/components/usage-breakdown/usage-breakdown.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { UsageBreakdown } from "./usage-breakdown";
+
+const meta = {
+  args: {
+    description: "Ranked resource consumption across your most active surfaces.",
+    items: [
+      {
+        description: "Prompt + completion tokens used this billing window.",
+        id: "tokens",
+        label: "Tokens",
+        meta: "LLM",
+        trend: { direction: "up", label: "+14%" },
+        value: 420,
+        valueLabel: "420k",
+      },
+      {
+        description: "Embeddings and cached retrieval index footprint.",
+        id: "storage",
+        label: "Storage",
+        meta: "Vector DB",
+        trend: { direction: "down", label: "-6%" },
+        value: 260,
+        valueLabel: "260 GB",
+      },
+      {
+        description: "Webhook and instrumentation traffic routed through analytics.",
+        id: "events",
+        label: "Events",
+        meta: "Tracking",
+        value: 180,
+        valueLabel: "180k",
+      },
+    ],
+    title: "Usage breakdown",
+  },
+  component: UsageBreakdown,
+  title: "Analytics/UsageBreakdown",
+} satisfies Meta<typeof UsageBreakdown>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const TopTwoOnly: Story = {
+  args: {
+    maxItems: 2,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    items: [],
+  },
+};

--- a/packages/ui/src/components/usage-breakdown/usage-breakdown.test.tsx
+++ b/packages/ui/src/components/usage-breakdown/usage-breakdown.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { UsageBreakdown } from "./usage-breakdown";
+
+const items = [
+  {
+    id: "models",
+    label: "Model inference",
+    value: 420,
+    valueLabel: "420k tokens",
+  },
+  {
+    id: "storage",
+    label: "Vector storage",
+    value: 160,
+    valueLabel: "160 GB",
+  },
+  {
+    id: "events",
+    label: "Events API",
+    value: 90,
+    valueLabel: "90k calls",
+  },
+];
+
+describe("UsageBreakdown", () => {
+  it("renders items ranked by descending value", () => {
+    render(<UsageBreakdown items={items} />);
+
+    const labels = screen
+      .getAllByText(/Model inference|Vector storage|Events API/)
+      .map((element) => element.textContent);
+
+    expect(labels).toEqual(["Model inference", "Vector storage", "Events API"]);
+  });
+
+  it("shows relative share details", () => {
+    render(<UsageBreakdown items={items} />);
+
+    expect(screen.getByText("63% of total")).toBeInTheDocument();
+    expect(screen.getByText("24% of total")).toBeInTheDocument();
+  });
+
+  it("renders the empty state when there are no items", () => {
+    render(<UsageBreakdown emptyMessage="Nothing to report" items={[]} />);
+
+    expect(screen.getByText("Nothing to report")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/usage-breakdown/usage-breakdown.tsx
+++ b/packages/ui/src/components/usage-breakdown/usage-breakdown.tsx
@@ -1,0 +1,233 @@
+import { forwardRef, type ReactNode, useMemo } from "react";
+
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Badge } from "../badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../card";
+
+export type UsageBreakdownTone = "danger" | "default" | "success" | "warning";
+
+export type UsageBreakdownItem = {
+  description?: string;
+  icon?: ReactNode;
+  id: string;
+  label: string;
+  meta?: string;
+  tone?: UsageBreakdownTone;
+  trend?: {
+    direction: "down" | "up";
+    label: string;
+  };
+  value: number;
+  valueLabel?: string;
+};
+
+export type UsageBreakdownProps = React.ComponentPropsWithoutRef<
+  typeof Card
+> & {
+  description?: string;
+  emptyMessage?: string;
+  items: UsageBreakdownItem[];
+  maxItems?: number;
+  title?: string;
+};
+
+type UsageBreakdownRowProps = {
+  item: UsageBreakdownItem;
+  maxValue: number;
+  rank: number;
+  totalValue: number;
+};
+
+const toneClasses: Record<UsageBreakdownTone, string> = {
+  danger:
+    "bg-destructive/10 text-destructive border-destructive/20 dark:text-destructive",
+  default: "bg-muted text-muted-foreground border-border",
+  success:
+    "bg-emerald-500/10 text-emerald-700 border-emerald-500/20 dark:text-emerald-300",
+  warning:
+    "bg-amber-500/10 text-amber-700 border-amber-500/20 dark:text-amber-300",
+};
+
+function formatPercent(value: number): string {
+  if (!Number.isFinite(value)) return "0%";
+  return `${Math.round(value)}%`;
+}
+
+function formatValue(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: value >= 100 ? 0 : 1,
+  }).format(value);
+}
+
+function getRelativeWidth(value: number, maxValue: number): number {
+  if (maxValue <= 0) return 0;
+  return Math.max((value / maxValue) * 100, 4);
+}
+
+function getShare(value: number, totalValue: number): number {
+  if (totalValue <= 0) return 0;
+  return (value / totalValue) * 100;
+}
+
+function UsageBreakdownTrend({ item }: { item: UsageBreakdownItem }) {
+  if (!item.trend) return null;
+
+  const trendTone = item.tone ?? "default";
+  const TrendIcon =
+    item.trend.direction === "down" ? ArrowDownRight : ArrowUpRight;
+
+  return (
+    <Badge className={cn("gap-1 border", toneClasses[trendTone])}>
+      <TrendIcon className="h-3.5 w-3.5" />
+      {item.trend.label}
+    </Badge>
+  );
+}
+
+function UsageBreakdownMeter({
+  maxValue,
+  value,
+}: {
+  maxValue: number;
+  value: number;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="h-2 overflow-hidden rounded-full bg-muted">
+        <div
+          aria-hidden="true"
+          className="h-full rounded-full bg-primary transition-[width]"
+          style={{ width: `${getRelativeWidth(value, maxValue)}%` }}
+        />
+      </div>
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>Relative usage</span>
+        <span>{formatPercent(getShare(value, maxValue))}</span>
+      </div>
+    </div>
+  );
+}
+
+function UsageBreakdownRow({
+  item,
+  maxValue,
+  rank,
+  totalValue,
+}: UsageBreakdownRowProps) {
+  return (
+    <li className="rounded-lg border bg-background/70 p-4">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border bg-muted text-sm font-semibold text-muted-foreground">
+          {item.icon ?? rank}
+        </div>
+        <div className="min-w-0 flex-1 space-y-3">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0 space-y-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="truncate font-medium text-foreground">
+                  {item.label}
+                </span>
+                {item.meta ? (
+                  <Badge className="border-border" variant="outline">
+                    {item.meta}
+                  </Badge>
+                ) : null}
+                <UsageBreakdownTrend item={item} />
+              </div>
+              {item.description ? (
+                <p className="text-sm text-muted-foreground">
+                  {item.description}
+                </p>
+              ) : null}
+            </div>
+            <div className="text-left sm:text-right">
+              <div className="font-semibold text-foreground">
+                {item.valueLabel ?? formatValue(item.value)}
+              </div>
+              <div className="text-sm text-muted-foreground">
+                {formatPercent(getShare(item.value, totalValue))} of total
+              </div>
+            </div>
+          </div>
+          <UsageBreakdownMeter maxValue={maxValue} value={item.value} />
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function getSortedItems(items: UsageBreakdownItem[], maxItems?: number) {
+  const rankedItems = [...items].sort(
+    (left, right) => right.value - left.value,
+  );
+  return typeof maxItems === "number"
+    ? rankedItems.slice(0, maxItems)
+    : rankedItems;
+}
+
+const UsageBreakdown = forwardRef<HTMLDivElement, UsageBreakdownProps>(
+  (
+    {
+      className,
+      description,
+      emptyMessage = "No usage data available.",
+      items,
+      maxItems,
+      title = "Usage breakdown",
+      ...props
+    },
+    ref,
+  ) => {
+    const sortedItems = useMemo(
+      () => getSortedItems(items, maxItems),
+      [items, maxItems],
+    );
+    const totalValue = useMemo(
+      () => sortedItems.reduce((sum, item) => sum + item.value, 0),
+      [sortedItems],
+    );
+    const maxValue = sortedItems[0]?.value ?? 0;
+
+    return (
+      <Card className={cn("w-full", className)} ref={ref} {...props}>
+        <CardHeader>
+          <CardTitle>{title}</CardTitle>
+          {description ? (
+            <CardDescription>{description}</CardDescription>
+          ) : null}
+        </CardHeader>
+        <CardContent>
+          {sortedItems.length === 0 ? (
+            <div className="rounded-lg border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
+              {emptyMessage}
+            </div>
+          ) : (
+            <ol className="space-y-3">
+              {sortedItems.map((item, index) => (
+                <UsageBreakdownRow
+                  item={item}
+                  key={item.id}
+                  maxValue={maxValue}
+                  rank={index + 1}
+                  totalValue={totalValue}
+                />
+              ))}
+            </ol>
+          )}
+        </CardContent>
+      </Card>
+    );
+  },
+);
+
+UsageBreakdown.displayName = "UsageBreakdown";
+
+export { UsageBreakdown };

--- a/packages/ui/src/components/usage-breakdown/usage-breakdown.visual.tsx
+++ b/packages/ui/src/components/usage-breakdown/usage-breakdown.visual.tsx
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { UsageBreakdown } from "./usage-breakdown";
+
+test.describe("UsageBreakdown Visual", () => {
+  test("default", async ({ mount, page }) => {
+    await mount(
+      <div className="w-[720px] p-6">
+        <UsageBreakdown
+          description="Ranked resource consumption across your top analytics surfaces."
+          items={[
+            {
+              id: "tokens",
+              label: "Tokens",
+              meta: "LLM",
+              trend: { direction: "up", label: "+14%" },
+              value: 420,
+              valueLabel: "420k",
+            },
+            {
+              id: "storage",
+              label: "Storage",
+              meta: "Vector DB",
+              trend: { direction: "down", label: "-6%" },
+              value: 260,
+              valueLabel: "260 GB",
+            },
+            {
+              id: "events",
+              label: "Events",
+              meta: "Tracking",
+              value: 180,
+              valueLabel: "180k",
+            },
+          ]}
+          title="Usage breakdown"
+        />
+      </div>,
+    );
+
+    await expect(page).toHaveScreenshot("usage-breakdown-default.png");
+  });
+});


### PR DESCRIPTION
## Summary
- add UsageBreakdown, ActivityLog, and ScopeSelector to `@vllnt/ui`
- add Storybook, unit, and Playwright CT coverage for the analytics family batch
- register the new components in the registry and component preview surface

## Issues
Closes #91
Closes #92
Closes #93

## Validation
- `pnpm -F @vllnt/ui lint --no-warn-ignored -- src/components/index.ts src/components/activity-log src/components/scope-selector src/components/usage-breakdown`
- `pnpm --dir apps/registry exec eslint components/component-preview/component-preview.tsx`
- `pnpm -F @vllnt/ui test:once -- src/components/activity-log/activity-log.test.tsx src/components/scope-selector/scope-selector.test.tsx src/components/usage-breakdown/usage-breakdown.test.tsx`
- `pnpm -F @vllnt/ui test:visual:update -- src/components/activity-log/activity-log.visual.tsx src/components/scope-selector/scope-selector.visual.tsx src/components/usage-breakdown/usage-breakdown.visual.tsx`
- `pnpm -F @vllnt/ui test:visual -- src/components/activity-log/activity-log.visual.tsx src/components/scope-selector/scope-selector.visual.tsx src/components/usage-breakdown/usage-breakdown.visual.tsx`
- `pnpm -F @vllnt/ui-registry registry:build`
- `pnpm -F @vllnt/ui build-storybook`

## Notes
- `pnpm -F @vllnt/ui-registry lint` has pre-existing failures outside this batch in `app/api/og/route.ts`, `app/components/page.tsx`, and `lib/sidebar-sections.ts`.