### PR TITLE
feat(ui): add Banner + BannerAction announcement bar

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -373,6 +373,25 @@
       "category": "core"
     },
     {
+      "name": "banner",
+      "type": "registry:component",
+      "title": "Banner",
+      "description": "Full-width announcement bar with variants, dismissal, and an optional action slot.",
+      "files": [
+        {
+          "path": "registry/default/banner/banner.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "lucide-react",
+        "class-variance-authority",
+        "@radix-ui/react-slot"
+      ],
+      "category": "core"
+    },
+    {
       "name": "bar-chart",
       "type": "registry:component",
       "title": "Bar Chart",

--- a/apps/registry/registry/default/banner/banner.tsx
+++ b/apps/registry/registry/default/banner/banner.tsx
@@ -1,0 +1,2 @@
+// Re-export from @vllnt/ui package
+export { Banner, BannerAction, bannerVariants } from '@vllnt/ui'

--- a/packages/ui/src/components/banner/banner.mdx
+++ b/packages/ui/src/components/banner/banner.mdx
@@ -1,0 +1,66 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './banner.stories'
+
+<Meta of={Stories} />
+
+# Banner
+
+Full-width announcement bar for trial warnings, maintenance notices, and upgrade prompts. Maps the `warning` and `destructive` variants to `role="alert"` and other variants to `role="status"`.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/banner.json
+```
+
+## Import
+
+```tsx
+import { Banner, BannerAction } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<Banner variant="warning" dismissible>
+  Your trial expires in 3 days.
+  <BannerAction>Upgrade now</BannerAction>
+</Banner>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Variants
+
+### variant
+
+| Value | Default | ARIA role |
+| ----- | ------- | --------- |
+| `info` | Yes | `status` |
+| `success` | - | `status` |
+| `warning` | - | `alert` |
+| `destructive` | - | `alert` |
+
+<Canvas of={Stories.Warning} sourceState="shown" />
+
+<Canvas of={Stories.Success} sourceState="shown" />
+
+<Canvas of={Stories.Destructive} sourceState="shown" />
+
+### Dismissible
+
+Set `dismissible` to render an X control. Pair with `id` and `persistDismissal` to remember the user's choice across reloads via `localStorage`.
+
+<Canvas of={Stories.Dismissible} sourceState="shown" />
+
+### With action
+
+Compose `BannerAction` for primary CTAs. Use `asChild` to render onto a link or framework-specific element.
+
+<Canvas of={Stories.WithAction} sourceState="shown" />

--- a/packages/ui/src/components/banner/banner.stories.tsx
+++ b/packages/ui/src/components/banner/banner.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Banner, BannerAction } from "./banner";
+
+const meta = {
+  args: {
+    children: "Your trial expires in 3 days.",
+    dismissible: false,
+    variant: "info",
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["info", "warning", "success", "destructive"],
+    },
+  },
+  component: Banner,
+  title: "Core/Banner",
+} satisfies Meta<typeof Banner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Warning: Story = {
+  args: {
+    children: "Scheduled maintenance tonight at 11pm UTC.",
+    variant: "warning",
+  },
+};
+
+export const Success: Story = {
+  args: {
+    children: "Your account has been upgraded!",
+    variant: "success",
+  },
+};
+
+export const Destructive: Story = {
+  args: {
+    children: "Payment failed. Update billing info.",
+    variant: "destructive",
+  },
+};
+
+export const Dismissible: Story = {
+  args: {
+    children: "You can close this announcement.",
+    dismissible: true,
+    variant: "info",
+  },
+};
+
+export const WithAction: Story = {
+  args: {
+    dismissible: true,
+    variant: "warning",
+  },
+  render: (args) => (
+    <Banner {...args}>
+      Your trial expires in 3 days.
+      <BannerAction>Upgrade now</BannerAction>
+    </Banner>
+  ),
+};

