### PR TITLE
feat(ui): add Kbd keyboard key indicator

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1445,6 +1445,23 @@
       "category": "navigation"
     },
     {
+      "name": "kbd",
+      "type": "registry:component",
+      "title": "Kbd",
+      "description": "Keyboard key indicator with platform-aware modifier expansion via the shortcut prop.",
+      "files": [
+        {
+          "path": "registry/default/kbd/kbd.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "class-variance-authority"
+      ],
+      "category": "core"
+    },
+    {
       "name": "key-concept",
       "type": "registry:component",
       "title": "Key Concept",

--- a/apps/registry/registry/default/kbd/kbd.tsx
+++ b/apps/registry/registry/default/kbd/kbd.tsx
@@ -1,0 +1,2 @@
+// Re-export from @vllnt/ui package
+export { Kbd, kbdVariants } from '@vllnt/ui'

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -58,6 +58,7 @@ export {
   DropdownMenuTrigger,
 } from "./dropdown-menu";
 export { Input } from "./input";
+export { Kbd, type KbdProps, kbdVariants } from "./kbd";
 export { Checkbox } from "./checkbox";
 export { FileUpload, type FileUploadProps } from "./file-upload";
 export { Label } from "./label";

--- a/packages/ui/src/components/kbd/index.ts
+++ b/packages/ui/src/components/kbd/index.ts
@@ -1,0 +1,1 @@
+export { Kbd, type KbdProps, kbdVariants } from "./kbd";

--- a/packages/ui/src/components/kbd/kbd.mdx
+++ b/packages/ui/src/components/kbd/kbd.mdx
@@ -1,0 +1,79 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './kbd.stories'
+
+<Meta of={Stories} />
+
+# Kbd
+
+Keyboard key indicator for displaying shortcuts. Pass a single child for one key, or use the `shortcut` prop with a `+`-delimited string for platform-aware multi-key combos.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/kbd.json
+```
+
+## Import
+
+```tsx
+import { Kbd } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<Kbd>K</Kbd>
+
+{/* Composed manually */}
+Press <Kbd>Ctrl</Kbd> + <Kbd>K</Kbd>
+
+{/* Auto-expanded via the shortcut prop */}
+<Kbd shortcut="mod+k" />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Sizes
+
+| Value | Default |
+| ----- | ------- |
+| `sm` | - |
+| `md` | Yes |
+| `lg` | - |
+
+<Canvas of={Stories.SizeSm} sourceState="shown" />
+
+<Canvas of={Stories.SizeLg} sourceState="shown" />
+
+## Shortcut prop
+
+The `shortcut` prop expands a `+`-delimited token list. Special tokens:
+
+| Token | Mac | Other |
+| ----- | --- | ----- |
+| `mod` | `⌘` | `Ctrl` |
+| `meta` | `⌘` | `Win` |
+| `ctrl` | `⌃` | `Ctrl` |
+| `alt` | `⌥` | `Alt` |
+| `shift` | `⇧` | `Shift` |
+| `enter` / `return` | `↵` | `↵` |
+| `escape` | `Esc` | `Esc` |
+| `tab` | `⇥` | `⇥` |
+| `space` | `Space` | `Space` |
+| `backspace` | `⌫` | `⌫` |
+| `delete` | `⌦` | `⌦` |
+| `arrowup` / `arrowdown` / `arrowleft` / `arrowright` | `↑` / `↓` / `←` / `→` | same |
+
+<Canvas of={Stories.Shortcut} sourceState="shown" />
+
+<Canvas of={Stories.ModShortcut} sourceState="shown" />
+
+## Composed
+
+<Canvas of={Stories.Composed} sourceState="shown" />

--- a/packages/ui/src/components/kbd/kbd.stories.tsx
+++ b/packages/ui/src/components/kbd/kbd.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Kbd } from "./kbd";
+
+const meta = {
+  args: {
+    children: "K",
+    size: "md",
+  },
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["sm", "md", "lg"],
+    },
+  },
+  component: Kbd,
+  title: "Core/Kbd",
+} satisfies Meta<typeof Kbd>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const SizeSm: Story = {
+  args: {
+    size: "sm",
+  },
+};
+
+export const SizeLg: Story = {
+  args: {
+    size: "lg",
+  },
+};
+
+export const Shortcut: Story = {
+  args: {
+    shortcut: "ctrl+k",
+  },
+};
+
+export const ModShortcut: Story = {
+  args: {
+    shortcut: "mod+shift+p",
+  },
+};
+
+export const Composed: Story = {
+  render: (args) => (
+    <span className="inline-flex items-center gap-1 text-sm">
+      Press <Kbd {...args}>Ctrl</Kbd> + <Kbd {...args}>K</Kbd> to open the
+      command palette.
+    </span>
+  ),
+};

