### PR TITLE
fix: enforce client directives for hook-based components

### DIFF
--- a/packages/ui/src/components/chart/area-chart.tsx
+++ b/packages/ui/src/components/chart/area-chart.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/chart/line-chart.tsx
+++ b/packages/ui/src/components/chart/line-chart.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 
 import { cn } from "../../lib/utils";

--- a/packages/ui/src/components/client-directives.test.ts
+++ b/packages/ui/src/components/client-directives.test.ts
@@ -1,0 +1,64 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const COMPONENTS_ROOT = join(__dirname);
+const CLIENT_HOOKS = [
+  "useState",
+  "useEffect",
+  "useLayoutEffect",
+  "useMemo",
+  "useCallback",
+  "useReducer",
+  "useRef",
+  "useImperativeHandle",
+] as const;
+const SKIPPED_SUFFIXES = [".stories.tsx", ".test.tsx", ".visual.tsx"] as const;
+
+function listTypeScriptFiles(directory: string): string[] {
+  return readdirSync(directory).flatMap((entry) => {
+    const path = join(directory, entry);
+    const stats = statSync(path);
+
+    if (stats.isDirectory()) {
+      return listTypeScriptFiles(path);
+    }
+
+    return path.endsWith(".tsx") ? [path] : [];
+  });
+}
+
+function usesClientHooks(source: string): boolean {
+  return CLIENT_HOOKS.some((hook) => source.includes(hook));
+}
+
+function hasUseClientDirective(source: string): boolean {
+  const firstNonEmptyLine = source
+    .split(/\r?\n/u)
+    .find((line) => line.trim().length > 0)
+    ?.trim();
+
+  return (
+    firstNonEmptyLine === '"use client";' ||
+    firstNonEmptyLine === "'use client';"
+  );
+}
+
+describe("client directives", () => {
+  it("marks hook-based shipped components as client components", () => {
+    const missingDirectiveFiles = listTypeScriptFiles(COMPONENTS_ROOT)
+      .filter((filePath) =>
+        SKIPPED_SUFFIXES.every((suffix) => !filePath.endsWith(suffix)),
+      )
+      .filter((filePath) => {
+        const source = readFileSync(filePath, "utf8");
+        return usesClientHooks(source) && !hasUseClientDirective(source);
+      })
+      .map((filePath) =>
+        filePath.replace(`${COMPONENTS_ROOT}/`, "components/"),
+      );
+
+    expect(missingDirectiveFiles).toEqual([]);
+  });
+});

--- a/packages/ui/src/components/client-directives.test.ts
+++ b/packages/ui/src/components/client-directives.test.ts
@@ -5,14 +5,22 @@ import { describe, expect, it } from "vitest";
 
 const COMPONENTS_ROOT = join(__dirname);
 const CLIENT_HOOKS = [
-  "useState",
+  "useActionState",
+  "useCallback",
+  "useContext",
+  "useDeferredValue",
   "useEffect",
+  "useId",
+  "useImperativeHandle",
+  "useInsertionEffect",
   "useLayoutEffect",
   "useMemo",
-  "useCallback",
+  "useOptimistic",
   "useReducer",
   "useRef",
-  "useImperativeHandle",
+  "useState",
+  "useSyncExternalStore",
+  "useTransition",
 ] as const;
 const SKIPPED_SUFFIXES = [".stories.tsx", ".test.tsx", ".visual.tsx"] as const;
 
@@ -30,7 +38,9 @@ function listTypeScriptFiles(directory: string): string[] {
 }
 
 function usesClientHooks(source: string): boolean {
-  return CLIENT_HOOKS.some((hook) => source.includes(hook));
+  return CLIENT_HOOKS.some((hook) =>
+    new RegExp(`\\b${hook}\\b`, "u").test(source),
+  );
 }
 
 function hasUseClientDirective(source: string): boolean {


### PR DESCRIPTION
## Summary
- add missing `"use client"` directives to the remaining hook-based chart components
- add a regression audit test that fails if shipped hook-based components miss the directive
- narrow issue #137 to the actual remaining scope on the current `feat/storybook` base

## Validation
- `pnpm -F @vllnt/ui exec eslint src/components/chart/line-chart.tsx src/components/chart/area-chart.tsx src/components/client-directives.test.ts`
- `pnpm -F @vllnt/ui test:once -- src/components/client-directives.test.ts`
- `pnpm -F @vllnt/ui build`

## Notes
- stacked on `feat/storybook`
- issue #137's original affected-file list is broader than the current branch state; audit found the remaining missing directives were the two chart components above

Fixes #137