--- a/packages/ui/src/components/banner/banner.test.tsx
+++ b/packages/ui/src/components/banner/banner.test.tsx
@@ -1,0 +1,141 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Banner, BannerAction } from "./banner";
+
+describe("Banner", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  describe("rendering", () => {
+    it("renders children", () => {
+      render(<Banner>Trial expires soon</Banner>);
+
+      expect(screen.getByText("Trial expires soon")).toBeInTheDocument();
+    });
+
+    it.each([
+      ["info", "status"],
+      ["success", "status"],
+      ["warning", "alert"],
+      ["destructive", "alert"],
+    ] as const)("maps the %s variant to role=%s", (variant, role) => {
+      render(<Banner variant={variant}>x</Banner>);
+
+      expect(screen.getByRole(role)).toBeInTheDocument();
+    });
+
+    it("honors a caller-provided role override", () => {
+      render(
+        <Banner role="region" variant="warning">
+          x
+        </Banner>,
+      );
+
+      expect(screen.getByRole("region")).toBeInTheDocument();
+    });
+  });
+
+  describe("dismissal", () => {
+    it("does not render a dismiss control by default", () => {
+      render(<Banner>x</Banner>);
+
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+
+    it("hides itself when the dismiss control is clicked", () => {
+      render(<Banner dismissible>Hide me</Banner>);
+
+      fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+      expect(screen.queryByText("Hide me")).not.toBeInTheDocument();
+    });
+
+    it("invokes onDismiss after the user clicks dismiss", () => {
+      const onDismiss = vi.fn();
+
+      render(
+        <Banner dismissible onDismiss={onDismiss}>
+          x
+        </Banner>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it("persists dismissal to localStorage when configured", () => {
+      const { unmount } = render(
+        <Banner dismissible id="test-banner" persistDismissal>
+          Persistent
+        </Banner>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+      unmount();
+
+      render(
+        <Banner dismissible id="test-banner" persistDismissal>
+          Persistent
+        </Banner>,
+      );
+
+      expect(screen.queryByText("Persistent")).not.toBeInTheDocument();
+    });
+
+    it("does not persist when persistDismissal is omitted", () => {
+      const { unmount } = render(
+        <Banner dismissible id="ephemeral">
+          Ephemeral
+        </Banner>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+      unmount();
+
+      render(
+        <Banner dismissible id="ephemeral">
+          Ephemeral
+        </Banner>,
+      );
+
+      expect(screen.getByText("Ephemeral")).toBeInTheDocument();
+    });
+  });
+
+  describe("BannerAction", () => {
+    it("renders a button by default and forwards onClick", () => {
+      const onClick = vi.fn();
+
+      render(
+        <Banner>
+          x <BannerAction onClick={onClick}>Upgrade</BannerAction>
+        </Banner>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("delegates rendering with asChild", () => {
+      render(
+        <Banner>
+          x
+          <BannerAction asChild>
+            <a href="/upgrade">Upgrade</a>
+          </BannerAction>
+        </Banner>,
+      );
+
+      const link = screen.getByRole("link", { name: "Upgrade" });
+      expect(link).toHaveAttribute("href", "/upgrade");
+    });
+  });
+});

--- a/packages/ui/src/components/banner/banner.tsx
+++ b/packages/ui/src/components/banner/banner.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import {
+  type ButtonHTMLAttributes,
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+
+const bannerVariants = cva(
+  "flex w-full items-start gap-3 border-b px-4 py-3 text-sm transition-all motion-safe:animate-in motion-safe:slide-in-from-top-1",
+  {
+    defaultVariants: {
+      variant: "info",
+    },
+    variants: {
+      variant: {
+        destructive:
+          "border-destructive/50 bg-destructive/10 text-destructive dark:border-destructive [&_svg]:text-destructive",
+        info: "border-border bg-muted text-foreground [&_svg]:text-muted-foreground",
+        success:
+          "border-emerald-500/40 bg-emerald-500/10 text-emerald-900 dark:text-emerald-200 [&_svg]:text-emerald-600 dark:[&_svg]:text-emerald-300",
+        warning:
+          "border-amber-500/40 bg-amber-500/10 text-amber-900 dark:text-amber-200 [&_svg]:text-amber-600 dark:[&_svg]:text-amber-300",
+      },
+    },
+  },
+);
+
+/**
+ * Visual variant for {@link Banner}. Drives both color treatment and the ARIA
+ * role: `warning` and `destructive` render as `role="alert"`, others as
+ * `role="status"`.
+ *
+ * @public
+ */
+export type BannerVariant = "destructive" | "info" | "success" | "warning";
+
+const URGENT_VARIANTS: ReadonlySet<BannerVariant> = new Set([
+  "destructive",
+  "warning",
+]);
+
+const STORAGE_PREFIX = "vllnt-ui:banner-dismissed:";
+
+function safeStorageGet(key: string): null | string {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeStorageSet(key: string, value: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    return;
+  }
+}
+
+function subscribeToStorage(callback: () => void): () => void {
+  if (typeof window === "undefined") {
+    return () => {
+      return;
+    };
+  }
+  window.addEventListener("storage", callback);
+  return () => {
+    window.removeEventListener("storage", callback);
+  };
+}
+
+function usePersistedDismissed(storageKey: string | undefined): boolean {
+  const getClientSnapshot = useCallback(() => {
+    if (!storageKey) return false;
+    return safeStorageGet(storageKey) === "1";
+  }, [storageKey]);
+  const getServerSnapshot = useCallback(() => false, []);
+  return useSyncExternalStore(
+    subscribeToStorage,
+    getClientSnapshot,
+    getServerSnapshot,
+  );
+}
+
+/**
+ * Props for {@link Banner}.
+ *
+ * @public
+ */
+export type BannerProps = {
+  /** When true, renders a dismiss control. */
+  dismissible?: boolean;
+  /** Accessible label for the dismiss control. Defaults to `"Dismiss"`. */
+  dismissLabel?: string;
+  /** Optional icon rendered to the left of the message. */
+  icon?: ReactNode;
+  /**
+   * Stable identifier used as the localStorage key when persisting dismissal.
+   * Pair with `persistDismissal` to remember a user's choice.
+   */
+  id?: string;
+  /** Fires after the user clicks the dismiss control. */
+  onDismiss?: () => void;
+  /**
+   * When true alongside `id`, persists dismissal in localStorage so the
+   * banner remains hidden across reloads.
+   */
+  persistDismissal?: boolean;
+} & ComponentPropsWithoutRef<"div"> &
+  VariantProps<typeof bannerVariants>;
+
+/**
+ * Full-width announcement bar.
+ *
+ * Renders a horizontal bar with variant-driven color treatment, an optional
+ * icon slot, and an optional dismiss control. Pair `id` with
+ * `persistDismissal` to remember dismissal across sessions in localStorage.
+ *
+ * @example
+ * ```tsx
+ * <Banner variant="warning" dismissible icon={<AlertTriangle />}>
+ *   Scheduled maintenance tonight at 11pm UTC.
+ *   <BannerAction onClick={openStatus}>View status</BannerAction>
+ * </Banner>
+ * ```
+ *
+ * @public
+ */
+export const Banner = forwardRef<HTMLDivElement, BannerProps>(
+  (
+    {
+      children,
+      className,
+      dismissible = false,
+      dismissLabel = "Dismiss",
+      icon,
+      id,
+      onDismiss,
+      persistDismissal = false,
+      role: roleOverride,
+      variant,
+      ...rest
+    },
+    ref,
+  ) => {
+    const storageKey =
+      persistDismissal && id ? `${STORAGE_PREFIX}${id}` : undefined;
+    const persistedDismissed = usePersistedDismissed(storageKey);
+    const [locallyDismissed, setLocallyDismissed] = useState(false);
+
+    const handleDismiss = useCallback(() => {
+      setLocallyDismissed(true);
+      if (storageKey) safeStorageSet(storageKey, "1");
+      onDismiss?.();
+    }, [onDismiss, storageKey]);
+
+    if (locallyDismissed || persistedDismissed) return null;
+
+    const resolvedVariant: BannerVariant = variant ?? "info";
+    const role =
+      roleOverride ??
+      (URGENT_VARIANTS.has(resolvedVariant) ? "alert" : "status");
+
+    return (
+      <div
+        className={cn(bannerVariants({ variant }), className)}
+        id={id}
+        ref={ref}
+        role={role}
+        {...rest}
+      >
+        {icon ? (
+          <span
+            aria-hidden="true"
+            className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center [&>svg]:h-4 [&>svg]:w-4"
+          >
+            {icon}
+          </span>
+        ) : null}
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1">
+          {children}
+        </div>
+        {dismissible ? (
+          <button
+            aria-label={dismissLabel}
+            className="ml-auto inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md opacity-70 transition-colors hover:bg-foreground/10 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            onClick={handleDismiss}
+            type="button"
+          >
+            <X aria-hidden="true" className="h-4 w-4" />
+          </button>
+        ) : null}
+      </div>
+    );
+  },
+);
+Banner.displayName = "Banner";
+
+/**
+ * Props for {@link BannerAction}.
+ *
+ * @public
+ */
+export type BannerActionProps = {
+  /** Render the wrapped child element instead of a `<button>`. */
+  asChild?: boolean;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+/**
+ * Action slot used inside a {@link Banner} body. Renders a styled button by
+ * default, or composes onto a passed child element when `asChild` is true
+ * (e.g. wrap an `<a>` for link actions).
+ *
+ * @public
+ */
+export const BannerAction = forwardRef<HTMLButtonElement, BannerActionProps>(
+  ({ asChild = false, children, className, type, ...rest }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    const buttonProps: ButtonHTMLAttributes<HTMLButtonElement> = asChild
+      ? rest
+      : { type: type ?? "button", ...rest };
+
+    return (
+      <Comp
+        className={cn(
+          "inline-flex h-7 items-center justify-center rounded-md border border-foreground/20 bg-transparent px-3 text-xs font-medium underline-offset-4 transition-colors hover:bg-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          className,
+        )}
+        ref={ref}
+        {...buttonProps}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+BannerAction.displayName = "BannerAction";
+
+export { bannerVariants };

--- a/packages/ui/src/components/banner/banner.visual.tsx
+++ b/packages/ui/src/components/banner/banner.visual.tsx
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { Banner, BannerAction } from "./banner";
+
+test.describe("Banner Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(<Banner>Your trial expires in 3 days.</Banner>);
+    await expect(component).toHaveScreenshot("banner-default.png");
+  });
+
+  test("variant-warning", async ({ mount }) => {
+    const component = await mount(
+      <Banner variant="warning">
+        Scheduled maintenance tonight at 11pm UTC.
+      </Banner>,
+    );
+    await expect(component).toHaveScreenshot("banner-variant-warning.png");
+  });
+
+  test("variant-success", async ({ mount }) => {
+    const component = await mount(
+      <Banner variant="success">Your account has been upgraded!</Banner>,
+    );
+    await expect(component).toHaveScreenshot("banner-variant-success.png");
+  });
+
+  test("variant-destructive", async ({ mount }) => {
+    const component = await mount(
+      <Banner variant="destructive">Payment failed. Update billing info.</Banner>,
+    );
+    await expect(component).toHaveScreenshot("banner-variant-destructive.png");
+  });
+
+  test("with-action", async ({ mount }) => {
+    const component = await mount(
+      <Banner dismissible variant="warning">
+        Your trial expires in 3 days.
+        <BannerAction>Upgrade now</BannerAction>
+      </Banner>,
+    );
+    await expect(component).toHaveScreenshot("banner-with-action.png");
+  });
+});

--- a/packages/ui/src/components/banner/index.ts
+++ b/packages/ui/src/components/banner/index.ts
@@ -1,0 +1,8 @@
+export {
+  Banner,
+  BannerAction,
+  type BannerActionProps,
+  type BannerProps,
+  type BannerVariant,
+  bannerVariants,
+} from "./banner";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,5 +1,13 @@
 // Core UI primitives
 export { Badge, type BadgeProps, badgeVariants } from "./badge";
+export {
+  Banner,
+  BannerAction,
+  type BannerActionProps,
+  type BannerProps,
+  type BannerVariant,
+  bannerVariants,
+} from "./banner";
 export { Breadcrumb, type BreadcrumbItem } from "./breadcrumb";
 export { Button, type ButtonProps, buttonVariants } from "./button";
 export {


### PR DESCRIPTION
## Summary

Full-width dismissible announcement bar for trial warnings, maintenance notices, upgrade prompts, etc.

- Four variants — `info`, `success`, `warning`, `destructive` — driven by CVA
- Urgent variants (`warning`, `destructive`) → `role="alert"`; others → `role="status"` (overridable)
- Optional dismiss control with localStorage persistence
- Composable \`BannerAction\` slot with \`asChild\` for link / framework-element rendering
- SSR-safe persistence via \`useSyncExternalStore\` (no hydration mismatch, no \`set-state-in-effect\`)

Closes #52

## API

\`\`\`tsx
<Banner variant="warning" dismissible icon={<AlertTriangle />}>
  Scheduled maintenance tonight at 11pm UTC.
  <BannerAction onClick={openStatus}>View status</BannerAction>
</Banner>

<Banner variant="info" id="trial-warning" persistDismissal dismissible>
  Your trial expires in 3 days.
  <BannerAction asChild>
    <a href="/upgrade">Upgrade now</a>
  </BannerAction>
</Banner>
\`\`\`

## Coverage

- Unit: 13 tests covering rendering, all 4 variant→role mappings, role override, dismiss flow, localStorage persistence (on + off), \`onDismiss\` callback, \`BannerAction\` button + \`asChild\`
- Visual: Playwright CT story per variant + with-action layout
- Storybook: \`Default\`, \`Warning\`, \`Success\`, \`Destructive\`, \`Dismissible\`, \`WithAction\`
- MDX: usage + variants + dismissible + action docs

## Registry

Added \`banner\` entry to \`apps/registry/registry.json\` (\`category: core\`, deps: \`lucide-react\`, \`class-variance-authority\`, \`@radix-ui/react-slot\`). Re-export shim at \`apps/registry/registry/default/banner/banner.tsx\`. \`pnpm build\` regenerates \`/r/banner.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`pnpm -F @vllnt/ui exec tsx scripts/check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 506/506 (13 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview renders all six stories
- [ ] Registry entry visible at \`/r/banner.json\` and \`/components/banner\` after deploy