--- a/packages/ui/src/components/kbd/kbd.test.tsx
+++ b/packages/ui/src/components/kbd/kbd.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Kbd } from "./kbd";
+
+function stubUserAgent(userAgent: string): () => void {
+  const original = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    value: userAgent,
+    writable: true,
+  });
+  return () => {
+    if (original) {
+      Object.defineProperty(navigator, "userAgent", original);
+    } else {
+      Reflect.deleteProperty(navigator, "userAgent");
+    }
+  };
+}
+
+const MAC_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0";
+const WIN_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0";
+
+function noopRestore(): void {
+  return;
+}
+
+describe("Kbd", () => {
+  let restore: () => void = noopRestore;
+
+  afterEach(() => {
+    restore();
+    vi.restoreAllMocks();
+  });
+
+  describe("children mode", () => {
+    it("renders children inside a kbd element", () => {
+      restore = stubUserAgent(WIN_UA);
+      render(<Kbd>K</Kbd>);
+
+      const element = screen.getByText("K");
+      expect(element.tagName).toBe("KBD");
+    });
+
+    it.each(["sm", "md", "lg"] as const)("supports %s size", (size) => {
+      restore = stubUserAgent(WIN_UA);
+      render(<Kbd size={size}>X</Kbd>);
+
+      expect(screen.getByText("X")).toBeInTheDocument();
+    });
+  });
+
+  describe("shortcut mode", () => {
+    it("renders one kbd per token", () => {
+      restore = stubUserAgent(WIN_UA);
+      render(<Kbd shortcut="ctrl+k" />);
+
+      expect(screen.getByText("Ctrl")).toBeInTheDocument();
+      expect(screen.getByText("K")).toBeInTheDocument();
+    });
+
+    it("expands `mod` to ⌘ on Mac", () => {
+      restore = stubUserAgent(MAC_UA);
+      render(<Kbd shortcut="mod+k" />);
+
+      expect(screen.getByText("⌘")).toBeInTheDocument();
+      expect(screen.getByText("K")).toBeInTheDocument();
+    });
+
+    it("expands `mod` to Ctrl on non-Mac", () => {
+      restore = stubUserAgent(WIN_UA);
+      render(<Kbd shortcut="mod+shift+p" />);
+
+      expect(screen.getByText("Ctrl")).toBeInTheDocument();
+      expect(screen.getByText("Shift")).toBeInTheDocument();
+      expect(screen.getByText("P")).toBeInTheDocument();
+    });
+
+    it("renders glyphs for special keys", () => {
+      restore = stubUserAgent(MAC_UA);
+      render(<Kbd shortcut="enter" />);
+
+      expect(screen.getByText("↵")).toBeInTheDocument();
+    });
+
+    it("emits an aria-label for the wrapper", () => {
+      restore = stubUserAgent(WIN_UA);
+      render(<Kbd shortcut="ctrl+k" />);
+
+      expect(screen.getByLabelText("Ctrl + K")).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("renders as a kbd element by default", () => {
+      restore = stubUserAgent(WIN_UA);
+      const { container } = render(<Kbd>X</Kbd>);
+
+      expect(container.querySelector("kbd")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/kbd/kbd.tsx
+++ b/packages/ui/src/components/kbd/kbd.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useSyncExternalStore,
+} from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../../lib/utils";
+
+const kbdVariants = cva(
+  "inline-flex select-none items-center justify-center rounded border border-border bg-muted font-mono font-medium text-foreground shadow-[0_1px_0_0_hsl(var(--border))] [&>svg]:h-3 [&>svg]:w-3",
+  {
+    defaultVariants: {
+      size: "md",
+    },
+    variants: {
+      size: {
+        lg: "h-7 min-w-[1.75rem] px-2 text-sm",
+        md: "h-5 min-w-[1.25rem] px-1.5 text-xs",
+        sm: "h-4 min-w-[1rem] px-1 text-[10px]",
+      },
+    },
+  },
+);
+
+const MAC_PLATFORM_PATTERN = /mac|iphone|ipad|ipod/i;
+
+const MODIFIER_LABELS: Record<
+  "alt" | "ctrl" | "meta" | "mod" | "shift",
+  { mac: string; other: string }
+> = {
+  alt: { mac: "⌥", other: "Alt" },
+  ctrl: { mac: "⌃", other: "Ctrl" },
+  meta: { mac: "⌘", other: "Win" },
+  mod: { mac: "⌘", other: "Ctrl" },
+  shift: { mac: "⇧", other: "Shift" },
+};
+
+const SPECIAL_KEY_LABELS: Record<string, string> = {
+  arrowdown: "↓",
+  arrowleft: "←",
+  arrowright: "→",
+  arrowup: "↑",
+  backspace: "⌫",
+  delete: "⌦",
+  enter: "↵",
+  escape: "Esc",
+  return: "↵",
+  space: "Space",
+  tab: "⇥",
+};
+
+const SHORTCUT_SEPARATOR = /\s*\+\s*/;
+
+function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return MAC_PLATFORM_PATTERN.test(navigator.userAgent);
+}
+
+function noopUnsubscribe(): void {
+  return;
+}
+
+function subscribeNoop(): () => void {
+  return noopUnsubscribe;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+function useIsMac(): boolean {
+  return useSyncExternalStore(subscribeNoop, isMacPlatform, getServerSnapshot);
+}
+
+function isModifier(value: string): value is keyof typeof MODIFIER_LABELS {
+  return Object.hasOwn(MODIFIER_LABELS, value);
+}
+
+function formatToken(token: string, mac: boolean): string {
+  const lowered = token.toLowerCase();
+  if (isModifier(lowered)) {
+    const labels = MODIFIER_LABELS[lowered];
+    return mac ? labels.mac : labels.other;
+  }
+  const special = SPECIAL_KEY_LABELS[lowered];
+  if (special !== undefined) return special;
+  return token.length === 1 ? token.toUpperCase() : token;
+}
+
+/**
+ * Props for {@link Kbd}.
+ *
+ * @public
+ */
+export type KbdProps = {
+  /** Optional explicit children. Takes precedence over `shortcut`. */
+  children?: ReactNode;
+  /**
+   * Shortcut string in the form `"mod+k"` or `"ctrl+shift+p"`. The `mod`
+   * token expands to `⌘` on Mac and `Ctrl` elsewhere.
+   */
+  shortcut?: string;
+} & ComponentPropsWithoutRef<"kbd"> &
+  VariantProps<typeof kbdVariants>;
+
+/**
+ * Keyboard key indicator. Renders a single key when used with `children`,
+ * or expands a shortcut string with platform-aware modifiers when given a
+ * `shortcut` prop.
+ *
+ * @example
+ * ```tsx
+ * <Kbd>Ctrl</Kbd> + <Kbd>K</Kbd>
+ *
+ * {/* Renders ⌘+K on Mac, Ctrl+K elsewhere *\/}
+ * <Kbd shortcut="mod+k" />
+ * ```
+ *
+ * @public
+ */
+export const Kbd = forwardRef<HTMLElement, KbdProps>(
+  ({ children, className, shortcut, size, ...rest }, ref) => {
+    const isMac = useIsMac();
+
+    if (children !== undefined) {
+      return (
+        <kbd
+          className={cn(kbdVariants({ size }), className)}
+          ref={ref}
+          {...rest}
+        >
+          {children}
+        </kbd>
+      );
+    }
+
+    if (shortcut) {
+      const tokens = shortcut.split(SHORTCUT_SEPARATOR).filter(Boolean);
+      const ariaLabel = tokens
+        .map((token) => formatToken(token, isMac))
+        .join(" + ");
+      return (
+        <span aria-label={ariaLabel} className="inline-flex items-center gap-1">
+          {tokens.map((token, index) => (
+            <kbd
+              className={cn(kbdVariants({ size }), className)}
+              key={`${token}-${index.toString()}`}
+              ref={index === 0 ? ref : undefined}
+              {...(index === 0 ? rest : {})}
+            >
+              {formatToken(token, isMac)}
+            </kbd>
+          ))}
+        </span>
+      );
+    }
+
+    return (
+      <kbd
+        className={cn(kbdVariants({ size }), className)}
+        ref={ref}
+        {...rest}
+      />
+    );
+  },
+);
+Kbd.displayName = "Kbd";
+
+export { kbdVariants };

--- a/packages/ui/src/components/kbd/kbd.visual.tsx
+++ b/packages/ui/src/components/kbd/kbd.visual.tsx
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { Kbd } from "./kbd";
+
+test.describe("Kbd Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(<Kbd>K</Kbd>);
+    await expect(component).toHaveScreenshot("kbd-default.png");
+  });
+
+  test("size-sm", async ({ mount }) => {
+    const component = await mount(<Kbd size="sm">K</Kbd>);
+    await expect(component).toHaveScreenshot("kbd-size-sm.png");
+  });
+
+  test("size-lg", async ({ mount }) => {
+    const component = await mount(<Kbd size="lg">K</Kbd>);
+    await expect(component).toHaveScreenshot("kbd-size-lg.png");
+  });
+
+  test("shortcut", async ({ mount }) => {
+    const component = await mount(<Kbd shortcut="ctrl+k" />);
+    await expect(component).toHaveScreenshot("kbd-shortcut.png");
+  });
+});


### PR DESCRIPTION
## Summary

Keyboard key indicator with three sizes and a platform-aware shortcut expander.

- Sizes — `sm`, `md` (default), `lg`
- \`children\` for single-key usage; \`shortcut="mod+k"\` for auto-expanded combos
- \`mod\` → `⌘` on Mac, `Ctrl` elsewhere; glyphs for `enter`, `escape`, `tab`, arrows, `backspace`, `delete`, `space`
- SSR-safe via \`useSyncExternalStore\` over \`navigator.userAgent\` (\`navigator.platform\` is deprecated)
- Multi-key wrapper exposes a single \`aria-label\` with the rendered combo

Closes #37

## API

\`\`\`tsx
<Kbd>K</Kbd>

Press <Kbd>Ctrl</Kbd> + <Kbd>K</Kbd>

{/* Auto: ⌘+K on Mac, Ctrl+K elsewhere */}
<Kbd shortcut="mod+k" />

<Kbd shortcut="mod+shift+p" size="lg" />
\`\`\`

## Coverage

- Unit: 10 tests covering children mode, all 3 sizes, shortcut tokens, Mac/non-Mac \`mod\` expansion, special key glyphs, aria-label, semantic \`<kbd>\` element
- Visual: Playwright CT story for default + each size + shortcut
- Storybook: \`Default\`, \`SizeSm\`, \`SizeLg\`, \`Shortcut\`, \`ModShortcut\`, \`Composed\`
- MDX: usage + sizes + full shortcut token table

## Registry

Added \`kbd\` entry to \`apps/registry/registry.json\` (\`category: core\`, deps: \`class-variance-authority\`). Re-export shim at \`apps/registry/registry/default/kbd/kbd.tsx\`. \`pnpm build\` regenerates \`/r/kbd.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`pnpm -F @vllnt/ui exec tsx scripts/check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 503/503 (10 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview renders all six stories with correct platform-specific glyphs
- [ ] Registry entry visible at \`/r/kbd.json\` and \`/components/kbd\` after deploy