### PR TITLE
docs: cover remaining public exports + fix llms-full casing

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -120,15 +120,15 @@ SubscriptionCard, PlanBadge, CreditBadge, UsageBreakdown.
 
 ### Animation
 
-AnimatedText, BorderBeam, Marquee, NumberTicker, Spinner.
+AnimatedText, BorderBeam, Marquee, NumberTicker, Spinner, UnicodeSpinner.
 
 ### Content
 
-BlogCard, ProTip, Callout, CodeBlock, CodePlayground, Comparison, Faq, FlowDiagram, MdxContent, ProfileSection, Terminal, VideoEmbed, TldrSection, ShareSection, ShareDialog.
+BlogCard, ProTip, Callout, CodeBlock, CodePlayground, Comparison (+ BeforeAfter), FAQ, FlowDiagram (+ FlowControls, FlowFullscreen, FlowErrorBoundary, hook `useFlowDiagram`), MDXContent, ProfileSection, Terminal, VideoEmbed, TLDRSection, ShareSection, ShareDialog.
 
 ### Tutorial / Educational
 
-ContentIntro, Exercise, Flashcard, KeyConcept, LearningObjectives, ProgressBar, ProgressCard, Quiz, StepByStep, StepNavigation, Stepper, TutorialCard, TutorialComplete, TutorialFilters, TutorialIntroContent, TutorialMdx, Checklist, Annotation, CompletionDialog, TruncatedText, TableOfContents, TableOfContentsPanel.
+ContentIntro, Exercise, Flashcard, KeyConcept (+ Glossary), LearningObjectives (+ Prerequisites, Summary), ProgressBar, ProgressCard, Quiz, StepByStep, StepNavigation, Stepper, TutorialCard, TutorialComplete, TutorialFilters, TutorialIntroContent, TutorialMDX, Checklist, Annotation (+ Highlight), CompletionDialog, TruncatedText, TableOfContents, TableOfContentsPanel.
 
 ### App shell
 
@@ -163,8 +163,19 @@ Variants are typed exports from each component module.
 ### Utilities
 
 ```tsx
-import { cn, useDebounce } from "@vllnt/ui";
+import { cn } from "@vllnt/ui";
 ```
