### PR TITLE
feat(ui): add PromptTemplates gallery

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -2012,6 +2012,27 @@
       "category": "data"
     },
     {
+      "name": "prompt-templates",
+      "type": "registry:component",
+      "title": "Prompt Templates",
+      "description": "Searchable prompt template gallery with category filter, variable fill-in form, and onSelect.",
+      "files": [
+        {
+          "path": "registry/default/prompt-templates/prompt-templates.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [
+        "badge",
+        "button",
+        "input"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "category": "ai"
+    },
+    {
       "name": "progress-card",
       "type": "registry:component",
       "title": "Progress Card",

--- a/apps/registry/registry/default/prompt-templates/prompt-templates.tsx
+++ b/apps/registry/registry/default/prompt-templates/prompt-templates.tsx
@@ -1,0 +1,2 @@
+// Re-export from @vllnt/ui package
+export { PromptTemplates } from '@vllnt/ui'

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -645,6 +645,13 @@ export {
 } from "./order-book";
 export { ProfileSection } from "./profile-section";
 export {
+  type PromptTemplate,
+  type PromptTemplateCategory,
+  PromptTemplates,
+  type PromptTemplatesLabels,
+  type PromptTemplatesProps,
+} from "./prompt-templates";
+export {
   PlanBadge,
   type PlanBadgeProps,
   type PlanBadgeState,

--- a/packages/ui/src/components/prompt-templates/index.ts
+++ b/packages/ui/src/components/prompt-templates/index.ts
@@ -1,0 +1,7 @@
+export {
+  type PromptTemplate,
+  type PromptTemplateCategory,
+  PromptTemplates,
+  type PromptTemplatesLabels,
+  type PromptTemplatesProps,
+} from "./prompt-templates";

--- a/packages/ui/src/components/prompt-templates/prompt-templates.mdx
+++ b/packages/ui/src/components/prompt-templates/prompt-templates.mdx
@@ -1,0 +1,85 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './prompt-templates.stories'
+
+<Meta of={Stories} />
+
+# PromptTemplates
+
+Library / gallery of saved prompt templates with search, category filter, and a built-in fill-in form for `{{variable}}` placeholders. Composes existing `Input`, `Button`, and `Badge` primitives.
+
+The component is data-driven — pass a `templates` array. Variables in the template body (`{{name}}`) are detected automatically (or pass an explicit `variables` array). Templates with variables expand into an inline form on click; templates without variables fire `onSelect` immediately.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/prompt-templates.json
+```
+
+## Import
+
+```tsx
+import { PromptTemplates } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<PromptTemplates
+  templates={[
+    {
+      id: 'code-review',
+      title: 'Code Review',
+      description: 'Review code for bugs and improvements',
+      template: 'Review this {{language}} code:\n\n{{code}}',
+      category: 'Code',
+    },
+  ]}
+  categories={[{ name: 'Code' }, { name: 'Writing' }]}
+  onSelect={(resolved, template) => insertIntoComposer(resolved)}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Variable placeholders
+
+Placeholders use `{{name}}` syntax. They are detected automatically; pass an explicit `variables` array on a template entry when the same placeholder appears more than once or when you want to override the detection order.
+
+When the user activates a template with variables, the card expands into an inline form. Submitting the form fires `onSelect` with the resolved string and the original template entry.
+
+```tsx
+{
+  id: 'code-review',
+  title: 'Code Review',
+  template: 'Review this {{language}} code:\n\n{{code}}',
+  // optional: lock the order / dedupe a placeholder used multiple times
+  variables: ['language', 'code'],
+}
+```
+
+## Without categories
+
+Pass no `categories` prop to skip the filter row.
+
+<Canvas of={Stories.NoCategories} sourceState="shown" />
+
+## Empty state
+
+<Canvas of={Stories.Empty} sourceState="shown" />
+
+## Custom labels
+
+All strings are overridable for i18n.
+
+<Canvas of={Stories.CustomLabels} sourceState="shown" />
+
+## Notes
+
+- Pinning / favorites and user-created prompts are intentionally **out of scope** — drive them from the consumer code by filtering or augmenting the `templates` array.
+- Each card emits `data-template-id="<id>"` so consumers can drive analytics off the DOM.

--- a/packages/ui/src/components/prompt-templates/prompt-templates.stories.tsx
+++ b/packages/ui/src/components/prompt-templates/prompt-templates.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  type PromptTemplate,
+  PromptTemplates,
+} from "./prompt-templates";
+
+const TEMPLATES: PromptTemplate[] = [
+  {
+    category: "Code",
+    description: "Review code for bugs, performance issues, and improvements",
+    id: "code-review",
+    template:
+      "Review this {{language}} code for bugs, performance issues, and improvements:\n\n{{code}}",
+    title: "Code Review",
+  },
+  {
+    category: "Code",
+    description: "Generate unit tests for a function",
+    id: "code-tests",
+    template: "Write unit tests for this {{language}} function:\n\n{{code}}",
+    title: "Generate tests",
+  },
+  {
+    category: "Writing",
+    description: "Polish a draft for clarity and concision",
+    id: "writing-polish",
+    template:
+      "Polish the following text for clarity and concision while keeping the original tone:\n\n{{text}}",
+    title: "Polish writing",
+  },
+  {
+    category: "Analysis",
+    description: "Summarize a document into bullet points",
+    id: "summary",
+    template: "Summarize the following document in {{count}} bullet points:\n\n{{document}}",
+    title: "Summarize",
+  },
+  {
+    category: "Analysis",
+    description: "Explain code line by line",
+    id: "code-explain",
+    template: "Explain what this code does line by line.",
+    title: "Explain code",
+  },
+];
+
+const meta = {
+  args: {
+    categories: [
+      { name: "Code" },
+      { name: "Writing" },
+      { name: "Analysis" },
+    ],
+    onSelect: (resolved) => {
+      console.log("selected", resolved);
+    },
+    templates: TEMPLATES,
+  },
+  component: PromptTemplates,
+  title: "AI/PromptTemplates",
+} satisfies Meta<typeof PromptTemplates>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const NoCategories: Story = {
+  args: {
+    categories: undefined,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    categories: undefined,
+    templates: [],
+  },
+};
+
+export const CustomLabels: Story = {
+  args: {
+    labels: {
+      empty: "No prompts saved yet.",
+      insert: "Apply",
+      searchPlaceholder: "Find a prompt…",
+      use: "Apply prompt",
+      variablesHeading: "Plug in your values",
+    },
+  },
+};

--- a/packages/ui/src/components/prompt-templates/prompt-templates.test.tsx
+++ b/packages/ui/src/components/prompt-templates/prompt-templates.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { type PromptTemplate, PromptTemplates } from "./prompt-templates";
+
+const TEMPLATES: PromptTemplate[] = [
+  {
+    category: "Code",
+    description: "Review code for bugs",
+    id: "code-review",
+    template: "Review this {{language}} code:\n\n{{code}}",
+    title: "Code Review",
+  },
+  {
+    category: "Writing",
+    description: "Polish a draft",
+    id: "writing-polish",
+    template: "Polish the following text:\n\n{{text}}",
+    title: "Polish writing",
+  },
+  {
+    category: "Code",
+    description: "Walk through what each line does",
+    id: "code-explain",
+    template: "Explain what this code does line by line.",
+    title: "Explain code",
+  },
+];
+
+function clickUseFor(title: string): void {
+  const card = screen.getByText(title).closest("article");
+  const useButton = card?.querySelector("button");
+  if (!useButton) throw new Error(`expected ${title} card to render`);
+  fireEvent.click(useButton);
+}
+
+describe("PromptTemplates", () => {
+  describe("rendering", () => {
+    it("renders all templates by default", () => {
+      render(<PromptTemplates templates={TEMPLATES} />);
+
+      expect(screen.getByText("Code Review")).toBeInTheDocument();
+      expect(screen.getByText("Polish writing")).toBeInTheDocument();
+      expect(screen.getByText("Explain code")).toBeInTheDocument();
+    });
+
+    it("renders the empty state when no template matches", () => {
+      render(
+        <PromptTemplates labels={{ empty: "Nothing here." }} templates={[]} />,
+      );
+
+      expect(screen.getByText("Nothing here.")).toBeInTheDocument();
+    });
+  });
+
+  describe("filtering", () => {
+    it("filters by search query against title and description", () => {
+      render(<PromptTemplates templates={TEMPLATES} />);
+
+      fireEvent.change(screen.getByPlaceholderText("Search prompts…"), {
+        target: { value: "polish" },
+      });
+
+      expect(screen.getByText("Polish writing")).toBeInTheDocument();
+      expect(screen.queryByText("Code Review")).not.toBeInTheDocument();
+    });
+
+    it("filters by category chip", () => {
+      render(
+        <PromptTemplates
+          categories={[{ name: "Code" }, { name: "Writing" }]}
+          templates={TEMPLATES}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("tab", { name: "Writing" }));
+
+      expect(screen.getByText("Polish writing")).toBeInTheDocument();
+      expect(screen.queryByText("Code Review")).not.toBeInTheDocument();
+    });
+
+    it("returns all templates when the All chip is selected again", () => {
+      render(
+        <PromptTemplates
+          categories={[{ name: "Code" }]}
+          templates={TEMPLATES}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("tab", { name: "Code" }));
+      expect(screen.queryByText("Polish writing")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("tab", { name: "All" }));
+      expect(screen.getByText("Polish writing")).toBeInTheDocument();
+    });
+  });
+
+  describe("variables", () => {
+    it("invokes onSelect immediately for templates without variables", () => {
+      const onSelect = vi.fn();
+      render(<PromptTemplates onSelect={onSelect} templates={TEMPLATES} />);
+
+      const card = screen.getByText("Explain code").closest("article");
+      const useButton = card?.querySelector("button");
+      if (!useButton) throw new Error("expected the use button to render");
+      fireEvent.click(useButton);
+
+      expect(onSelect).toHaveBeenCalledWith(
+        "Explain what this code does line by line.",
+        TEMPLATES[2],
+      );
+    });
+
+    it("opens an inline form when the user activates a template with variables", () => {
+      render(<PromptTemplates templates={TEMPLATES} />);
+
+      clickUseFor("Code Review");
+
+      expect(screen.getByText("Fill in the placeholders")).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText("Value for language"),
+      ).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("Value for code")).toBeInTheDocument();
+    });
+
+    it("resolves the template with the user's values on Insert", () => {
+      const onSelect = vi.fn();
+      render(<PromptTemplates onSelect={onSelect} templates={TEMPLATES} />);
+
+      clickUseFor("Code Review");
+      fireEvent.change(screen.getByPlaceholderText("Value for language"), {
+        target: { value: "TypeScript" },
+      });
+      fireEvent.change(screen.getByPlaceholderText("Value for code"), {
+        target: { value: "const x = 1" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Insert" }));
+
+      expect(onSelect).toHaveBeenCalledWith(
+        "Review this TypeScript code:\n\nconst x = 1",
+        TEMPLATES[0],
+      );
+    });
+
+    it("leaves placeholders intact when the user submits without filling them", () => {
+      const onSelect = vi.fn();
+      render(<PromptTemplates onSelect={onSelect} templates={TEMPLATES} />);
+
+      clickUseFor("Code Review");
+      fireEvent.click(screen.getByRole("button", { name: "Insert" }));
+
+      expect(onSelect).toHaveBeenCalledWith(
+        "Review this {{language}} code:\n\n{{code}}",
+        TEMPLATES[0],
+      );
+    });
+
+    it("clears the form on Cancel", () => {
+      render(<PromptTemplates templates={TEMPLATES} />);
+
+      clickUseFor("Code Review");
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      expect(
+        screen.queryByText("Fill in the placeholders"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/prompt-templates/prompt-templates.tsx
+++ b/packages/ui/src/components/prompt-templates/prompt-templates.tsx
@@ -1,0 +1,631 @@
+"use client";
+
+import {
+  type ChangeEvent,
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+
+import { Search, Sparkles } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Badge } from "../badge/badge";
+import { Button } from "../button/button";
+import { Input } from "../input/input";
+
+const VARIABLE_PATTERN = /{{\s*([\w-]+)\s*}}/g;
+const ALL_CATEGORY_VALUE = "__all__";
+
+/**
+ * One prompt template entry.
+ *
+ * @public
+ */
+export type PromptTemplate = {
+  /** Optional category (matched against {@link PromptTemplateCategory.name}). */
+  category?: string;
+  /** Sub-headline shown under the title. */
+  description?: ReactNode;
+  /** Stable identifier. */
+  id: string;
+  /**
+   * Raw template body with `{{variable}}` placeholders. Placeholders are
+   * detected automatically; the explicit `variables` array overrides
+   * detection (useful when the same placeholder appears more than once).
+   */
+  template: string;
+  /** Display title. */
+  title: ReactNode;
+  /** Override for detected variable names. */
+  variables?: string[];
+};
+
+/**
+ * Category chip for filtering.
+ *
+ * @public
+ */
+export type PromptTemplateCategory = {
+  /** Optional icon rendered next to the name. */
+  icon?: ReactNode;
+  /** Category display name (matched against {@link PromptTemplate.category}). */
+  name: string;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type PromptTemplatesLabels = {
+  /** Caption for the all-categories chip. Defaults to `"All"`. */
+  allCategory?: string;
+  /** Caption for the cancel button on the variable form. Defaults to `"Cancel"`. */
+  cancel?: string;
+  /** Empty-state heading when no templates match. Defaults to `"No prompts found."`. */
+  empty?: string;
+  /** Caption for the use button when filling in variables. Defaults to `"Insert"`. */
+  insert?: string;
+  /** Search input placeholder. Defaults to `"Search prompts…"`. */
+  searchPlaceholder?: string;
+  /** Caption for the use button on a card. Defaults to `"Use template"`. */
+  use?: string;
+  /** Caption above the variable form. Defaults to `"Fill in the placeholders"`. */
+  variablesHeading?: string;
+};
+
+const DEFAULT_LABELS = {
+  allCategory: "All",
+  cancel: "Cancel",
+  empty: "No prompts found.",
+  insert: "Insert",
+  searchPlaceholder: "Search prompts…",
+  use: "Use template",
+  variablesHeading: "Fill in the placeholders",
+} as const satisfies Required<PromptTemplatesLabels>;
+
+/**
+ * Props for {@link PromptTemplates}.
+ *
+ * @public
+ */
+export type PromptTemplatesProps = {
+  /** Optional list of categories to render as filter chips. */
+  categories?: PromptTemplateCategory[];
+  /** Localizable strings. */
+  labels?: PromptTemplatesLabels;
+  /**
+   * Fires with the resolved template body. When the template has variables,
+   * the user fills them in first; otherwise this fires on click.
+   */
+  onSelect?: (resolved: string, template: PromptTemplate) => void;
+  /** The template list. */
+  templates: PromptTemplate[];
+} & ComponentPropsWithoutRef<"section">;
+
+function detectVariables(template: PromptTemplate): string[] {
+  if (template.variables) return template.variables;
+  const matches = [...template.template.matchAll(VARIABLE_PATTERN)];
+  const seen = new Set<string>();
+  return matches.reduce<string[]>((accumulator, match) => {
+    const name = match[1];
+    if (name && !seen.has(name)) {
+      seen.add(name);
+      accumulator.push(name);
+    }
+    return accumulator;
+  }, []);
+}
+
+function fillTemplate(
+  template: string,
+  values: Record<string, string>,
+): string {
+  return template.replaceAll(
+    VARIABLE_PATTERN,
+    (_match: string, name: string) => values[name] ?? `{{${name}}}`,
+  );
+}
+
+function matchesCategory(template: PromptTemplate, selected: string): boolean {
+  if (selected === ALL_CATEGORY_VALUE) return true;
+  return template.category === selected;
+}
+
+function matchesQuery(template: PromptTemplate, query: string): boolean {
+  if (!query) return true;
+  const lowered = query.toLowerCase();
+  const title =
+    typeof template.title === "string" ? template.title.toLowerCase() : "";
+  const description =
+    typeof template.description === "string"
+      ? template.description.toLowerCase()
+      : "";
+  return title.includes(lowered) || description.includes(lowered);
+}
+
+type FilterBarProps = {
+  categories: PromptTemplateCategory[];
+  labels: Required<PromptTemplatesLabels>;
+  onCategoryChange: (value: string) => void;
+  onQueryChange: (value: string) => void;
+  query: string;
+  searchId: string;
+  selectedCategory: string;
+};
+
+function FilterBar({
+  categories,
+  labels,
+  onCategoryChange,
+  onQueryChange,
+  query,
+  searchId,
+  selectedCategory,
+}: FilterBarProps): ReactNode {
+  const handleSearch = (event: ChangeEvent<HTMLInputElement>): void => {
+    onQueryChange(event.target.value);
+  };
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="relative">
+        <Search
+          aria-hidden="true"
+          className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          aria-label={labels.searchPlaceholder}
+          className="pl-9"
+          id={searchId}
+          onChange={handleSearch}
+          placeholder={labels.searchPlaceholder}
+          type="search"
+          value={query}
+        />
+      </div>
+      {categories.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5" role="tablist">
+          <CategoryChip
+            active={selectedCategory === ALL_CATEGORY_VALUE}
+            label={labels.allCategory}
+            onClick={() => {
+              onCategoryChange(ALL_CATEGORY_VALUE);
+            }}
+            value={ALL_CATEGORY_VALUE}
+          />
+          {categories.map((category) => (
+            <CategoryChip
+              active={selectedCategory === category.name}
+              icon={category.icon}
+              key={category.name}
+              label={category.name}
+              onClick={() => {
+                onCategoryChange(category.name);
+              }}
+              value={category.name}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+type CategoryChipProps = {
+  active: boolean;
+  icon?: ReactNode;
+  label: string;
+  onClick: () => void;
+  value: string;
+};
+
+function CategoryChip({
+  active,
+  icon,
+  label,
+  onClick,
+  value,
+}: CategoryChipProps): ReactNode {
+  return (
+    <button
+      aria-selected={active}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        active
+          ? "border-primary bg-primary text-primary-foreground"
+          : "border-border bg-background text-foreground hover:bg-accent",
+      )}
+      data-value={value}
+      onClick={onClick}
+      role="tab"
+      type="button"
+    >
+      {icon ? (
+        <span aria-hidden="true" className="[&>svg]:h-3.5 [&>svg]:w-3.5">
+          {icon}
+        </span>
+      ) : null}
+      {label}
+    </button>
+  );
+}
+
+type CardProps = {
+  active: boolean;
+  labels: Required<PromptTemplatesLabels>;
+  onActivate: (template: PromptTemplate) => void;
+  onCancel: () => void;
+  onResolve: (resolved: string, template: PromptTemplate) => void;
+  onValueChange: (name: string, value: string) => void;
+  template: PromptTemplate;
+  values: Record<string, string>;
+};
+
+type CardHeaderProps = {
+  category?: string;
+  description?: ReactNode;
+  title: ReactNode;
+};
+
+function CardHeader({
+  category,
+  description,
+  title,
+}: CardHeaderProps): ReactNode {
+  return (
+    <header className="flex flex-col gap-1">
+      <h4 className="text-sm font-semibold tracking-tight text-foreground">
+        {title}
+      </h4>
+      {description ? (
+        <p className="text-xs text-muted-foreground">{description}</p>
+      ) : null}
+      {category ? (
+        <Badge className="self-start" variant="outline">
+          {category}
+        </Badge>
+      ) : null}
+    </header>
+  );
+}
+
+type CardActionsProps = {
+  onUse: () => void;
+  useLabel: string;
+  variableCount: number;
+};
+
+function CardActions({
+  onUse,
+  useLabel,
+  variableCount,
+}: CardActionsProps): ReactNode {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      {variableCount > 0 ? (
+        <span className="text-xs text-muted-foreground">
+          {variableCount.toString()} variable{variableCount === 1 ? "" : "s"}
+        </span>
+      ) : (
+        <span aria-hidden="true" />
+      )}
+      <Button
+        onClick={onUse}
+        size="sm"
+        type="button"
+        variant={variableCount > 0 ? "outline" : "default"}
+      >
+        <Sparkles aria-hidden="true" className="mr-2 h-3.5 w-3.5" />
+        {useLabel}
+      </Button>
+    </div>
+  );
+}
+
+function PromptTemplateCard({
+  active,
+  labels,
+  onActivate,
+  onCancel,
+  onResolve,
+  onValueChange,
+  template,
+  values,
+}: CardProps): ReactNode {
+  const variables = detectVariables(template);
+  const handleUse = useCallback(() => {
+    if (variables.length === 0) {
+      onResolve(template.template, template);
+      return;
+    }
+    if (active) {
+      onResolve(fillTemplate(template.template, values), template);
+      return;
+    }
+    onActivate(template);
+  }, [active, onActivate, onResolve, template, values, variables.length]);
+
+  return (
+    <article
+      className="flex flex-col gap-3 rounded-xl border border-border bg-background p-4 shadow-sm"
+      data-template-id={template.id}
+    >
+      <CardHeader
+        category={template.category}
+        description={template.description}
+        title={template.title}
+      />
+      {active && variables.length > 0 ? (
+        <VariableForm
+          fieldIdPrefix={template.id}
+          labels={labels}
+          onCancel={onCancel}
+          onSubmit={handleUse}
+          onValueChange={onValueChange}
+          values={values}
+          variables={variables}
+        />
+      ) : (
+        <CardActions
+          onUse={handleUse}
+          useLabel={labels.use}
+          variableCount={variables.length}
+        />
+      )}
+    </article>
+  );
+}
+
+type VariableFormProps = {
+  fieldIdPrefix: string;
+  labels: Required<PromptTemplatesLabels>;
+  onCancel: () => void;
+  onSubmit: () => void;
+  onValueChange: (name: string, value: string) => void;
+  values: Record<string, string>;
+  variables: string[];
+};
+
+type VariableFieldProps = {
+  fieldId: string;
+  name: string;
+  onValueChange: (name: string, value: string) => void;
+  value: string;
+};
+
+function VariableField({
+  fieldId,
+  name,
+  onValueChange,
+  value,
+}: VariableFieldProps): ReactNode {
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onValueChange(name, event.target.value);
+    },
+    [name, onValueChange],
+  );
+  return (
+    <div className="flex flex-col gap-1 text-xs">
+      <label className="font-medium text-foreground" htmlFor={fieldId}>
+        {name}
+      </label>
+      <Input
+        id={fieldId}
+        onChange={handleChange}
+        placeholder={`Value for ${name}`}
+        value={value}
+      />
+    </div>
+  );
+}
+
+function VariableForm({
+  fieldIdPrefix,
+  labels,
+  onCancel,
+  onSubmit,
+  onValueChange,
+  values,
+  variables,
+}: VariableFormProps): ReactNode {
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-dashed border-border bg-muted/30 p-3">
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {labels.variablesHeading}
+      </p>
+      <div className="flex flex-col gap-2">
+        {variables.map((name) => (
+          <VariableField
+            fieldId={`${fieldIdPrefix}-${name}`}
+            key={name}
+            name={name}
+            onValueChange={onValueChange}
+            value={values[name] ?? ""}
+          />
+        ))}
+      </div>
+      <div className="mt-1 flex justify-end gap-2">
+        <Button onClick={onCancel} size="sm" type="button" variant="ghost">
+          {labels.cancel}
+        </Button>
+        <Button onClick={onSubmit} size="sm" type="button">
+          {labels.insert}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Library / gallery of saved prompt templates with search, category filter,
+ * and a built-in fill-in form for `{{variable}}` placeholders. Composes
+ * existing {@link Input}, {@link Button}, and {@link Badge} primitives.
+ *
+ * @example
+ * ```tsx
+ * <PromptTemplates
+ *   templates={[
+ *     {
+ *       id: "code-review",
+ *       title: "Code Review",
+ *       description: "Review code for bugs and improvements",
+ *       template: "Review this {{language}} code:\n\n{{code}}",
+ *       category: "Code",
+ *     },
+ *   ]}
+ *   categories={[{ name: "Code" }, { name: "Writing" }]}
+ *   onSelect={(resolved) => insertIntoComposer(resolved)}
+ * />
+ * ```
+ *
+ * @public
+ */
+type ControllerState = {
+  activeId: null | string;
+  filtered: PromptTemplate[];
+  handleActivate: (template: PromptTemplate) => void;
+  handleCancel: () => void;
+  handleCategoryChange: (value: string) => void;
+  handleQueryChange: (value: string) => void;
+  handleResolve: (resolved: string, template: PromptTemplate) => void;
+  handleValueChange: (name: string, value: string) => void;
+  query: string;
+  searchId: string;
+  selectedCategory: string;
+  values: Record<string, string>;
+};
+
+function usePromptTemplatesController(
+  templates: PromptTemplate[],
+  onSelect: PromptTemplatesProps["onSelect"],
+): ControllerState {
+  const searchId = useId();
+  const [query, setQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState(ALL_CATEGORY_VALUE);
+  const [activeId, setActiveId] = useState<null | string>(null);
+  const [values, setValues] = useState<Record<string, string>>({});
+
+  const filtered = useMemo(
+    () =>
+      templates.filter(
+        (template) =>
+          matchesCategory(template, selectedCategory) &&
+          matchesQuery(template, query),
+      ),
+    [query, selectedCategory, templates],
+  );
+
+  const handleActivate = useCallback((template: PromptTemplate) => {
+    setActiveId(template.id);
+    setValues({});
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    setActiveId(null);
+    setValues({});
+  }, []);
+
+  const handleResolve = useCallback(
+    (resolved: string, template: PromptTemplate) => {
+      onSelect?.(resolved, template);
+      setActiveId(null);
+      setValues({});
+    },
+    [onSelect],
+  );
+
+  const handleValueChange = useCallback((name: string, value: string) => {
+    setValues((current) => ({ ...current, [name]: value }));
+  }, []);
+
+  return {
+    activeId,
+    filtered,
+    handleActivate,
+    handleCancel,
+    handleCategoryChange: setSelectedCategory,
+    handleQueryChange: setQuery,
+    handleResolve,
+    handleValueChange,
+    query,
+    searchId,
+    selectedCategory,
+    values,
+  };
+}
+
+type GridProps = {
+  controller: ControllerState;
+  labels: Required<PromptTemplatesLabels>;
+};
+
+function TemplateGrid({ controller, labels }: GridProps): ReactNode {
+  if (controller.filtered.length === 0) {
+    return (
+      <p className="rounded-lg border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+        {labels.empty}
+      </p>
+    );
+  }
+  return (
+    <div
+      className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3"
+      role="tabpanel"
+    >
+      {controller.filtered.map((template) => (
+        <PromptTemplateCard
+          active={controller.activeId === template.id}
+          key={template.id}
+          labels={labels}
+          onActivate={controller.handleActivate}
+          onCancel={controller.handleCancel}
+          onResolve={controller.handleResolve}
+          onValueChange={controller.handleValueChange}
+          template={template}
+          values={controller.values}
+        />
+      ))}
+    </div>
+  );
+}
+
+export const PromptTemplates = forwardRef<HTMLElement, PromptTemplatesProps>(
+  (props, ref) => {
+    const { categories, className, labels, onSelect, templates, ...rest } =
+      props;
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const controller = usePromptTemplatesController(templates, onSelect);
+
+    return (
+      <section
+        className={cn(
+          "flex flex-col gap-4 rounded-2xl border bg-background p-4",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <FilterBar
+          categories={categories ?? []}
+          labels={resolvedLabels}
+          onCategoryChange={controller.handleCategoryChange}
+          onQueryChange={controller.handleQueryChange}
+          query={controller.query}
+          searchId={controller.searchId}
+          selectedCategory={controller.selectedCategory}
+        />
+        <TemplateGrid controller={controller} labels={resolvedLabels} />
+      </section>
+    );
+  },
+);
+PromptTemplates.displayName = "PromptTemplates";

--- a/packages/ui/src/components/prompt-templates/prompt-templates.visual.tsx
+++ b/packages/ui/src/components/prompt-templates/prompt-templates.visual.tsx
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import {
+  type PromptTemplate,
+  PromptTemplates,
+} from "./prompt-templates";
+
+const TEMPLATES: PromptTemplate[] = [
+  {
+    category: "Code",
+    description: "Review code for bugs and improvements",
+    id: "code-review",
+    template: "Review this {{language}} code:\n\n{{code}}",
+    title: "Code Review",
+  },
+  {
+    category: "Writing",
+    description: "Polish a draft",
+    id: "writing-polish",
+    template: "Polish the following text:\n\n{{text}}",
+    title: "Polish writing",
+  },
+  {
+    category: "Analysis",
+    description: "Summarize a document",
+    id: "summary",
+    template: "Summarize the following document in {{count}} bullet points.",
+    title: "Summarize",
+  },
+];
+
+test.describe("PromptTemplates Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <PromptTemplates
+        categories={[
+          { name: "Code" },
+          { name: "Writing" },
+          { name: "Analysis" },
+        ]}
+        templates={TEMPLATES}
+      />,
+    );
+    await expect(component).toHaveScreenshot("prompt-templates-default.png");
+  });
+
+  test("empty", async ({ mount }) => {
+    const component = await mount(<PromptTemplates templates={[]} />);
+    await expect(component).toHaveScreenshot("prompt-templates-empty.png");
+  });
+});


### PR DESCRIPTION
## Summary

Searchable, category-filterable prompt template gallery with built-in fill-in for \`{{variable}}\` placeholders. Composes existing \`Input\`, \`Button\`, and \`Badge\` primitives.

- **Data-driven** — pass a \`templates: PromptTemplate[]\` array. Use case: preset library, user-saved prompts, GPT Store-style catalogs all flow through the same render path.
- **Search** — title + description matched against the query (case-insensitive).
- **Category chips** — opt-in via the \`categories\` prop. Always rendered alongside an "All" chip.
- **Variable detection** — \`{{name}}\` placeholders detected from the body via regex. Pass an explicit \`variables\` array to lock the order or dedupe placeholders that appear more than once.
- **Inline fill-in** — templates with variables expand the card into a form on the first click; submitting fires \`onSelect\` with the resolved string. Templates without variables fire on the first click.

Pinning, favorites, custom prompts, and preview dialogs are intentionally **out of scope** — drive them from consumer code by augmenting the \`templates\` array.

Closes #59

## API

\`\`\`tsx
<PromptTemplates
  templates={[
    {
      id: 'code-review',
      title: 'Code Review',
      description: 'Review code for bugs and improvements',
      template: 'Review this {{language}} code:\n\n{{code}}',
      category: 'Code',
    },
  ]}
  categories={[{ name: 'Code' }, { name: 'Writing' }]}
  onSelect={(resolved, template) => insertIntoComposer(resolved)}
/>
\`\`\`

## Coverage

- Unit: 10 tests covering rendering all templates, empty state, search filter, category chip filter, "All" chip restore, immediate \`onSelect\` for zero-variable templates, inline form opens on activation, resolved fill-in via Insert, placeholder fallback when fields are blank, Cancel clears the form
- Visual: Playwright CT story for default + empty state
- Storybook: \`Default\`, \`NoCategories\`, \`Empty\`, \`CustomLabels\`
- MDX: usage + variable placeholders + categories + empty + custom labels + scope notes

## Registry

Added \`prompt-templates\` (\`category: ai\`, \`registryDependencies: [badge, button, input]\`, deps: \`lucide-react\`). Re-export shim and \`pnpm build\` regenerates \`/r/prompt-templates.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 503/503 (10 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview exercises search + category filter + variable form
- [ ] Registry entry visible at \`/r/prompt-templates.json\` and \`/components/prompt-templates\` after deploy