### PR TITLE
feat(ui): add EmptyState placeholder

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -996,6 +996,23 @@
       "category": "overlay"
     },
     {
+      "name": "empty-state",
+      "type": "registry:component",
+      "title": "Empty State",
+      "description": "Centered placeholder for empty lists, tables, and search results with sm/md/lg sizes.",
+      "files": [
+        {
+          "path": "registry/default/empty-state/empty-state.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "class-variance-authority"
+      ],
+      "category": "core"
+    },
+    {
       "name": "era-comparison",
       "type": "registry:component",
       "title": "Era Comparison",

--- a/apps/registry/registry/default/empty-state/empty-state.tsx
+++ b/apps/registry/registry/default/empty-state/empty-state.tsx
@@ -1,0 +1,2 @@
+// Re-export from @vllnt/ui package
+export { EmptyState, emptyStateVariants } from '@vllnt/ui'

--- a/packages/ui/src/components/empty-state/empty-state.mdx
+++ b/packages/ui/src/components/empty-state/empty-state.mdx
@@ -1,0 +1,56 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './empty-state.stories'
+
+<Meta of={Stories} />
+
+# EmptyState
+
+Placeholder for empty lists, tables, and search results. Composes a centered icon, title, description, and an action slot. Announces itself via `role="status"` so assistive tech can pick up state changes when filters clear results.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/empty-state.json
+```
+
+## Import
+
+```tsx
+import { EmptyState } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<EmptyState
+  icon={<InboxIcon />}
+  title="No results found"
+  description="Try adjusting your search or filters."
+>
+  <Button variant="outline" onClick={clearFilters}>Clear filters</Button>
+</EmptyState>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Sizes
+
+| Value | Default | Use case |
+| ----- | ------- | -------- |
+| `sm` | - | Inline placeholders inside cards or compact lists |
+| `md` | Yes | Section-level placeholders |
+| `lg` | - | Full-page placeholders, onboarding screens |
+
+<Canvas of={Stories.SizeSm} sourceState="shown" />
+
+<Canvas of={Stories.SizeLg} sourceState="shown" />
+
+## With action
+
+<Canvas of={Stories.WithAction} sourceState="shown" />

--- a/packages/ui/src/components/empty-state/empty-state.stories.tsx
+++ b/packages/ui/src/components/empty-state/empty-state.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { EmptyState } from "./empty-state";
+
+const meta = {
+  args: {
+    description: "Try adjusting your search or filters.",
+    size: "md",
+    title: "No results found",
+  },
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["sm", "md", "lg"],
+    },
+  },
+  component: EmptyState,
+  title: "Core/EmptyState",
+} satisfies Meta<typeof EmptyState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const SizeSm: Story = {
+  args: {
+    description: "Inline placeholder.",
+    size: "sm",
+    title: "Empty",
+  },
+};
+
+export const SizeLg: Story = {
+  args: {
+    description:
+      "There is nothing here yet. Get started by creating your first item.",
+    size: "lg",
+    title: "Welcome",
+  },
+};
+
+export const WithAction: Story = {
+  render: (args) => (
+    <EmptyState {...args}>
+      <button
+        className="inline-flex h-9 items-center justify-center rounded-md border border-input bg-background px-3 text-sm font-medium hover:bg-accent"
+        type="button"
+      >
+        Clear filters
+      </button>
+    </EmptyState>
+  ),
+};

