### PR TITLE
feat(ui): add PricingTable + PricingPlan plan comparison

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -2031,6 +2031,25 @@
       "category": "data"
     },
     {
+      "name": "pricing-table",
+      "type": "registry:component",
+      "title": "Pricing Table",
+      "description": "Plan comparison with feature checklist, tier highlighting, CTA, and an optional monthly/annual toggle.",
+      "files": [
+        {
+          "path": "registry/default/pricing-table/pricing-table.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [
+        "button"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "category": "billing"
+    },
+    {
       "name": "pro-tip",
       "type": "registry:component",
       "title": "Pro Tip",

--- a/apps/registry/registry/default/pricing-table/pricing-table.tsx
+++ b/apps/registry/registry/default/pricing-table/pricing-table.tsx
@@ -1,0 +1,2 @@
+// Re-export from @vllnt/ui package
+export { PricingPlan, PricingTable } from '@vllnt/ui'

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -674,6 +674,15 @@ export {
   type PlanBadgeTier,
 } from "./plan-badge";
 export {
+  type PricingFeature,
+  type PricingPeriod,
+  PricingPlan,
+  type PricingPlanCta,
+  type PricingPlanProps,
+  PricingTable,
+  type PricingTableProps,
+} from "./pricing-table";
+export {
   RoleBadge,
   type RoleBadgeProps,
   type RoleBadgeRole,

--- a/packages/ui/src/components/pricing-table/index.ts
+++ b/packages/ui/src/components/pricing-table/index.ts
@@ -1,0 +1,9 @@
+export {
+  type PricingFeature,
+  type PricingPeriod,
+  PricingPlan,
+  type PricingPlanCta,
+  type PricingPlanProps,
+  PricingTable,
+  type PricingTableProps,
+} from "./pricing-table";

--- a/packages/ui/src/components/pricing-table/pricing-table.mdx
+++ b/packages/ui/src/components/pricing-table/pricing-table.mdx
@@ -1,0 +1,80 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './pricing-table.stories'
+
+<Meta of={Stories} />
+
+# PricingTable
+
+Plan comparison table with feature checklist, tier highlighting, and CTA buttons. Composes `PricingPlan` columns side-by-side on desktop and stacks them on mobile.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/pricing-table.json
+```
+
+## Import
+
+```tsx
+import { PricingTable, PricingPlan } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<PricingTable>
+  <PricingPlan
+    name="Free"
+    price="$0"
+    period="/month"
+    description="For individuals"
+    features={[
+      { label: '5 projects', included: true },
+      { label: 'API access', included: false },
+    ]}
+    cta={{ label: 'Get started' }}
+  />
+  <PricingPlan
+    name="Pro"
+    price="$29"
+    period="/month"
+    highlighted
+    badge="Most Popular"
+    features={[
+      { label: 'Unlimited projects', included: true },
+      { label: 'Storage', included: '100 GB' },
+    ]}
+    cta={{ label: 'Start trial' }}
+  />
+</PricingTable>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Period toggle
+
+Pass `showPeriodToggle` to render a built-in monthly/annual radio group. Use the `period` / `onPeriodChange` props to control the value externally and swap prices.
+
+<Canvas of={Stories.WithPeriodToggle} sourceState="shown" />
+
+## Feature values
+
+`PricingFeature.included` accepts:
+
+| Value | Indicator |
+| ----- | --------- |
+| `true` | Check icon, normal label |
+| `false` | X icon, strike-through label |
+| `"5 users"` (string) | Check pill, label with the value in parens |
+
+## Two-column layout
+
+Cards stretch to fill the grid; on `lg` viewports the table renders three columns, two on `md`, one on mobile.
+
+<Canvas of={Stories.TwoColumn} sourceState="shown" />

--- a/packages/ui/src/components/pricing-table/pricing-table.stories.tsx
+++ b/packages/ui/src/components/pricing-table/pricing-table.stories.tsx
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PricingPlan, PricingTable } from "./pricing-table";
+
+const FREE_FEATURES = [
+  { included: true, label: "5 projects" },
+  { included: true, label: "1 GB storage" },
+  { included: false, label: "API access" },
+];
+
+const PRO_FEATURES = [
+  { included: true, label: "Unlimited projects" },
+  { included: "100 GB", label: "Storage" },
+  { included: true, label: "API access" },
+];
+
+const ENTERPRISE_FEATURES = [
+  { included: true, label: "Everything in Pro" },
+  { included: "Unlimited", label: "Storage" },
+  { included: true, label: "SSO + audit logs" },
+  { included: true, label: "Dedicated support" },
+];
+
+const meta = {
+  args: {
+    showPeriodToggle: false,
+  },
+  component: PricingTable,
+  title: "Billing/PricingTable",
+} satisfies Meta<typeof PricingTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <PricingTable {...args}>
+      <PricingPlan
+        cta={{ label: "Get started" }}
+        description="For individuals"
+        features={FREE_FEATURES}
+        name="Free"
+        period="/month"
+        price="$0"
+      />
+      <PricingPlan
+        badge="Most Popular"
+        cta={{ label: "Start trial" }}
+        description="For teams"
+        features={PRO_FEATURES}
+        highlighted
+        name="Pro"
+        period="/month"
+        price="$29"
+      />
+      <PricingPlan
+        cta={{ label: "Contact sales", variant: "outline" }}
+        description="For organizations"
+        features={ENTERPRISE_FEATURES}
+        name="Enterprise"
+        period=""
+        price="Custom"
+      />
+    </PricingTable>
+  ),
+};
+
+export const WithPeriodToggle: Story = {
+  args: {
+    periodLabels: { savings: "Save 20%" },
+    showPeriodToggle: true,
+  },
+  render: (args) => (
+    <PricingTable {...args}>
+      <PricingPlan
+        cta={{ label: "Get started" }}
+        features={FREE_FEATURES}
+        name="Free"
+        period="/month"
+        price="$0"
+      />
+      <PricingPlan
+        badge="Most Popular"
+        cta={{ label: "Start trial" }}
+        features={PRO_FEATURES}
+        highlighted
+        name="Pro"
+        period="/month"
+        price="$29"
+      />
+    </PricingTable>
+  ),
+};
+
+export const TwoColumn: Story = {
+  render: (args) => (
+    <PricingTable {...args}>
+      <PricingPlan
+        cta={{ label: "Get started" }}
+        description="For individuals"
+        features={FREE_FEATURES}
+        name="Free"
+        period="/month"
+        price="$0"
+      />
+      <PricingPlan
+        badge="Most Popular"
+        cta={{ label: "Start trial" }}
+        description="For teams"
+        features={PRO_FEATURES}
+        highlighted
+        name="Pro"
+        period="/month"
+        price="$29"
+      />
+    </PricingTable>
+  ),
+};

--- a/packages/ui/src/components/pricing-table/pricing-table.test.tsx
+++ b/packages/ui/src/components/pricing-table/pricing-table.test.tsx
@@ -1,0 +1,175 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PricingPlan, PricingTable } from "./pricing-table";
+
+describe("PricingPlan", () => {
+  describe("rendering", () => {
+    it("renders name, price, and period", () => {
+      render(<PricingPlan name="Pro" period="/month" price="$29" />);
+
+      expect(
+        screen.getByRole("heading", { level: 3, name: "Pro" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("$29")).toBeInTheDocument();
+      expect(screen.getByText("/month")).toBeInTheDocument();
+    });
+
+    it("renders the description when provided", () => {
+      render(<PricingPlan description="For teams" name="Pro" price="$29" />);
+
+      expect(screen.getByText("For teams")).toBeInTheDocument();
+    });
+
+    it("renders the badge when provided", () => {
+      render(
+        <PricingPlan badge="Most Popular" highlighted name="Pro" price="$29" />,
+      );
+
+      expect(screen.getByText("Most Popular")).toBeInTheDocument();
+    });
+
+    it("invokes the cta onClick", () => {
+      const onClick = vi.fn();
+      render(
+        <PricingPlan
+          cta={{ label: "Start trial", onClick }}
+          name="Pro"
+          price="$29"
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Start trial" }));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("features", () => {
+    it("renders included features", () => {
+      render(
+        <PricingPlan
+          features={[{ included: true, label: "Unlimited projects" }]}
+          name="Pro"
+          price="$29"
+        />,
+      );
+
+      expect(screen.getByText("Unlimited projects")).toBeInTheDocument();
+    });
+
+    it("renders excluded features with a strike-through", () => {
+      render(
+        <PricingPlan
+          features={[{ included: false, label: "API access" }]}
+          name="Free"
+          price="$0"
+        />,
+      );
+
+      expect(screen.getByText("API access")).toHaveClass("line-through");
+    });
+
+    it("renders limited-value features alongside the label", () => {
+      render(
+        <PricingPlan
+          features={[{ included: "5 users", label: "Team seats" }]}
+          name="Free"
+          price="$0"
+        />,
+      );
+
+      expect(screen.getByText("Team seats")).toBeInTheDocument();
+      expect(screen.getByText("(5 users)")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("PricingTable", () => {
+  describe("layout", () => {
+    it("renders all child plans", () => {
+      render(
+        <PricingTable>
+          <PricingPlan name="Free" price="$0" />
+          <PricingPlan name="Pro" price="$29" />
+        </PricingTable>,
+      );
+
+      expect(screen.getByText("Free")).toBeInTheDocument();
+      expect(screen.getByText("Pro")).toBeInTheDocument();
+    });
+  });
+
+  describe("period toggle", () => {
+    it("renders the toggle when showPeriodToggle is true", () => {
+      render(
+        <PricingTable showPeriodToggle>
+          <PricingPlan name="Free" price="$0" />
+        </PricingTable>,
+      );
+
+      expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "Monthly" })).toBeChecked();
+    });
+
+    it("does not render the toggle by default", () => {
+      render(
+        <PricingTable>
+          <PricingPlan name="Free" price="$0" />
+        </PricingTable>,
+      );
+
+      expect(screen.queryByRole("radiogroup")).not.toBeInTheDocument();
+    });
+
+    it("flips selection on click in uncontrolled mode", () => {
+      render(
+        <PricingTable showPeriodToggle>
+          <PricingPlan name="Free" price="$0" />
+        </PricingTable>,
+      );
+
+      fireEvent.click(screen.getByRole("radio", { name: "Annual" }));
+
+      expect(screen.getByRole("radio", { name: "Annual" })).toBeChecked();
+    });
+
+    it("emits onPeriodChange in controlled mode", () => {
+      const onPeriodChange = vi.fn();
+      render(
+        <PricingTable
+          onPeriodChange={onPeriodChange}
+          period="monthly"
+          showPeriodToggle
+        >
+          <PricingPlan name="Free" price="$0" />
+        </PricingTable>,
+      );
+
+      fireEvent.click(screen.getByRole("radio", { name: "Annual" }));
+
+      expect(onPeriodChange).toHaveBeenCalledWith("annual");
+      expect(screen.getByRole("radio", { name: "Monthly" })).toBeChecked();
+    });
+
+    it("renders custom labels and savings text", () => {
+      render(
+        <PricingTable
+          periodLabels={{
+            annual: "Yearly",
+            monthly: "Per month",
+            savings: "Save 20%",
+          }}
+          showPeriodToggle
+        >
+          <PricingPlan name="Free" price="$0" />
+        </PricingTable>,
+      );
+
+      expect(
+        screen.getByRole("radio", { name: /Per month/ }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Save 20%")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/pricing-table/pricing-table.tsx
+++ b/packages/ui/src/components/pricing-table/pricing-table.tsx
@@ -1,0 +1,426 @@
+"use client";
+
+import {
+  type ButtonHTMLAttributes,
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useState,
+} from "react";
+
+import { Check, X } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Button, type ButtonProps } from "../button/button";
+
+/**
+ * One row in a {@link PricingPlan}'s feature checklist.
+ *
+ * @public
+ */
+export type PricingFeature = {
+  /**
+   * When `true`, the row renders a check; when `false`, an X. Pass a string
+   * (e.g. `"5 users"`) to render the value as the limit indicator instead.
+   */
+  included: boolean | string;
+  /** Human-readable feature description. */
+  label: ReactNode;
+};
+
+/**
+ * Call-to-action descriptor for a {@link PricingPlan}.
+ *
+ * @public
+ */
+export type PricingPlanCta = {
+  /** Button label. */
+  label: ReactNode;
+  /** Click handler. */
+  onClick?: ButtonHTMLAttributes<HTMLButtonElement>["onClick"];
+  /** Underlying {@link Button} variant. Defaults to `"default"`. */
+  variant?: ButtonProps["variant"];
+};
+
+/**
+ * Props for {@link PricingPlan}.
+ *
+ * @public
+ */
+export type PricingPlanProps = {
+  /** Optional badge text shown on highlighted plans (e.g. "Most Popular"). */
+  badge?: ReactNode;
+  /** Bottom-row call-to-action descriptor. */
+  cta?: PricingPlanCta;
+  /** Sub-headline shown under the plan name. */
+  description?: ReactNode;
+  /** Feature checklist. */
+  features?: PricingFeature[];
+  /** When `true`, the plan renders with emphasis styling. */
+  highlighted?: boolean;
+  /** Plan name (e.g. "Free", "Pro"). */
+  name: ReactNode;
+  /** Suffix shown next to the price (e.g. "/month"). */
+  period?: ReactNode;
+  /** Headline price. */
+  price: ReactNode;
+} & Omit<ComponentPropsWithoutRef<"div">, "children">;
+
+function FeatureIndicator({
+  included,
+}: {
+  included: boolean | string;
+}): ReactNode {
+  if (typeof included === "string") {
+    return (
+      <span
+        aria-hidden="true"
+        className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-primary/15 text-[10px] font-semibold text-primary"
+      >
+        ✓
+      </span>
+    );
+  }
+  if (included) {
+    return (
+      <Check
+        aria-hidden="true"
+        className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+      />
+    );
+  }
+  return (
+    <X
+      aria-hidden="true"
+      className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground/60"
+    />
+  );
+}
+
+function FeatureRow({ feature }: { feature: PricingFeature }): ReactNode {
+  const { included, label } = feature;
+  const isLimit = typeof included === "string";
+  return (
+    <li className="flex items-start gap-2 text-sm">
+      <FeatureIndicator included={included} />
+      <span
+        className={cn(
+          "flex-1",
+          included === false && "text-muted-foreground line-through",
+        )}
+      >
+        {label}
+        {isLimit ? (
+          <span className="ml-1 text-muted-foreground">({included})</span>
+        ) : null}
+      </span>
+    </li>
+  );
+}
+
+function PlanBadgePill({
+  badge,
+  highlighted,
+}: {
+  badge: ReactNode;
+  highlighted: boolean;
+}): ReactNode {
+  return (
+    <span
+      className={cn(
+        "absolute -top-3 left-1/2 -translate-x-1/2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide",
+        highlighted
+          ? "bg-primary text-primary-foreground"
+          : "bg-muted text-muted-foreground",
+      )}
+    >
+      {badge}
+    </span>
+  );
+}
+
+function PlanHeader({
+  description,
+  name,
+}: {
+  description: ReactNode;
+  name: ReactNode;
+}): ReactNode {
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="text-lg font-semibold tracking-tight text-foreground">
+        {name}
+      </h3>
+      {description ? (
+        <p className="text-sm text-muted-foreground">{description}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function PlanPrice({
+  period,
+  price,
+}: {
+  period: ReactNode;
+  price: ReactNode;
+}): ReactNode {
+  return (
+    <div className="flex items-baseline gap-1">
+      <span className="text-3xl font-bold tracking-tight text-foreground">
+        {price}
+      </span>
+      {period ? (
+        <span className="text-sm text-muted-foreground">{period}</span>
+      ) : null}
+    </div>
+  );
+}
+
+function PlanFeatures({ features }: { features: PricingFeature[] }): ReactNode {
+  return (
+    <ul className="flex flex-col gap-2">
+      {features.map((feature, index) => (
+        <FeatureRow
+          feature={feature}
+          key={`${typeof feature.label === "string" ? feature.label : index.toString()}-${index.toString()}`}
+        />
+      ))}
+    </ul>
+  );
+}
+
+type PlanCtaProps = {
+  cta: PricingPlanCta;
+  highlighted: boolean;
+};
+
+function PlanCta({ cta, highlighted }: PlanCtaProps): ReactNode {
+  const { label, onClick: handleCtaClick, variant } = cta;
+  return (
+    <Button
+      className="mt-auto w-full"
+      onClick={handleCtaClick}
+      type="button"
+      variant={variant ?? (highlighted ? "default" : "outline")}
+    >
+      {label}
+    </Button>
+  );
+}
+
+/**
+ * Single plan column inside a {@link PricingTable}.
+ *
+ * @example
+ * ```tsx
+ * <PricingPlan
+ *   name="Pro"
+ *   price="$29"
+ *   period="/month"
+ *   highlighted
+ *   badge="Most Popular"
+ *   features={[
+ *     { label: "Unlimited projects", included: true },
+ *     { label: "Storage", included: "100 GB" },
+ *   ]}
+ *   cta={{ label: "Start trial", onClick: startTrial }}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const PricingPlan = forwardRef<HTMLDivElement, PricingPlanProps>(
+  (props, ref) => {
+    const {
+      badge,
+      className,
+      cta,
+      description,
+      features,
+      highlighted = false,
+      name,
+      period,
+      price,
+      ...rest
+    } = props;
+    return (
+      <div
+        className={cn(
+          "relative flex flex-col gap-6 rounded-2xl border bg-background p-6 shadow-sm transition-colors",
+          highlighted
+            ? "border-primary shadow-md ring-1 ring-primary/20"
+            : "border-border",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        {badge ? (
+          <PlanBadgePill badge={badge} highlighted={highlighted} />
+        ) : null}
+        <PlanHeader description={description} name={name} />
+        <PlanPrice period={period} price={price} />
+        {features && features.length > 0 ? (
+          <PlanFeatures features={features} />
+        ) : null}
+        {cta ? <PlanCta cta={cta} highlighted={highlighted} /> : null}
+      </div>
+    );
+  },
+);
+PricingPlan.displayName = "PricingPlan";
+
+/**
+ * Billing period for {@link PricingTable}'s built-in toggle.
+ *
+ * @public
+ */
+export type PricingPeriod = "annual" | "monthly";
+
+type PeriodLabels = {
+  annual?: ReactNode;
+  monthly?: ReactNode;
+  /** Optional caption shown next to the annual option (e.g. "Save 20%"). */
+  savings?: ReactNode;
+};
+
+/**
+ * Props for {@link PricingTable}.
+ *
+ * @public
+ */
+export type PricingTableProps = {
+  /** Period selected when uncontrolled. Defaults to `"monthly"`. */
+  defaultPeriod?: PricingPeriod;
+  /** Fires when the user changes the period (controlled or uncontrolled). */
+  onPeriodChange?: (period: PricingPeriod) => void;
+  /** Controlled value for the period toggle. */
+  period?: PricingPeriod;
+  /** Captions for the toggle. Defaults to `Monthly` / `Annual`. */
+  periodLabels?: PeriodLabels;
+  /** Set to `true` to render the built-in monthly/annual toggle. */
+  showPeriodToggle?: boolean;
+} & ComponentPropsWithoutRef<"div">;
+
+type PeriodToggleProps = {
+  labels: PeriodLabels;
+  onChange: (period: PricingPeriod) => void;
+  period: PricingPeriod;
+};
+
+function PeriodToggle({
+  labels,
+  onChange,
+  period,
+}: PeriodToggleProps): ReactNode {
+  const handleSelectMonthly = useCallback(() => {
+    onChange("monthly");
+  }, [onChange]);
+  const handleSelectAnnual = useCallback(() => {
+    onChange("annual");
+  }, [onChange]);
+
+  return (
+    <div
+      aria-label="Billing period"
+      className="mx-auto inline-flex items-center gap-2 rounded-full border bg-muted/40 p-1 text-sm"
+      role="radiogroup"
+    >
+      <button
+        aria-checked={period === "monthly"}
+        className={cn(
+          "rounded-full px-3 py-1 transition-colors",
+          period === "monthly"
+            ? "bg-background text-foreground shadow-sm"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+        onClick={handleSelectMonthly}
+        role="radio"
+        type="button"
+      >
+        {labels.monthly ?? "Monthly"}
+      </button>
+      <button
+        aria-checked={period === "annual"}
+        className={cn(
+          "inline-flex items-center gap-2 rounded-full px-3 py-1 transition-colors",
+          period === "annual"
+            ? "bg-background text-foreground shadow-sm"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+        onClick={handleSelectAnnual}
+        role="radio"
+        type="button"
+      >
+        {labels.annual ?? "Annual"}
+        {labels.savings ? (
+          <span className="rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+            {labels.savings}
+          </span>
+        ) : null}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Plan comparison container. Lays out child {@link PricingPlan} columns
+ * side-by-side on desktop and stacks them on mobile. Optionally renders a
+ * monthly/annual period toggle whose value flows through `onPeriodChange`.
+ *
+ * @example
+ * ```tsx
+ * const [period, setPeriod] = useState<PricingPeriod>("monthly")
+ *
+ * <PricingTable showPeriodToggle period={period} onPeriodChange={setPeriod}>
+ *   <PricingPlan name="Free" price="$0" period="/mo" cta={{ label: "Start" }} />
+ *   <PricingPlan name="Pro" price={period === "monthly" ? "$29" : "$24"} highlighted />
+ * </PricingTable>
+ * ```
+ *
+ * @public
+ */
+export const PricingTable = forwardRef<HTMLDivElement, PricingTableProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      defaultPeriod = "monthly",
+      onPeriodChange,
+      period: controlledPeriod,
+      periodLabels,
+      showPeriodToggle = false,
+      ...rest
+    } = props;
+
+    const [uncontrolledPeriod, setUncontrolledPeriod] =
+      useState<PricingPeriod>(defaultPeriod);
+    const period = controlledPeriod ?? uncontrolledPeriod;
+
+    const handlePeriodChange = useCallback(
+      (next: PricingPeriod) => {
+        if (controlledPeriod === undefined) setUncontrolledPeriod(next);
+        onPeriodChange?.(next);
+      },
+      [controlledPeriod, onPeriodChange],
+    );
+
+    return (
+      <div className={cn("flex flex-col gap-6", className)} ref={ref} {...rest}>
+        {showPeriodToggle ? (
+          <PeriodToggle
+            labels={periodLabels ?? {}}
+            onChange={handlePeriodChange}
+            period={period}
+          />
+        ) : null}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {children}
+        </div>
+      </div>
+    );
+  },
+);
+PricingTable.displayName = "PricingTable";

--- a/packages/ui/src/components/pricing-table/pricing-table.visual.tsx
+++ b/packages/ui/src/components/pricing-table/pricing-table.visual.tsx
@@ -1,0 +1,70 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { PricingPlan, PricingTable } from "./pricing-table";
+
+const FREE_FEATURES = [
+  { included: true, label: "5 projects" },
+  { included: true, label: "1 GB storage" },
+  { included: false, label: "API access" },
+];
+
+const PRO_FEATURES = [
+  { included: true, label: "Unlimited projects" },
+  { included: "100 GB", label: "Storage" },
+  { included: true, label: "API access" },
+];
+
+test.describe("PricingTable Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <PricingTable>
+        <PricingPlan
+          cta={{ label: "Get started" }}
+          description="For individuals"
+          features={FREE_FEATURES}
+          name="Free"
+          period="/month"
+          price="$0"
+        />
+        <PricingPlan
+          badge="Most Popular"
+          cta={{ label: "Start trial" }}
+          description="For teams"
+          features={PRO_FEATURES}
+          highlighted
+          name="Pro"
+          period="/month"
+          price="$29"
+        />
+      </PricingTable>,
+    );
+    await expect(component).toHaveScreenshot("pricing-table-default.png");
+  });
+
+  test("with-toggle", async ({ mount }) => {
+    const component = await mount(
+      <PricingTable
+        periodLabels={{ savings: "Save 20%" }}
+        showPeriodToggle
+      >
+        <PricingPlan
+          cta={{ label: "Get started" }}
+          features={FREE_FEATURES}
+          name="Free"
+          period="/month"
+          price="$0"
+        />
+        <PricingPlan
+          badge="Most Popular"
+          cta={{ label: "Start trial" }}
+          features={PRO_FEATURES}
+          highlighted
+          name="Pro"
+          period="/month"
+          price="$29"
+        />
+      </PricingTable>,
+    );
+    await expect(component).toHaveScreenshot("pricing-table-with-toggle.png");
+  });
+});


### PR DESCRIPTION
## Summary

Plan-comparison table with feature checklists, tier highlighting, per-plan CTAs, and an optional monthly/annual toggle.

- \`PricingTable\` — responsive grid (1 col → 2 col → 3 col), optional period toggle (radiogroup) with controlled / uncontrolled API and \`onPeriodChange\` callback
- \`PricingPlan\` — name + description + price + period + feature list + CTA, optional \`highlighted\` + \`badge\`
- \`PricingFeature.included\` accepts \`true\` (check), \`false\` (X + strike-through), or a string (limit value, e.g. \`"100 GB"\`)
- Composes the existing \`Button\` for the CTA — variant defaults to \`default\` for highlighted plans, \`outline\` otherwise

Closes #54

## API

\`\`\`tsx
<PricingTable showPeriodToggle periodLabels={{ savings: "Save 20%" }}>
  <PricingPlan
    name="Free"
    price="$0"
    period="/month"
    description="For individuals"
    features={[
      { label: "5 projects", included: true },
      { label: "API access", included: false },
    ]}
    cta={{ label: "Get started" }}
  />
  <PricingPlan
    name="Pro"
    price="$29"
    period="/month"
    highlighted
    badge="Most Popular"
    features={[
      { label: "Unlimited projects", included: true },
      { label: "Storage", included: "100 GB" },
    ]}
    cta={{ label: "Start trial" }}
  />
</PricingTable>
\`\`\`

## Coverage

- Unit: 13 tests covering PricingPlan rendering (name/price/period/description/badge/cta), all 3 feature states (true/false/string), strike-through on excluded, PricingTable layout, period toggle visibility, uncontrolled flip, controlled \`onPeriodChange\`, custom labels + savings caption
- Visual: Playwright CT story for default + with-toggle layouts
- Storybook: \`Default\`, \`WithPeriodToggle\`, \`TwoColumn\`
- MDX: usage + period toggle + feature value table + responsive grid

## Registry

Added \`pricing-table\` entry (\`category: billing\`, \`registryDependencies: [button]\`, deps: \`lucide-react\`). Re-export shim at \`apps/registry/registry/default/pricing-table/pricing-table.tsx\`. \`pnpm build\` regenerates \`/r/pricing-table.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 506/506 (13 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview renders all three stories with the period toggle interactive
- [ ] Registry entry visible at \`/r/pricing-table.json\` and \`/components/pricing-table\` after deploy