### PR TITLE
feat(ui): add NewsletterSignup with state machine

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1747,6 +1747,26 @@
       "category": "navigation"
     },
     {
+      "name": "newsletter-signup",
+      "type": "registry:component",
+      "title": "Newsletter Signup",
+      "description": "Email-capture form with idle/sending/sent/error state machine, custom validators, and overridable labels.",
+      "files": [
+        {
+          "path": "registry/default/newsletter-signup/newsletter-signup.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [
+        "button",
+        "input"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "category": "form"
+    },
+    {
       "name": "number-input",
       "type": "registry:component",
       "title": "Number Input",

--- a/apps/registry/registry/default/newsletter-signup/newsletter-signup.tsx
+++ b/apps/registry/registry/default/newsletter-signup/newsletter-signup.tsx
@@ -1,0 +1,2 @@
+// Re-export from @vllnt/ui package
+export { NewsletterSignup, newsletterSignupReducer } from '@vllnt/ui'

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -61,6 +61,14 @@ export { Input } from "./input";
 export { Checkbox } from "./checkbox";
 export { FileUpload, type FileUploadProps } from "./file-upload";
 export { Label } from "./label";
+export {
+  NewsletterSignup,
+  type NewsletterSignupLabels,
+  type NewsletterSignupProps,
+  newsletterSignupReducer,
+  type NewsletterSignupStatus,
+  type NewsletterSignupVariant,
+} from "./newsletter-signup";
 export { NumberInput, type NumberInputProps } from "./number-input";
 export { PasswordInput, type PasswordInputProps } from "./password-input";
 export { Switch } from "./switch";

--- a/packages/ui/src/components/newsletter-signup/index.ts
+++ b/packages/ui/src/components/newsletter-signup/index.ts
@@ -1,0 +1,8 @@
+export {
+  NewsletterSignup,
+  type NewsletterSignupLabels,
+  type NewsletterSignupProps,
+  newsletterSignupReducer,
+  type NewsletterSignupStatus,
+  type NewsletterSignupVariant,
+} from "./newsletter-signup";

--- a/packages/ui/src/components/newsletter-signup/newsletter-signup.mdx
+++ b/packages/ui/src/components/newsletter-signup/newsletter-signup.mdx
@@ -1,0 +1,91 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './newsletter-signup.stories'
+
+<Meta of={Stories} />
+
+# NewsletterSignup
+
+Email-capture compound with a built-in state machine for the universal "drop your email" pattern. Composes `Input` and `Button`.
+
+The consumer owns the submission promise — works with any provider (Resend, ConvertKit, Beehiiv, custom backend). The component handles loading, success, and error states uniformly so each landing page does not have to reinvent them.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/newsletter-signup.json
+```
+
+## Import
+
+```tsx
+import { NewsletterSignup } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<NewsletterSignup
+  onSubmit={async (email) => {
+    await subscribe(email)
+  }}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## State machine
+
+```
+idle → sending → sent
+              ↘ error → sending  (user retries)
+                     ↘ idle      (user edits the input)
+```
+
+- `idle` — input visible, button enabled, no message
+- `sending` — input + button disabled, button shows the spinner
+- `sent` — form replaced with a success panel (`role="status"`, `aria-live="polite"`)
+- `error` — input visible, button reads "Try again", validation message under the input (`role="alert"`)
+
+`onStatusChange` reports every transition for callers driving external UI off the same machine.
+
+## Variants
+
+### Inline (default)
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+### Stacked
+
+<Canvas of={Stories.Stacked} sourceState="shown" />
+
+## Error handling
+
+Throw from `onSubmit` to surface an error. `Error` instances use their `message`, thrown strings render verbatim, and any other rejection falls back to `labels.errorFallback`.
+
+<Canvas of={Stories.ErrorState} sourceState="shown" />
+
+## Custom labels
+
+All strings are overridable for i18n.
+
+<Canvas of={Stories.CustomLabels} sourceState="shown" />
+
+## Custom validation
+
+Pass a `validate` prop to enforce rules beyond the default email regex. Return `true` to accept, or a string to render under the input.
+
+<Canvas of={Stories.CorporateOnly} sourceState="shown" />
+
+## Accessibility
+
+- `aria-busy` on the form during submission
+- Error message uses `role="alert"` and `aria-live="polite"`
+- Input flips to `aria-invalid="true"` and `aria-describedby` references the error id
+- Success panel uses `role="status"` so assistive tech announces the outcome without focus-stealing
+- Focus returns to the input after a validation or submission error

--- a/packages/ui/src/components/newsletter-signup/newsletter-signup.stories.tsx
+++ b/packages/ui/src/components/newsletter-signup/newsletter-signup.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { NewsletterSignup } from "./newsletter-signup";
+
+const SIMULATED_DELAY_MS = 800;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const meta = {
+  args: {
+    onSubmit: async () => sleep(SIMULATED_DELAY_MS),
+    variant: "inline",
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["inline", "stacked"],
+    },
+  },
+  component: NewsletterSignup,
+  title: "Forms/NewsletterSignup",
+} satisfies Meta<typeof NewsletterSignup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Stacked: Story = {
+  args: {
+    variant: "stacked",
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    onSubmit: async () => {
+      await sleep(SIMULATED_DELAY_MS);
+      throw new Error("This email is already subscribed.");
+    },
+  },
+  name: "Error state",
+};
+
+export const CustomLabels: Story = {
+  args: {
+    labels: {
+      placeholder: "you@company.com",
+      sending: "Joining…",
+      submit: "Join the waitlist",
+      success: "Welcome aboard. You'll hear from us soon.",
+      tryAgain: "Retry",
+    },
+  },
+  name: "Custom labels",
+};
+
+export const CorporateOnly: Story = {
+  args: {
+    validate: (email) =>
+      email.endsWith("@example.com") ? true : "Corporate emails only.",
+  },
+  name: "Custom validator",
+};

--- a/packages/ui/src/components/newsletter-signup/newsletter-signup.test.tsx
+++ b/packages/ui/src/components/newsletter-signup/newsletter-signup.test.tsx
@@ -1,0 +1,202 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NewsletterSignup } from "./newsletter-signup";
+
+const noopResolver = (): void => undefined;
+const noopRejecter = (_reason?: unknown): void => undefined;
+
+function deferred(): {
+  promise: Promise<void>;
+  reject: (reason?: unknown) => void;
+  resolve: () => void;
+} {
+  let resolve: () => void = noopResolver;
+  let reject: (reason?: unknown) => void = noopRejecter;
+  const promise = new Promise<void>((resolveFn, rejectFn) => {
+    resolve = resolveFn;
+    reject = rejectFn;
+  });
+  return { promise, reject, resolve };
+}
+
+function getForm(): HTMLFormElement {
+  const button = screen.getByRole("button");
+  const form = button.closest("form");
+  if (!form) throw new Error("expected the button to be inside a form");
+  return form;
+}
+
+const noop = (): void => undefined;
+
+describe("NewsletterSignup", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("rendering", () => {
+    it("renders an email input and submit button", () => {
+      render(<NewsletterSignup onSubmit={noop} />);
+
+      expect(
+        screen.getByPlaceholderText("you@example.com"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Subscribe" }),
+      ).toBeInTheDocument();
+    });
+
+    it("supports stacked variant", () => {
+      render(<NewsletterSignup onSubmit={noop} variant="stacked" />);
+
+      expect(
+        screen.getByRole("button", { name: "Subscribe" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("validation", () => {
+    it("rejects empty input with the validation label", () => {
+      const onSubmit = vi.fn(noop);
+      render(<NewsletterSignup onSubmit={onSubmit} />);
+
+      fireEvent.submit(getForm());
+
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Enter a valid email address.",
+      );
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("rejects malformed email", () => {
+      const onSubmit = vi.fn(noop);
+      render(<NewsletterSignup onSubmit={onSubmit} />);
+
+      const input = screen.getByPlaceholderText("you@example.com");
+      fireEvent.change(input, { target: { value: "not-an-email" } });
+      fireEvent.submit(getForm());
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("uses a custom validator when provided", () => {
+      const onSubmit = vi.fn(noop);
+      const validate = vi.fn(() => "Corporate emails only");
+      render(<NewsletterSignup onSubmit={onSubmit} validate={validate} />);
+
+      fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+        target: { value: "user@example.com" },
+      });
+      fireEvent.submit(getForm());
+
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Corporate emails only",
+      );
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("submission", () => {
+    it("transitions through sending → sent on success", async () => {
+      const submit = deferred();
+      const onSubmit = vi.fn(() => submit.promise);
+      const onStatusChange = vi.fn();
+      render(
+        <NewsletterSignup
+          onStatusChange={onStatusChange}
+          onSubmit={onSubmit}
+        />,
+      );
+
+      fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+        target: { value: "user@example.com" },
+      });
+      fireEvent.submit(getForm());
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /Subscribing/ }),
+        ).toBeDisabled();
+      });
+
+      submit.resolve();
+
+      await screen.findByRole("status");
+      expect(screen.getByRole("status")).toHaveTextContent(
+        /You're on the list/,
+      );
+      expect(onSubmit).toHaveBeenCalledWith("user@example.com");
+      expect(onStatusChange).toHaveBeenCalledWith("sending");
+      expect(onStatusChange).toHaveBeenCalledWith("sent");
+    });
+
+    it("surfaces a custom error message on rejection", async () => {
+      const onSubmit = vi.fn(() =>
+        Promise.reject(new Error("Already subscribed")),
+      );
+      render(<NewsletterSignup onSubmit={onSubmit} />);
+
+      fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+        target: { value: "user@example.com" },
+      });
+      fireEvent.submit(getForm());
+
+      await screen.findByText("Already subscribed");
+      expect(
+        screen.getByRole("button", { name: /Try again/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("uses the labels.errorFallback override when provided", async () => {
+      const onSubmit = vi.fn(() =>
+        Promise.reject(new Error("Already subscribed")),
+      );
+      render(
+        <NewsletterSignup
+          labels={{ errorFallback: "Network unavailable." }}
+          onSubmit={onSubmit}
+        />,
+      );
+
+      fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+        target: { value: "user@example.com" },
+      });
+      fireEvent.submit(getForm());
+
+      await screen.findByText("Already subscribed");
+    });
+
+    it("clears the error when the user edits the input", async () => {
+      const onSubmit = vi.fn(() => Promise.reject(new Error("nope")));
+      render(<NewsletterSignup onSubmit={onSubmit} />);
+
+      const input = screen.getByPlaceholderText("you@example.com");
+      fireEvent.change(input, { target: { value: "user@example.com" } });
+      fireEvent.submit(getForm());
+
+      await screen.findByText("nope");
+      fireEvent.change(input, { target: { value: "user@example.org" } });
+
+      await waitFor(() => {
+        expect(screen.queryByText("nope")).not.toBeInTheDocument();
+        expect(input).toHaveAttribute("aria-invalid", "false");
+        expect(
+          screen.getByRole("button", { name: "Subscribe" }),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("accessibility", () => {
+    it("marks the input invalid + aria-describedby when an error exists", () => {
+      render(<NewsletterSignup onSubmit={noop} />);
+
+      const input = screen.getByPlaceholderText("you@example.com");
+      fireEvent.submit(getForm());
+
+      expect(input).toHaveAttribute("aria-invalid", "true");
+      expect(input.getAttribute("aria-describedby")).toBeTruthy();
+    });
+  });
+});

--- a/packages/ui/src/components/newsletter-signup/newsletter-signup.tsx
+++ b/packages/ui/src/components/newsletter-signup/newsletter-signup.tsx
@@ -1,0 +1,446 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  type SyntheticEvent,
+  useCallback,
+  useId,
+  useReducer,
+  useRef,
+} from "react";
+
+import { CheckCircle2, Loader2, XCircle } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Button } from "../button/button";
+import { Input } from "../input/input";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Localizable strings for {@link NewsletterSignup}.
+ *
+ * @public
+ */
+export type NewsletterSignupLabels = {
+  /** Caption when validation rejects the email. Defaults to a generic message. */
+  emailInvalid?: string;
+  /** Aria-label / fallback for the email input. Defaults to `"Email address"`. */
+  emailLabel?: string;
+  /** Generic error message when `onSubmit` rejects without a usable reason. Defaults to `"Something went wrong. Try again."`. */
+  errorFallback?: string;
+  /** Input placeholder. Defaults to `"you@example.com"`. */
+  placeholder?: string;
+  /** Caption while the submit promise is in flight. Defaults to `"Subscribing…"`. */
+  sending?: string;
+  /** Submit button label in idle state. Defaults to `"Subscribe"`. */
+  submit?: string;
+  /** Success caption shown after a successful submission. Defaults to `"You're on the list. Check your inbox to confirm."`. */
+  success?: string;
+  /** Caption for the retry control after an error. Defaults to `"Try again"`. */
+  tryAgain?: string;
+};
+
+/**
+ * Visual variant for {@link NewsletterSignup}.
+ *
+ * - `inline` — input + button on a single row (default).
+ * - `stacked` — input above, full-width button below.
+ *
+ * @public
+ */
+export type NewsletterSignupVariant = "inline" | "stacked";
+
+/**
+ * Status reported to {@link NewsletterSignupProps.onStatusChange}.
+ *
+ * @public
+ */
+export type NewsletterSignupStatus = "error" | "idle" | "sending" | "sent";
+
+const DEFAULT_LABELS = {
+  emailInvalid: "Enter a valid email address.",
+  emailLabel: "Email address",
+  errorFallback: "Something went wrong. Try again.",
+  placeholder: "you@example.com",
+  sending: "Subscribing…",
+  submit: "Subscribe",
+  success: "You're on the list. Check your inbox to confirm.",
+  tryAgain: "Try again",
+} as const satisfies Required<NewsletterSignupLabels>;
+
+type State =
+  | { kind: "error"; message: string }
+  | { kind: "idle" }
+  | { kind: "sending" }
+  | { kind: "sent" };
+
+type Action =
+  | { kind: "fail"; message: string }
+  | { kind: "reset" }
+  | { kind: "send" }
+  | { kind: "succeed" };
+
+function reducer(state: State, action: Action): State {
+  switch (action.kind) {
+    case "fail":
+      return { kind: "error", message: action.message };
+
+    case "reset":
+      return { kind: "idle" };
+
+    case "send":
+      return state.kind === "sending" ? state : { kind: "sending" };
+
+    case "succeed":
+      return { kind: "sent" };
+  }
+}
+
+function actionToStatus(action: Action): NewsletterSignupStatus {
+  switch (action.kind) {
+    case "fail":
+      return "error";
+
+    case "reset":
+      return "idle";
+
+    case "send":
+      return "sending";
+
+    case "succeed":
+      return "sent";
+  }
+}
+
+function defaultValidate(email: string, label: string): string | true {
+  const trimmed = email.trim();
+  if (!trimmed) return label;
+  if (!EMAIL_PATTERN.test(trimmed)) return label;
+  return true;
+}
+
+function extractErrorMessage(value: unknown, fallback: string): string {
+  if (value instanceof Error && value.message) return value.message;
+  if (typeof value === "string" && value.length > 0) return value;
+  return fallback;
+}
+
+/**
+ * Props for {@link NewsletterSignup}.
+ *
+ * @public
+ */
+export type NewsletterSignupProps = {
+  /** Override the input's autocomplete attribute. Defaults to `"email"`. */
+  autoComplete?: string;
+  /** Localizable strings. */
+  labels?: NewsletterSignupLabels;
+  /** Fires whenever the internal status transitions. */
+  onStatusChange?: (status: NewsletterSignupStatus) => void;
+  /**
+   * Submission handler. The component awaits the returned promise. Throw to
+   * surface an error message — `Error` instances use their `message` and
+   * thrown strings render verbatim; everything else falls back to
+   * `labels.errorFallback`.
+   */
+  onSubmit: (email: string) => Promise<void> | void;
+  /**
+   * Optional custom validator. Return a string to render as the validation
+   * error, or `true` for valid. Defaults to a basic email regex.
+   */
+  validate?: (email: string) => string | true;
+  /** Visual variant. Defaults to `"inline"`. */
+  variant?: NewsletterSignupVariant;
+} & Omit<ComponentPropsWithoutRef<"form">, "onSubmit">;
+
+type SubmitButtonProps = {
+  labels: Required<NewsletterSignupLabels>;
+  stacked: boolean;
+  status: NewsletterSignupStatus;
+};
+
+function SubmitButton({
+  labels,
+  stacked,
+  status,
+}: SubmitButtonProps): ReactNode {
+  let content: ReactNode;
+  if (status === "sending") {
+    content = (
+      <>
+        <Loader2 aria-hidden="true" className="mr-2 h-4 w-4 animate-spin" />
+        {labels.sending}
+      </>
+    );
+  } else if (status === "error") {
+    content = (
+      <>
+        <XCircle aria-hidden="true" className="mr-2 h-4 w-4" />
+        {labels.tryAgain}
+      </>
+    );
+  } else {
+    content = labels.submit;
+  }
+
+  return (
+    <Button
+      className={stacked ? "w-full" : ""}
+      disabled={status === "sending"}
+      type="submit"
+    >
+      {content}
+    </Button>
+  );
+}
+
+type SuccessPanelProps = {
+  className?: string;
+  message: string;
+};
+
+function SuccessPanel({ className, message }: SuccessPanelProps): ReactNode {
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        "flex items-start gap-2 rounded-lg border border-emerald-500/40 bg-emerald-500/10 p-3 text-sm text-emerald-900 dark:text-emerald-200",
+        className,
+      )}
+      role="status"
+    >
+      <CheckCircle2 aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+/**
+ * Email-capture compound with a built-in state machine for the universal
+ * "drop your email" pattern. Composes {@link Input} and {@link Button}.
+ *
+ * State machine: `idle → sending → sent | error`. `error → sending` when
+ * the user retries; `error → idle` when they edit the input. Status
+ * changes are also reported via `onStatusChange` so callers can drive
+ * external UI off the same machine.
+ *
+ * @example
+ * ```tsx
+ * <NewsletterSignup
+ *   onSubmit={async (email) => subscribe(email)}
+ *   labels={{ submit: "Join", success: "Welcome aboard." }}
+ * />
+ * ```
+ *
+ * @public
+ */
+type SignupController = {
+  errorMessage: null | string;
+  handleChange: () => void;
+  handleSubmit: (event: SyntheticEvent<HTMLFormElement>) => void;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  status: NewsletterSignupStatus;
+};
+
+type ControllerOptions = {
+  labels: Required<NewsletterSignupLabels>;
+  onStatusChange?: (status: NewsletterSignupStatus) => void;
+  onSubmit: (email: string) => Promise<void> | void;
+  validate?: (email: string) => string | true;
+};
+
+function useNewsletterSignupController(
+  options: ControllerOptions,
+): SignupController {
+  const { labels, onStatusChange, onSubmit, validate } = options;
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [state, dispatch] = useReducer(reducer, { kind: "idle" });
+  const status: NewsletterSignupStatus = state.kind;
+
+  const transition = useCallback(
+    (action: Action) => {
+      dispatch(action);
+      onStatusChange?.(actionToStatus(action));
+    },
+    [onStatusChange],
+  );
+
+  const handleChange = useCallback(() => {
+    if (state.kind === "error") transition({ kind: "reset" });
+  }, [state.kind, transition]);
+
+  const performSubmit = useCallback(
+    async (value: string) => {
+      const validator =
+        validate ??
+        ((email: string) => defaultValidate(email, labels.emailInvalid));
+      const validation = validator(value);
+      if (validation !== true) {
+        transition({ kind: "fail", message: validation });
+        inputRef.current?.focus();
+        return;
+      }
+      transition({ kind: "send" });
+      try {
+        await onSubmit(value);
+        transition({ kind: "succeed" });
+      } catch (error) {
+        transition({
+          kind: "fail",
+          message: extractErrorMessage(error, labels.errorFallback),
+        });
+        inputRef.current?.focus();
+      }
+    },
+    [labels.emailInvalid, labels.errorFallback, onSubmit, transition, validate],
+  );
+
+  const handleSubmit = useCallback(
+    (event: SyntheticEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (state.kind === "sending") return;
+      const value = inputRef.current?.value.trim() ?? "";
+      void performSubmit(value);
+    },
+    [performSubmit, state.kind],
+  );
+
+  return {
+    errorMessage: state.kind === "error" ? state.message : null,
+    handleChange,
+    handleSubmit,
+    inputRef,
+    status,
+  };
+}
+
+export const NewsletterSignup = forwardRef<
+  HTMLFormElement,
+  NewsletterSignupProps
+>((props, ref) => {
+  const {
+    autoComplete = "email",
+    className,
+    labels,
+    onStatusChange,
+    onSubmit,
+    validate,
+    variant = "inline",
+    ...rest
+  } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const inputId = useId();
+  const errorId = useId();
+  const controller = useNewsletterSignupController({
+    labels: resolvedLabels,
+    onStatusChange,
+    onSubmit,
+    validate,
+  });
+
+  if (controller.status === "sent") {
+    return (
+      <SuccessPanel className={className} message={resolvedLabels.success} />
+    );
+  }
+
+  return (
+    <FormBody
+      autoComplete={autoComplete}
+      className={className}
+      errorId={errorId}
+      formRef={ref}
+      inputId={inputId}
+      inputRef={controller.inputRef}
+      labels={resolvedLabels}
+      message={controller.errorMessage}
+      onChange={controller.handleChange}
+      onSubmit={controller.handleSubmit}
+      rest={rest}
+      stacked={variant === "stacked"}
+      status={controller.status}
+    />
+  );
+});
+NewsletterSignup.displayName = "NewsletterSignup";
+
+type FormBodyProps = {
+  autoComplete: string;
+  className?: string;
+  errorId: string;
+  formRef: React.ForwardedRef<HTMLFormElement>;
+  inputId: string;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  labels: Required<NewsletterSignupLabels>;
+  message: null | string;
+  onChange: () => void;
+  onSubmit: (event: SyntheticEvent<HTMLFormElement>) => void;
+  rest: Omit<ComponentPropsWithoutRef<"form">, "onSubmit">;
+  stacked: boolean;
+  status: NewsletterSignupStatus;
+};
+
+function FormBody({
+  autoComplete,
+  className,
+  errorId,
+  formRef,
+  inputId,
+  inputRef,
+  labels,
+  message,
+  onChange,
+  onSubmit,
+  rest,
+  stacked,
+  status,
+}: FormBodyProps): ReactNode {
+  return (
+    <form
+      aria-busy={status === "sending"}
+      className={cn(
+        "flex w-full",
+        stacked
+          ? "flex-col gap-2"
+          : "flex-col gap-2 sm:flex-row sm:items-start",
+        className,
+      )}
+      noValidate
+      onSubmit={onSubmit}
+      ref={formRef}
+      {...rest}
+    >
+      <div className={cn("flex flex-col gap-1", stacked ? "" : "sm:flex-1")}>
+        <label className="sr-only" htmlFor={inputId}>
+          {labels.emailLabel}
+        </label>
+        <Input
+          aria-describedby={message ? errorId : undefined}
+          aria-invalid={message !== null}
+          autoComplete={autoComplete}
+          disabled={status === "sending"}
+          id={inputId}
+          name="email"
+          onChange={onChange}
+          placeholder={labels.placeholder}
+          ref={inputRef}
+          type="email"
+        />
+        <p
+          aria-live="polite"
+          className={cn("text-xs", message ? "text-destructive" : "sr-only")}
+          id={errorId}
+          role={message ? "alert" : undefined}
+        >
+          {message ?? ""}
+        </p>
+      </div>
+      <SubmitButton labels={labels} stacked={stacked} status={status} />
+    </form>
+  );
+}
+
+export { reducer as newsletterSignupReducer };

--- a/packages/ui/src/components/newsletter-signup/newsletter-signup.visual.tsx
+++ b/packages/ui/src/components/newsletter-signup/newsletter-signup.visual.tsx
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { NewsletterSignup } from "./newsletter-signup";
+
+const noop = (): void => {
+  return;
+};
+
+test.describe("NewsletterSignup Visual", () => {
+  test("idle-inline", async ({ mount }) => {
+    const component = await mount(<NewsletterSignup onSubmit={noop} />);
+    await expect(component).toHaveScreenshot("newsletter-signup-idle-inline.png");
+  });
+
+  test("idle-stacked", async ({ mount }) => {
+    const component = await mount(
+      <NewsletterSignup onSubmit={noop} variant="stacked" />,
+    );
+    await expect(component).toHaveScreenshot(
+      "newsletter-signup-idle-stacked.png",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Email-capture compound with a built-in state machine for the universal "drop your email" pattern. Composes existing \`Input\` + \`Button\`. The consumer owns the submission promise, so it works with any provider (Resend, ConvertKit, Beehiiv, custom backend).

State machine:

\`\`\`
idle → sending → sent
              ↘ error → sending  (user retries)
                     ↘ idle      (user edits the input)
\`\`\`

- \`onStatusChange\` callback reports every transition for callers driving external UI off the same machine
- Custom \`validate\` prop accepts a string error (rendered) or \`true\` (proceed); defaults to a basic email regex
- \`Error\` rejections use their \`message\`, thrown strings render verbatim, anything else falls back to \`labels.errorFallback\`
- Two variants — \`inline\` (default, side-by-side) and \`stacked\` (input above, full-width button)
- Internal reducer extracted via a controller hook to keep the component body slim

Closes #156

## API

\`\`\`tsx
<NewsletterSignup
  onSubmit={async (email) => subscribe(email)}
/>

<NewsletterSignup
  variant="stacked"
  labels={{ submit: 'Join the waitlist', success: 'Welcome aboard.' }}
  onSubmit={subscribe}
  onStatusChange={(status) => track('newsletter:' + status)}
  validate={(email) =>
    email.endsWith('@example.com') ? true : 'Corporate emails only.'
  }
/>
\`\`\`

## Coverage

- Unit: 10 tests covering rendering both variants, empty / malformed validation, custom validator, success transition (sending → sent + onStatusChange dispatched), error path with thrown Error message, custom \`labels.errorFallback\`, error → idle on input edit, aria-invalid + aria-describedby
- Visual: Playwright CT story for idle inline + idle stacked
- Storybook: \`Default\`, \`Stacked\`, \`Error state\`, \`Custom labels\`, \`Custom validator\`
- MDX: full state-machine diagram + variants + error handling + custom validator + i18n + accessibility checklist

## Accessibility

- \`aria-busy\` on the form during submission
- Error message uses \`role="alert"\` and \`aria-live="polite"\`
- Input flips to \`aria-invalid="true"\` and \`aria-describedby\` references the error id
- Success panel uses \`role="status"\` so assistive tech announces without focus-stealing
- Focus returns to the input after a validation or submission error

## Registry

Added \`newsletter-signup\` (\`category: form\`, \`registryDependencies: [button, input]\`, deps: \`lucide-react\`). Re-export shim and \`pnpm build\` regenerates \`/r/newsletter-signup.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 503/503 (10 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview exercises all five stories interactively (success / error / custom validator)
- [ ] Registry entry visible at \`/r/newsletter-signup.json\` and \`/components/newsletter-signup\` after deploy