--- a/packages/ui/src/components/empty-state/empty-state.test.tsx
+++ b/packages/ui/src/components/empty-state/empty-state.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { EmptyState } from "./empty-state";
+
+describe("EmptyState", () => {
+  describe("rendering", () => {
+    it("renders title and description", () => {
+      render(
+        <EmptyState
+          description="Try adjusting your search."
+          title="No results"
+        />,
+      );
+
+      expect(
+        screen.getByRole("heading", { name: "No results" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Try adjusting your search."),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the icon as a presentational element", () => {
+      render(
+        <EmptyState
+          icon={<svg aria-hidden="true" data-testid="icon" />}
+          title="x"
+        />,
+      );
+
+      expect(screen.getByTestId("icon")).toBeInTheDocument();
+    });
+
+    it("renders action children", () => {
+      render(
+        <EmptyState title="x">
+          <button type="button">Clear filters</button>
+        </EmptyState>,
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Clear filters" }),
+      ).toBeInTheDocument();
+    });
+
+    it.each(["sm", "md", "lg"] as const)("supports the %s size", (size) => {
+      const { container } = render(<EmptyState size={size} title="x" />);
+
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("omits sub-elements when their props are absent", () => {
+      const { container } = render(<EmptyState />);
+
+      expect(container.querySelector("h3")).not.toBeInTheDocument();
+      expect(container.querySelector("p")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it('uses role="status" by default', () => {
+      render(<EmptyState title="x" />);
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    it("honors a caller-provided role override", () => {
+      render(
+        <EmptyState role="region" title="x">
+          y
+        </EmptyState>,
+      );
+
+      expect(screen.getByRole("region")).toBeInTheDocument();
+    });
+
+    it("renders the title as a heading", () => {
+      render(<EmptyState title="No results" />);
+
+      expect(
+        screen.getByRole("heading", { level: 3, name: "No results" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/empty-state/empty-state.tsx
+++ b/packages/ui/src/components/empty-state/empty-state.tsx
@@ -1,0 +1,162 @@
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../../lib/utils";
+
+const emptyStateVariants = cva(
+  "flex flex-col items-center justify-center gap-3 text-center text-foreground",
+  {
+    defaultVariants: {
+      size: "md",
+    },
+    variants: {
+      size: {
+        lg: "px-6 py-16",
+        md: "px-4 py-10",
+        sm: "px-3 py-6",
+      },
+    },
+  },
+);
+
+const titleVariants = cva("font-semibold tracking-tight", {
+  defaultVariants: {
+    size: "md",
+  },
+  variants: {
+    size: {
+      lg: "text-xl",
+      md: "text-lg",
+      sm: "text-base",
+    },
+  },
+});
+
+const descriptionVariants = cva("max-w-prose text-muted-foreground", {
+  defaultVariants: {
+    size: "md",
+  },
+  variants: {
+    size: {
+      lg: "text-base",
+      md: "text-sm",
+      sm: "text-xs",
+    },
+  },
+});
+
+const iconVariants = cva(
+  "mb-1 flex items-center justify-center rounded-full bg-muted text-muted-foreground [&_svg]:h-1/2 [&_svg]:w-1/2",
+  {
+    defaultVariants: {
+      size: "md",
+    },
+    variants: {
+      size: {
+        lg: "h-16 w-16",
+        md: "h-12 w-12",
+        sm: "h-8 w-8",
+      },
+    },
+  },
+);
+
+/**
+ * Visual size for {@link EmptyState}.
+ *
+ * - `sm` — inline, suitable for compact lists or cards
+ * - `md` — section-level (default)
+ * - `lg` — full-page placeholder
+ *
+ * @public
+ */
+export type EmptyStateSize = "lg" | "md" | "sm";
+
+/**
+ * Props for {@link EmptyState}.
+ *
+ * @public
+ */
+export type EmptyStateProps = {
+  /**
+   * Action slot rendered below the description. Compose with `Button` or any
+   * interactive element.
+   */
+  children?: ReactNode;
+  /** Optional secondary text describing the empty condition. */
+  description?: ReactNode;
+  /** Optional icon or illustration shown above the title. */
+  icon?: ReactNode;
+  /** Headline rendered as a heading element. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"div"> &
+  VariantProps<typeof emptyStateVariants>;
+
+/**
+ * Placeholder for empty lists, tables, and search results. Composes a
+ * centered icon, title, description, and an action slot. Announces itself
+ * via `role="status"` so assistive tech can pick up state changes
+ * (e.g. when filters clear results).
+ *
+ * @example
+ * ```tsx
+ * <EmptyState
+ *   icon={<Inbox />}
+ *   title="No results found"
+ *   description="Try adjusting your search or filters."
+ * >
+ *   <Button variant="outline" onClick={clearFilters}>Clear filters</Button>
+ * </EmptyState>
+ * ```
+ *
+ * @public
+ */
+export const EmptyState = forwardRef<HTMLDivElement, EmptyStateProps>(
+  (
+    {
+      children,
+      className,
+      description,
+      icon,
+      role: roleOverride,
+      size,
+      title,
+      ...rest
+    },
+    ref,
+  ) => {
+    return (
+      <div
+        className={cn(emptyStateVariants({ size }), className)}
+        ref={ref}
+        role={roleOverride ?? "status"}
+        {...rest}
+      >
+        {icon ? (
+          <span aria-hidden="true" className={cn(iconVariants({ size }))}>
+            {icon}
+          </span>
+        ) : null}
+        {title ? (
+          <h3 className={cn(titleVariants({ size }))}>{title}</h3>
+        ) : null}
+        {description ? (
+          <p className={cn(descriptionVariants({ size }))}>{description}</p>
+        ) : null}
+        {children ? (
+          <div className="mt-2 flex flex-wrap items-center justify-center gap-2">
+            {children}
+          </div>
+        ) : null}
+      </div>
+    );
+  },
+);
+EmptyState.displayName = "EmptyState";
+
+export { emptyStateVariants };

--- a/packages/ui/src/components/empty-state/empty-state.visual.tsx
+++ b/packages/ui/src/components/empty-state/empty-state.visual.tsx
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { EmptyState } from "./empty-state";
+
+test.describe("EmptyState Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <EmptyState
+        description="Try adjusting your search or filters."
+        title="No results found"
+      />,
+    );
+    await expect(component).toHaveScreenshot("empty-state-default.png");
+  });
+
+  test("size-sm", async ({ mount }) => {
+    const component = await mount(
+      <EmptyState description="x" size="sm" title="Empty" />,
+    );
+    await expect(component).toHaveScreenshot("empty-state-size-sm.png");
+  });
+
+  test("size-lg", async ({ mount }) => {
+    const component = await mount(
+      <EmptyState
+        description="There is nothing here yet. Get started by creating your first item."
+        size="lg"
+        title="Welcome"
+      />,
+    );
+    await expect(component).toHaveScreenshot("empty-state-size-lg.png");
+  });
+});

--- a/packages/ui/src/components/empty-state/index.ts
+++ b/packages/ui/src/components/empty-state/index.ts
@@ -1,0 +1,6 @@
+export {
+  EmptyState,
+  type EmptyStateProps,
+  type EmptyStateSize,
+  emptyStateVariants,
+} from "./empty-state";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -815,6 +815,12 @@ export {
   type ComparisonProps,
 } from "./comparison";
 export {
+  EmptyState,
+  type EmptyStateProps,
+  type EmptyStateSize,
+  emptyStateVariants,
+} from "./empty-state";
+export {
   type EraColor,
   EraColumn,
   type EraColumnProps,


### PR DESCRIPTION
## Summary

Placeholder for empty lists, tables, and search results.

- Composes icon, title (h3), description, action slot in a centered column
- Three sizes — `sm` (inline), `md` (section, default), `lg` (full-page) — tune padding, type scale, icon size
- \`role="status"\` by default so assistive tech announces state changes when filters clear results; overridable
- Renders only the slots that are passed — no empty `<h3>` / `<p>` if `title` / `description` omitted

Closes #38

## API

\`\`\`tsx
<EmptyState
  icon={<Inbox />}
  title="No results found"
  description="Try adjusting your search or filters."
>
  <Button variant="outline" onClick={clearFilters}>Clear filters</Button>
</EmptyState>

<EmptyState size="lg" title="Welcome" description="Create your first item to get started.">
  <Button>New item</Button>
</EmptyState>
\`\`\`

## Coverage

- Unit: 10 tests covering title + description rendering, presentational icon slot, action children, all 3 sizes, slot omission, default \`role="status"\`, role override, semantic h3 heading
- Visual: Playwright CT story for default + size-sm + size-lg
- Storybook: \`Default\`, \`SizeSm\`, \`SizeLg\`, \`WithAction\`
- MDX: usage + sizes + with-action

## Registry

Added \`empty-state\` entry to \`apps/registry/registry.json\` (\`category: core\`, deps: \`class-variance-authority\`). Re-export shim at \`apps/registry/registry/default/empty-state/empty-state.tsx\`. \`pnpm build\` regenerates \`/r/empty-state.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`pnpm -F @vllnt/ui exec tsx scripts/check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 503/503 (10 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview renders all four stories
- [ ] Registry entry visible at \`/r/empty-state.json\` and \`/components/empty-state\` after deploy