### PR TITLE
docs(agents): consolidate AGENTS.md as index + add agent rules/playbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,29 @@
 # Agent Instructions
 
 Canonical instructions for AI coding agents working in this repository.
-Harness-specific aliases (`CLAUDE.md`, `.cursorrules`, `codex.md`, etc.) should reference this file.
+Harness-specific aliases (`CLAUDE.md`, `.cursorrules`, `codex.md`, etc.) reference this file.
+
+This file is the **index**. Detailed rules live in [`docs/agents/`](./docs/agents/).
+
+---
 
 ## Repository at a glance
 
-- **Project:** `@vllnt/ui` — 144-component React library (Radix primitives + Tailwind + CVA).
+- **Project:** `@vllnt/ui` — accessible React component library (Radix primitives + Tailwind + CVA).
 - **Language:** TypeScript (strict mode via `@vllnt/typescript`).
-- **Package manager:** pnpm (lockfile: `pnpm-lock.yaml`). Never use `npm` / `yarn` / `bun`.
-- **Monorepo tool:** Turborepo via `turbo.json`.
-- **Primary branch:** `main`. Never commit to `main` — push branches, open PRs.
+- **Package manager:** pnpm. Lockfile: `pnpm-lock.yaml`. Never use `npm` / `yarn` / `bun`.
+- **Monorepo tool:** Turborepo (`turbo.json`).
+- **Primary branch:** `main`. Never commit directly to `main` — push branches, open PRs.
 
 ## Package map
 
-| Path | Purpose | Published? |
-|------|---------|------------|
+| Path | Purpose | Published |
+|------|---------|-----------|
 | `packages/ui/` | `@vllnt/ui` component library | npm (public) |
-| `apps/registry/` | `ui.vllnt.ai` — Next.js registry + docs site | deployed, not a package |
-| `.github/workflows/` | CI: `ci.yml`, `publish.yml`, `storybook.yml` | — |
+| `apps/registry/` | `ui.vllnt.ai` — Next.js registry + docs site | deployed (Vercel) |
+| `.github/workflows/` | CI: `ci.yml`, `publish.yml`, `storybook.yml`, `pr-issue-link.yml` | — |
 
-External shared configs (published to npm separately): `@vllnt/eslint-config`, `@vllnt/typescript`.
+External shared configs (separate npm packages): `@vllnt/eslint-config`, `@vllnt/typescript`.
 
 ## Commands (run from repo root)
 
@@ -33,69 +37,41 @@ External shared configs (published to npm separately): `@vllnt/eslint-config`, `
 | `pnpm -F @vllnt/ui test:coverage` | Vitest with coverage |
 | `pnpm check:circular` | Fail on circular imports |
 
-## Component conventions
+---
 
-Every component lives at `packages/ui/src/components/{name}/`:
+## Agent rule index
 
-```
-{name}/
-  {name}.tsx         # implementation — React.forwardRef + CVA + cn()
-  {name}.test.tsx    # Vitest unit
-  {name}.visual.tsx  # Playwright CT story
-  {name}.mdx         # registry docs (auto-generated where possible)
-  index.ts           # barrel export
-```
+Read these in order. Each is BLOCKING — violations keep a PR in draft.
 
-Patterns every component follows:
+| File | What |
+|------|------|
+| [`docs/agents/RULES.md`](./docs/agents/RULES.md) | The 15 BLOCKING rules — process + code quality. **Read first.** |
+| [`docs/agents/PR_PLAYBOOK.md`](./docs/agents/PR_PLAYBOOK.md) | Ship checklist: diff sanity → gates → evidence → body refresh → ready |
+| [`docs/agents/COMPONENTS.md`](./docs/agents/COMPONENTS.md) | Component patterns: forwardRef, semantic root, ARIA, events, props |
+| [`docs/agents/BRANCHING.md`](./docs/agents/BRANCHING.md) | Branch hygiene: zero-diff, supersede, reconcile, worktrees |
 
-- `React.forwardRef` + `React.ComponentPropsWithoutRef`.
-- `cn()` from `src/lib/utils.ts` (clsx + tailwind-merge).
-- CVA (`class-variance-authority`) for variant props.
-- Radix primitives for accessible behavior (focus, keyboard, ARIA).
-- `asChild` prop via `@radix-ui/react-slot` for render delegation where composable.
+Repository-wide docs (audience = contributors, not just agents):
 
-## Code rules (non-negotiable)
+| File | What |
+|------|------|
+| [`README.md`](./README.md) | Public README + component catalog |
+| [`CONTRIBUTING.md`](./CONTRIBUTING.md) | Contributor onramp |
+| [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) | Monorepo layout, build graph, theming |
+| [`docs/RELEASING.md`](./docs/RELEASING.md) | Release + canary flow |
+| [`SECURITY.md`](./SECURITY.md) | Security policy (don't modify without authorization) |
 
-- TypeScript strict. **No** `any`, `as`, `@ts-ignore`, `@ts-expect-error`, `eslint-disable`.
-- Zod at boundaries (not inside components).
-- Inline `//` comments forbidden in shipped code — prefer TSDoc on exports, or refactor.
-- Additive architecture: new feature → new file. Never edit hub files (`index.ts`, `routes.ts`, global configs) reflexively.
-- Follow existing codebase patterns. If a pattern exists in 3+ files, use it.
+---
 