+
+### Hooks
+
+| Hook | Purpose |
+|------|---------|
+| `useDebounce(value, delayMs)` | Debounce a value — idle-settled state for search inputs. |
+| `useHorizontalScroll(ref)` | Wheel-to-horizontal + scroll-snap helpers used by `HorizontalScrollRow`. |
+| `useMobile(breakpoint?)` | `true` below the given breakpoint (default 768). SSR-safe. |
+| `useSidebar()` | Read `SidebarProvider` state: `{ open, setOpen, toggle }`. |
+| `useFlowDiagram(options)` | Imperative handle for `FlowDiagram`: fit view, zoom, PNG export. |
+| `useSocialFab()` | Open/close state for `SocialFab`. |
 
 ## Requirements
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -218,7 +218,7 @@ import {
 | `Alert` | `{ Alert, AlertTitle, AlertDescription, alertVariants }` | Static alert banner |
 | `Badge` | `{ Badge, badgeVariants }` | Inline status label. Variants: default, secondary, destructive, outline |
 | `Skeleton` | `{ Skeleton }` | Loading placeholder |
-| `Spinner` | `{ Spinner }` | Loading spinner |
+| `Spinner` | `{ Spinner, UnicodeSpinner }` | Styled spinner + ASCII-art `UnicodeSpinner` for terminals / code blocks |
 
 ### Navigation
 
@@ -242,7 +242,7 @@ import {
 | `BarChart` | `{ BarChart }` | Chart component |
 | `LineChart` | `{ LineChart }` | Chart component |
 | `CodeBlock` | `{ CodeBlock }` | Syntax-highlighted code via `react-syntax-highlighter` |
-| `FlowDiagram` | `{ FlowDiagram }` | Flow diagram via `@xyflow/react` |
+| `FlowDiagram` | `{ FlowDiagram, FlowControls, FlowFullscreen, FlowErrorBoundary, useFlowDiagram }` | Flow diagram via `@xyflow/react`. Extras: custom controls, fullscreen wrapper, error boundary, and the `useFlowDiagram` hook for imperative access. |
 | `TableOfContents` | `{ TableOfContents }` | Page table of contents |
 
 ### App Components
@@ -276,7 +276,10 @@ import {
 | `Flashcard` | `{ Flashcard }` | Flip-card for spaced repetition |
 | `Stepper` | `{ Stepper }` | Linear progress stepper |
 | `Tour` | `{ Tour }` | Guided product tour |
-| `Annotation` | `{ Annotation }` | Inline annotation / highlight |
+| `Annotation` | `{ Annotation, Highlight }` | Inline annotation block + inline `Highlight` span for in-prose emphasis |
+| `LearningObjectives` | `{ LearningObjectives, Prerequisites, Summary }` | Objectives list plus companion `Prerequisites` and `Summary` blocks |
+| `KeyConcept` | `{ KeyConcept, Glossary }` | Concept callout + `Glossary` term list |
+| `Comparison` | `{ Comparison, BeforeAfter }` | Side-by-side compare block + `BeforeAfter` slider |
 | `CompletionDialog` | `{ CompletionDialog }` | End-of-flow celebration dialog |
 | `TruncatedText` | `{ TruncatedText }` | Expand-on-overflow text block |
 | `TableOfContentsPanel` | `{ TableOfContentsPanel }` | Sidebar TOC panel |
@@ -334,7 +337,7 @@ import {
 | `BorderBeam` | `{ BorderBeam }` | Animated gradient border |
 | `Marquee` | `{ Marquee }` | Infinite scroll marquee |
 | `NumberTicker` | `{ NumberTicker }` | Animated number counter |
-| `Spinner` | `{ Spinner }` | Rich loading-spinner library |
+| `Spinner` | `{ Spinner, UnicodeSpinner }` | Styled spinner + ASCII-art `UnicodeSpinner` for terminals / code blocks |
 
 ### Form Additions
 
@@ -386,10 +389,22 @@ import { cn } from "@vllnt/ui";
 <div className={cn("p-4 bg-primary", isActive && "bg-accent", className)} />
 ```
 
-```tsx
-import { useDebounce } from "@vllnt/ui";
+### Hooks
 
-const debouncedValue = useDebounce(searchTerm, 300);
+| Hook | Purpose |
+|------|---------|
+| `useDebounce(value, delayMs)` | Returns the value after `delayMs` of idle — ideal for search inputs. |
+| `useHorizontalScroll(ref)` | Drives the behavior used by `HorizontalScrollRow` — wheel → horizontal scroll, scroll-snap helpers. |
+| `useMobile(breakpoint?)` | Boolean for "viewport is below breakpoint" (default `768`). SSR-safe. |
+| `useSidebar()` | Reads `SidebarProvider` state — `{ open, setOpen, toggle }`. Throws outside a provider. |
+| `useFlowDiagram(options)` | Imperative controller for `FlowDiagram` — fit view, zoom, export to PNG. |
+| `useSocialFab()` | Drives the open/close state of `SocialFab`. |
+
+```tsx
+import { useDebounce, useMobile } from "@vllnt/ui";
+
+const query = useDebounce(input, 300);
+const isMobile = useMobile();
 ```
 
 ## Types


### PR DESCRIPTION
## Context

During post-release verification of `@vllnt/ui@0.2.1` I noticed the published `dist/index.d.ts` exports several names that weren't mentioned anywhere in the docs. Users would be able to `import { X }` them and get working types and behavior, but would never find out they existed from reading the README or llms files.

Also caught a few casing drifts in `llms-full.txt` that slipped past the 0.2.1 fix.

This PR is **docs-only** — no code change, no version bump.

## Under-documented exports now covered

### `FlowDiagram` family
Added to the `FlowDiagram` row in both `packages/ui/README.md` data table:
- `FlowControls` — custom flow-diagram controls
- `FlowFullscreen` — fullscreen wrapper
- `FlowErrorBoundary` — error boundary around the diagram
- `useFlowDiagram` — imperative hook (fit view, zoom, PNG export)

### `Spinner` family
- `UnicodeSpinner` — ASCII-art spinner for terminals / code blocks. Listed next to `Spinner` in both Feedback and Animation tables.

### Tutorial / Educational extras (inline companions of existing components)
- `Annotation` → add `Highlight`
- `LearningObjectives` → add `Prerequisites`, `Summary`
- `KeyConcept` → add `Glossary`
- `Comparison` → add `BeforeAfter`

### Hooks section
Previously only `useDebounce` was mentioned in inline prose. Now there's a proper table in `packages/ui/README.md` and `llms-full.txt` covering:

| Hook | Purpose |
|---|---|
| `useDebounce(value, delayMs)` | Idle-settled value for search |
| `useHorizontalScroll(ref)` | Wheel→horizontal + snap helpers |
| `useMobile(breakpoint?)` | `true` below breakpoint (SSR-safe) |
| `useSidebar()` | Read `SidebarProvider` state |
| `useFlowDiagram(options)` | Imperative `FlowDiagram` handle |
| `useSocialFab()` | Open/close state for `SocialFab` |

## llms-full.txt casing fixes

| Before | After |
|---|---|
| `Faq` | `FAQ` |
| `MdxContent` | `MDXContent` |
| `TldrSection` | `TLDRSection` |
| `TutorialMdx` | `TutorialMDX` |

## Out of scope (tracked separately)

- `toast` runtime function re-exports from `sonner` at runtime but is absent from the rolled-up `dist/index.d.ts` — TypeScript users will get a "no exported member" error. That's a tsup rollup issue, not a docs issue — separate fix.
- Dependabot triage and Node-20 action deprecation bumps — still pending.

## Test plan

- [ ] `pnpm -F @vllnt/ui lint` green locally.
- [ ] CI green on this branch (no TS/JS changed; just Markdown + llms-full).
- [ ] No canary will publish from this PR since `pnpm-lock.yaml` and `packages/ui/**` source aren't touched — but `packages/ui/README.md` path IS covered by the publish-workflow path filter; a canary will run. Expected: `@vllnt/ui@0.2.1-canary.<sha>` publishes cleanly (identical tarball; only README shipped changed).
