### PR TITLE
fix(ci): restore OIDC publish via npx

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,7 +88,7 @@ jobs:
           CANARY_VERSION="${BASE_VERSION}-canary.${SHORT_SHA}"
           npm version "$CANARY_VERSION" --no-git-tag-version
           TARBALL=$(pnpm pack --pack-destination /tmp | tail -1)
-          npm publish "$TARBALL" --tag canary --provenance --access public
+          npx --yes npm@latest publish "$TARBALL" --tag canary --provenance --access public
 
   release:
     name: Publish Release
@@ -177,7 +177,7 @@ jobs:
           sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
           unset NODE_AUTH_TOKEN
           TARBALL=$(pnpm pack --pack-destination /tmp | tail -1)
-          npm publish "$TARBALL" --tag latest --provenance --access public
+          npx --yes npm@latest publish "$TARBALL" --tag latest --provenance --access public
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Summary
- Fixes `ENEEDAUTH` on every `Publish` run since #114.
- Root cause: #114 removed `npm install -g npm@latest` (which was crashing with `Cannot find module 'promise-retry'`) but that also dropped the workflow onto the runner-bundled npm `10.9.7`, which predates OIDC trusted-publisher support. With `_authToken` and `NODE_AUTH_TOKEN` stripped for OIDC, npm 10.9.7 has nothing to authenticate with → `ENEEDAUTH`.
- Fix: `npx --yes npm@latest publish …` in both canary and release jobs. Pulls an OIDC-capable npm on demand, no global mutation.

## Why this avoids both failure modes
- No `npm install -g` ⇒ no `promise-retry` bootstrap bug.
- `npm@latest` via `npx` ⇒ OIDC exchange path available, `--provenance` works.

## Evidence
Failing run on `main` (post-#114): `24692057580`

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org
```

## Test plan
- [ ] Merge to `main` → `Publish Canary` job turns green.
- [ ] Confirm a fresh `@vllnt/ui@x.y.z-canary.<sha>` is pushed to the canary dist-tag.
- [ ] `workflow_dispatch` (next release) exercises the same path for `latest`.

## Assumptions / risks
- Trusted publishing is still configured for `@vllnt/ui` on the public registry (same as before #114). If it was revoked, we would need an `NPM_TOKEN` fallback instead.
