### PR TITLE
feat(ui): add DocumentSiblingNav newer/older navigator

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -949,6 +949,23 @@
       "category": "overlay"
     },
     {
+      "name": "document-sibling-nav",
+      "type": "registry:component",
+      "title": "Document Sibling Nav",
+      "description": "Newer/older navigator: links to the previous and next item in an ordered series.",
+      "files": [
+        {
+          "path": "registry/default/document-sibling-nav/document-sibling-nav.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "class-variance-authority"
+      ],
+      "category": "content"
+    },
+    {
       "name": "dropdown-menu",
       "type": "registry:component",
       "title": "Dropdown Menu",

--- a/apps/registry/registry/default/document-sibling-nav/document-sibling-nav.tsx
+++ b/apps/registry/registry/default/document-sibling-nav/document-sibling-nav.tsx
@@ -1,0 +1,2 @@
+// Re-export from @vllnt/ui package
+export { DocumentSiblingNav, documentSiblingNavVariants } from '@vllnt/ui'

--- a/packages/ui/src/components/document-sibling-nav/document-sibling-nav.mdx
+++ b/packages/ui/src/components/document-sibling-nav/document-sibling-nav.mdx
@@ -1,0 +1,71 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './document-sibling-nav.stories'
+
+<Meta of={Stories} />
+
+# DocumentSiblingNav
+
+Sibling-document navigator: links to the previous and next item in an ordered series (e.g. newer/older blog post, prev/next doc page). Pairs naturally with `BlogCard`, `MDXContent`, `TableOfContents`.
+
+This is **not** `Pagination` — `Pagination` handles page numbers for paginated lists, while `DocumentSiblingNav` handles per-item navigation with item titles.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/document-sibling-nav.json
+```
+
+## Import
+
+```tsx
+import { DocumentSiblingNav } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<DocumentSiblingNav
+  previous={{ href: '/posts/foo', title: 'Foo post' }}
+  next={{ href: '/posts/bar', title: 'Bar post' }}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Edge cases
+
+Either side may be omitted (first / last item). When **both** are absent, the component renders `null`.
+
+<Canvas of={Stories.OnlyPrevious} sourceState="shown" />
+
+<Canvas of={Stories.OnlyNext} sourceState="shown" />
+
+## Variants
+
+### compact
+
+Single-line caption and arrow only — useful in dense layouts.
+
+<Canvas of={Stories.Compact} sourceState="shown" />
+
+### with-meta
+
+Adds an optional secondary line per side (date, author, reading time).
+
+<Canvas of={Stories.WithMeta} sourceState="shown" />
+
+## i18n
+
+Pass `labels` to localize the captions and the wrapping nav's `aria-label`.
+
+<Canvas of={Stories.Localized} sourceState="shown" />
+
+## Server rendering
+
+No client hooks. Safe to render on the server with no hydration penalty.

--- a/packages/ui/src/components/document-sibling-nav/document-sibling-nav.stories.tsx
+++ b/packages/ui/src/components/document-sibling-nav/document-sibling-nav.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { DocumentSiblingNav } from "./document-sibling-nav";
+
+const FOO = { href: "/posts/foo", title: "Why thin clients are back" };
+const BAR = { href: "/posts/bar", title: "What we shipped this quarter" };
+
+const meta = {
+  args: {
+    next: BAR,
+    previous: FOO,
+    variant: "with-title",
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["compact", "with-title", "with-meta"],
+    },
+  },
+  component: DocumentSiblingNav,
+  title: "Content/DocumentSiblingNav",
+} satisfies Meta<typeof DocumentSiblingNav>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const OnlyPrevious: Story = {
+  args: {
+    next: undefined,
+    previous: FOO,
+  },
+};
+
+export const OnlyNext: Story = {
+  args: {
+    next: BAR,
+    previous: undefined,
+  },
+};
+
+export const Compact: Story = {
+  args: {
+    variant: "compact",
+  },
+};
+
+export const WithMeta: Story = {
+  args: {
+    next: { ...BAR, meta: "May 2026" },
+    previous: { ...FOO, meta: "April 2026" },
+    variant: "with-meta",
+  },
+};
+
+export const Localized: Story = {
+  args: {
+    labels: {
+      navigation: "Navigation des articles",
+      next: "Suivant",
+      previous: "Précédent",
+    },
+  },
+};

--- a/packages/ui/src/components/document-sibling-nav/document-sibling-nav.test.tsx
+++ b/packages/ui/src/components/document-sibling-nav/document-sibling-nav.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DocumentSiblingNav } from "./document-sibling-nav";
+
+const FOO = { href: "/posts/foo", title: "Foo post" };
+const BAR = { href: "/posts/bar", title: "Bar post" };
+
+describe("DocumentSiblingNav", () => {
+  describe("rendering", () => {
+    it("renders previous and next links", () => {
+      render(<DocumentSiblingNav next={BAR} previous={FOO} />);
+
+      expect(
+        screen.getByRole("link", { name: /Older.*Foo post/ }),
+      ).toHaveAttribute("href", "/posts/foo");
+      expect(
+        screen.getByRole("link", { name: /Newer.*Bar post/ }),
+      ).toHaveAttribute("href", "/posts/bar");
+    });
+
+    it("renders only the previous link when next is absent", () => {
+      render(<DocumentSiblingNav previous={FOO} />);
+
+      expect(screen.getByRole("link")).toHaveAttribute("href", "/posts/foo");
+    });
+
+    it("renders only the next link when previous is absent", () => {
+      render(<DocumentSiblingNav next={BAR} />);
+
+      expect(screen.getByRole("link")).toHaveAttribute("href", "/posts/bar");
+    });
+
+    it("returns null when both sides are absent", () => {
+      const { container } = render(<DocumentSiblingNav />);
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("variants", () => {
+    it("hides the title in compact variant", () => {
+      render(<DocumentSiblingNav previous={FOO} variant="compact" />);
+
+      expect(screen.queryByText("Foo post")).not.toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Older" })).toBeInTheDocument();
+    });
+
+    it("renders the meta line in with-meta variant", () => {
+      render(
+        <DocumentSiblingNav
+          previous={{ ...FOO, meta: "May 2026" }}
+          variant="with-meta"
+        />,
+      );
+
+      expect(screen.getByText("May 2026")).toBeInTheDocument();
+    });
+
+    it("ignores meta in default variant", () => {
+      render(<DocumentSiblingNav previous={{ ...FOO, meta: "May 2026" }} />);
+
+      expect(screen.queryByText("May 2026")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("i18n", () => {
+    it("honors custom labels", () => {
+      render(
+        <DocumentSiblingNav
+          labels={{
+            navigation: "Navigation des articles",
+            next: "Suivant",
+            previous: "Précédent",
+          }}
+          next={BAR}
+          previous={FOO}
+        />,
+      );
+
+      expect(
+        screen.getByRole("navigation", { name: "Navigation des articles" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /Précédent.*Foo post/ }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /Suivant.*Bar post/ }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("anchor passthrough", () => {
+    it("forwards anchorProps to the rendered <a>", () => {
+      render(
+        <DocumentSiblingNav
+          next={{ ...BAR, anchorProps: { rel: "next", target: "_blank" } }}
+        />,
+      );
+
+      const link = screen.getByRole("link");
+      expect(link).toHaveAttribute("rel", "next");
+      expect(link).toHaveAttribute("target", "_blank");
+    });
+  });
+});

--- a/packages/ui/src/components/document-sibling-nav/document-sibling-nav.tsx
+++ b/packages/ui/src/components/document-sibling-nav/document-sibling-nav.tsx
@@ -1,0 +1,217 @@
+import {
+  type AnchorHTMLAttributes,
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../../lib/utils";
+
+const navVariants = cva("grid w-full gap-3 text-sm sm:grid-cols-2", {
+  defaultVariants: {
+    variant: "with-title",
+  },
+  variants: {
+    variant: {
+      compact: "",
+      "with-meta": "",
+      "with-title": "",
+    },
+  },
+});
+
+const itemVariants = cva(
+  "group flex flex-col gap-1 rounded-lg border border-border bg-background p-4 text-foreground transition-colors hover:border-foreground/30 hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+  {
+    defaultVariants: {
+      side: "previous",
+    },
+    variants: {
+      side: {
+        next: "items-end text-right sm:col-start-2",
+        previous: "items-start text-left",
+      },
+    },
+  },
+);
+
+/**
+ * Visual variant for {@link DocumentSiblingNav}.
+ *
+ * - `compact` — single-line caption and arrow, no title.
+ * - `with-title` — caption plus the sibling document title (default).
+ * - `with-meta` — caption, title, and an optional `meta` line (date, author, etc.).
+ *
+ * @public
+ */
+export type DocumentSiblingNavVariant = "compact" | "with-meta" | "with-title";
+
+type AnchorPassthroughProps = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  "href" | "title"
+>;
+
+/**
+ * Per-side description for {@link DocumentSiblingNav}.
+ *
+ * @public
+ */
+export type DocumentSiblingNavLink = {
+  /** Optional anchor props (rel, target, etc.) forwarded to the rendered `<a>`. */
+  anchorProps?: AnchorPassthroughProps;
+  /** Destination URL. */
+  href: string;
+  /** Optional secondary line shown when `variant="with-meta"`. */
+  meta?: ReactNode;
+  /** Title of the sibling document. */
+  title: ReactNode;
+};
+
+type LabelDictionary = {
+  /** Aria label for the wrapping `<nav>`. */
+  navigation?: string;
+  /** Caption above the next link. */
+  next?: string;
+  /** Caption above the previous link. */
+  previous?: string;
+};
+
+/**
+ * Props for {@link DocumentSiblingNav}.
+ *
+ * @public
+ */
+export type DocumentSiblingNavProps = {
+  /** Localizable captions. */
+  labels?: LabelDictionary;
+  /** The next sibling, or `undefined` at the end of the series. */
+  next?: DocumentSiblingNavLink;
+  /** The previous sibling, or `undefined` at the start of the series. */
+  previous?: DocumentSiblingNavLink;
+} & Omit<ComponentPropsWithoutRef<"nav">, "title"> &
+  VariantProps<typeof navVariants>;
+
+const DEFAULT_LABELS = {
+  navigation: "Document navigation",
+  next: "Newer",
+  previous: "Older",
+} as const satisfies Required<LabelDictionary>;
+
+type ItemProps = {
+  ariaLabel: string;
+  caption: string;
+  link: DocumentSiblingNavLink;
+  side: "next" | "previous";
+  variant: DocumentSiblingNavVariant;
+};
+
+function SiblingItem({
+  ariaLabel,
+  caption,
+  link,
+  side,
+  variant,
+}: ItemProps): ReactNode {
+  const { anchorProps, href, meta, title } = link;
+  return (
+    <a
+      aria-label={ariaLabel}
+      className={cn(itemVariants({ side }))}
+      href={href}
+      {...anchorProps}
+    >
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {caption}
+      </span>
+      {variant === "compact" ? null : (
+        <span className="line-clamp-2 text-sm font-semibold text-foreground group-hover:underline">
+          {title}
+        </span>
+      )}
+      {variant === "with-meta" && meta ? (
+        <span className="text-xs text-muted-foreground">{meta}</span>
+      ) : null}
+    </a>
+  );
+}
+
+function buildAriaLabel(
+  caption: string,
+  link: DocumentSiblingNavLink,
+  variant: DocumentSiblingNavVariant,
+): string {
+  if (variant === "compact" || typeof link.title !== "string") {
+    return caption;
+  }
+  return `${caption}: ${link.title}`;
+}
+
+/**
+ * Sibling-document navigator. Renders previous / next links to the surrounding
+ * items in an ordered series (e.g. newer/older blog post, prev/next doc page).
+ * Pass `previous`, `next`, or both — the component returns `null` when both
+ * are absent.
+ *
+ * Server-renderable — no client hooks required.
+ *
+ * @example
+ * ```tsx
+ * <DocumentSiblingNav
+ *   previous={{ href: '/posts/foo', title: 'Foo post' }}
+ *   next={{ href: '/posts/bar', title: 'Bar post' }}
+ *   labels={{ previous: 'Older', next: 'Newer' }}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const DocumentSiblingNav = forwardRef<
+  HTMLElement,
+  DocumentSiblingNavProps
+>(({ className, labels, next, previous, variant, ...rest }, ref) => {
+  if (!previous && !next) return null;
+
+  const resolvedVariant: DocumentSiblingNavVariant = variant ?? "with-title";
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+
+  return (
+    <nav
+      aria-label={resolvedLabels.navigation}
+      className={cn(navVariants({ variant: resolvedVariant }), className)}
+      ref={ref}
+      {...rest}
+    >
+      {previous ? (
+        <SiblingItem
+          ariaLabel={buildAriaLabel(
+            resolvedLabels.previous,
+            previous,
+            resolvedVariant,
+          )}
+          caption={resolvedLabels.previous}
+          link={previous}
+          side="previous"
+          variant={resolvedVariant}
+        />
+      ) : (
+        <span aria-hidden="true" />
+      )}
+      {next ? (
+        <SiblingItem
+          ariaLabel={buildAriaLabel(resolvedLabels.next, next, resolvedVariant)}
+          caption={resolvedLabels.next}
+          link={next}
+          side="next"
+          variant={resolvedVariant}
+        />
+      ) : (
+        <span aria-hidden="true" />
+      )}
+    </nav>
+  );
+});
+DocumentSiblingNav.displayName = "DocumentSiblingNav";
+
+export { navVariants as documentSiblingNavVariants };

--- a/packages/ui/src/components/document-sibling-nav/document-sibling-nav.visual.tsx
+++ b/packages/ui/src/components/document-sibling-nav/document-sibling-nav.visual.tsx
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { DocumentSiblingNav } from "./document-sibling-nav";
+
+const FOO = { href: "/posts/foo", title: "Why thin clients are back" };
+const BAR = { href: "/posts/bar", title: "What we shipped this quarter" };
+
+test.describe("DocumentSiblingNav Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <DocumentSiblingNav next={BAR} previous={FOO} />,
+    );
+    await expect(component).toHaveScreenshot("document-sibling-nav-default.png");
+  });
+
+  test("only-previous", async ({ mount }) => {
+    const component = await mount(<DocumentSiblingNav previous={FOO} />);
+    await expect(component).toHaveScreenshot(
+      "document-sibling-nav-only-previous.png",
+    );
+  });
+
+  test("only-next", async ({ mount }) => {
+    const component = await mount(<DocumentSiblingNav next={BAR} />);
+    await expect(component).toHaveScreenshot(
+      "document-sibling-nav-only-next.png",
+    );
+  });
+
+  test("variant-compact", async ({ mount }) => {
+    const component = await mount(
+      <DocumentSiblingNav next={BAR} previous={FOO} variant="compact" />,
+    );
+    await expect(component).toHaveScreenshot(
+      "document-sibling-nav-variant-compact.png",
+    );
+  });
+
+  test("variant-with-meta", async ({ mount }) => {
+    const component = await mount(
+      <DocumentSiblingNav
+        next={{ ...BAR, meta: "May 2026" }}
+        previous={{ ...FOO, meta: "April 2026" }}
+        variant="with-meta"
+      />,
+    );
+    await expect(component).toHaveScreenshot(
+      "document-sibling-nav-variant-with-meta.png",
+    );
+  });
+});

--- a/packages/ui/src/components/document-sibling-nav/index.ts
+++ b/packages/ui/src/components/document-sibling-nav/index.ts
@@ -1,0 +1,7 @@
+export {
+  DocumentSiblingNav,
+  type DocumentSiblingNavLink,
+  type DocumentSiblingNavProps,
+  type DocumentSiblingNavVariant,
+  documentSiblingNavVariants,
+} from "./document-sibling-nav";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -230,6 +230,13 @@ export {
   DrawerTrigger,
 } from "./drawer";
 export {
+  DocumentSiblingNav,
+  type DocumentSiblingNavLink,
+  type DocumentSiblingNavProps,
+  type DocumentSiblingNavVariant,
+  documentSiblingNavVariants,
+} from "./document-sibling-nav";
+export {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,


### PR DESCRIPTION
## Summary

Sibling-document navigator: links to the previous and next item in an ordered series (e.g. newer/older blog post, prev/next doc page, tutorial chapter).

Distinct from \`Pagination\`, which already exists in the library — \`Pagination\` handles page numbers for paginated lists; \`DocumentSiblingNav\` handles per-item navigation with item titles.

- Server-renderable — no client hooks
- Either side may be absent (first / last item)
- Returns \`null\` when **both** are absent
- Three variants — \`compact\`, \`with-title\` (default), \`with-meta\`
- Localizable captions + nav \`aria-label\`
- \`anchorProps\` passthrough on each side for \`rel\`, \`target\`, etc.

Closes #155

## API

\`\`\`tsx
<DocumentSiblingNav
  previous={{ href: '/posts/foo', title: 'Foo post' }}
  next={{ href: '/posts/bar', title: 'Bar post' }}
  labels={{ previous: 'Older', next: 'Newer' }}
/>

<DocumentSiblingNav
  variant="with-meta"
  previous={{ href: '/p/a', title: 'A', meta: 'April 2026' }}
  next={{ href: '/p/b', title: 'B', meta: 'May 2026', anchorProps: { rel: 'next' } }}
/>
\`\`\`

## Coverage

- Unit: 9 tests covering both-sides rendering, only-previous, only-next, null when both absent, all 3 variants (compact hides title, with-meta shows meta, default ignores meta), i18n labels, anchorProps passthrough
- Visual: Playwright CT story for default + only-previous + only-next + variant-compact + variant-with-meta
- Storybook: \`Default\`, \`OnlyPrevious\`, \`OnlyNext\`, \`Compact\`, \`WithMeta\`, \`Localized\`
- MDX: usage + edge cases + variants + i18n + SSR note

## Registry

Added \`document-sibling-nav\` entry to \`apps/registry/registry.json\` (\`category: content\`, deps: \`class-variance-authority\`). Re-export shim at \`apps/registry/registry/default/document-sibling-nav/document-sibling-nav.tsx\`. \`pnpm build\` regenerates \`/r/document-sibling-nav.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`pnpm -F @vllnt/ui exec tsx scripts/check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 502/502 (9 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview renders all six stories
- [ ] Registry entry visible at \`/r/document-sibling-nav.json\` and \`/components/document-sibling-nav\` after deploy