### PR TITLE
fix(ci): repair canary publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,9 +78,6 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
-
       - name: Publish canary
         working-directory: packages/ui
         run: |
@@ -173,9 +170,6 @@ jobs:
           git commit -m "chore(release): v${{ steps.version.outputs.version }}"
           git tag -a "v${{ steps.version.outputs.version }}" -m "v${{ steps.version.outputs.version }}"
           git push origin main --follow-tags
-
-      - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
 
       - name: Publish to npm
         working-directory: packages/ui


### PR DESCRIPTION
## Summary
- remove the runtime `npm install -g npm@latest` step from the publish workflow
- keep canary and release publish paths on the runner-provided npm
- avoid mutating npm mid-job before `npm publish --provenance`

## What I found
This **did** work before.

Evidence:
- older `Publish` runs on this repo succeeded with the same workflow shape
- recent `Publish` runs on `main` now fail consistently in the same place across multiple merges

Recent failing runs:
- `24689281424`
- `24689695886`
- `24690317659`
- `24690959402`
- `24691418136`

All fail at the same step:
- `Upgrade npm for OIDC support`

With the same error:
- `Cannot find module 'promise-retry'`

So the real issue is not “publish never worked.”
The issue is that the workflow depends on a **runtime upgrade to `npm@latest`**, and that path has become unstable/regressed on current GitHub runners.

## Why this fix is still the right one
I verified on the current environment used here:
- Node `v22.22.2`
- npm `10.9.7`
- `npm publish --help` already includes `--provenance`

That means the workflow does **not** need to self-upgrade npm just to publish with provenance.

Removing the upgrade step is the minimal fix because it:
- removes the failing moving part
- keeps provenance support
- avoids mutating the package manager mid-job
- aligns with the fact that the bundled npm already has the required capability

## Why this matters for canary verification
Because the publish job dies before `npm publish`, the `canary` dist-tag stays stale.
That is why the currently published canary does not reflect the newly shipped component stack.

## Validation
- confirmed recent publish failures all die in the npm upgrade step
- confirmed current npm already supports `--provenance`
- confirmed no remaining `npm@latest` / upgrade-step references in `publish.yml`
- `git diff --check`

## Expected outcome
After merge, the next push to `main` should:
- get past the failing npm-upgrade step
- publish a fresh canary
- let us verify the new package contents/export surface against the components we just shipped
