### PR TITLE
feat(ui): add ModelComparison + Column + Meta + Vote

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1647,6 +1647,26 @@
       "category": "data"
     },
     {
+      "name": "model-comparison",
+      "type": "registry:component",
+      "title": "Model Comparison",
+      "description": "Side-by-side comparison of AI model responses with optional blind mode, metadata stats, and a vote bar.",
+      "files": [
+        {
+          "path": "registry/default/model-comparison/model-comparison.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [
+        "badge",
+        "button"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "category": "ai"
+    },
+    {
       "name": "model-selector",
       "type": "registry:component",
       "title": "Model Selector",

--- a/apps/registry/registry/default/model-comparison/model-comparison.tsx
+++ b/apps/registry/registry/default/model-comparison/model-comparison.tsx
@@ -1,0 +1,7 @@
+// Re-export from @vllnt/ui package
+export {
+  ModelComparison,
+  ModelComparisonColumn,
+  ModelComparisonMeta,
+  ModelComparisonVote,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -710,6 +710,18 @@ export {
   type MetricGaugeThreshold,
 } from "./metric-gauge";
 export {
+  ModelComparison,
+  ModelComparisonColumn,
+  type ModelComparisonColumnProps,
+  type ModelComparisonLabels,
+  ModelComparisonMeta,
+  type ModelComparisonMetaProps,
+  type ModelComparisonProps,
+  ModelComparisonVote,
+  type ModelComparisonVoteProps,
+  type ModelComparisonVoteValue,
+} from "./model-comparison";
+export {
   SeverityBadge,
   type SeverityBadgeLevel,
   type SeverityBadgeProps,

--- a/packages/ui/src/components/model-comparison/index.ts
+++ b/packages/ui/src/components/model-comparison/index.ts
@@ -1,0 +1,12 @@
+export {
+  ModelComparison,
+  ModelComparisonColumn,
+  type ModelComparisonColumnProps,
+  type ModelComparisonLabels,
+  ModelComparisonMeta,
+  type ModelComparisonMetaProps,
+  type ModelComparisonProps,
+  ModelComparisonVote,
+  type ModelComparisonVoteProps,
+  type ModelComparisonVoteValue,
+} from "./model-comparison";

--- a/packages/ui/src/components/model-comparison/model-comparison.mdx
+++ b/packages/ui/src/components/model-comparison/model-comparison.mdx
@@ -1,0 +1,79 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './model-comparison.stories'
+
+<Meta of={Stories} />
+
+# ModelComparison
+
+Side-by-side comparison of multiple AI model responses to the same prompt. For A/B testing, evaluation, and educational comparison of AI capabilities.
+
+A compound component family:
+
+- `ModelComparison` — root container with optional prompt header and blind-mode toggle
+- `ModelComparisonColumn` — one column per model (label, model id, badge, content)
+- `ModelComparisonMeta` — stats row (tokens, latency, cost)
+- `ModelComparisonVote` — three-way vote (left / tie / right)
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/model-comparison.json
+```
+
+## Import
+
+```tsx
+import {
+  ModelComparison,
+  ModelComparisonColumn,
+  ModelComparisonMeta,
+  ModelComparisonVote,
+} from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<ModelComparison prompt="Explain closures in JavaScript">
+  <ModelComparisonColumn model="claude-sonnet-4-6" label="Sonnet">
+    <p>{sonnetResponse}</p>
+    <ModelComparisonMeta tokens={320} latency="0.8s" cost="$0.003" />
+  </ModelComparisonColumn>
+  <ModelComparisonColumn model="gpt-4o" label="GPT-4o">
+    <p>{gptResponse}</p>
+    <ModelComparisonMeta tokens={410} latency="1.1s" cost="$0.005" />
+  </ModelComparisonColumn>
+  <ModelComparisonVote onVote={(vote) => recordVote(vote)} />
+</ModelComparison>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Blind mode
+
+`blindDefault` starts the comparison anonymized; the user reveals labels via the built-in toggle. `hideBlindToggle` opts out of the toggle entirely. Use this for unbiased evaluation flows.
+
+<Canvas of={Stories.Blind} sourceState="shown" />
+
+## With vote bar
+
+`ModelComparisonVote` emits one of `"left" | "tie" | "right"`.
+
+<Canvas of={Stories.WithVote} sourceState="shown" />
+
+## Three columns
+
+The grid stretches to two columns on `md` viewports and three on `xl`.
+
+<Canvas of={Stories.ThreeColumns} sourceState="shown" />
+
+## Notes
+
+- Streaming, diff highlighting, synchronized scrolling, and share permalinks are intentionally **out of scope** — drive them from the consumer code with the existing component slots.
+- Each column emits `data-model="<id>"` (omitted in blind mode) so consumers can drive analytics off the DOM.

--- a/packages/ui/src/components/model-comparison/model-comparison.stories.tsx
+++ b/packages/ui/src/components/model-comparison/model-comparison.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  ModelComparison,
+  ModelComparisonColumn,
+  ModelComparisonMeta,
+  ModelComparisonVote,
+} from "./model-comparison";
+
+const meta = {
+  args: {
+    prompt: "Explain closures in JavaScript",
+  },
+  component: ModelComparison,
+  title: "AI/ModelComparison",
+} satisfies Meta<typeof ModelComparison>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const SONNET = `A closure is a function bundled together with references to its surrounding state. Whenever the inner function is called, it can read and modify those variables, even after the outer function has returned.`;
+
+const GPT = `Closures let an inner function remember the variables of the outer function it was created in. They are common when returning a function from a factory, or when using callbacks that need access to data from a parent scope.`;
+
+export const Default: Story = {
+  render: (args) => (
+    <ModelComparison {...args}>
+      <ModelComparisonColumn label="Sonnet" model="claude-sonnet-4-6">
+        <p>{SONNET}</p>
+        <ModelComparisonMeta cost="$0.003" latency="0.8s" tokens={320} />
+      </ModelComparisonColumn>
+      <ModelComparisonColumn label="GPT-4o" model="gpt-4o">
+        <p>{GPT}</p>
+        <ModelComparisonMeta cost="$0.005" latency="1.1s" tokens={410} />
+      </ModelComparisonColumn>
+    </ModelComparison>
+  ),
+};
+
+export const Blind: Story = {
+  args: {
+    blindDefault: true,
+  },
+  render: (args) => (
+    <ModelComparison {...args}>
+      <ModelComparisonColumn label="Sonnet" model="claude-sonnet-4-6">
+        <p>{SONNET}</p>
+      </ModelComparisonColumn>
+      <ModelComparisonColumn label="GPT-4o" model="gpt-4o">
+        <p>{GPT}</p>
+      </ModelComparisonColumn>
+    </ModelComparison>
+  ),
+};
+
+export const WithVote: Story = {
+  render: (args) => (
+    <ModelComparison {...args}>
+      <ModelComparisonColumn label="Sonnet" model="claude-sonnet-4-6">
+        <p>{SONNET}</p>
+        <ModelComparisonMeta latency="0.8s" tokens={320} />
+      </ModelComparisonColumn>
+      <ModelComparisonColumn label="GPT-4o" model="gpt-4o">
+        <p>{GPT}</p>
+        <ModelComparisonMeta latency="1.1s" tokens={410} />
+      </ModelComparisonColumn>
+      <ModelComparisonVote
+        onVote={(vote) => {
+          console.log("vote", vote);
+        }}
+      />
+    </ModelComparison>
+  ),
+};
+
+export const ThreeColumns: Story = {
+  render: (args) => (
+    <ModelComparison {...args}>
+      <ModelComparisonColumn label="Sonnet" model="claude-sonnet-4-6">
+        <p>{SONNET}</p>
+        <ModelComparisonMeta latency="0.8s" tokens={320} />
+      </ModelComparisonColumn>
+      <ModelComparisonColumn label="GPT-4o" model="gpt-4o">
+        <p>{GPT}</p>
+        <ModelComparisonMeta latency="1.1s" tokens={410} />
+      </ModelComparisonColumn>
+      <ModelComparisonColumn label="Haiku" model="claude-haiku-4-5">
+        <p>
+          A closure remembers the variables of the function it was defined
+          inside, even after that function has returned.
+        </p>
+        <ModelComparisonMeta latency="0.4s" tokens={210} />
+      </ModelComparisonColumn>
+    </ModelComparison>
+  ),
+};

--- a/packages/ui/src/components/model-comparison/model-comparison.test.tsx
+++ b/packages/ui/src/components/model-comparison/model-comparison.test.tsx
@@ -1,0 +1,133 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ModelComparison,
+  ModelComparisonColumn,
+  ModelComparisonMeta,
+  ModelComparisonVote,
+} from "./model-comparison";
+
+describe("ModelComparison", () => {
+  describe("rendering", () => {
+    it("renders the prompt when provided", () => {
+      render(
+        <ModelComparison prompt="Explain closures">
+          <ModelComparisonColumn label="Sonnet" model="claude-sonnet-4-6">
+            {null}
+          </ModelComparisonColumn>
+        </ModelComparison>,
+      );
+
+      expect(screen.getByText("Prompt")).toBeInTheDocument();
+      expect(screen.getByText("Explain closures")).toBeInTheDocument();
+    });
+
+    it("hides the header when prompt is omitted and toggle is suppressed", () => {
+      render(
+        <ModelComparison hideBlindToggle>
+          <ModelComparisonColumn label="A" model="m" />
+        </ModelComparison>,
+      );
+
+      expect(screen.queryByText("Prompt")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /Hide|Reveal/ }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("blind mode", () => {
+    it("toggles blind mode when the user clicks the control", () => {
+      render(
+        <ModelComparison>
+          <ModelComparisonColumn label="Sonnet" model="claude-sonnet-4-6">
+            content
+          </ModelComparisonColumn>
+        </ModelComparison>,
+      );
+
+      expect(screen.getByText("Sonnet")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Hide models" }));
+
+      expect(screen.queryByText("Sonnet")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Reveal models" }),
+      ).toBeInTheDocument();
+    });
+
+    it("respects blindDefault", () => {
+      render(
+        <ModelComparison blindDefault>
+          <ModelComparisonColumn label="Sonnet" model="claude-sonnet-4-6">
+            content
+          </ModelComparisonColumn>
+        </ModelComparison>,
+      );
+
+      expect(screen.queryByText("Sonnet")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Reveal models" }),
+      ).toBeInTheDocument();
+    });
+
+    it("strips data-model when blind", () => {
+      render(
+        <ModelComparison blindDefault>
+          <ModelComparisonColumn label="Sonnet" model="claude-sonnet-4-6">
+            content
+          </ModelComparisonColumn>
+        </ModelComparison>,
+      );
+
+      const articles = document.querySelectorAll("article");
+      expect(articles.length).toBe(1);
+      expect(articles[0]).toHaveAttribute("data-blind", "true");
+      expect(articles[0]?.dataset.model).toBeUndefined();
+    });
+  });
+
+  describe("ModelComparisonMeta", () => {
+    it("renders only the stats provided", () => {
+      render(
+        <ModelComparison hideBlindToggle>
+          <ModelComparisonColumn label="A" model="m">
+            <ModelComparisonMeta cost="$0.003" tokens={320} />
+          </ModelComparisonColumn>
+        </ModelComparison>,
+      );
+
+      expect(screen.getByText("Tokens")).toBeInTheDocument();
+      expect(screen.getByText("320")).toBeInTheDocument();
+      expect(screen.getByText("Cost")).toBeInTheDocument();
+      expect(screen.getByText("$0.003")).toBeInTheDocument();
+      expect(screen.queryByText("Latency")).not.toBeInTheDocument();
+    });
+
+    it("returns null when nothing is provided", () => {
+      const { container } = render(<ModelComparisonMeta />);
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("ModelComparisonVote", () => {
+    it("emits the vote value", () => {
+      const onVote = vi.fn();
+      render(
+        <ModelComparison hideBlindToggle>
+          <ModelComparisonVote onVote={onVote} />
+        </ModelComparison>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /Left/ }));
+      fireEvent.click(screen.getByRole("button", { name: "Tie" }));
+      fireEvent.click(screen.getByRole("button", { name: /Right/ }));
+
+      expect(onVote).toHaveBeenNthCalledWith(1, "left");
+      expect(onVote).toHaveBeenNthCalledWith(2, "tie");
+      expect(onVote).toHaveBeenNthCalledWith(3, "right");
+    });
+  });
+});

--- a/packages/ui/src/components/model-comparison/model-comparison.tsx
+++ b/packages/ui/src/components/model-comparison/model-comparison.tsx
@@ -1,0 +1,405 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+
+import { Eye, EyeOff } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Badge } from "../badge/badge";
+import { Button } from "../button/button";
+
+const HIDDEN_LABEL_PREFIX = "Model";
+
+/**
+ * Localizable strings for {@link ModelComparison}.
+ *
+ * @public
+ */
+export type ModelComparisonLabels = {
+  /** Caption for the cost stat. Defaults to `"Cost"`. */
+  cost?: string;
+  /** Caption for the blind-mode toggle when on. Defaults to `"Hide models"`. */
+  hide?: string;
+  /** Caption for the latency stat. Defaults to `"Latency"`. */
+  latency?: string;
+  /** Caption for the prompt heading. Defaults to `"Prompt"`. */
+  prompt?: string;
+  /** Caption for the blind-mode toggle when off. Defaults to `"Reveal models"`. */
+  reveal?: string;
+  /** Caption for the token count stat. Defaults to `"Tokens"`. */
+  tokens?: string;
+  /** Caption for the vote heading. Defaults to `"Which response is better?"`. */
+  voteHeading?: string;
+  /** Caption for the "tie" vote option. Defaults to `"Tie"`. */
+  voteTie?: string;
+};
+
+const DEFAULT_LABELS = {
+  cost: "Cost",
+  hide: "Hide models",
+  latency: "Latency",
+  prompt: "Prompt",
+  reveal: "Reveal models",
+  tokens: "Tokens",
+  voteHeading: "Which response is better?",
+  voteTie: "Tie",
+} as const satisfies Required<ModelComparisonLabels>;
+
+type ModelComparisonContextValue = {
+  blind: boolean;
+  labels: Required<ModelComparisonLabels>;
+};
+
+const DEFAULT_CONTEXT: ModelComparisonContextValue = {
+  blind: false,
+  labels: DEFAULT_LABELS,
+};
+
+const ModelComparisonContext = createContext(DEFAULT_CONTEXT);
+
+/**
+ * Props for {@link ModelComparison}.
+ *
+ * @public
+ */
+export type ModelComparisonProps = {
+  /** When true, replaces model labels with anonymous placeholders. */
+  blindDefault?: boolean;
+  /** When true, suppresses the built-in blind-mode toggle. */
+  hideBlindToggle?: boolean;
+  /** Localizable strings. */
+  labels?: ModelComparisonLabels;
+  /** The prompt that drove all responses. Hidden when omitted. */
+  prompt?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+type ComparisonHeaderProps = {
+  blind: boolean;
+  hideBlindToggle: boolean;
+  labels: Required<ModelComparisonLabels>;
+  onToggleBlind: () => void;
+  prompt?: ReactNode;
+};
+
+function ComparisonHeader({
+  blind,
+  hideBlindToggle,
+  labels,
+  onToggleBlind,
+  prompt,
+}: ComparisonHeaderProps): ReactNode {
+  if (!prompt && hideBlindToggle) return null;
+  return (
+    <header className="flex items-start justify-between gap-3">
+      {prompt ? (
+        <div className="flex min-w-0 flex-col gap-1">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {labels.prompt}
+          </span>
+          <p className="text-sm text-foreground">{prompt}</p>
+        </div>
+      ) : (
+        <span aria-hidden="true" />
+      )}
+      {hideBlindToggle ? null : (
+        <Button
+          aria-pressed={blind}
+          onClick={onToggleBlind}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          {blind ? (
+            <>
+              <Eye aria-hidden="true" className="mr-2 h-4 w-4" />
+              {labels.reveal}
+            </>
+          ) : (
+            <>
+              <EyeOff aria-hidden="true" className="mr-2 h-4 w-4" />
+              {labels.hide}
+            </>
+          )}
+        </Button>
+      )}
+    </header>
+  );
+}
+
+/**
+ * Side-by-side comparison of AI model responses to the same prompt.
+ * Composes {@link Badge} and {@link Button}.
+ *
+ * @example
+ * ```tsx
+ * <ModelComparison prompt="Explain closures in JavaScript">
+ *   <ModelComparisonColumn model="claude-sonnet-4-6" label="Sonnet">
+ *     {sonnetResponse}
+ *     <ModelComparisonMeta tokens={320} latency="0.8s" cost="$0.003" />
+ *   </ModelComparisonColumn>
+ *   <ModelComparisonColumn model="gpt-4o" label="GPT-4o">
+ *     {gptResponse}
+ *     <ModelComparisonMeta tokens={410} latency="1.1s" cost="$0.005" />
+ *   </ModelComparisonColumn>
+ *   <ModelComparisonVote onVote={handleVote} />
+ * </ModelComparison>
+ * ```
+ *
+ * @public
+ */
+export const ModelComparison = forwardRef<HTMLElement, ModelComparisonProps>(
+  (props, ref) => {
+    const {
+      blindDefault = false,
+      children,
+      className,
+      hideBlindToggle = false,
+      labels,
+      prompt,
+      ...rest
+    } = props;
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const [blind, setBlind] = useState(blindDefault);
+
+    const contextValue = useMemo<ModelComparisonContextValue>(
+      () => ({ blind, labels: resolvedLabels }),
+      [blind, resolvedLabels],
+    );
+
+    const handleToggleBlind = useCallback(() => {
+      setBlind((value) => !value);
+    }, []);
+
+    return (
+      <ModelComparisonContext.Provider value={contextValue}>
+        <section
+          className={cn(
+            "flex flex-col gap-4 rounded-2xl border bg-background p-4",
+            className,
+          )}
+          ref={ref}
+          {...rest}
+        >
+          <ComparisonHeader
+            blind={blind}
+            hideBlindToggle={hideBlindToggle}
+            labels={resolvedLabels}
+            onToggleBlind={handleToggleBlind}
+            prompt={prompt}
+          />
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {children}
+          </div>
+        </section>
+      </ModelComparisonContext.Provider>
+    );
+  },
+);
+ModelComparison.displayName = "ModelComparison";
+
+/**
+ * Props for {@link ModelComparisonColumn}.
+ *
+ * @public
+ */
+export type ModelComparisonColumnProps = {
+  /** Optional badge text shown alongside the label (e.g. "Winner"). */
+  badge?: ReactNode;
+  /** Friendly display label for the model. Hidden in blind mode. */
+  label?: ReactNode;
+  /** Model identifier. Hidden in blind mode. */
+  model: string;
+} & ComponentPropsWithoutRef<"article">;
+
+/**
+ * Column for {@link ModelComparison}. Renders the model label and badge in
+ * the header and the response content in the body.
+ *
+ * @public
+ */
+export const ModelComparisonColumn = forwardRef<
+  HTMLElement,
+  ModelComparisonColumnProps
+>((props, ref) => {
+  const { badge, children, className, label, model, ...rest } = props;
+  const id = useId();
+  const { blind } = useContext(ModelComparisonContext);
+  const displayLabel = blind
+    ? `${HIDDEN_LABEL_PREFIX} ${id.slice(-2)}`
+    : (label ?? model);
+
+  return (
+    <article
+      aria-label={typeof displayLabel === "string" ? displayLabel : undefined}
+      className={cn(
+        "flex flex-col gap-3 rounded-xl border border-border bg-muted/30 p-3",
+        className,
+      )}
+      data-blind={blind ? "true" : "false"}
+      data-model={blind ? undefined : model}
+      ref={ref}
+      {...rest}
+    >
+      <header className="flex items-center justify-between gap-2">
+        <h4 className="text-sm font-semibold tracking-tight text-foreground">
+          {displayLabel}
+        </h4>
+        {badge ? <Badge variant="secondary">{badge}</Badge> : null}
+      </header>
+      <div className="flex flex-1 flex-col gap-2 text-sm text-foreground">
+        {children}
+      </div>
+    </article>
+  );
+});
+ModelComparisonColumn.displayName = "ModelComparisonColumn";
+
+/**
+ * Props for {@link ModelComparisonMeta}.
+ *
+ * @public
+ */
+export type ModelComparisonMetaProps = {
+  /** Cost stat (formatted). */
+  cost?: ReactNode;
+  /** Latency stat (formatted). */
+  latency?: ReactNode;
+  /** Token count. */
+  tokens?: number | ReactNode;
+} & ComponentPropsWithoutRef<"dl">;
+
+/**
+ * Inline statistics row for a {@link ModelComparisonColumn}: tokens,
+ * latency, cost. Renders the stats whose props are present.
+ *
+ * @public
+ */
+export const ModelComparisonMeta = forwardRef<
+  HTMLDListElement,
+  ModelComparisonMetaProps
+>((props, ref) => {
+  const { className, cost, latency, tokens, ...rest } = props;
+  const { labels } = useContext(ModelComparisonContext);
+
+  const items: { caption: string; value: ReactNode }[] = [];
+  if (tokens !== undefined && tokens !== null) {
+    items.push({
+      caption: labels.tokens,
+      value: typeof tokens === "number" ? tokens.toLocaleString() : tokens,
+    });
+  }
+  if (latency !== undefined && latency !== null) {
+    items.push({ caption: labels.latency, value: latency });
+  }
+  if (cost !== undefined && cost !== null) {
+    items.push({ caption: labels.cost, value: cost });
+  }
+  if (items.length === 0) return null;
+
+  return (
+    <dl
+      className={cn(
+        "mt-auto flex flex-wrap gap-x-3 gap-y-1 border-t border-border pt-2 text-xs",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      {items.map((item) => (
+        <div className="flex items-baseline gap-1" key={item.caption}>
+          <dt className="font-medium uppercase tracking-wide text-muted-foreground">
+            {item.caption}
+          </dt>
+          <dd className="text-foreground">{item.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+});
+ModelComparisonMeta.displayName = "ModelComparisonMeta";
+
+/**
+ * Vote payload shape passed to {@link ModelComparisonVoteProps.onVote}.
+ *
+ * @public
+ */
+export type ModelComparisonVoteValue = "left" | "right" | "tie";
+
+type VoteLabels = {
+  left?: ReactNode;
+  right?: ReactNode;
+  tie?: ReactNode;
+};
+
+/**
+ * Props for {@link ModelComparisonVote}.
+ *
+ * @public
+ */
+export type ModelComparisonVoteProps = {
+  /** Optional captions for the left / right / tie buttons. */
+  buttonLabels?: VoteLabels;
+  /** Fires with the user's choice. */
+  onVote?: (vote: ModelComparisonVoteValue) => void;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * Vote bar for {@link ModelComparison}. Renders three buttons — left, tie,
+ * right — that each emit `onVote` with the chosen value.
+ *
+ * @public
+ */
+export const ModelComparisonVote = forwardRef<
+  HTMLDivElement,
+  ModelComparisonVoteProps
+>((props, ref) => {
+  const { buttonLabels, className, onVote, ...rest } = props;
+  const { labels: contextLabels } = useContext(ModelComparisonContext);
+
+  const handleLeft = useCallback(() => {
+    onVote?.("left");
+  }, [onVote]);
+  const handleTie = useCallback(() => {
+    onVote?.("tie");
+  }, [onVote]);
+  const handleRight = useCallback(() => {
+    onVote?.("right");
+  }, [onVote]);
+
+  return (
+    <div
+      className={cn("flex flex-col items-center gap-2", className)}
+      ref={ref}
+      {...rest}
+    >
+      <p className="text-sm font-medium text-foreground">
+        {contextLabels.voteHeading}
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <Button onClick={handleLeft} size="sm" type="button" variant="outline">
+          {buttonLabels?.left ?? "← Left"}
+        </Button>
+        <Button onClick={handleTie} size="sm" type="button" variant="ghost">
+          {buttonLabels?.tie ?? contextLabels.voteTie}
+        </Button>
+        <Button onClick={handleRight} size="sm" type="button" variant="outline">
+          {buttonLabels?.right ?? "Right →"}
+        </Button>
+      </div>
+    </div>
+  );
+});
+ModelComparisonVote.displayName = "ModelComparisonVote";

--- a/packages/ui/src/components/model-comparison/model-comparison.visual.tsx
+++ b/packages/ui/src/components/model-comparison/model-comparison.visual.tsx
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import {
+  ModelComparison,
+  ModelComparisonColumn,
+  ModelComparisonMeta,
+  ModelComparisonVote,
+} from "./model-comparison";
+
+const noop = (): void => {
+  return;
+};
+
+test.describe("ModelComparison Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <ModelComparison prompt="Explain closures in JavaScript">
+        <ModelComparisonColumn label="Sonnet" model="claude-sonnet-4-6">
+          <p>
+            A closure is a function bundled together with references to its
+            surrounding state.
+          </p>
+          <ModelComparisonMeta cost="$0.003" latency="0.8s" tokens={320} />
+        </ModelComparisonColumn>
+        <ModelComparisonColumn label="GPT-4o" model="gpt-4o">
+          <p>
+            Closures let an inner function remember the variables of the
+            outer function it was created in.
+          </p>
+          <ModelComparisonMeta cost="$0.005" latency="1.1s" tokens={410} />
+        </ModelComparisonColumn>
+        <ModelComparisonVote onVote={noop} />
+      </ModelComparison>,
+    );
+    await expect(component).toHaveScreenshot("model-comparison-default.png");
+  });
+});


### PR DESCRIPTION
## Summary

Compound family for side-by-side AI model response comparison. Composes existing \`Badge\` + \`Button\`.

- **ModelComparison** — root container, optional prompt header, built-in blind-mode toggle (anonymizes model labels). Exposes context so children read the blind state and labels.
- **ModelComparisonColumn** — one column per model, accepts \`label\` + \`badge\`. Emits \`data-model\` attribute (omitted when blind) for analytics.
- **ModelComparisonMeta** — inline \`tokens\` / \`latency\` / \`cost\` stats; renders only the props that are present.
- **ModelComparisonVote** — three-way \`left\` / \`tie\` / \`right\` vote bar emitting a typed \`ModelComparisonVoteValue\`.

Streaming, diff highlighting, synchronized scrolling, and share permalinks are intentionally **out of scope** — drive them from consumer code via the slots.

Closes #58

## API

\`\`\`tsx
<ModelComparison prompt="Explain closures in JavaScript">
  <ModelComparisonColumn model="claude-sonnet-4-6" label="Sonnet">
    <p>{sonnetResponse}</p>
    <ModelComparisonMeta tokens={320} latency="0.8s" cost="$0.003" />
  </ModelComparisonColumn>
  <ModelComparisonColumn model="gpt-4o" label="GPT-4o">
    <p>{gptResponse}</p>
    <ModelComparisonMeta tokens={410} latency="1.1s" cost="$0.005" />
  </ModelComparisonColumn>
  <ModelComparisonVote onVote={(vote) => recordVote(vote)} />
</ModelComparison>
\`\`\`

## Coverage

- Unit: 8 tests covering prompt header rendering, suppressed header, blind toggle (off → on, default-on, model attribute strip), \`Meta\` rendering only provided stats + null when empty, vote bar emits left/tie/right
- Visual: Playwright CT story for the default 3-way comparison
- Storybook: \`Default\`, \`Blind\`, \`WithVote\`, \`ThreeColumns\`
- MDX: usage + blind mode + vote + 3-column layout + scope notes

## Registry

Added \`model-comparison\` (\`category: ai\`, \`registryDependencies: [badge, button]\`, deps: \`lucide-react\`). Re-export shim and \`pnpm build\` regenerates \`/r/model-comparison.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 501/501 (8 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview exercises blind toggle + vote callback (\`console.log\`)
- [ ] Registry entry visible at \`/r/model-comparison.json\` and \`/components/model-comparison\` after deploy