### PR TITLE
feat(ui): add CopyButton + useCopyToClipboard hook

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -696,6 +696,26 @@
       "category": "content"
     },
     {
+      "name": "copy-button",
+      "type": "registry:component",
+      "title": "Copy Button",
+      "description": "Click-to-copy utility with confirmation feedback and a useCopyToClipboard hook.",
+      "files": [
+        {
+          "path": "registry/default/copy-button/copy-button.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [
+        "button",
+        "tooltip"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "category": "core"
+    },
+    {
       "name": "code-playground",
       "type": "registry:component",
       "title": "Code Playground",

--- a/apps/registry/registry/default/copy-button/copy-button.tsx
+++ b/apps/registry/registry/default/copy-button/copy-button.tsx
@@ -1,0 +1,2 @@
+// Re-export from @vllnt/ui package
+export { CopyButton, useCopyToClipboard } from '@vllnt/ui'

--- a/packages/ui/src/components/copy-button/copy-button.mdx
+++ b/packages/ui/src/components/copy-button/copy-button.mdx
@@ -1,0 +1,72 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './copy-button.stories'
+
+<Meta of={Stories} />
+
+# CopyButton
+
+Click-to-copy utility with confirmation feedback. Copies `value` to the clipboard via the async Clipboard API and announces success to assistive tech.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/copy-button.json
+```
+
+## Import
+
+```tsx
+import { CopyButton, useCopyToClipboard } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<CopyButton value="EXAMPLE_API_KEY" />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Variants
+
+### variant
+
+| Value | Default |
+| ----- | ------- |
+| `icon` | Yes |
+| `inline` | - |
+| `button` | - |
+
+### Inline
+
+Compact form sized to sit alongside short inline text.
+
+<Canvas of={Stories.Inline} sourceState="shown" />
+
+### Button
+
+Full button with a text label. Useful when copy is the primary action.
+
+<Canvas of={Stories.ButtonVariant} sourceState="shown" />
+
+### Custom labels
+
+Override the default `Copy` / `Copied!` strings via `label` and `copiedLabel`.
+
+<Canvas of={Stories.CustomLabels} sourceState="shown" />
+
+## Hook
+
+`useCopyToClipboard` exposes the same clipboard write + transient `copied` flag that powers the component, for cases where the rendered button is not appropriate.
+
+```tsx
+const { copied, copy, reset } = useCopyToClipboard({ timeout: 2000 })
+
+await copy('hello')
+```

--- a/packages/ui/src/components/copy-button/copy-button.stories.tsx
+++ b/packages/ui/src/components/copy-button/copy-button.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { CopyButton } from "./copy-button";
+
+const meta = {
+  args: {
+    value: "EXAMPLE_API_KEY",
+    variant: "icon",
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["icon", "inline", "button"],
+    },
+  },
+  component: CopyButton,
+  title: "Core/CopyButton",
+} satisfies Meta<typeof CopyButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Inline: Story = {
+  args: {
+    value: "usr_42",
+    variant: "inline",
+  },
+  render: (args) => (
+    <span className="inline-flex items-center gap-1 text-sm">
+      User ID: usr_42 <CopyButton {...args} />
+    </span>
+  ),
+};
+
+export const ButtonVariant: Story = {
+  args: {
+    label: "Copy link",
+    value: "https://ui.vllnt.ai",
+    variant: "button",
+  },
+};
+
+export const CustomLabels: Story = {
+  args: {
+    copiedLabel: "Got it!",
+    label: "Copy API key",
+    value: "EXAMPLE_API_KEY",
+    variant: "button",
+  },
+};

--- a/packages/ui/src/components/copy-button/copy-button.test.tsx
+++ b/packages/ui/src/components/copy-button/copy-button.test.tsx
@@ -1,0 +1,145 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CopyButton } from "./copy-button";
+
+type ClipboardLike = {
+  writeText: (value: string) => Promise<void>;
+};
+
+function setClipboard(clipboard: ClipboardLike | undefined): () => void {
+  const original = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: clipboard,
+    writable: true,
+  });
+  return () => {
+    if (original) {
+      Object.defineProperty(navigator, "clipboard", original);
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
+  };
+}
+
+function noop(): void {
+  return;
+}
+
+describe("CopyButton", () => {
+  let restoreClipboard: () => void = noop;
+  const writeText = vi.fn<(value: string) => Promise<void>>();
+
+  beforeEach(() => {
+    writeText.mockReset();
+    writeText.mockResolvedValue();
+    restoreClipboard = setClipboard({ writeText });
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    restoreClipboard();
+    vi.useRealTimers();
+  });
+
+  describe("rendering", () => {
+    it("renders an icon-style button by default", () => {
+      render(<CopyButton value="abc" />);
+
+      const button = screen.getByRole("button", { name: "Copy" });
+      expect(button).toBeInTheDocument();
+    });
+
+    it("renders text in the button variant", () => {
+      render(<CopyButton label="Copy key" value="abc" variant="button" />);
+
+      expect(
+        screen.getByRole("button", { name: "Copy key" }),
+      ).toHaveTextContent("Copy key");
+    });
+
+    it.each(["icon", "inline", "button"] as const)(
+      "supports the %s variant",
+      (variant) => {
+        render(<CopyButton value="abc" variant={variant} />);
+
+        expect(screen.getByRole("button", { name: "Copy" })).toBeVisible();
+      },
+    );
+  });
+
+  describe("clipboard", () => {
+    it("writes the value to the clipboard on click", async () => {
+      render(<CopyButton value="EXAMPLE_API_KEY" />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith("EXAMPLE_API_KEY");
+      });
+    });
+
+    it("flips the accessible label to the copied state after a click", async () => {
+      render(<CopyButton copiedLabel="Done!" value="x" />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+      await screen.findByRole("button", { name: "Done!" });
+    });
+
+    it("resets the copied state after the timeout elapses", async () => {
+      render(<CopyButton timeout={500} value="x" />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+      await screen.findByRole("button", { name: "Copied!" });
+
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Copy" }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("respects preventDefault from a caller's onClick", async () => {
+      const onClick = vi.fn((event: React.MouseEvent<HTMLButtonElement>) => {
+        event.preventDefault();
+      });
+
+      render(<CopyButton onClick={onClick} value="x" />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+      await Promise.resolve();
+      expect(writeText).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("exposes a status live region", () => {
+      render(<CopyButton value="x" />);
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    it("honors a custom aria-label", () => {
+      render(<CopyButton aria-label="Copy API key" value="x" />);
+
+      expect(
+        screen.getByRole("button", { name: "Copy API key" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/copy-button/copy-button.tsx
+++ b/packages/ui/src/components/copy-button/copy-button.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type MouseEvent as ReactMouseEvent,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import { Check, Copy } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Button } from "../button/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../tooltip/tooltip";
+
+const FALLBACK_TIMEOUT_MS = 2000;
+
+/**
+ * Options for {@link useCopyToClipboard}.
+ *
+ * @public
+ */
+export type UseCopyToClipboardOptions = {
+  /** Milliseconds the `copied` flag stays true after a successful copy. */
+  timeout?: number;
+};
+
+/**
+ * Return shape for {@link useCopyToClipboard}.
+ *
+ * @public
+ */
+export type UseCopyToClipboardResult = {
+  /** True for `timeout` ms after the most recent successful copy. */
+  copied: boolean;
+  /** Writes `value` to the clipboard. Resolves to `true` on success. */
+  copy: (value: string) => Promise<boolean>;
+  /** Clears the `copied` flag and pending timer. */
+  reset: () => void;
+};
+
+/**
+ * React hook that copies arbitrary strings to the clipboard with a transient
+ * `copied` flag suitable for visual feedback.
+ *
+ * @example
+ * ```tsx
+ * const { copied, copy } = useCopyToClipboard()
+ * <button onClick={() => copy(apiKey)}>{copied ? "Copied!" : "Copy"}</button>
+ * ```
+ *
+ * @public
+ */
+export function useCopyToClipboard(
+  options: UseCopyToClipboardOptions = {},
+): UseCopyToClipboardResult {
+  const { timeout = FALLBACK_TIMEOUT_MS } = options;
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== undefined) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const reset = useCallback(() => {
+    if (timerRef.current !== undefined) clearTimeout(timerRef.current);
+    setCopied(false);
+  }, []);
+
+  const copy = useCallback(
+    async (value: string): Promise<boolean> => {
+      try {
+        if (
+          typeof navigator === "undefined" ||
+          typeof navigator.clipboard?.writeText !== "function"
+        ) {
+          return false;
+        }
+        await navigator.clipboard.writeText(value);
+        if (timerRef.current !== undefined) clearTimeout(timerRef.current);
+        setCopied(true);
+        timerRef.current = setTimeout(() => {
+          setCopied(false);
+        }, timeout);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [timeout],
+  );
+
+  return { copied, copy, reset };
+}
+
+/**
+ * Visual variant for {@link CopyButton}.
+ *
+ * - `icon`   — compact icon-style button (default), suitable for toolbars.
+ * - `inline` — small button sized to sit next to short inline text.
+ * - `button` — full button with text label, suitable for primary CTAs.
+ *
+ * @public
+ */
+export type CopyButtonVariant = "button" | "icon" | "inline";
+
+type ButtonElementProps = ComponentPropsWithoutRef<"button">;
+
+/**
+ * Props for {@link CopyButton}.
+ *
+ * @public
+ */
+export type CopyButtonProps = {
+  /** Tooltip + announcement text after a successful copy. Defaults to `"Copied!"`. */
+  copiedLabel?: string;
+  /** Class name forwarded to the rendered icon. */
+  iconClassName?: string;
+  /** Tooltip + accessible label before copy. Defaults to `"Copy"`. */
+  label?: string;
+  /** Set to `false` to suppress the tooltip. */
+  showTooltip?: boolean;
+  /** Milliseconds the success state persists. Defaults to 2000. */
+  timeout?: number;
+  /** String to write to the clipboard when clicked. */
+  value: string;
+  /** Visual variant. */
+  variant?: CopyButtonVariant;
+} & Omit<ButtonElementProps, "value">;
+
+function CopyIcon({
+  className,
+  copied,
+  size,
+}: {
+  className?: string;
+  copied: boolean;
+  size: "sm" | "xs";
+}): ReactNode {
+  const Icon = copied ? Check : Copy;
+  const sizeClass = size === "xs" ? "h-3 w-3" : "h-4 w-4";
+  return <Icon aria-hidden="true" className={cn(sizeClass, className)} />;
+}
+
+type TriggerProps = Omit<
+  CopyButtonProps,
+  "copiedLabel" | "showTooltip" | "timeout"
+> & {
+  accessibleLabel: string;
+  copied: boolean;
+  copiedText: string;
+  onClickHandler: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+};
+
+const ButtonTrigger = forwardRef<HTMLButtonElement, TriggerProps>(
+  (
+    {
+      accessibleLabel,
+      className,
+      copied,
+      copiedText,
+      iconClassName,
+      label = "Copy",
+      onClick: _onClick,
+      onClickHandler,
+      value: _value,
+      variant = "icon",
+      ...rest
+    },
+    ref,
+  ) => {
+    if (variant === "button") {
+      return (
+        <Button
+          aria-label={accessibleLabel}
+          className={cn(className)}
+          onClick={onClickHandler}
+          ref={ref}
+          size="sm"
+          type="button"
+          variant="outline"
+          {...rest}
+        >
+          <CopyIcon className={iconClassName} copied={copied} size="sm" />
+          <span>{copied ? copiedText : label}</span>
+        </Button>
+      );
+    }
+
+    if (variant === "inline") {
+      return (
+        <Button
+          aria-label={accessibleLabel}
+          className={cn(
+            "h-6 w-6 align-middle text-muted-foreground hover:text-foreground",
+            className,
+          )}
+          onClick={onClickHandler}
+          ref={ref}
+          size="icon"
+          type="button"
+          variant="ghost"
+          {...rest}
+        >
+          <CopyIcon className={iconClassName} copied={copied} size="xs" />
+        </Button>
+      );
+    }
+
+    return (
+      <Button
+        aria-label={accessibleLabel}
+        className={cn("h-8 w-8", className)}
+        onClick={onClickHandler}
+        ref={ref}
+        size="icon"
+        type="button"
+        variant="ghost"
+        {...rest}
+      >
+        <CopyIcon className={iconClassName} copied={copied} size="sm" />
+      </Button>
+    );
+  },
+);
+ButtonTrigger.displayName = "CopyButton.Trigger";
+
+/**
+ * Click-to-copy button with confirmation feedback.
+ *
+ * Composes {@link Button} and {@link Tooltip}. Copies `value` to the clipboard
+ * via the async Clipboard API and announces success to assistive tech via a
+ * visually hidden status region.
+ *
+ * @example
+ * ```tsx
+ * <CopyButton value={apiKey} />
+ * <CopyButton value={url} variant="button" label="Copy link" />
+ * <span>ID: usr_42 <CopyButton value="usr_42" variant="inline" /></span>
+ * ```
+ *
+ * @public
+ */
+export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
+  (
+    {
+      "aria-label": ariaLabelOverride,
+      copiedLabel = "Copied!",
+      label = "Copy",
+      onClick,
+      showTooltip = true,
+      timeout = FALLBACK_TIMEOUT_MS,
+      value,
+      ...rest
+    },
+    ref,
+  ) => {
+    const { copied, copy } = useCopyToClipboard({ timeout });
+
+    const handleClick = useCallback(
+      (event: ReactMouseEvent<HTMLButtonElement>) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        void copy(value);
+      },
+      [copy, onClick, value],
+    );
+
+    const accessibleLabel = ariaLabelOverride ?? (copied ? copiedLabel : label);
+    const tooltipText = copied ? copiedLabel : label;
+
+    const trigger: ReactElement = (
+      <ButtonTrigger
+        {...rest}
+        accessibleLabel={accessibleLabel}
+        copied={copied}
+        copiedText={copiedLabel}
+        label={label}
+        onClickHandler={handleClick}
+        ref={ref}
+        value={value}
+      />
+    );
+
+    const liveRegion = (
+      <span aria-live="polite" className="sr-only" role="status">
+        {copied ? copiedLabel : ""}
+      </span>
+    );
+
+    if (!showTooltip) {
+      return (
+        <>
+          {trigger}
+          {liveRegion}
+        </>
+      );
+    }
+
+    return (
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+          <TooltipContent>{tooltipText}</TooltipContent>
+        </Tooltip>
+        {liveRegion}
+      </TooltipProvider>
+    );
+  },
+);
+CopyButton.displayName = "CopyButton";

--- a/packages/ui/src/components/copy-button/copy-button.visual.tsx
+++ b/packages/ui/src/components/copy-button/copy-button.visual.tsx
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { CopyButton } from "./copy-button";
+
+test.describe("CopyButton Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(<CopyButton value="EXAMPLE_API_KEY" />);
+    await expect(component).toHaveScreenshot("copy-button-default.png");
+  });
+
+  test("variant-inline", async ({ mount }) => {
+    const component = await mount(
+      <CopyButton value="usr_42" variant="inline" />,
+    );
+    await expect(component).toHaveScreenshot("copy-button-variant-inline.png");
+  });
+
+  test("variant-button", async ({ mount }) => {
+    const component = await mount(
+      <CopyButton label="Copy link" value="https://ui.vllnt.ai" variant="button" />,
+    );
+    await expect(component).toHaveScreenshot("copy-button-variant-button.png");
+  });
+});

--- a/packages/ui/src/components/copy-button/index.ts
+++ b/packages/ui/src/components/copy-button/index.ts
@@ -1,0 +1,8 @@
+export {
+  CopyButton,
+  type CopyButtonProps,
+  type CopyButtonVariant,
+  useCopyToClipboard,
+  type UseCopyToClipboardOptions,
+  type UseCopyToClipboardResult,
+} from "./copy-button";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -517,6 +517,14 @@ export {
 
 // Content components
 export { CodeBlock } from "./code-block";
+export {
+  CopyButton,
+  type CopyButtonProps,
+  type CopyButtonVariant,
+  useCopyToClipboard,
+  type UseCopyToClipboardOptions,
+  type UseCopyToClipboardResult,
+} from "./copy-button";
 export { MDXContent } from "./mdx-content";
 
 // Layout components


### PR DESCRIPTION
## Summary

Click-to-copy utility with confirmation feedback. Composes `Button` + `Tooltip`, exposes `useCopyToClipboard` for callers that need a custom UI.

Three visual variants:

- `icon` (default) — square icon-only button, suitable for toolbars
- `inline` — compact button sized to sit next to short inline text
- `button` — full button with text label

Closes #51

## API

\`\`\`tsx
<CopyButton value="EXAMPLE_API_KEY" />
<CopyButton value={apiKey} label="Copy API Key" variant="button" />
<span>User ID: usr_42 <CopyButton value="usr_42" variant="inline" /></span>

const { copied, copy, reset } = useCopyToClipboard({ timeout: 2000 })
\`\`\`

## Coverage

- Unit: 11 tests covering rendering, all 3 variants, clipboard write, copied-state lifecycle, timeout reset, \`onClick\` \`preventDefault\` short-circuit, and a11y (status live region + custom \`aria-label\`)
- Visual: Playwright CT story per variant
- Storybook: \`Default\`, \`Inline\`, \`ButtonVariant\`, \`CustomLabels\`
- MDX: usage + variants + hook docs

## Registry

Added \`copy-button\` entry to \`apps/registry/registry.json\` with \`registryDependencies: [button, tooltip]\` and \`dependencies: [lucide-react]\`. Re-export shim at \`apps/registry/registry/default/copy-button/copy-button.tsx\` matches existing pattern. Verified \`pnpm build\` regenerates \`/r/copy-button.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean (\`"use client"\` declared, hook usage detected)
- \`pnpm -F @vllnt/ui exec tsx scripts/check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 504/504 (11 new in this PR)
- \`pnpm build\` — green; registry regenerates copy-button.json
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview renders all four stories
- [ ] Registry entry visible at \`/r/copy-button.json\` and \`/components/copy-button\` after deploy