### PR TITLE
fix(api): export ProgressCard + correct AI/SocialFAB casing (0.2.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Override CSS variables after importing styles:
 | **Feedback** | Alert, Badge, Callout, Skeleton, Spinner, Toast, Tour |
 | **Navigation** | Breadcrumb, Pagination, Sidebar, Sidebar Provider, Sidebar Toggle, Search Bar, Search Dialog, Keyboard Shortcuts Help, Floating Action Button, Social FAB |
 | **Data / Charts** | Area Chart, Bar Chart, Line Chart, Candlestick Chart, Sparkline Grid, Market Treemap, Order Book, Ticker Tape, Metric Gauge, Activity Heatmap, Activity Log, Table, Data Table, Data List, Stat Card, Number Ticker |
-| **AI** | AI Chat Input, AI Message Bubble, AI Source Citation, AI Streaming Text, AI Tool Call Display, Thinking Block |
+| **AI** | AIChatInput, AIMessageBubble, AISourceCitation, AIStreamingText, AIToolCallDisplay, ThinkingBlock |
 | **Financial** | Candlestick Chart, Market Treemap, Order Book, Ticker Tape, Wallet Card, Watchlist, Sparkline Grid |
 | **Ops / Status** | Status Board, Status Indicator, Live Feed, World Clock Bar, Severity Badge, Role Badge, Scope Selector |
 | **Billing / Plans** | Subscription Card, Plan Badge, Credit Badge, Usage Breakdown |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -96,7 +96,7 @@ Alert, Badge, Callout, Skeleton, Spinner, Toast, Tour.
 
 ### Navigation
 
-Breadcrumb, Pagination, Sidebar, SidebarProvider, SidebarToggle, SearchBar, SearchDialog, KeyboardShortcutsHelp, FloatingActionButton, SocialFab.
+Breadcrumb, Pagination, Sidebar, SidebarProvider, SidebarToggle, SearchBar, SearchDialog, KeyboardShortcutsHelp, FloatingActionButton, SocialFAB.
 
 ### Data / Charts
 
@@ -104,7 +104,7 @@ AreaChart, BarChart, LineChart, CandlestickChart, SparklineGrid, MarketTreemap, 
 
 ### AI
 
-AiChatInput, AiMessageBubble, AiSourceCitation, AiStreamingText, AiToolCallDisplay, ThinkingBlock, ModelSelector.
+AIChatInput, AIMessageBubble, AISourceCitation, AIStreamingText, AIToolCallDisplay, ThinkingBlock, ModelSelector.
 
 ### Financial
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,11 +4,21 @@ All notable changes to `@vllnt/ui` are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-04-21
+
+### Fixed
+
+- **Public API:** `ProgressCard` now re-exported from `@vllnt/ui` — it shipped in `0.2.0`'s tarball but was missing from the barrel, so `import { ProgressCard } from "@vllnt/ui"` resolved to `undefined`.
+
+### Docs
+
+- Correct casing for the AI family (`AIChatInput`, `AIMessageBubble`, `AISourceCitation`, `AIStreamingText`, `AIToolCallDisplay`) and `SocialFAB` across README, package README, CHANGELOG, and `llms-full.txt`.
+
 ## [0.2.0] - 2026-04-21
 
 ### Added
 
-- **AI family** — `AiChatInput`, `AiMessageBubble`, `AiSourceCitation`, `AiStreamingText`, `AiToolCallDisplay`, `ThinkingBlock`, `ModelSelector`.
+- **AI family** — `AIChatInput`, `AIMessageBubble`, `AISourceCitation`, `AIStreamingText`, `AIToolCallDisplay`, `ThinkingBlock`, `ModelSelector`.
 - **Financial family** — `CandlestickChart`, `MarketTreemap`, `OrderBook`, `TickerTape`, `SparklineGrid`, `WalletCard`, `Watchlist`.
 - **Ops / Status family** — `StatusBoard`, `StatusIndicator`, `LiveFeed`, `WorldClockBar`, `SeverityBadge`, `RoleBadge`, `ScopeSelector`.
 - **Billing & Plans family** — `SubscriptionCard`, `PlanBadge`, `CreditBadge`, `UsageBreakdown`.
@@ -96,6 +106,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Initial public publish to the public npm registry.
 
+[0.2.1]: https://github.com/vllnt/ui/releases/tag/v0.2.1
 [0.2.0]: https://github.com/vllnt/ui/releases/tag/v0.2.0
 [0.1.11]: https://github.com/vllnt/ui/releases/tag/v0.1.11
 [0.1.10]: https://github.com/vllnt/ui/releases/tag/v0.1.10

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -286,11 +286,11 @@ import {
 
 | Component | Import | Notes |
 |-----------|--------|-------|
-| `AiChatInput` | `{ AiChatInput }` | Chat composer with submit + attachments |
-| `AiMessageBubble` | `{ AiMessageBubble }` | User/assistant message bubble |
-| `AiStreamingText` | `{ AiStreamingText }` | Token-stream renderer |
-| `AiToolCallDisplay` | `{ AiToolCallDisplay }` | Tool-use invocation render |
-| `AiSourceCitation` | `{ AiSourceCitation }` | Inline citation reference |
+| `AIChatInput` | `{ AIChatInput }` | Chat composer with submit + attachments |
+| `AIMessageBubble` | `{ AIMessageBubble }` | User/assistant message bubble |
+| `AIStreamingText` | `{ AIStreamingText }` | Token-stream renderer |
+| `AIToolCallDisplay` | `{ AIToolCallDisplay }` | Tool-use invocation render |
+| `AISourceCitation` | `{ AISourceCitation }` | Inline citation reference |
 | `ModelSelector` | `{ ModelSelector }` | Model picker (provider-agnostic) |
 
 ### Financial
@@ -371,7 +371,7 @@ import {
 | `CountdownTimer` | `{ CountdownTimer }` | Event countdown |
 | `AvatarGroup` | `{ AvatarGroup }` | Stacked avatar group |
 | `FloatingActionButton` | `{ FloatingActionButton }` | Anchored FAB |
-| `SocialFab` | `{ SocialFab }` | Social-links FAB |
+| `SocialFAB` | `{ SocialFab }` | Social-links FAB |
 | `KeyboardShortcutsHelp` | `{ KeyboardShortcutsHelp }` | Cmd-? shortcut dialog |
 | `ShareDialog` | `{ ShareDialog }` | Shareable-link dialog |
 | `HorizontalScrollRow` | `{ HorizontalScrollRow }` | Scroll-snap row |

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vllnt/ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "React component library — 93 components built on Radix UI, Tailwind CSS, and CVA",
   "license": "MIT",
   "author": "vllnt",

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -497,6 +497,11 @@ export {
 } from "./learning-objectives";
 export { ProgressBar, type ProgressBarProps } from "./progress-bar";
 export {
+  ProgressCard,
+  type ProgressCardProgress,
+  type ProgressCardProps,
+} from "./progress-card";
+export {
   CommonMistake,
   type CommonMistakeProps,
   ProTip,


### PR DESCRIPTION
## Found during post-release verification of 0.2.0

Downloaded `@vllnt/ui@0.2.0` from the registry and diffed against source:

- **144 / 144 component folders ship.** Tarball is correct.
- **143 / 144 are reachable** via `import { X } from "@vllnt/ui"`.
- **1 unreachable:** `ProgressCard`. It ships under `dist/components/progress-card/` but was never added to `packages/ui/src/components/index.ts`. Pre-existing since `c12255a feat: prepare @vllnt/ui for npm publishing` — surfaced now because `0.2.0` docs advertise the export.
- **6 casing drifts** between docs and actual exports:

| Doc (wrong) | Actual export |
|---|---|
| `AiChatInput` | `AIChatInput` |
| `AiMessageBubble` | `AIMessageBubble` |
| `AiSourceCitation` | `AISourceCitation` |
| `AiStreamingText` | `AIStreamingText` |
| `AiToolCallDisplay` | `AIToolCallDisplay` |
| `SocialFab` | `SocialFAB` |

## Fix

- Add `ProgressCard` (+ `ProgressCardProgress`, `ProgressCardProps` types) to the components barrel.
- Correct casing in root `README.md`, `packages/ui/README.md`, `packages/ui/CHANGELOG.md`, and `llms-full.txt`.
- Bump `packages/ui/package.json` to `0.2.1` so the dispatch after merge ships the fix.
- Add a `[0.2.1]` entry to `packages/ui/CHANGELOG.md`.

## Test plan

- [ ] CI green on this branch (lint + typecheck + build + test).
- [ ] Post-merge canary `@vllnt/ui@0.2.1-canary.<sha>` publishes.
- [ ] Dispatch `Publish` workflow → `v0.2.1` tag, npm publish, GitHub release.
- [ ] `npm pack @vllnt/ui@0.2.1` → `tar -tzf | grep progress-card` shows the folder.
- [ ] `grep ProgressCard dist/index.d.ts` non-empty in the published tarball.
