### PR TITLE
feat(ui): add HistoricalFigureCard biography card

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1301,6 +1301,26 @@
       "category": "overlay"
     },
     {
+      "name": "historical-figure-card",
+      "type": "registry:component",
+      "title": "Historical Figure Card",
+      "description": "Profile card with portrait, lifespan timeline, fields, works, quote, connections, and an expandable biography section.",
+      "files": [
+        {
+          "path": "registry/default/historical-figure-card/historical-figure-card.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [
+        "avatar",
+        "badge"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "category": "educational"
+    },
+    {
       "name": "infinite-plane",
       "type": "registry:component",
       "title": "Infinite Plane",

--- a/apps/registry/registry/default/historical-figure-card/historical-figure-card.tsx
+++ b/apps/registry/registry/default/historical-figure-card/historical-figure-card.tsx
@@ -1,0 +1,2 @@
+// Re-export from @vllnt/ui package
+export { HistoricalFigureCard } from '@vllnt/ui'

--- a/packages/ui/src/components/historical-figure-card/historical-figure-card.mdx
+++ b/packages/ui/src/components/historical-figure-card/historical-figure-card.mdx
@@ -1,0 +1,68 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './historical-figure-card.stories'
+
+<Meta of={Stories} />
+
+# HistoricalFigureCard
+
+Profile card for historical figures with portrait, lifespan timeline, fields / works / connections, optional pull-quote, and an expandable biography section. Pairs naturally with timeline and map components for biography-focused educational content.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/historical-figure-card.json
+```
+
+## Import
+
+```tsx
+import { HistoricalFigureCard } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<HistoricalFigureCard
+  name="Leonardo da Vinci"
+  title="Polymath"
+  era="Renaissance"
+  birth={{ year: 1452, place: 'Vinci, Italy' }}
+  death={{ year: 1519, place: 'Amboise, France' }}
+  fields={['Art', 'Science', 'Engineering', 'Anatomy']}
+  works={['Mona Lisa', 'The Last Supper', 'Vitruvian Man']}
+  quote={{ text: 'Learning never exhausts the mind.', source: 'Notebooks' }}
+  profileHref="/figures/da-vinci"
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## With connections
+
+Pass `connections` to surface relationships to other figures. Set `href` per connection to render as a link to their profile.
+
+<Canvas of={Stories.WithConnections} sourceState="shown" />
+
+## With biography
+
+Set `biography` to render an expandable section with a localizable toggle.
+
+<Canvas of={Stories.WithBiography} sourceState="shown" />
+
+## Antiquity
+
+Pass negative integers for `year` to render BC dates with the suffix.
+
+<Canvas of={Stories.Antiquity} sourceState="shown" />
+
+## Minimal
+
+Every prop except `name` is optional — every section is omitted gracefully when empty.
+
+<Canvas of={Stories.Minimal} sourceState="shown" />

--- a/packages/ui/src/components/historical-figure-card/historical-figure-card.stories.tsx
+++ b/packages/ui/src/components/historical-figure-card/historical-figure-card.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { HistoricalFigureCard } from "./historical-figure-card";
+
+const meta = {
+  args: {
+    birth: { place: "Vinci, Italy", year: 1452 },
+    death: { place: "Amboise, France", year: 1519 },
+    era: "Renaissance",
+    fields: ["Art", "Science", "Engineering", "Anatomy"],
+    name: "Leonardo da Vinci",
+    quote: {
+      source: "Notebooks",
+      text: "Learning never exhausts the mind.",
+    },
+    title: "Polymath",
+    works: ["Mona Lisa", "The Last Supper", "Vitruvian Man"],
+  },
+  component: HistoricalFigureCard,
+  title: "Educational/HistoricalFigureCard",
+} satisfies Meta<typeof HistoricalFigureCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithConnections: Story = {
+  args: {
+    connections: [
+      { name: "Michelangelo", relation: "Contemporary/rival" },
+      { name: "Lorenzo de Medici", relation: "Patron" },
+      { name: "Cesare Borgia", relation: "Employer" },
+    ],
+    profileHref: "/figures/da-vinci",
+  },
+};
+
+export const WithBiography: Story = {
+  args: {
+    biography:
+      "Born out of wedlock to a notary and a peasant woman, Leonardo was apprenticed to Andrea del Verrocchio in Florence. He served the Sforza court in Milan and later returned to Florence, where he painted the Mona Lisa. He spent his final years in France under the patronage of Francis I.",
+  },
+};
+
+export const Antiquity: Story = {
+  args: {
+    birth: { place: "Arpinum, Roman Republic", year: -106 },
+    death: { place: "Formia", year: -43 },
+    era: "Roman Republic",
+    fields: ["Philosophy", "Politics", "Law", "Rhetoric"],
+    name: "Marcus Tullius Cicero",
+    quote: undefined,
+    title: "Statesman & orator",
+    works: ["De Oratore", "De Re Publica"],
+  },
+};
+
+export const Minimal: Story = {
+  args: {
+    birth: undefined,
+    connections: undefined,
+    death: undefined,
+    era: undefined,
+    fields: undefined,
+    name: "Marie Curie",
+    quote: undefined,
+    title: "Physicist & chemist",
+    works: undefined,
+  },
+};

--- a/packages/ui/src/components/historical-figure-card/historical-figure-card.test.tsx
+++ b/packages/ui/src/components/historical-figure-card/historical-figure-card.test.tsx
@@ -1,0 +1,180 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { HistoricalFigureCard } from "./historical-figure-card";
+
+const NAME = "Leonardo da Vinci";
+
+describe("HistoricalFigureCard", () => {
+  describe("rendering", () => {
+    it("renders the name as a heading", () => {
+      render(<HistoricalFigureCard name={NAME} />);
+
+      expect(
+        screen.getByRole("heading", { level: 3, name: NAME }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders title and era when provided", () => {
+      render(
+        <HistoricalFigureCard era="Renaissance" name={NAME} title="Polymath" />,
+      );
+
+      expect(screen.getByText("Polymath")).toBeInTheDocument();
+      expect(screen.getByText("Renaissance")).toBeInTheDocument();
+    });
+
+    it("renders fallback initials when no portrait is provided", () => {
+      render(<HistoricalFigureCard name={NAME} />);
+
+      expect(screen.getByText("LD")).toBeInTheDocument();
+    });
+  });
+
+  describe("life events", () => {
+    it("renders birth and death lines with formatted years", () => {
+      render(
+        <HistoricalFigureCard
+          birth={{ place: "Vinci, Italy", year: 1452 }}
+          death={{ place: "Amboise, France", year: 1519 }}
+          name={NAME}
+        />,
+      );
+
+      expect(screen.getByText("Born")).toBeInTheDocument();
+      expect(screen.getByText(/1452/)).toBeInTheDocument();
+      expect(screen.getByText(/Vinci, Italy/)).toBeInTheDocument();
+      expect(screen.getByText("Died")).toBeInTheDocument();
+      expect(screen.getByText(/1519/)).toBeInTheDocument();
+    });
+
+    it("formats BC years with the suffix", () => {
+      render(
+        <HistoricalFigureCard
+          birth={{ year: -106 }}
+          death={{ year: -43 }}
+          name="Cicero"
+        />,
+      );
+
+      expect(screen.getByText(/106 BC/)).toBeInTheDocument();
+      expect(screen.getByText(/43 BC/)).toBeInTheDocument();
+    });
+
+    it("renders the lifespan bar when both years are present", () => {
+      render(
+        <HistoricalFigureCard
+          birth={{ year: 1452 }}
+          death={{ year: 1519 }}
+          name={NAME}
+        />,
+      );
+
+      expect(screen.getByRole("img", { name: /Lifespan/ })).toBeInTheDocument();
+    });
+
+    it("hides the lifespan bar when years are missing", () => {
+      render(<HistoricalFigureCard birth={{ year: 1452 }} name={NAME} />);
+
+      expect(
+        screen.queryByRole("img", { name: /Lifespan/ }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("lists", () => {
+    it("renders fields as chips", () => {
+      render(<HistoricalFigureCard fields={["Art", "Science"]} name={NAME} />);
+
+      expect(screen.getByText("Art")).toBeInTheDocument();
+      expect(screen.getByText("Science")).toBeInTheDocument();
+    });
+
+    it("renders works", () => {
+      render(<HistoricalFigureCard name={NAME} works={["Mona Lisa"]} />);
+
+      expect(screen.getByText("Mona Lisa")).toBeInTheDocument();
+    });
+
+    it("renders connections with relation", () => {
+      render(
+        <HistoricalFigureCard
+          connections={[{ name: "Lorenzo de Medici", relation: "Patron" }]}
+          name={NAME}
+        />,
+      );
+
+      expect(screen.getByText("Lorenzo de Medici")).toBeInTheDocument();
+      expect(screen.getByText("Patron")).toBeInTheDocument();
+    });
+
+    it("renders connections as links when href is provided", () => {
+      render(
+        <HistoricalFigureCard
+          connections={[
+            {
+              href: "/figures/michelangelo",
+              name: "Michelangelo",
+              relation: "Rival",
+            },
+          ]}
+          name={NAME}
+        />,
+      );
+
+      expect(
+        screen.getByRole("link", { name: "Michelangelo" }),
+      ).toHaveAttribute("href", "/figures/michelangelo");
+    });
+  });
+
+  describe("quote", () => {
+    it("renders quote and source", () => {
+      render(
+        <HistoricalFigureCard
+          name={NAME}
+          quote={{
+            source: "Notebooks",
+            text: "Learning never exhausts the mind.",
+          }}
+        />,
+      );
+
+      expect(screen.getByRole("blockquote")).toBeInTheDocument();
+      expect(
+        screen.getByText(/Learning never exhausts the mind./),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Notebooks/)).toBeInTheDocument();
+    });
+  });
+
+  describe("biography", () => {
+    it("renders the bio toggle and toggles content", () => {
+      render(
+        <HistoricalFigureCard biography="Long biography text" name={NAME} />,
+      );
+
+      const toggle = screen.getByRole("button", { name: "Read biography" });
+      expect(screen.queryByText("Long biography text")).not.toBeInTheDocument();
+
+      fireEvent.click(toggle);
+
+      expect(screen.getByText("Long biography text")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Hide biography" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("profile link", () => {
+    it("renders profileHref as a link", () => {
+      render(
+        <HistoricalFigureCard name={NAME} profileHref="/figures/da-vinci" />,
+      );
+
+      expect(
+        screen.getByRole("link", { name: /full profile/ }),
+      ).toHaveAttribute("href", "/figures/da-vinci");
+    });
+  });
+});

--- a/packages/ui/src/components/historical-figure-card/historical-figure-card.tsx
+++ b/packages/ui/src/components/historical-figure-card/historical-figure-card.tsx
@@ -1,0 +1,506 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useState,
+} from "react";
+
+import { ChevronDown, User } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Avatar, AvatarFallback, AvatarImage } from "../avatar/avatar";
+import { Badge } from "../badge/badge";
+
+const FALLBACK_LIFESPAN_MIN_YEAR = 1500;
+const FALLBACK_LIFESPAN_SPAN_YEARS = 100;
+
+/**
+ * Birth or death record for {@link HistoricalFigureCardProps}.
+ *
+ * @public
+ */
+export type HistoricalFigureCardLifeEvent = {
+  /** Optional secondary line (e.g. "Vinci, Italy"). */
+  place?: ReactNode;
+  /**
+   * Year as a positive integer for AD / a negative integer for BC.
+   * Pass `undefined` for unknown.
+   */
+  year?: number;
+};
+
+/**
+ * Connection between this figure and another.
+ *
+ * @public
+ */
+export type HistoricalFigureCardConnection = {
+  /** Optional URL for the connected figure's profile. */
+  href?: string;
+  /** Connected figure's display name. */
+  name: ReactNode;
+  /** Free-form relation label (e.g. "Patron", "Contemporary/rival"). */
+  relation: ReactNode;
+};
+
+/**
+ * Pull-quote with attribution for {@link HistoricalFigureCardProps}.
+ *
+ * @public
+ */
+export type HistoricalFigureCardQuote = {
+  /** Source/citation for the quote (book, letter, year). */
+  source?: ReactNode;
+  /** Quote text. */
+  text: ReactNode;
+};
+
+/**
+ * Localizable strings for the bio toggle button.
+ *
+ * @public
+ */
+export type HistoricalFigureCardLabels = {
+  /** Caption for the bio toggle when expanded. Defaults to `"Hide biography"`. */
+  collapseBio?: string;
+  /** Heading rendered above the connections list. Defaults to `"Connections"`. */
+  connections?: string;
+  /** Caption for the bio toggle when collapsed. Defaults to `"Read biography"`. */
+  expandBio?: string;
+  /** Heading rendered above the fields list. Defaults to `"Fields"`. */
+  fields?: string;
+  /** Aria-label for the lifespan timeline bar. Defaults to `"Lifespan"`. */
+  lifespan?: string;
+  /** Heading rendered above the works list. Defaults to `"Notable works"`. */
+  works?: string;
+};
+
+/**
+ * Props for {@link HistoricalFigureCard}.
+ *
+ * @public
+ */
+export type HistoricalFigureCardProps = {
+  /** Optional expandable biography content. */
+  biography?: ReactNode;
+  /** Birth event (year + optional place). */
+  birth?: HistoricalFigureCardLifeEvent;
+  /** Connections / relationships to other figures. */
+  connections?: HistoricalFigureCardConnection[];
+  /** Death event (year + optional place). */
+  death?: HistoricalFigureCardLifeEvent;
+  /** Era label, rendered as a Badge. */
+  era?: ReactNode;
+  /** Fields / domains tags (e.g. "Art", "Anatomy"). */
+  fields?: ReactNode[];
+  /** Localizable captions. */
+  labels?: HistoricalFigureCardLabels;
+  /** Display name. */
+  name: ReactNode;
+  /** Portrait image src. Falls back to a silhouette when omitted. */
+  portrait?: string;
+  /** Optional URL pointing to the full profile. */
+  profileHref?: string;
+  /** Optional pull-quote with attribution. */
+  quote?: HistoricalFigureCardQuote;
+  /** Optional descriptor under the name (e.g. "Polymath"). */
+  title?: ReactNode;
+  /** Notable works list. */
+  works?: ReactNode[];
+} & ComponentPropsWithoutRef<"article">;
+
+const DEFAULT_LABELS = {
+  collapseBio: "Hide biography",
+  connections: "Connections",
+  expandBio: "Read biography",
+  fields: "Fields",
+  lifespan: "Lifespan",
+  works: "Notable works",
+} as const satisfies Required<HistoricalFigureCardLabels>;
+
+function formatYear(year: number | undefined): string | undefined {
+  if (year === undefined) return undefined;
+  if (year < 0) return `${Math.abs(year).toString()} BC`;
+  return year.toString();
+}
+
+function getInitials(name: ReactNode): string {
+  if (typeof name !== "string") return "";
+  const parts = name.trim().split(/\s+/).slice(0, 2);
+  return parts
+    .map((part) => part.charAt(0).toUpperCase())
+    .join("")
+    .slice(0, 2);
+}
+
+type LifespanBarProps = {
+  birthYear?: number;
+  deathYear?: number;
+  label: string;
+};
+
+function LifespanBar({
+  birthYear,
+  deathYear,
+  label,
+}: LifespanBarProps): ReactNode {
+  if (birthYear === undefined || deathYear === undefined) return null;
+  if (deathYear <= birthYear) return null;
+
+  const span = deathYear - birthYear;
+  const min = Math.min(birthYear, FALLBACK_LIFESPAN_MIN_YEAR);
+  const range =
+    Math.max(deathYear, min + FALLBACK_LIFESPAN_SPAN_YEARS) - min || 1;
+  const start = ((birthYear - min) / range) * 100;
+  const width = (span / range) * 100;
+
+  return (
+    <div
+      aria-label={`${label}: ${formatYear(birthYear) ?? ""} – ${formatYear(deathYear) ?? ""}`}
+      className="relative mt-2 h-1.5 w-full rounded-full bg-muted"
+      role="img"
+    >
+      <span
+        className="absolute h-full rounded-full bg-primary"
+        style={{ left: `${start.toString()}%`, width: `${width.toString()}%` }}
+      />
+    </div>
+  );
+}
+
+type LifeEventLineProps = {
+  caption: string;
+  event?: HistoricalFigureCardLifeEvent;
+};
+
+function LifeEventLine({ caption, event }: LifeEventLineProps): ReactNode {
+  if (!event) return null;
+  const year = formatYear(event.year);
+  if (year === undefined && !event.place) return null;
+  return (
+    <p className="text-xs text-muted-foreground">
+      <span className="font-semibold text-foreground">{caption}</span>{" "}
+      {year ?? "Unknown"}
+      {event.place ? <span> · {event.place}</span> : null}
+    </p>
+  );
+}
+
+type FigureChipsProps = {
+  heading: string;
+  items: ReactNode[];
+};
+
+function FigureChips({ heading, items }: FigureChipsProps): ReactNode {
+  if (items.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2">
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {heading}
+      </h4>
+      <div className="flex flex-wrap gap-1.5">
+        {items.map((item, index) => (
+          <Badge key={`chip-${index.toString()}`} variant="secondary">
+            {item}
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type FigureWorksListProps = {
+  heading: string;
+  items: ReactNode[];
+};
+
+function FigureWorksList({ heading, items }: FigureWorksListProps): ReactNode {
+  if (items.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2">
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {heading}
+      </h4>
+      <ul className="flex flex-col gap-1 text-sm text-foreground">
+        {items.map((item, index) => (
+          <li className="leading-tight" key={`work-${index.toString()}`}>
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+type FigureConnectionsProps = {
+  heading: string;
+  items: HistoricalFigureCardConnection[];
+};
+
+function FigureConnections({
+  heading,
+  items,
+}: FigureConnectionsProps): ReactNode {
+  if (items.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2">
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {heading}
+      </h4>
+      <ul className="flex flex-col gap-1.5 text-sm">
+        {items.map((connection, index) => {
+          const labelNode = connection.href ? (
+            <a
+              className="font-medium text-foreground underline-offset-4 hover:underline"
+              href={connection.href}
+            >
+              {connection.name}
+            </a>
+          ) : (
+            <span className="font-medium text-foreground">
+              {connection.name}
+            </span>
+          );
+          return (
+            <li
+              className="flex items-baseline justify-between gap-3"
+              key={`connection-${index.toString()}`}
+            >
+              {labelNode}
+              <span className="text-xs text-muted-foreground">
+                {connection.relation}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+type FigureQuoteProps = {
+  quote: HistoricalFigureCardQuote;
+};
+
+function FigureQuote({ quote }: FigureQuoteProps): ReactNode {
+  return (
+    <blockquote className="border-l-2 border-primary/40 pl-3 text-sm italic text-muted-foreground">
+      “{quote.text}”
+      {quote.source ? (
+        <footer className="mt-1 text-xs not-italic text-muted-foreground/80">
+          — {quote.source}
+        </footer>
+      ) : null}
+    </blockquote>
+  );
+}
+
+type FigureBioProps = {
+  biography: ReactNode;
+  collapseLabel: string;
+  expandLabel: string;
+};
+
+function FigureBio({
+  biography,
+  collapseLabel,
+  expandLabel,
+}: FigureBioProps): ReactNode {
+  const [open, setOpen] = useState(false);
+  const handleToggle = useCallback(() => {
+    setOpen((value) => !value);
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        aria-expanded={open}
+        className="inline-flex w-fit items-center gap-1 text-sm font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        onClick={handleToggle}
+        type="button"
+      >
+        {open ? collapseLabel : expandLabel}
+        <ChevronDown
+          aria-hidden="true"
+          className={cn(
+            "h-4 w-4 transition-transform",
+            open ? "rotate-180" : "rotate-0",
+          )}
+        />
+      </button>
+      {open ? (
+        <div className="text-sm leading-relaxed text-foreground">
+          {biography}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Profile card for historical figures with portrait, lifespan timeline,
+ * fields / works / connections, optional pull-quote, and an expandable
+ * biography section. Composes Avatar and Badge.
+ *
+ * @example
+ * ```tsx
+ * <HistoricalFigureCard
+ *   name="Leonardo da Vinci"
+ *   title="Polymath"
+ *   era="Renaissance"
+ *   birth={{ year: 1452, place: "Vinci, Italy" }}
+ *   death={{ year: 1519, place: "Amboise, France" }}
+ *   fields={["Art", "Science"]}
+ *   works={["Mona Lisa", "Vitruvian Man"]}
+ *   quote={{ text: "Learning never exhausts the mind.", source: "Notebooks" }}
+ *   profileHref="/figures/da-vinci"
+ * />
+ * ```
+ *
+ * @public
+ */
+type FigureHeaderProps = {
+  era?: ReactNode;
+  name: ReactNode;
+  portrait?: string;
+  title?: ReactNode;
+};
+
+function FigureHeader({
+  era,
+  name,
+  portrait,
+  title,
+}: FigureHeaderProps): ReactNode {
+  const initials = getInitials(name);
+  const altName = typeof name === "string" ? name : undefined;
+  return (
+    <header className="flex items-start gap-4">
+      <Avatar className="h-14 w-14 shrink-0 ring-2 ring-border">
+        {portrait ? <AvatarImage alt={altName} src={portrait} /> : null}
+        <AvatarFallback className="text-sm">
+          {initials || <User aria-hidden="true" className="h-5 w-5" />}
+        </AvatarFallback>
+      </Avatar>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <h3 className="text-base font-semibold leading-tight tracking-tight">
+          {name}
+        </h3>
+        {title ? (
+          <p className="text-sm text-muted-foreground">{title}</p>
+        ) : null}
+        {era ? (
+          <Badge className="self-start" variant="outline">
+            {era}
+          </Badge>
+        ) : null}
+      </div>
+    </header>
+  );
+}
+
+type FigureLifeBlockProps = {
+  birth?: HistoricalFigureCardLifeEvent;
+  death?: HistoricalFigureCardLifeEvent;
+  lifespanLabel: string;
+};
+
+function FigureLifeBlock({
+  birth,
+  death,
+  lifespanLabel,
+}: FigureLifeBlockProps): ReactNode {
+  return (
+    <div className="flex flex-col gap-1">
+      <LifeEventLine caption="Born" event={birth} />
+      <LifeEventLine caption="Died" event={death} />
+      <LifespanBar
+        birthYear={birth?.year}
+        deathYear={death?.year}
+        label={lifespanLabel}
+      />
+    </div>
+  );
+}
+
+export const HistoricalFigureCard = forwardRef<
+  HTMLElement,
+  HistoricalFigureCardProps
+>((props, ref) => {
+  const {
+    biography,
+    birth,
+    className,
+    connections,
+    death,
+    era,
+    fields,
+    labels,
+    name,
+    portrait,
+    profileHref,
+    quote,
+    title,
+    works,
+    ...rest
+  } = props;
+
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+
+  return (
+    <article
+      className={cn(
+        "flex flex-col gap-4 rounded-2xl border bg-background p-5 text-foreground shadow-sm",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      <FigureHeader era={era} name={name} portrait={portrait} title={title} />
+
+      <FigureLifeBlock
+        birth={birth}
+        death={death}
+        lifespanLabel={resolvedLabels.lifespan}
+      />
+
+      {fields && fields.length > 0 ? (
+        <FigureChips heading={resolvedLabels.fields} items={fields} />
+      ) : null}
+
+      {works && works.length > 0 ? (
+        <FigureWorksList heading={resolvedLabels.works} items={works} />
+      ) : null}
+
+      {quote ? <FigureQuote quote={quote} /> : null}
+
+      {connections && connections.length > 0 ? (
+        <FigureConnections
+          heading={resolvedLabels.connections}
+          items={connections}
+        />
+      ) : null}
+
+      {biography ? (
+        <FigureBio
+          biography={biography}
+          collapseLabel={resolvedLabels.collapseBio}
+          expandLabel={resolvedLabels.expandBio}
+        />
+      ) : null}
+
+      {profileHref ? (
+        <a
+          className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+          href={profileHref}
+        >
+          View full profile →
+        </a>
+      ) : null}
+    </article>
+  );
+});
+HistoricalFigureCard.displayName = "HistoricalFigureCard";

--- a/packages/ui/src/components/historical-figure-card/historical-figure-card.visual.tsx
+++ b/packages/ui/src/components/historical-figure-card/historical-figure-card.visual.tsx
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { HistoricalFigureCard } from "./historical-figure-card";
+
+const FIGURE = {
+  birth: { place: "Vinci, Italy", year: 1452 },
+  death: { place: "Amboise, France", year: 1519 },
+  era: "Renaissance",
+  fields: ["Art", "Science", "Engineering", "Anatomy"],
+  name: "Leonardo da Vinci",
+  quote: {
+    source: "Notebooks",
+    text: "Learning never exhausts the mind.",
+  },
+  title: "Polymath",
+  works: ["Mona Lisa", "Vitruvian Man"],
+};
+
+test.describe("HistoricalFigureCard Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(<HistoricalFigureCard {...FIGURE} />);
+    await expect(component).toHaveScreenshot(
+      "historical-figure-card-default.png",
+    );
+  });
+
+  test("with-connections", async ({ mount }) => {
+    const component = await mount(
+      <HistoricalFigureCard
+        {...FIGURE}
+        connections={[
+          { name: "Michelangelo", relation: "Contemporary/rival" },
+          { name: "Lorenzo de Medici", relation: "Patron" },
+        ]}
+        profileHref="/figures/da-vinci"
+      />,
+    );
+    await expect(component).toHaveScreenshot(
+      "historical-figure-card-with-connections.png",
+    );
+  });
+
+  test("minimal", async ({ mount }) => {
+    const component = await mount(
+      <HistoricalFigureCard name="Marie Curie" title="Physicist" />,
+    );
+    await expect(component).toHaveScreenshot(
+      "historical-figure-card-minimal.png",
+    );
+  });
+});

--- a/packages/ui/src/components/historical-figure-card/index.ts
+++ b/packages/ui/src/components/historical-figure-card/index.ts
@@ -1,0 +1,8 @@
+export {
+  HistoricalFigureCard,
+  type HistoricalFigureCardConnection,
+  type HistoricalFigureCardLabels,
+  type HistoricalFigureCardLifeEvent,
+  type HistoricalFigureCardProps,
+  type HistoricalFigureCardQuote,
+} from "./historical-figure-card";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -254,6 +254,14 @@ export {
 } from "./historic-timeline";
 export { HoverCard, HoverCardContent, HoverCardTrigger } from "./hover-card";
 export {
+  HistoricalFigureCard,
+  type HistoricalFigureCardConnection,
+  type HistoricalFigureCardLabels,
+  type HistoricalFigureCardLifeEvent,
+  type HistoricalFigureCardProps,
+  type HistoricalFigureCardQuote,
+} from "./historical-figure-card";
+export {
   ContextMenu,
   ContextMenuCheckboxItem,
   ContextMenuContent,


### PR DESCRIPTION
## Summary

Profile card for historical figures with portrait, lifespan timeline, fields / works / connections, optional pull-quote, and an expandable biography section. Pairs with timeline + map components for biography-focused educational content.

- **Portrait** — \`Avatar\` with image + initials fallback (silhouette icon when name is non-string)
- **Lifespan** — birth + death lines with formatted year (negative integer → BC suffix) and place; proportional bar between the two when both years are known
- **Era / fields / works** — Badge + chip / list with semantic headings
- **Quote** — semantic \`<blockquote>\` with attribution \`<footer>\`
- **Connections** — relation list, individual connections optionally render as links
- **Biography** — collapsible toggle with localizable captions
- **Profile link** — optional \`profileHref\` rendered as a follow-up CTA

Closes #67

## API

\`\`\`tsx
<HistoricalFigureCard
  name="Leonardo da Vinci"
  title="Polymath"
  era="Renaissance"
  birth={{ year: 1452, place: 'Vinci, Italy' }}
  death={{ year: 1519, place: 'Amboise, France' }}
  fields={['Art', 'Science', 'Engineering', 'Anatomy']}
  works={['Mona Lisa', 'The Last Supper', 'Vitruvian Man']}
  quote={{ text: 'Learning never exhausts the mind.', source: 'Notebooks' }}
  connections={[
    { name: 'Michelangelo', relation: 'Contemporary/rival' },
    { name: 'Lorenzo de Medici', relation: 'Patron' },
  ]}
  biography="Born out of wedlock to a notary..."
  profileHref="/figures/da-vinci"
/>
\`\`\`

## Coverage

- Unit: 14 tests covering name as h3, title + era, initials fallback, birth/death lines + place, BC year suffix, lifespan bar shown only when both years present, fields chips, works list, connections (text + linked), quote with source, bio toggle (collapsed → expanded → collapse-label), profile link
- Visual: Playwright CT story for default + with-connections + minimal layouts
- Storybook: \`Default\`, \`WithConnections\`, \`WithBiography\`, \`Antiquity\` (BC dates), \`Minimal\`
- MDX: usage + connections + biography + antiquity + minimal

## Registry

Added \`historical-figure-card\` (\`category: educational\`, \`registryDependencies: [avatar, badge]\`, deps: \`lucide-react\`). Re-export shim and \`pnpm build\` regenerates \`/r/historical-figure-card.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 507/507 (14 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview renders all five stories with the biography toggle interactive
- [ ] Registry entry visible at \`/r/historical-figure-card.json\` and \`/components/historical-figure-card\` after deploy