### PR TITLE
feat(ui): add CivilizationCard + CivilizationComparison

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -643,6 +643,25 @@
       "category": "data-display"
     },
     {
+      "name": "civilization-card",
+      "type": "registry:component",
+      "title": "Civilization Card",
+      "description": "Civilization overview with hero band, BCE/CE era timeline, key stats, achievements, and notable leaders.",
+      "files": [
+        {
+          "path": "registry/default/civilization-card/civilization-card.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [
+        "badge"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "category": "educational"
+    },
+    {
       "name": "code-block",
       "type": "registry:component",
       "title": "Code Block",

--- a/apps/registry/registry/default/civilization-card/civilization-card.tsx
+++ b/apps/registry/registry/default/civilization-card/civilization-card.tsx
@@ -1,0 +1,2 @@
+// Re-export from @vllnt/ui package
+export { CivilizationCard, CivilizationComparison } from '@vllnt/ui'

--- a/packages/ui/src/components/civilization-card/civilization-card.mdx
+++ b/packages/ui/src/components/civilization-card/civilization-card.mdx
@@ -1,0 +1,66 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './civilization-card.stories'
+
+<Meta of={Stories} />
+
+# CivilizationCard
+
+Overview card for historical civilizations: hero band with optional image + color theme, era timeline with BCE / CE / `present` formatting, key stats (region, capital, peak population, computed duration), achievement chips, notable leaders, and an optional follow-up link. Pairs with `CivilizationComparison` for side-by-side layouts.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/civilization-card.json
+```
+
+## Import
+
+```tsx
+import { CivilizationCard, CivilizationComparison } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<CivilizationCard
+  name="Roman Empire"
+  era={{ start: -27, end: 476 }}
+  region="Mediterranean"
+  capital="Rome"
+  peakPopulation="70 million"
+  color="red"
+  achievements={['Aqueducts', 'Roads', 'Law']}
+  leaders={['Augustus', 'Trajan', 'Marcus Aurelius']}
+  actionHref="/civilizations/rome"
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Era format
+
+`era.start` and `era.end` accept positive integers for CE / negative integers for BCE. Omit `end` for extant civilizations — the card prints `"present"` and computes the duration against the current year.
+
+<Canvas of={Stories.Extant} sourceState="shown" />
+
+## Action link
+
+<Canvas of={Stories.WithAction} sourceState="shown" />
+
+## Comparison
+
+Wrap multiple cards in `CivilizationComparison` for a responsive comparison grid.
+
+<Canvas of={Stories.Comparison} sourceState="shown" />
+
+## Minimal
+
+Every prop except `name` is optional — sections drop out when empty.
+
+<Canvas of={Stories.Minimal} sourceState="shown" />

--- a/packages/ui/src/components/civilization-card/civilization-card.stories.tsx
+++ b/packages/ui/src/components/civilization-card/civilization-card.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  CivilizationCard,
+  CivilizationComparison,
+} from "./civilization-card";
+
+const meta = {
+  args: {
+    achievements: ["Aqueducts", "Roads", "Law", "Architecture"],
+    capital: "Rome",
+    color: "red",
+    era: { end: 476, start: -27 },
+    leaders: ["Augustus", "Trajan", "Marcus Aurelius"],
+    name: "Roman Empire",
+    peakPopulation: "70 million",
+    region: "Mediterranean",
+  },
+  argTypes: {
+    color: {
+      control: "select",
+      options: ["amber", "blue", "emerald", "neutral", "purple", "red"],
+    },
+  },
+  component: CivilizationCard,
+  title: "Educational/CivilizationCard",
+} satisfies Meta<typeof CivilizationCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithAction: Story = {
+  args: {
+    actionHref: "/civilizations/rome",
+  },
+};
+
+export const Extant: Story = {
+  args: {
+    achievements: ["Constitution", "Industrial revolution", "Internet"],
+    capital: "Washington, D.C.",
+    color: "blue",
+    era: { start: 1776 },
+    leaders: ["Lincoln", "Roosevelt"],
+    name: "United States",
+    peakPopulation: "335 million",
+    region: "North America",
+  },
+};
+
+export const Comparison: Story = {
+  render: (args) => (
+    <CivilizationComparison>
+      <CivilizationCard {...args} />
+      <CivilizationCard
+        achievements={["Paper", "Silk Road", "Bureaucracy"]}
+        capital="Chang'an"
+        color="amber"
+        era={{ end: 220, start: -202 }}
+        leaders={["Liu Bang", "Wu of Han"]}
+        name="Han Dynasty"
+        peakPopulation="60 million"
+        region="East Asia"
+      />
+    </CivilizationComparison>
+  ),
+};
+
+export const Minimal: Story = {
+  args: {
+    achievements: undefined,
+    capital: undefined,
+    color: "neutral",
+    era: undefined,
+    leaders: undefined,
+    name: "Mystery civilization",
+    peakPopulation: undefined,
+    region: undefined,
+  },
+};

--- a/packages/ui/src/components/civilization-card/civilization-card.test.tsx
+++ b/packages/ui/src/components/civilization-card/civilization-card.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CivilizationCard, CivilizationComparison } from "./civilization-card";
+
+describe("CivilizationCard", () => {
+  describe("rendering", () => {
+    it("renders the name as a heading", () => {
+      render(<CivilizationCard name="Roman Empire" />);
+
+      expect(
+        screen.getByRole("heading", { level: 3, name: "Roman Empire" }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders region when provided", () => {
+      render(<CivilizationCard name="Rome" region="Mediterranean" />);
+
+      expect(screen.getByText("Mediterranean")).toBeInTheDocument();
+    });
+
+    it("renders the hero globe fallback when no image is provided", () => {
+      const { container } = render(<CivilizationCard name="Rome" />);
+
+      expect(container.querySelector("svg")).toBeInTheDocument();
+    });
+  });
+
+  describe("era", () => {
+    it("formats BCE/CE start and end", () => {
+      render(
+        <CivilizationCard era={{ end: 476, start: -27 }} name="Roman Empire" />,
+      );
+
+      expect(screen.getByText("27 BCE – 476 CE")).toBeInTheDocument();
+    });
+
+    it('uses "present" when end is omitted', () => {
+      render(<CivilizationCard era={{ start: 1776 }} name="USA" />);
+
+      expect(screen.getByText("1776 CE – present")).toBeInTheDocument();
+    });
+
+    it("renders the era timeline bar", () => {
+      render(
+        <CivilizationCard era={{ end: 476, start: -27 }} name="Roman Empire" />,
+      );
+
+      expect(
+        screen.getByRole("img", { name: /Era timeline/ }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("stats", () => {
+    it("renders capital and peak population", () => {
+      render(
+        <CivilizationCard
+          capital="Rome"
+          name="Roman Empire"
+          peakPopulation="70 million"
+        />,
+      );
+
+      expect(screen.getByText("Capital")).toBeInTheDocument();
+      expect(screen.getByText("Rome")).toBeInTheDocument();
+      expect(screen.getByText("Peak population")).toBeInTheDocument();
+      expect(screen.getByText("70 million")).toBeInTheDocument();
+    });
+
+    it("computes a duration when both era endpoints exist", () => {
+      render(
+        <CivilizationCard era={{ end: 476, start: -27 }} name="Roman Empire" />,
+      );
+
+      expect(screen.getByText("Duration")).toBeInTheDocument();
+      expect(screen.getByText("503 years")).toBeInTheDocument();
+    });
+  });
+
+  describe("lists", () => {
+    it("renders achievements as badges", () => {
+      render(
+        <CivilizationCard
+          achievements={["Aqueducts", "Law"]}
+          name="Roman Empire"
+        />,
+      );
+
+      expect(screen.getByText("Aqueducts")).toBeInTheDocument();
+      expect(screen.getByText("Law")).toBeInTheDocument();
+    });
+
+    it("renders leaders as a list", () => {
+      render(
+        <CivilizationCard
+          leaders={["Augustus", "Trajan"]}
+          name="Roman Empire"
+        />,
+      );
+
+      expect(screen.getByText("Augustus")).toBeInTheDocument();
+      expect(screen.getByText("Trajan")).toBeInTheDocument();
+    });
+  });
+
+  describe("action", () => {
+    it("renders actionHref as a link", () => {
+      render(<CivilizationCard actionHref="/civ/rome" name="Roman Empire" />);
+
+      expect(screen.getByRole("link", { name: /Explore/ })).toHaveAttribute(
+        "href",
+        "/civ/rome",
+      );
+    });
+  });
+});
+
+describe("CivilizationComparison", () => {
+  it("renders all child cards", () => {
+    render(
+      <CivilizationComparison>
+        <CivilizationCard name="Rome" />
+        <CivilizationCard name="Han" />
+      </CivilizationComparison>,
+    );
+
+    expect(screen.getByText("Rome")).toBeInTheDocument();
+    expect(screen.getByText("Han")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/civilization-card/civilization-card.tsx
+++ b/packages/ui/src/components/civilization-card/civilization-card.tsx
@@ -1,0 +1,460 @@
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { Globe } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Badge } from "../badge/badge";
+
+const CIVILIZATION_COLOR_VARIANTS: Record<
+  CivilizationCardColor,
+  { gradient: string; ring: string }
+> = {
+  amber: {
+    gradient: "from-amber-500/20 to-amber-700/40",
+    ring: "ring-amber-500/30",
+  },
+  blue: {
+    gradient: "from-blue-500/20 to-blue-700/40",
+    ring: "ring-blue-500/30",
+  },
+  emerald: {
+    gradient: "from-emerald-500/20 to-emerald-700/40",
+    ring: "ring-emerald-500/30",
+  },
+  neutral: {
+    gradient: "from-muted to-muted-foreground/10",
+    ring: "ring-border",
+  },
+  purple: {
+    gradient: "from-purple-500/20 to-purple-700/40",
+    ring: "ring-purple-500/30",
+  },
+  red: {
+    gradient: "from-red-500/20 to-red-700/40",
+    ring: "ring-red-500/30",
+  },
+};
+
+/**
+ * Color theme for the {@link CivilizationCard} hero band.
+ *
+ * @public
+ */
+export type CivilizationCardColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "neutral"
+  | "purple"
+  | "red";
+
+/**
+ * Era span (start / end years) for {@link CivilizationCardProps}.
+ *
+ * Use positive integers for CE / negative integers for BCE. `end` may be
+ * omitted when the civilization is extant.
+ *
+ * @public
+ */
+export type CivilizationCardEra = {
+  /** End year. Negative for BCE; omit when extant. */
+  end?: number;
+  /** Start year. Negative for BCE. */
+  start: number;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type CivilizationCardLabels = {
+  /** Heading above the achievements list. Defaults to `"Achievements"`. */
+  achievements?: string;
+  /** Caption for the capital row. Defaults to `"Capital"`. */
+  capital?: string;
+  /** Caption for the duration stat. Defaults to `"Duration"`. */
+  duration?: string;
+  /** Heading above the leaders list. Defaults to `"Notable leaders"`. */
+  leaders?: string;
+  /** Caption for the peak population stat. Defaults to `"Peak population"`. */
+  peakPopulation?: string;
+  /** Aria-label on the era timeline bar. Defaults to `"Era timeline"`. */
+  timeline?: string;
+};
+
+/**
+ * Props for {@link CivilizationCard}.
+ *
+ * @public
+ */
+export type CivilizationCardProps = {
+  /** Notable achievements / cultural contributions. */
+  achievements?: ReactNode[];
+  /** Optional primary CTA href. Renders the card as a link card when set. */
+  actionHref?: string;
+  /** Optional capital city. */
+  capital?: ReactNode;
+  /** Color theme for the hero band. Defaults to `"neutral"`. */
+  color?: CivilizationCardColor;
+  /** Era span. */
+  era?: CivilizationCardEra;
+  /** Optional hero image src. Falls back to a globe icon. */
+  image?: string;
+  /** Localizable captions. */
+  labels?: CivilizationCardLabels;
+  /** Notable leaders. */
+  leaders?: ReactNode[];
+  /** Display name. */
+  name: ReactNode;
+  /** Optional peak population stat (string). */
+  peakPopulation?: ReactNode;
+  /** Optional geographic region. */
+  region?: ReactNode;
+} & ComponentPropsWithoutRef<"article">;
+
+const DEFAULT_LABELS = {
+  achievements: "Achievements",
+  capital: "Capital",
+  duration: "Duration",
+  leaders: "Notable leaders",
+  peakPopulation: "Peak population",
+  timeline: "Era timeline",
+} as const satisfies Required<CivilizationCardLabels>;
+
+function formatEraYear(year: number): string {
+  if (year < 0) return `${Math.abs(year).toString()} BCE`;
+  return `${year.toString()} CE`;
+}
+
+function formatEra(era: CivilizationCardEra): string {
+  const start = formatEraYear(era.start);
+  if (era.end === undefined) return `${start} – present`;
+  return `${start} – ${formatEraYear(era.end)}`;
+}
+
+function getDuration(era: CivilizationCardEra | undefined): string | undefined {
+  if (!era) return undefined;
+  const end = era.end ?? new Date().getFullYear();
+  const years = end - era.start;
+  if (years <= 0) return undefined;
+  return `${years.toString()} years`;
+}
+
+type HeroProps = {
+  color: CivilizationCardColor;
+  image?: string;
+  imageAlt?: string;
+};
+
+function CivilizationHero({ color, image, imageAlt }: HeroProps): ReactNode {
+  const palette = CIVILIZATION_COLOR_VARIANTS[color];
+  return (
+    <div
+      className={cn(
+        "relative h-32 w-full overflow-hidden rounded-t-2xl bg-gradient-to-br",
+        palette.gradient,
+      )}
+    >
+      {image ? (
+        <img
+          alt={imageAlt ?? ""}
+          className="h-full w-full object-cover mix-blend-multiply"
+          src={image}
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center text-muted-foreground/50">
+          <Globe aria-hidden="true" className="h-12 w-12" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+type EraTimelineProps = {
+  era: CivilizationCardEra;
+  label: string;
+};
+
+function EraTimeline({ era, label }: EraTimelineProps): ReactNode {
+  const eraLabel = formatEra(era);
+  return (
+    <div
+      aria-label={`${label}: ${eraLabel}`}
+      className="flex flex-col gap-1"
+      role="img"
+    >
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {eraLabel}
+      </span>
+      <div className="h-1.5 w-full rounded-full bg-muted">
+        <span className="block h-full w-2/3 rounded-full bg-primary" />
+      </div>
+    </div>
+  );
+}
+
+type StatsProps = {
+  capital?: ReactNode;
+  capitalCaption: string;
+  durationCaption: string;
+  durationValue?: string;
+  peakCaption: string;
+  peakPopulation?: ReactNode;
+};
+
+function CivilizationStats({
+  capital,
+  capitalCaption,
+  durationCaption,
+  durationValue,
+  peakCaption,
+  peakPopulation,
+}: StatsProps): ReactNode {
+  const items: { caption: string; value: ReactNode }[] = [];
+  if (capital) items.push({ caption: capitalCaption, value: capital });
+  if (peakPopulation) {
+    items.push({ caption: peakCaption, value: peakPopulation });
+  }
+  if (durationValue) {
+    items.push({ caption: durationCaption, value: durationValue });
+  }
+  if (items.length === 0) return null;
+  return (
+    <dl className="grid grid-cols-2 gap-x-3 gap-y-2 text-sm">
+      {items.map((item) => (
+        <div className="flex flex-col" key={item.caption}>
+          <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {item.caption}
+          </dt>
+          <dd className="font-medium text-foreground">{item.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+type ListBlockProps = {
+  emptyHidden?: boolean;
+  heading: string;
+  items: ReactNode[];
+  variant: "badge" | "list";
+};
+
+function CivilizationListBlock({
+  heading,
+  items,
+  variant,
+}: ListBlockProps): ReactNode {
+  if (items.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2">
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {heading}
+      </h4>
+      {variant === "badge" ? (
+        <div className="flex flex-wrap gap-1.5">
+          {items.map((item, index) => (
+            <Badge key={`${heading}-${index.toString()}`} variant="secondary">
+              {item}
+            </Badge>
+          ))}
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-1 text-sm text-foreground">
+          {items.map((item, index) => (
+            <li
+              className="leading-tight"
+              key={`${heading}-${index.toString()}`}
+            >
+              {item}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Overview card for historical civilizations: hero band with optional image
+ * + color theme, era timeline (BCE / CE / present), key stats, achievement
+ * chips, notable leaders, and an optional follow-up link.
+ *
+ * @example
+ * ```tsx
+ * <CivilizationCard
+ *   name="Roman Empire"
+ *   era={{ start: -27, end: 476 }}
+ *   region="Mediterranean"
+ *   capital="Rome"
+ *   peakPopulation="70 million"
+ *   color="red"
+ *   achievements={["Aqueducts", "Roads", "Law", "Architecture"]}
+ *   leaders={["Augustus", "Trajan", "Marcus Aurelius"]}
+ *   actionHref="/civilizations/rome"
+ * />
+ * ```
+ *
+ * @public
+ */
+type CivilizationBodyProps = {
+  achievements?: ReactNode[];
+  actionHref?: string;
+  capital?: ReactNode;
+  era?: CivilizationCardEra;
+  labels: Required<CivilizationCardLabels>;
+  leaders?: ReactNode[];
+  name: ReactNode;
+  peakPopulation?: ReactNode;
+  region?: ReactNode;
+};
+
+function CivilizationBody({
+  achievements,
+  actionHref,
+  capital,
+  era,
+  labels,
+  leaders,
+  name,
+  peakPopulation,
+  region,
+}: CivilizationBodyProps): ReactNode {
+  const durationValue = getDuration(era);
+  return (
+    <div className="flex flex-col gap-4 p-5">
+      <header className="flex flex-col gap-1">
+        <h3 className="text-lg font-semibold leading-tight tracking-tight">
+          {name}
+        </h3>
+        {region ? (
+          <p className="text-sm text-muted-foreground">{region}</p>
+        ) : null}
+      </header>
+
+      {era ? <EraTimeline era={era} label={labels.timeline} /> : null}
+
+      <CivilizationStats
+        capital={capital}
+        capitalCaption={labels.capital}
+        durationCaption={labels.duration}
+        durationValue={durationValue}
+        peakCaption={labels.peakPopulation}
+        peakPopulation={peakPopulation}
+      />
+
+      {achievements && achievements.length > 0 ? (
+        <CivilizationListBlock
+          heading={labels.achievements}
+          items={achievements}
+          variant="badge"
+        />
+      ) : null}
+
+      {leaders && leaders.length > 0 ? (
+        <CivilizationListBlock
+          heading={labels.leaders}
+          items={leaders}
+          variant="list"
+        />
+      ) : null}
+
+      {actionHref ? (
+        <a
+          className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+          href={actionHref}
+        >
+          Explore →
+        </a>
+      ) : null}
+    </div>
+  );
+}
+
+export const CivilizationCard = forwardRef<HTMLElement, CivilizationCardProps>(
+  (props, ref) => {
+    const {
+      achievements,
+      actionHref,
+      capital,
+      className,
+      color = "neutral",
+      era,
+      image,
+      labels,
+      leaders,
+      name,
+      peakPopulation,
+      region,
+      ...rest
+    } = props;
+
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const palette = CIVILIZATION_COLOR_VARIANTS[color];
+    const altName = typeof name === "string" ? name : undefined;
+
+    return (
+      <article
+        className={cn(
+          "flex flex-col overflow-hidden rounded-2xl border bg-background text-foreground shadow-sm ring-1",
+          palette.ring,
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <CivilizationHero color={color} image={image} imageAlt={altName} />
+        <CivilizationBody
+          achievements={achievements}
+          actionHref={actionHref}
+          capital={capital}
+          era={era}
+          labels={resolvedLabels}
+          leaders={leaders}
+          name={name}
+          peakPopulation={peakPopulation}
+          region={region}
+        />
+      </article>
+    );
+  },
+);
+CivilizationCard.displayName = "CivilizationCard";
+
+/**
+ * Props for {@link CivilizationComparison}.
+ *
+ * @public
+ */
+export type CivilizationComparisonProps = ComponentPropsWithoutRef<"div">;
+
+/**
+ * Side-by-side comparison container for {@link CivilizationCard}s. Renders
+ * children in a responsive grid (single column on mobile, two columns on
+ * `md`, three on `lg`).
+ *
+ * @public
+ */
+export const CivilizationComparison = forwardRef<
+  HTMLDivElement,
+  CivilizationComparisonProps
+>(({ children, className, ...rest }, ref) => {
+  return (
+    <div
+      className={cn(
+        "grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+});
+CivilizationComparison.displayName = "CivilizationComparison";

--- a/packages/ui/src/components/civilization-card/civilization-card.visual.tsx
+++ b/packages/ui/src/components/civilization-card/civilization-card.visual.tsx
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import {
+  CivilizationCard,
+  CivilizationComparison,
+} from "./civilization-card";
+
+const ROME = {
+  achievements: ["Aqueducts", "Roads", "Law", "Architecture"],
+  capital: "Rome",
+  color: "red" as const,
+  era: { end: 476, start: -27 },
+  leaders: ["Augustus", "Trajan", "Marcus Aurelius"],
+  name: "Roman Empire",
+  peakPopulation: "70 million",
+  region: "Mediterranean",
+};
+
+const HAN = {
+  achievements: ["Paper", "Silk Road", "Bureaucracy"],
+  capital: "Chang'an",
+  color: "amber" as const,
+  era: { end: 220, start: -202 },
+  leaders: ["Liu Bang", "Wu of Han"],
+  name: "Han Dynasty",
+  peakPopulation: "60 million",
+  region: "East Asia",
+};
+
+test.describe("CivilizationCard Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(<CivilizationCard {...ROME} />);
+    await expect(component).toHaveScreenshot("civilization-card-default.png");
+  });
+
+  test("comparison", async ({ mount }) => {
+    const component = await mount(
+      <CivilizationComparison>
+        <CivilizationCard {...ROME} />
+        <CivilizationCard {...HAN} />
+      </CivilizationComparison>,
+    );
+    await expect(component).toHaveScreenshot(
+      "civilization-card-comparison.png",
+    );
+  });
+
+  test("minimal", async ({ mount }) => {
+    const component = await mount(
+      <CivilizationCard era={{ start: 1776 }} name="USA" />,
+    );
+    await expect(component).toHaveScreenshot("civilization-card-minimal.png");
+  });
+});

--- a/packages/ui/src/components/civilization-card/index.ts
+++ b/packages/ui/src/components/civilization-card/index.ts
@@ -1,0 +1,9 @@
+export {
+  CivilizationCard,
+  type CivilizationCardColor,
+  type CivilizationCardEra,
+  type CivilizationCardLabels,
+  type CivilizationCardProps,
+  CivilizationComparison,
+  type CivilizationComparisonProps,
+} from "./civilization-card";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -770,6 +770,15 @@ export {
   type ChecklistProps,
 } from "./checklist";
 export {
+  CivilizationCard,
+  type CivilizationCardColor,
+  type CivilizationCardEra,
+  type CivilizationCardLabels,
+  type CivilizationCardProps,
+  CivilizationComparison,
+  type CivilizationComparisonProps,
+} from "./civilization-card";
+export {
   CodePlayground,
   type CodePlaygroundProps,
   FileTree,


### PR DESCRIPTION
## Summary

Civilization overview card and matching comparison grid container, for history-focused educational content.

- Hero band — six color themes (`amber`, `blue`, `emerald`, `neutral`, `purple`, `red`) with optional cover image and a Globe icon fallback
- Era — `era.start` / `era.end` accept positive integers for CE / negative integers for BCE; omit `end` for extant civilizations (renders \`"present"\` and computes the duration against the current year)
- Stats — region (sub-headline), capital, peak population, computed duration in years
- Achievement chips, notable leaders list, optional Explore link
- \`CivilizationComparison\` — responsive grid (1 col → 2 col on \`md\` → 3 col on \`lg\`) for side-by-side cards

Closes #66

## API

\`\`\`tsx
<CivilizationCard
  name="Roman Empire"
  era={{ start: -27, end: 476 }}
  region="Mediterranean"
  capital="Rome"
  peakPopulation="70 million"
  color="red"
  achievements={["Aqueducts", "Roads", "Law", "Architecture"]}
  leaders={["Augustus", "Trajan", "Marcus Aurelius"]}
  actionHref="/civilizations/rome"
/>

<CivilizationComparison>
  <CivilizationCard name="Rome" ... />
  <CivilizationCard name="Han Dynasty" ... />
</CivilizationComparison>
\`\`\`

## Coverage

- Unit: 12 tests covering name as h3, region rendering, globe fallback, BCE/CE formatting, "present" suffix, era timeline aria, stats (capital + peak), computed duration, achievements as chips, leaders list, action link, comparison grid renders both children
- Visual: Playwright CT story for default + comparison + minimal layouts
- Storybook: \`Default\`, \`WithAction\`, \`Extant\`, \`Comparison\`, \`Minimal\`
- MDX: usage + era format + action + comparison + minimal

## Registry

Added \`civilization-card\` (\`category: educational\`, \`registryDependencies: [badge]\`, deps: \`lucide-react\`). Re-export shim and \`pnpm build\` regenerates \`/r/civilization-card.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 505/505 (12 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview renders all five stories with correct era formatting
- [ ] Registry entry visible at \`/r/civilization-card.json\` and \`/components/civilization-card\` after deploy