### PR TITLE
chore(release): 0.2.0 + drop PAT-based release push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,16 +7,7 @@ on:
       - "packages/ui/**"
       - "pnpm-lock.yaml"
       - ".github/workflows/publish.yml"
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: "Version bump type"
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
+  workflow_dispatch: {}
 
 concurrency:
   group: publish-${{ github.event_name }}
@@ -102,7 +93,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PAT }}
 
       - uses: pnpm/action-setup@v4
 
@@ -117,13 +107,16 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Bump version
+      - name: Read version + guard against retag
         id: version
         working-directory: packages/ui
         run: |
-          npm version ${{ inputs.bump }} --no-git-tag-version
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git -C "$GITHUB_WORKSPACE" rev-parse "v${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag v${VERSION} already exists on this repo. Bump packages/ui/package.json on main via a PR before dispatching."
+            exit 1
+          fi
 
       - name: Generate changelog
         id: changelog
@@ -162,14 +155,12 @@ jobs:
             echo "CHANGELOG_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Commit and tag
+      - name: Tag release
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add packages/ui/package.json
-          git commit -m "chore(release): v${{ steps.version.outputs.version }}"
           git tag -a "v${{ steps.version.outputs.version }}" -m "v${{ steps.version.outputs.version }}"
-          git push origin main --follow-tags
+          git push origin "v${{ steps.version.outputs.version }}"
 
       - name: Publish to npm
         working-directory: packages/ui

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -14,19 +14,31 @@ Consume the latest canary locally:
 pnpm add @vllnt/ui@canary
 ```
 
-## Stable release (manual `workflow_dispatch`)
+## Stable release (PR-driven, no PAT)
 
-1. Go to **Actions → Publish → Run workflow**.
-2. Pick a bump level:
-   - `patch` — bug fixes only
-   - `minor` — new components, new variants, new exports (non-breaking)
-   - `major` — breaking changes to existing exports
-3. Confirm. CI will:
-   - Run quality gates.
-   - Bump `packages/ui/package.json` and push a `chore(release): v{x.y.z}` commit + annotated `v{x.y.z}` tag to `main`.
-   - Generate release notes grouped by `feat` / `fix` / other, aggregating commit subjects since the previous tag.
-   - `pnpm pack` and `npx --yes npm@latest publish --tag latest --provenance --access public`.
-   - Create the matching GitHub Release.
+The release workflow does not push commits to `main`. Version bumps land via normal PRs so branch protection stays in effect and no PAT / bypass is required.
+
+### 1. Bump the version in a PR
+
+Open a PR that:
+
+- Updates `packages/ui/package.json` `"version"` to the new target (follow SemVer — see below).
+- Moves the matching entry in `packages/ui/CHANGELOG.md` from `[Unreleased]` to a dated `[x.y.z]` section.
+
+Merge the PR normally. The canary workflow on `main` will immediately publish `@vllnt/ui@{x.y.z}-canary.{sha}` — a dress-rehearsal of the release tarball.
+
+### 2. Dispatch the release
+
+Go to **Actions → Publish → Run workflow** on `main`. No inputs.
+
+CI will:
+
+- Run quality gates (lint / typecheck / build / test).
+- Read the version from `packages/ui/package.json`. **Fails fast** if a matching `v{x.y.z}` tag already exists — catches dispatches against stale main.
+- Generate release notes grouped by `feat` / `fix` / other, aggregating commit subjects since the previous tag.
+- Push an annotated tag `v{x.y.z}` (tags are not blocked by branch protection; `GITHUB_TOKEN` is sufficient).
+- `pnpm pack` and `npx --yes npm@latest publish --tag latest --provenance --access public`. OIDC trusted publishing signs the provenance attestation.
+- Create the GitHub Release for the new tag.
 
 ## Versioning policy
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vllnt/ui",
-  "version": "0.1.11",
+  "version": "0.2.0",
   "description": "React component library — 93 components built on Radix UI, Tailwind CSS, and CVA",
   "license": "MIT",
   "author": "vllnt",


### PR DESCRIPTION
## Why

The `Publish Release` job authenticated as `secrets.RELEASE_PAT` to push the version-bump commit + tag back to `main` (bypassing branch protection). That secret is not — and should not need to be — provisioned.

OIDC covers the npm provenance path already. OIDC does **not** replace GitHub push auth. The right fix is to stop pushing to `main` from CI at all.

## What changed

### `publish.yml`

- Drop `token: secrets.RELEASE_PAT` from the release-job checkout.
- Remove the `bump` input from `workflow_dispatch`. Version is whatever is currently in `packages/ui/package.json`.
- Remove the CI-side `npm version` step and the `git push origin main --follow-tags` step. The job now only **tags + publishes + creates the GitHub Release**.
- Add a guard that fails fast if `v{version}` already exists on the repo — catches dispatches against stale `main`.

### Auth model after this change

| Action | Token |
|---|---|
| Checkout | `GITHUB_TOKEN` |
| Push tag `v*` | `GITHUB_TOKEN` (no tag rulesets; works fine) |
| npm publish | OIDC trusted publisher |
| Create GH release | `GITHUB_TOKEN` |

No PAT, no bypass, branch protection on `main` stays strict.

### Version bump

`packages/ui/package.json` bumped `0.1.11 -> 0.2.0` in this same PR so the dispatch right after merge ships `v0.2.0` cleanly. Matches the `[0.2.0]` entry already committed to `packages/ui/CHANGELOG.md` on the previous release-docs PR.

### Docs

`docs/RELEASING.md` rewritten to describe the new PR-driven flow.

## Test plan

- [ ] CI green on this branch (`ci.yml` + `publish.yml` quality gates).
- [ ] Post-merge canary on `main` publishes `@vllnt/ui@0.2.0-canary.<sha>` — confirms the tarball for `0.2.0` is sane.
- [ ] Dispatch `Publish` workflow on `main` with no inputs → release job now:
  - [ ] checks out with `GITHUB_TOKEN` (no PAT)
  - [ ] reads `0.2.0` from `package.json`
  - [ ] pushes tag `v0.2.0`
  - [ ] publishes to npm with OIDC provenance
  - [ ] creates the GitHub Release
- [ ] `https://www.npmjs.com/package/@vllnt/ui` lists `0.2.0` under `latest`.

## Rollback

If the tag-only flow turns out to be insufficient, revert this PR and restore the PAT path. No destructive changes to history.
