### PR TITLE
ci: enforce issue-linked pull requests

### DIFF
--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -1,0 +1,40 @@
+name: PR Issue Link
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-issue-link-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enforce-issue-link:
+    name: Enforce issue-linked PRs
+    runs-on: ubuntu-latest
+    env:
+      PR_BODY: ${{ github.event.pull_request.body || '' }}
+    steps:
+      - name: Validate PR body links a GitHub issue
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pattern='(Closes|Fixes|Resolves|Part of|Related to)[[:space:]]+([[:alnum:]_.-]+/[[:alnum:]_.-]+)?#[0-9]+'
+
+          if [[ "$PR_BODY" =~ $pattern ]]; then
+            echo "Issue link found in PR body."
+            exit 0
+          fi
+
+          echo "PR body must link a GitHub issue using one of: Closes #123, Fixes #123, Resolves #123, Part of #123, Related to #123." >&2
+          exit 1

--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -28,13 +28,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          shopt -s nocasematch
 
-          pattern='(Closes|Fixes|Resolves|Part of|Related to)[[:space:]]+([[:alnum:]_.-]+/[[:alnum:]_.-]+)?#[0-9]+'
+          pattern='(close[sd]?|fix(es|ed)?|resolve[sd]?|part of|related to):?[[:space:]]+([[:alnum:]_.-]+/[[:alnum:]_.-]+)?#[0-9]+'
 
           if [[ "$PR_BODY" =~ $pattern ]]; then
             echo "Issue link found in PR body."
             exit 0
           fi
 
-          echo "PR body must link a GitHub issue using one of: Closes #123, Fixes #123, Resolves #123, Part of #123, Related to #123." >&2
+          echo "PR body must link a GitHub issue. Accepted (case-insensitive, optional colon): close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved, Part of, Related to -- followed by #123 or owner/repo#123." >&2
           exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ The two most-violated rules in PR review history:
 
 1. **Workspace gates green at HEAD** ([R6](./docs/agents/RULES.md#r6--workspace-gates-green-at-head)). Touched-file passes alone are not ship-OK. Run `pnpm -F @vllnt/ui lint && pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json && pnpm build && pnpm test:once` — all must be green.
 2. **PR body matches HEAD** ([R3](./docs/agents/RULES.md#r3--pr-body-matches-head)). After every push, rewrite the body to match the current head. Stale claims block ship.
-3. **Linked issue required** ([R5](./docs/agents/RULES.md#r5--linked-issue-required)). Every PR must reference a GitHub issue via `Closes #...`, `Fixes #...`, `Resolves #...`, `Part of #...`, or `Related to #...`.
+3. **Linked issue required** ([R5](./docs/agents/RULES.md#r5--linked-issue-required)). Every PR must reference a GitHub issue. Accepted keywords: `close` / `closes` / `closed`, `fix` / `fixes` / `fixed`, `resolve` / `resolves` / `resolved`, or repo phrases `Part of` / `Related to` — all case-insensitive, optional colon — followed by `#123` or `owner/repo#123`.
 
 ## Out of scope for agents
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ The two most-violated rules in PR review history:
 
 1. **Workspace gates green at HEAD** ([R6](./docs/agents/RULES.md#r6--workspace-gates-green-at-head)). Touched-file passes alone are not ship-OK. Run `pnpm -F @vllnt/ui lint && pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json && pnpm build && pnpm test:once` — all must be green.
 2. **PR body matches HEAD** ([R3](./docs/agents/RULES.md#r3--pr-body-matches-head)). After every push, rewrite the body to match the current head. Stale claims block ship.
+3. **Linked issue required** ([R5](./docs/agents/RULES.md#r5--linked-issue-required)). Every PR must reference a GitHub issue via `Closes #...`, `Fixes #...`, `Resolves #...`, `Part of #...`, or `Related to #...`.
 
 ## Out of scope for agents
 


### PR DESCRIPTION
Closes #152

## Summary
- add a PR-body workflow gate that requires an explicit GitHub issue link
- document the issue-link requirement in `AGENTS.md`
- cover non-Hermes PRs like Dependabot so repo policy matches Hermes orchestration assumptions

## Validation
- parsed `.github/workflows/pr-issue-link.yml` with Python + YAML
- tested the regex against valid and invalid sample PR body strings

## Test plan
- open or edit a PR without an issue link and confirm the new check fails
- add `Closes #...` / `Related to #...` and confirm the check passes