-## Testing expectations
+## Quick reference
 
-- Unit tests run under Vitest + Testing Library (`*.test.tsx`).
-- Visual regression: Playwright Component Testing (`*.visual.tsx`) — real browser, no jsdom.
-- For UI changes, run both unit and visual, or explicitly note which were skipped and why.
-- For bug fixes, add a regression test that fails before the fix and passes after.
+The two most-violated rules in PR review history:
 
-## Quality gates before marking a task done
-
-1. `pnpm lint` — clean on changed files.
-2. `pnpm exec tsc --noEmit` in the touched package — clean.
-3. `pnpm build` — full build succeeds.
-4. `pnpm test:once` — relevant tests pass.
-5. If UI routes / components changed: `pnpm -F @vllnt/ui test:visual`.
-
-## Git & PR workflow
-
-- Branch naming: `feat/`, `fix/`, `chore/`, `docs/`, `ci/`.
-- Conventional commit messages (`feat:`, `fix:`, `chore:`, etc.). The release workflow groups them into notes.
-- PR body covers: summary (why), evidence (CI run IDs, screenshots, numbers), test plan.
-- Never force-push `main`. Never skip hooks (`--no-verify`).
-- Automatic CI monitoring is expected after `gh pr create` — watch the run and report its outcome back into the PR.
-
-## Release
-
-Releases are cut via `workflow_dispatch` on `.github/workflows/publish.yml`:
-
-1. Pick `patch` / `minor` / `major`.
-2. CI bumps `packages/ui/package.json`, regenerates notes from commits, pushes tag, publishes to the public npm registry with OIDC-signed provenance, and creates the GitHub Release.
-
-Canary builds ship automatically on every push to `main`.
+1. **Workspace gates green at HEAD** ([R6](./docs/agents/RULES.md#r6--workspace-gates-green-at-head)). Touched-file passes alone are not ship-OK. Run `pnpm -F @vllnt/ui lint && pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json && pnpm build && pnpm test:once` — all must be green.
+2. **PR body matches HEAD** ([R3](./docs/agents/RULES.md#r3--pr-body-matches-head)). After every push, rewrite the body to match the current head. Stale claims block ship.
 
 ## Out of scope for agents
 
-- Do not modify `LICENSE`, `CODE_OF_CONDUCT.md`, or `SECURITY.md` without explicit human authorization.
-- Do not add new dependencies without explaining the tradeoff (bundle size, security surface, maintenance).
-- Do not publish, push to `main`, or merge PRs without explicit authorization.
+- Don't modify `LICENSE`, `CODE_OF_CONDUCT.md`, or `SECURITY.md` without explicit human authorization.
+- Don't add new dependencies without explaining the tradeoff (bundle size, maintenance, security surface).
+- Don't publish, push to `main`, or merge PRs without explicit authorization.
+- Don't hand-edit generated files (`apps/registry/lib/component-metadata.json`, `dist/`). Regenerate via the documented script.

--- a/docs/agents/BRANCHING.md
+++ b/docs/agents/BRANCHING.md
@@ -1,0 +1,64 @@
+# Branch Hygiene
+
+How to avoid orphaned branches and supersede churn.
+
+---
+
+## Rules
+
+### B1 — Zero-diff branches close, not ready
+
+Before `gh pr ready`:
+
+```bash
+git diff --stat origin/main...HEAD
+```
+
+Empty → the branch is stale or its work already landed somewhere else. Close the PR with a 1-line comment pointing at what superseded it.
+
+> **Counters:** PR #121 (`feat: restore storybook integration base`) was closed: *"This PR is a zero-file diff against main, so there is nothing left to review or merge."*
+
+### B2 — Supersede explicitly
+
+When you re-cut a branch (rebase landed elsewhere, base changed, branch got orphaned), close the older PR and link the canonical one:
+
+> Superseded by #N after the original head branch was orphaned. Use #N for final review.
+
+Don't leave parallel ghost branches racing.
+
+> **Counters:** Pairs #138/#143, #142/#123, #146/#145.
+
+### B3 — Reconcile before requesting review
+
+If your branch falls behind `main`, rebase or merge `main` into the branch **before** asking for review. Resolve generated-file conflicts (`apps/registry/lib/component-metadata.json`) by regenerating — never hand-edit.
+
+```bash
+git fetch origin
+git rebase origin/main          # or: git merge origin/main
+pnpm -F @vllnt/ui-registry sync-storybook
+pnpm -F @vllnt/ui-registry registry:build
+git add -p
+```
+
+### B4 — Worktrees for parallel work
+
+Default to git worktrees when starting a second feature, taking a hotfix, or reviewing a PR. Don't pile parallel work onto `main`.
+
+```bash
+git worktree add -b feat/my-feature .worktrees/my-feature main
+```
+
+---
+
+## Branch naming
+
+| Prefix | When |
+|--------|------|
+| `feat/` | New component, API, or behavior |
+| `fix/`  | Bug fix |
+| `chore/` | Tooling, deps, repo housekeeping |
+| `docs/` | Documentation only |
+| `ci/`   | CI / workflow changes |
+| `refactor/` | No behavior change |
+
+Match the prefix to the conventional commit type. Release notes are grouped from these.

--- a/docs/agents/COMPONENTS.md
+++ b/docs/agents/COMPONENTS.md
@@ -1,0 +1,170 @@
+# Component Conventions
+
+Authoritative pattern catalog for every component in `packages/ui/src/components/`. Rules here are referenced from [`RULES.md`](./RULES.md).
+
+---
+
+## Folder layout
+
+Every component lives at `packages/ui/src/components/{name}/`:
+
+```
+{name}/
+  {name}.tsx         # implementation — React.forwardRef + CVA + cn()
+  {name}.test.tsx    # Vitest unit tests
+  {name}.visual.tsx  # Playwright CT story (real Chromium)
+  {name}.stories.tsx # Storybook story (default export + named stories)
+  {name}.mdx         # registry/docs (auto-generated where possible)
+  index.ts           # barrel export from the folder
+```
+
+Add the export to `packages/ui/src/index.ts`.
+
+---
+
+## The forwardRef + displayName contract
+
+Every named export — primitives **and compound subcomponents** — uses:
+
+```tsx
+const Card = React.forwardRef<HTMLDivElement, CardProps>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("rounded-md border", className)} {...props} />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<"div">>(
+  ({ className, ...props }, ref) => <div ref={ref} className={cn("p-6", className)} {...props} />,
+);
+CardHeader.displayName = "CardHeader";
+```
+
+Compound parts (`Card.Header`, `Form.Field`, `Conversation.Title`, …) get the **same treatment**. No exceptions.
+
+> **Counters:** PR #150 — auto-fix added `forwardRef` + `displayName` to 8 compound parts of `ConversationThread`.
+
+---
+
+## Semantic root
+
+When a component's name implies an HTML element, the root must render that element:
+
+| Name | Root element |
+|------|--------------|
+| `Form` | `<form>` (`form.tsx`) |
+| `Nav`, `Navbar*` | `<nav>` |
+| `List` | `<ul>` / `<ol>` |
+| `Article` | `<article>` |
+| `Header`, `Footer` | `<header>` / `<footer>` |
+| `Button` | `<button>` (or asChild) |
+
+`<div role="form">` is a smell — rename the component or use the real tag. If a wrapper is needed, name it for what it is (`FormShell`, `FormSurface`).
+
+> **Counters:** PR #145 — `Form` shipped as styled `<div>`.
+
+---
+
+## ARIA — by spec, not vibe
+
+### Roles to be careful with
+
+| Role | Use only when | Don't use when |
+|------|---------------|----------------|
+| `button` | A single, atomic, accessible action with no nested interactives | Wrapper hosts complex children (canvas, workspace, panel) |
+| `status` | Live status region with text content updating | Static marker / decorative element |
+| `alert` | Time-sensitive announcements | Persistent UI |
+| `presentation` / `none` | Element is purely visual scaffolding | Anywhere semantics matter |
+
+When introducing a non-obvious role, **cite the WAI-ARIA Authoring Practices section or the Radix pattern** in the PR body.
+
+> **Counters:** PR #139 — `role="button"` on canvas workspace; PR #140 — `role="status"` on a static port marker.
+
+### `aria-describedby` / `aria-labelledby` must point at rendered nodes
+
+```tsx
+// Wrong — id always set, target may not render
+<input id={inputId} aria-describedby={`${inputId}-desc ${inputId}-msg`} />
+{description ? <span id={`${inputId}-desc`}>…</span> : null}
+
+// Right — id only set when target renders
+<input
+  id={inputId}
+  aria-describedby={cn(description && `${inputId}-desc`, message && `${inputId}-msg`) || undefined}
+/>
+```
+
+> **Counters:** PR #145 — `FormControl` composed `aria-describedby` with ids of unrendered nodes.
+
+---
+
+## Event handling — don't hijack what isn't yours
+
+For container components (canvas, scrollers, keyboard-shortcut hosts):
+
+- Before `event.preventDefault()` on wheel / key / pointer handlers, check `event.target` is not a nested scroll container or interactive element.
+- Defer to nested handlers first; hijack only when the target is the container itself.
+- Native scroll on a child should not be silenced by a container's wheel handler.
+
+```tsx
+function onWheel(e: React.WheelEvent) {
+  const target = e.target as HTMLElement;
+  if (target.closest("[data-canvas-passthrough]")) return; // descendant claims wheel
+  if (isScrollableAncestor(target, e.currentTarget)) return;
+  e.preventDefault();
+  // … pan logic
+}
+```
+
+> **Counters:** PR #139 — `canvas-view` globally `preventDefault`-ed wheel and stole arrow/zoom keys regardless of focus.
+
+---
+
+## Prop naming = trigger
+
+Event-handler prop names map to the actual trigger. If `onSend` only fires on suggestion clicks, it's not `onSend` — it's `onSuggestionClick` (or `onSubmit` if it's the real submit).
+
+When in doubt, qualify with the trigger noun.
+
+> **Counters:** PR #150 — `onSend` only fired on suggestion clicks.
+
+---
+
+## Legacy props = legacy behavior
+
+Keeping a prop **name** while changing its **layout/behavior** is a breaking change. Two options:
+
+1. **Preserve** the documented behavior under the legacy name and add the new path under a new name.
+2. **Rename** with a major bump and a migration note in `CHANGELOG.md` + the PR body.
+
+Don't leave a prop that "still exists" but means something different.
+
+> **Counters:** PR #141 — `leftRail` / `rightDock` / `bottomSlot` on `CanvasShell` kept as names but lost their grid/full-width layout contract.
+
+---
+
+## Code-style non-negotiables
+
+- TypeScript strict via `@vllnt/typescript`. **No** `any`, `as`, `@ts-ignore`, `@ts-expect-error`, `eslint-disable`.
+- Zod at boundaries (server actions, public APIs), not inside components.
+- No inline `//` comments in shipped code — use TSDoc on exports, or refactor.
+- Additive architecture: new feature → new file. Don't reflexively edit hub files (`index.ts`, `routes.ts`, global configs).
+- Follow existing codebase patterns. If a pattern exists in 3+ files, use it.
+
+---
+
+## Hooks → `"use client"`
+
+Any component that uses React hooks must start with `"use client"`. There is a CI test (`packages/ui/src/components/client-directives.test.ts`) that audits this. Don't suppress it — fix the directive.
+
+> **Counters:** PR #138 / #143 / #144 — chart components were shipped without `"use client"`.
+
+---
+
+## Testing expectations
+
+- Unit: Vitest + Testing Library (`*.test.tsx`).
+- Visual: Playwright CT (`*.visual.tsx`) — real browser, no jsdom.
+- Story: Storybook story (`*.stories.tsx`) for every shipped component.
+- For UI changes: run unit + visual, or explicitly note which were skipped and why.
+- For bug fixes: add a regression test that fails before the fix and passes after.
+
+Visual regression baselines are **committed** to `packages/ui/.snapshots/`. Don't run `--update-snapshots` in CI; refresh locally and commit the diff.

--- a/docs/agents/PR_PLAYBOOK.md
+++ b/docs/agents/PR_PLAYBOOK.md
@@ -1,0 +1,112 @@
+# PR Playbook
+
+The canonical ship checklist. Mirrors the BLOCKING rules in [`RULES.md`](./RULES.md) but ordered as a runbook.
+
+If any step fails, the PR stays in draft until fixed.
+
+---
+
+## 0. Branch + issue link
+
+- Branch name follows `feat/`, `fix/`, `chore/`, `docs/`, `ci/`, `refactor/`.
+- Reference an issue in the PR body: `Closes #N`, `Fixes #N`, or `Related to #N`. CI gate: `.github/workflows/pr-issue-link.yml`.
+
+## 1. Diff sanity (R2)
+
+```bash
+git diff --stat origin/main...HEAD
+```
+
+Zero diff → close the branch. Don't ship a no-op.
+
+## 2. Targeted gates (after each edit batch)
+
+```bash
+pnpm -F @vllnt/ui exec eslint <changed files>
+pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json
+```
+
+## 3. Workspace gates (R6 — before requesting merge)
+
+All four must be green at HEAD:
+
+```bash
+pnpm -F @vllnt/ui lint
+pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json
+pnpm build
+pnpm test:once
+```
+
+Touched-file passes alone are **not** ship-OK. If `tsc` is red package-wide, the PR is red package-wide.
+
+## 4. UI evidence (R4)
+
+For UI behavior changes:
+
+```bash
+pnpm -F @vllnt/ui test:visual
+```
+
+Plus, paste in the PR body **one of**:
+
+- The exact verification command + its output, or
+- A screenshot / recording from the current head.
+
+Bare ticked checkboxes don't count.
+
+## 5. Story coverage
+
+```bash
+pnpm -F @vllnt/ui exec tsx scripts/check-story-coverage.ts
+pnpm -F @vllnt/ui exec tsx scripts/verify-stories.ts
+```
+
+These also run in CI (`storybook.yml`). Run them locally first.
+
+## 6. Refresh PR body to match HEAD (R3)
+
+After your final push, **rewrite** the PR body so it matches the current head:
+
+- Validation commands actually run on this commit.
+- Screenshots / recordings from this commit.
+- CI status as-of-now.
+- Listed components match the actual diff.
+
+Stale claims block ship.
+
+## 7. CHANGELOG (user-facing changes)
+
+If the change is user-facing, add an entry under `[Unreleased]` in `packages/ui/CHANGELOG.md`. Group as `Added` / `Changed` / `Fixed` / `Deprecated` / `Removed`.
+
+## 8. Mark ready
+
+Only after steps 1–7 pass:
+
+```bash
+gh pr ready
+```
+
+## 9. Post-PR monitoring
+
+Watch CI through to green. If a check fails:
+
+- Diagnose the root cause (don't bypass with `--no-verify` or `eslint-disable`).
+- Push a fix commit on the same branch.
+- Re-run [step 6](#6-refresh-pr-body-to-match-head-r3).
+
+## 10. Codex review (optional)
+
+If Codex CLI is available + `OPENAI_API_KEY` is set, run it and include findings.
+
+If not available, **omit the section entirely**. Don't paste *"Codex unavailable"* boilerplate. (R7)
+
+---
+
+## Anti-patterns
+
+- ❌ "Targeted lint/tests passed; package-wide is red on pre-existing issues" → fix or escalate, don't normalize.
+- ❌ Marking ready with stale PR body claims.
+- ❌ Marking ready with zero diff vs `main`.
+- ❌ Empty `## Manual verification` section.
+- ❌ Skipping visual regression for "just a style tweak."
+- ❌ Suppressing lint/typecheck errors instead of fixing the source.

--- a/docs/agents/RULES.md
+++ b/docs/agents/RULES.md
@@ -1,0 +1,145 @@
+# Rules for AI Coding Agents
+
+BLOCKING rules every AI agent (Claude Code, Cursor, Codex, opencode, …) must follow when working in this repo. Derived from real failure patterns in PR review history.
+
+When a rule is violated, the PR must stay in draft until fixed.
+
+---
+
+## Process rules
+
+### R1 — Plan-grounding
+
+Before opening a `feat: plan …` or any planning PR, **cite an existing peer pattern** in:
+
+- `packages/ui/src/components/` (component family precedent), or
+- `apps/registry/registry.ts` (registry category precedent), or
+- `specs/shipped/` (prior spec that solved a comparable shape).
+
+No inventing categories or families that don't exist in the design system.
+
+> **Why:** PRs #124–#131 (`feat: plan {system|brand|data|canvas} icon family`) were all closed for: *"Wrong direction: no icon family in the design system."*
+
+### R2 — Diff sanity
+
+Before `gh pr ready` (or marking a draft ready), run:
+
+```bash
+git diff --stat origin/main...HEAD
+```
+
+Zero diff → close the branch. Don't ship a no-op.
+
+> **Why:** PRs #121, #146 closed because they had zero diff vs `main`.
+
+### R3 — PR body matches HEAD
+
+After every push, **rewrite** the PR body so it matches the current head:
+
+- Validation commands actually run on this commit.
+- Screenshots / recordings from this commit.
+- CI status as-of-now.
+- Listed components match the actual diff.
+
+Stale claims block ship.
+
+> **Why:** PR #103 needed *"removed stale body claims that visual regression and root quality gates already pass."*
+
+### R4 — Manual verification = evidence, not a checkbox
+
+For UI behavior changes, paste the verification command + its output, or attach a screenshot/recording of the verified behavior. Bare ticked checkboxes don't count.
+
+> **Why:** PR #123 reviewer flagged: *"the spec calls for explicit manual verification … I did not find that evidence attached to the PR."*
+
+### R5 — Issue link required
+
+Every PR body must contain `Closes #N`, `Fixes #N`, or `Related to #N`. Mirrors the CI gate (`.github/workflows/pr-issue-link.yml`, issue #152, PR #153).
+
+### R6 — Workspace gates green at HEAD
+
+These must all pass on the PR head before requesting merge:
+
+```bash
+pnpm -F @vllnt/ui lint
+pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json
+pnpm build
+pnpm test:once
+```
+
+Touched-file passes alone are **not** ship-OK. If `tsc` is red package-wide, the PR is red package-wide.
+
+> **Why:** PRs #122, #123, #145 each shipped while `pnpm -F @vllnt/ui exec tsc --noEmit` was red on the branch. Reviewers had to backstop.
+
+### R7 — Codex review reporting
+
+Don't paste *"Codex unavailable: OPENAI_API_KEY unset"* boilerplate into PR comments. Either:
+
+- Codex ran → include findings,
+- Codex didn't run → omit the section entirely.
+
+> **Why:** Boilerplate noise across PRs #140, #141, #145, #146, #149, #150, #153.
+
+### R8 — Branch hygiene
+
+If a branch becomes orphaned (rebased away, superseded, or zero-diff), close the PR with a 1-liner pointing at the canonical PR. Don't leave parallel ghost branches.
+
+See [`BRANCHING.md`](./BRANCHING.md).
+
+> **Why:** PR pairs #138/#143, #142/#123, #146/#145 each had review churn from orphaned branches.
+
+---
+
+## Code-quality rules
+
+See [`COMPONENTS.md`](./COMPONENTS.md) for the full pattern catalog. Summary of what's BLOCKING:
+
+### R9 — Compound `forwardRef` + `displayName`
+
+Every named export — including compound subcomponents (`Card.Header`, `Conversation.Title`, `Form.Field`) — has `React.forwardRef` and a set `displayName`.
+
+> **Why:** PR #150 needed an auto-fix to add `forwardRef` to all 8 compound parts of `ConversationThread`.
+
+### R10 — Semantic root
+
+If the component name implies an HTML element (`Form`, `Nav`, `List`, `Article`, `Header`), the root **renders that element**. `<div role="…">` is a smell — rename, or use the real tag.
+
+> **Why:** PR #145: `Form` shipped as a styled `<div>` while docs presented it as the form primitive.
+
+### R11 — No dangling ARIA references
+
+`aria-describedby` and `aria-labelledby` only emit when the referenced node will render. Generated ids must be conditional, not unconditional.
+
+> **Why:** PR #145 `FormControl` composed `aria-describedby` with ids that pointed at nothing when no `FormDescription` / `FormMessage` was rendered.
+
+### R12 — Don't hijack events from descendants
+
+For container components (canvas, scroll wrappers, key-shortcut hosts): before `preventDefault()` on wheel / key / pointer handlers, check `event.target` is not a nested scroll container or interactive element. Defer first, hijack last.
+
+> **Why:** PR #139 — `canvas-view` globally prevented wheel and stole arrow/zoom keys, breaking nested scrollers and inputs.
+
+### R13 — Legacy prop = legacy behavior
+
+Keeping a prop name but changing its layout/behavior is a breaking change. Either preserve the documented behavior, or rename + bump major + write a migration note.
+
+> **Why:** PR #141 — `leftRail` / `rightDock` / `bottomSlot` on `CanvasShell` survived as names but lost their grid/full-width contract.
+
+### R14 — Prop name = trigger
+
+Event-handler prop names map to the actual trigger. `onSend` fires on send, not on suggestion click. If unsure, qualify (`onSuggestionClick`).
+
+> **Why:** PR #150 — `onSend` only fired on suggestion clicks; reviewer flagged the misleading name.
+
+### R15 — ARIA by spec, not vibe
+
+Pick roles from Radix's pattern + WAI-ARIA Authoring Practices, not intuition. When introducing a non-obvious role, cite the source in the PR body.
+
+> **Why:** PR #139 (`role="button"` on a complex workspace host), PR #140 (`role="status"` on a static marker).
+
+---
+
+## Out of scope for agents
+
+- Don't modify `LICENSE`, `CODE_OF_CONDUCT.md`, or `SECURITY.md` without explicit human authorization.
+- Don't add new dependencies without explaining the tradeoff (bundle size, maintenance, security surface).
+- Don't publish, push to `main`, or merge PRs without explicit authorization.
+- Don't hand-edit generated files (`apps/registry/lib/component-metadata.json`, dist outputs). Regenerate via the documented script.


### PR DESCRIPTION
Closes #157

## Summary
- Restructure agent-facing docs based on failure patterns extracted from PR reviews/comments across PRs #103–#153
- `AGENTS.md` becomes a compact index pointing at the new `docs/agents/` folder
- `CLAUDE.md` already mirrors `AGENTS.md` as a Claude-Code-specific alias — no content change needed (the alias still resolves to the canonical index)
- Every rule cites the PR(s) it counters, so future agents see *why* it exists

## What's in `docs/agents/`

| File | Audience use |
|------|--------------|
| `RULES.md` | 15 BLOCKING rules — read first |
| `PR_PLAYBOOK.md` | Step-by-step ship checklist |
| `COMPONENTS.md` | forwardRef / semantic root / ARIA / event handling / prop naming |
| `BRANCHING.md` | Zero-diff, supersede, reconcile, worktrees |

## Failure patterns this PR addresses

Top items, with the PRs that triggered each rule:

- **R1 plan-grounding** — PRs #124–#131 closed for *"Wrong direction: no icon family in the design system"*
- **R2 diff sanity** — PRs #121, #146 closed as zero-diff
- **R3 PR body matches HEAD** — PR #103 had to remove stale body claims
- **R4 manual verification = evidence** — PR #123 flagged for missing evidence
- **R6 workspace gates green at HEAD** — PRs #122, #145, #149 shipped with package-wide `tsc --noEmit` red
- **R9 compound forwardRef + displayName** — PR #150 auto-fix on 8 compound parts
- **R10 semantic root** — PR #145 `Form` shipped as `<div>`
- **R11 no dangling ARIA** — PR #145 `FormControl` `aria-describedby` to nothing
- **R12 don't hijack events from descendants** — PR #139 canvas-view wheel/key
- **R13 legacy prop = legacy behavior** — PR #141 CanvasShell layout regression
- **R14 prop name = trigger** — PR #150 `onSend` fired on suggestion click
- **R15 ARIA by spec, not vibe** — PR #139, #140 misused roles

## Validation

- `git diff --stat origin/main...HEAD` non-empty (5 files, +531/-64)
- All changes are markdown — no code/lint/test/build impact
- Internal links inside the new docs use repo-relative paths

## Out of scope (follow-ups in separate PRs)

- Wiring rules into CI gates: full-workspace lint/tsc, baseline-respecting visual regression, client-directives audit, registry-metadata regen
- PR template / CHANGELOG enforcement updates
- Removing `specs/history.log` stub or upgrading it to a structured index