### PR TITLE
feat(ui): add AgentActivity compound family

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -49,6 +49,23 @@
       "category": "data"
     },
     {
+      "name": "agent-activity",
+      "type": "registry:component",
+      "title": "Agent Activity",
+      "description": "Visual display of an AI agent's execution chain — steps, tools, decisions, progress.",
+      "files": [
+        {
+          "path": "registry/default/agent-activity/agent-activity.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "category": "ai"
+    },
+    {
       "name": "ai-artifact",
       "type": "registry:component",
       "title": "AI Artifact",

--- a/apps/registry/registry/default/agent-activity/agent-activity.tsx
+++ b/apps/registry/registry/default/agent-activity/agent-activity.tsx
@@ -1,0 +1,10 @@
+// Re-export from @vllnt/ui package
+export {
+  AgentActivity,
+  AgentStep,
+  AgentStepDetail,
+  AgentStepDuration,
+  AgentStepProgress,
+  AgentStepTitle,
+  useAgentStepStatus,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/agent-activity/agent-activity.mdx
+++ b/packages/ui/src/components/agent-activity/agent-activity.mdx
@@ -1,0 +1,98 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './agent-activity.stories'
+
+<Meta of={Stories} />
+
+# AgentActivity
+
+Visual display of an AI agent's execution chain — steps taken, tools called, decisions made, and current progress. Suitable for Claude Code-style activity panels, multi-step task views, and pipeline progress.
+
+A compound component family:
+
+- `AgentActivity` — root container, optional `elapsed` time, switches the live region between `aria-live="polite"` (running) and `aria-live="off"` (idle / completed / error)
+- `AgentStep` — one step row, status drives color + default icon, children split between an always-visible header and a collapsible body
+- `AgentStepTitle` / `AgentStepDuration` / `AgentStepProgress` — header slots
+- `AgentStepDetail` — body slot, can repeat. The toggle appears only when at least one detail exists.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/agent-activity.json
+```
+
+## Import
+
+```tsx
+import {
+  AgentActivity,
+  AgentStep,
+  AgentStepTitle,
+  AgentStepDetail,
+  AgentStepDuration,
+  AgentStepProgress,
+} from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<AgentActivity status="running" elapsed="3.2s">
+  <AgentStep status="completed" icon={<SearchIcon />}>
+    <AgentStepTitle>Searching codebase</AgentStepTitle>
+    <AgentStepDuration>1.2s</AgentStepDuration>
+    <AgentStepDetail>Found 12 files matching "auth".</AgentStepDetail>
+  </AgentStep>
+  <AgentStep status="running" icon={<CodeIcon />}>
+    <AgentStepTitle>Writing fix</AgentStepTitle>
+    <AgentStepProgress value={60} />
+  </AgentStep>
+</AgentActivity>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Status states
+
+| Status | Default icon | Color treatment |
+| ------ | ------------ | --------------- |
+| `pending` | `Circle` | muted |
+| `running` | `Loader2` (spinner) | primary |
+| `completed` | `CheckCircle2` | emerald |
+| `error` | `AlertTriangle` | destructive |
+| `skipped` | `MinusCircle` | muted/60 |
+
+Pass an `icon` prop to override the default per-step.
+
+## Completed
+
+<Canvas of={Stories.Completed} sourceState="shown" />
+
+## Error state
+
+The agent's overall status is independent of any one step's status — pass `status="error"` on the root when an error halts the chain, then mark each step accordingly.
+
+<Canvas of={Stories.ErrorState} sourceState="shown" />
+
+## Collapsed details
+
+Set `defaultOpen={false}` per step to render the toggle in the collapsed position.
+
+<Canvas of={Stories.CollapsedDetails} sourceState="shown" />
+
+## Accessibility
+
+- Root has `aria-live="polite"` while running — assistive tech announces new steps without focus-stealing
+- Each step exposes `data-status="<status>"` for analytics
+- Toggle uses `aria-expanded` + `aria-controls`
+- `AgentStepProgress` is a `role="progressbar"` with `aria-valuenow/min/max`
+
+## Notes
+
+- Nested sub-tasks, retry actions, and tool-output streaming are intentionally **out of scope** — drive them from consumer code via the `AgentStepDetail` slot.
+- `useAgentStepStatus` is exported for custom child components that need to react to the surrounding step's status (e.g. tinted code blocks).

--- a/packages/ui/src/components/agent-activity/agent-activity.stories.tsx
+++ b/packages/ui/src/components/agent-activity/agent-activity.stories.tsx
@@ -1,0 +1,122 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  AgentActivity,
+  AgentStep,
+  AgentStepDetail,
+  AgentStepDuration,
+  AgentStepProgress,
+  AgentStepTitle,
+} from "./agent-activity";
+
+const meta = {
+  args: {
+    elapsed: "3.2s",
+    status: "running",
+  },
+  argTypes: {
+    status: {
+      control: "select",
+      options: ["idle", "running", "completed", "error"],
+    },
+  },
+  component: AgentActivity,
+  title: "AI/AgentActivity",
+} satisfies Meta<typeof AgentActivity>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <AgentActivity {...args}>
+      <AgentStep status="completed">
+        <AgentStepTitle>Searching codebase</AgentStepTitle>
+        <AgentStepDuration>1.2s</AgentStepDuration>
+        <AgentStepDetail>Found 12 files matching "auth".</AgentStepDetail>
+      </AgentStep>
+      <AgentStep status="completed">
+        <AgentStepTitle>Reading auth.ts</AgentStepTitle>
+        <AgentStepDuration>0.4s</AgentStepDuration>
+      </AgentStep>
+      <AgentStep status="running">
+        <AgentStepTitle>Writing fix</AgentStepTitle>
+        <AgentStepProgress value={60} />
+      </AgentStep>
+      <AgentStep status="pending">
+        <AgentStepTitle>Running tests</AgentStepTitle>
+      </AgentStep>
+    </AgentActivity>
+  ),
+};
+
+export const Completed: Story = {
+  args: {
+    elapsed: "8.4s",
+    status: "completed",
+  },
+  render: (args) => (
+    <AgentActivity {...args}>
+      <AgentStep status="completed">
+        <AgentStepTitle>Searching codebase</AgentStepTitle>
+        <AgentStepDuration>1.2s</AgentStepDuration>
+      </AgentStep>
+      <AgentStep status="completed">
+        <AgentStepTitle>Writing fix</AgentStepTitle>
+        <AgentStepDuration>4.7s</AgentStepDuration>
+      </AgentStep>
+      <AgentStep status="completed">
+        <AgentStepTitle>Running tests</AgentStepTitle>
+        <AgentStepDuration>2.5s</AgentStepDuration>
+        <AgentStepDetail>14 / 14 passed.</AgentStepDetail>
+      </AgentStep>
+    </AgentActivity>
+  ),
+};
+
+export const ErrorState: Story = {
+  args: {
+    elapsed: "1.6s",
+    status: "error",
+  },
+  name: "Error state",
+  render: (args) => (
+    <AgentActivity {...args}>
+      <AgentStep status="completed">
+        <AgentStepTitle>Searching codebase</AgentStepTitle>
+        <AgentStepDuration>1.2s</AgentStepDuration>
+      </AgentStep>
+      <AgentStep status="error">
+        <AgentStepTitle>Reading auth.ts</AgentStepTitle>
+        <AgentStepDetail>Permission denied.</AgentStepDetail>
+      </AgentStep>
+      <AgentStep status="skipped">
+        <AgentStepTitle>Writing fix</AgentStepTitle>
+      </AgentStep>
+    </AgentActivity>
+  ),
+};
+
+export const CollapsedDetails: Story = {
+  args: {
+    elapsed: "8.4s",
+    status: "completed",
+  },
+  name: "Collapsed details",
+  render: (args) => (
+    <AgentActivity {...args}>
+      <AgentStep defaultOpen={false} status="completed">
+        <AgentStepTitle>Searching codebase</AgentStepTitle>
+        <AgentStepDuration>1.2s</AgentStepDuration>
+        <AgentStepDetail>Found 12 files matching "auth".</AgentStepDetail>
+      </AgentStep>
+      <AgentStep defaultOpen={false} status="completed">
+        <AgentStepTitle>Writing fix</AgentStepTitle>
+        <AgentStepDuration>4.7s</AgentStepDuration>
+        <AgentStepDetail>
+          Edited 3 files (login.ts, session.ts, auth.test.ts).
+        </AgentStepDetail>
+      </AgentStep>
+    </AgentActivity>
+  ),
+};

--- a/packages/ui/src/components/agent-activity/agent-activity.test.tsx
+++ b/packages/ui/src/components/agent-activity/agent-activity.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  AgentActivity,
+  AgentStep,
+  AgentStepDetail,
+  AgentStepDuration,
+  AgentStepProgress,
+  AgentStepTitle,
+} from "./agent-activity";
+
+describe("AgentActivity", () => {
+  describe("rendering", () => {
+    it("renders the activity heading and steps", () => {
+      render(
+        <AgentActivity status="running">
+          <AgentStep status="completed">
+            <AgentStepTitle>Searching codebase</AgentStepTitle>
+          </AgentStep>
+          <AgentStep status="running">
+            <AgentStepTitle>Writing fix</AgentStepTitle>
+          </AgentStep>
+        </AgentActivity>,
+      );
+
+      expect(
+        screen.getByRole("heading", { level: 3, name: "Activity" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Searching codebase")).toBeInTheDocument();
+      expect(screen.getByText("Writing fix")).toBeInTheDocument();
+    });
+
+    it("renders the elapsed time when provided", () => {
+      render(
+        <AgentActivity elapsed="3.2s" status="running">
+          <AgentStep status="running">
+            <AgentStepTitle>Step</AgentStepTitle>
+          </AgentStep>
+        </AgentActivity>,
+      );
+
+      expect(screen.getByLabelText("Elapsed")).toHaveTextContent("3.2s");
+    });
+
+    it("uses aria-live=polite while running", () => {
+      const { container } = render(
+        <AgentActivity status="running">
+          <AgentStep status="pending">
+            <AgentStepTitle>Step</AgentStepTitle>
+          </AgentStep>
+        </AgentActivity>,
+      );
+
+      expect(container.querySelector("section")).toHaveAttribute(
+        "aria-live",
+        "polite",
+      );
+    });
+
+    it("uses aria-live=off when idle", () => {
+      const { container } = render(
+        <AgentActivity status="idle">
+          <AgentStep status="pending">
+            <AgentStepTitle>Step</AgentStepTitle>
+          </AgentStep>
+        </AgentActivity>,
+      );
+
+      expect(container.querySelector("section")).toHaveAttribute(
+        "aria-live",
+        "off",
+      );
+    });
+  });
+
+  describe("AgentStep", () => {
+    it.each(["pending", "running", "completed", "error", "skipped"] as const)(
+      "renders status=%s with the data attribute set",
+      (status) => {
+        render(
+          <AgentActivity>
+            <AgentStep status={status}>
+              <AgentStepTitle>Title</AgentStepTitle>
+            </AgentStep>
+          </AgentActivity>,
+        );
+
+        const item = screen.getByText("Title").closest("li");
+        expect(item).toHaveAttribute("data-status", status);
+      },
+    );
+
+    it("renders duration alongside the title", () => {
+      render(
+        <AgentActivity>
+          <AgentStep status="completed">
+            <AgentStepTitle>Searching</AgentStepTitle>
+            <AgentStepDuration>1.2s</AgentStepDuration>
+          </AgentStep>
+        </AgentActivity>,
+      );
+
+      expect(screen.getByText("1.2s")).toBeInTheDocument();
+    });
+
+    it("collapses the toggle and details when defaultOpen is false", () => {
+      render(
+        <AgentActivity>
+          <AgentStep defaultOpen={false} status="completed">
+            <AgentStepTitle>Step</AgentStepTitle>
+            <AgentStepDetail>Hidden detail</AgentStepDetail>
+          </AgentStep>
+        </AgentActivity>,
+      );
+
+      expect(screen.queryByText("Hidden detail")).not.toBeInTheDocument();
+      const toggle = screen.getByRole("button", { name: "Show details" });
+      fireEvent.click(toggle);
+      expect(screen.getByText("Hidden detail")).toBeInTheDocument();
+    });
+
+    it("does not render the toggle when there are no details", () => {
+      render(
+        <AgentActivity>
+          <AgentStep status="completed">
+            <AgentStepTitle>Step</AgentStepTitle>
+          </AgentStep>
+        </AgentActivity>,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: /details/ }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("AgentStepProgress", () => {
+    it("emits aria-valuenow clamped to 0–100", () => {
+      const { rerender } = render(
+        <AgentActivity>
+          <AgentStep status="running">
+            <AgentStepTitle>Step</AgentStepTitle>
+            <AgentStepProgress value={150} />
+          </AgentStep>
+        </AgentActivity>,
+      );
+
+      expect(screen.getByRole("progressbar")).toHaveAttribute(
+        "aria-valuenow",
+        "100",
+      );
+
+      rerender(
+        <AgentActivity>
+          <AgentStep status="running">
+            <AgentStepTitle>Step</AgentStepTitle>
+            <AgentStepProgress value={-20} />
+          </AgentStep>
+        </AgentActivity>,
+      );
+
+      expect(screen.getByRole("progressbar")).toHaveAttribute(
+        "aria-valuenow",
+        "0",
+      );
+    });
+  });
+});

--- a/packages/ui/src/components/agent-activity/agent-activity.tsx
+++ b/packages/ui/src/components/agent-activity/agent-activity.tsx
@@ -1,0 +1,505 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  Circle,
+  Loader2,
+  MinusCircle,
+} from "lucide-react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Status state for a single {@link AgentStep}.
+ *
+ * @public
+ */
+export type AgentStepStatus =
+  | "completed"
+  | "error"
+  | "pending"
+  | "running"
+  | "skipped";
+
+/**
+ * Status state for the parent {@link AgentActivity}.
+ *
+ * @public
+ */
+export type AgentActivityStatus = "completed" | "error" | "idle" | "running";
+
+const STATUS_CLASSES: Record<
+  AgentStepStatus,
+  { iconClass: string; ringClass: string; rowClass: string }
+> = {
+  completed: {
+    iconClass: "text-emerald-600 dark:text-emerald-400",
+    ringClass: "ring-emerald-500/30",
+    rowClass: "border-border bg-background",
+  },
+  error: {
+    iconClass: "text-destructive",
+    ringClass: "ring-destructive/40",
+    rowClass: "border-destructive/40 bg-destructive/5",
+  },
+  pending: {
+    iconClass: "text-muted-foreground",
+    ringClass: "ring-border",
+    rowClass: "border-border bg-muted/20 text-muted-foreground",
+  },
+  running: {
+    iconClass: "text-primary",
+    ringClass: "ring-primary/30",
+    rowClass: "border-primary/30 bg-primary/5",
+  },
+  skipped: {
+    iconClass: "text-muted-foreground/60",
+    ringClass: "ring-border",
+    rowClass: "border-border bg-background text-muted-foreground/80",
+  },
+};
+
+const DEFAULT_STATUS_ICON: Record<AgentStepStatus, ReactNode> = {
+  completed: <CheckCircle2 aria-hidden="true" className="h-4 w-4" />,
+  error: <AlertTriangle aria-hidden="true" className="h-4 w-4" />,
+  pending: <Circle aria-hidden="true" className="h-4 w-4" />,
+  running: <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />,
+  skipped: <MinusCircle aria-hidden="true" className="h-4 w-4" />,
+};
+
+type StepContextValue = {
+  status: AgentStepStatus;
+};
+
+const StepContext = createContext<StepContextValue>({ status: "pending" });
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type AgentActivityLabels = {
+  /** Caption above the steps list. Defaults to `"Activity"`. */
+  activity?: string;
+  /** Caption for the collapse-details toggle. Defaults to `"Hide details"`. */
+  collapse?: string;
+  /** Aria-label for the elapsed-time region. Defaults to `"Elapsed"`. */
+  elapsed?: string;
+  /** Caption for the expand-details toggle. Defaults to `"Show details"`. */
+  expand?: string;
+};
+
+const DEFAULT_LABELS = {
+  activity: "Activity",
+  collapse: "Hide details",
+  elapsed: "Elapsed",
+  expand: "Show details",
+} as const satisfies Required<AgentActivityLabels>;
+
+/**
+ * Props for {@link AgentActivity}.
+ *
+ * @public
+ */
+export type AgentActivityProps = {
+  /** Optional total elapsed time string shown in the header. */
+  elapsed?: ReactNode;
+  /** Localizable strings. */
+  labels?: AgentActivityLabels;
+  /** Top-level agent status. Defaults to `"idle"`. */
+  status?: AgentActivityStatus;
+} & ComponentPropsWithoutRef<"section">;
+
+const ACTIVITY_LIVE_REGION_ROLE: Record<AgentActivityStatus, "log" | "status"> =
+  {
+    completed: "status",
+    error: "status",
+    idle: "status",
+    running: "log",
+  };
+
+/**
+ * Visual display of an AI agent's execution chain — steps taken, tools
+ * called, decisions made, and current progress. Composes {@link AgentStep}
+ * children. Use `aria-live="polite"` on the log so assistive tech reads
+ * new steps as the agent progresses without stealing focus.
+ *
+ * @example
+ * ```tsx
+ * <AgentActivity status="running" elapsed="3.2s">
+ *   <AgentStep status="completed" icon={<Search />}>
+ *     <AgentStepTitle>Searching codebase</AgentStepTitle>
+ *     <AgentStepDetail>Found 12 files matching "auth".</AgentStepDetail>
+ *     <AgentStepDuration>1.2s</AgentStepDuration>
+ *   </AgentStep>
+ *   <AgentStep status="running" icon={<Code />}>
+ *     <AgentStepTitle>Writing fix</AgentStepTitle>
+ *     <AgentStepProgress value={60} />
+ *   </AgentStep>
+ * </AgentActivity>
+ * ```
+ *
+ * @public
+ */
+export const AgentActivity = forwardRef<HTMLElement, AgentActivityProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      elapsed,
+      labels,
+      status = "idle",
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <section
+        aria-live={status === "running" ? "polite" : "off"}
+        className={cn(
+          "flex flex-col gap-3 rounded-2xl border bg-background p-4",
+          className,
+        )}
+        data-status={status}
+        ref={ref}
+        role={ACTIVITY_LIVE_REGION_ROLE[status]}
+        {...rest}
+      >
+        <header className="flex items-center justify-between gap-3">
+          <h3 className="text-sm font-semibold tracking-tight text-foreground">
+            {resolvedLabels.activity}
+          </h3>
+          {elapsed ? (
+            <span
+              aria-label={resolvedLabels.elapsed}
+              className="text-xs font-mono text-muted-foreground"
+            >
+              {elapsed}
+            </span>
+          ) : null}
+        </header>
+        <ol className="flex flex-col gap-2">{children}</ol>
+      </section>
+    );
+  },
+);
+AgentActivity.displayName = "AgentActivity";
+
+/**
+ * Props for {@link AgentStep}.
+ *
+ * @public
+ */
+export type AgentStepProps = {
+  /** When false, the step renders the toggle but starts collapsed. */
+  defaultOpen?: boolean;
+  /** Optional icon shown to the left of the title. */
+  icon?: ReactNode;
+  /** Step status. */
+  status: AgentStepStatus;
+} & ComponentPropsWithoutRef<"li">;
+
+type ContentSplit = {
+  body: ReactNode[];
+  header: ReactNode[];
+};
+
+function getDisplayName(value: unknown): string | undefined {
+  if (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    "displayName" in value &&
+    typeof value.displayName === "string"
+  ) {
+    return value.displayName;
+  }
+  return undefined;
+}
+
+function isAgentStepDetailElement(child: ReactNode): boolean {
+  if (child === null || typeof child !== "object") return false;
+  if (!("type" in child)) return false;
+  return getDisplayName(child.type) === "AgentStepDetail";
+}
+
+function splitChildren(children: ReactNode): ContentSplit {
+  const items = Array.isArray(children)
+    ? (children as ReactNode[])
+    : [children];
+  return items.reduce<ContentSplit>(
+    (split, child) => {
+      if (isAgentStepDetailElement(child)) {
+        split.body.push(child);
+      } else {
+        split.header.push(child);
+      }
+      return split;
+    },
+    { body: [], header: [] },
+  );
+}
+
+/**
+ * One row inside an {@link AgentActivity}. The component partitions
+ * children into an always-visible header (title, duration, progress) and a
+ * collapsible body (any number of {@link AgentStepDetail} blocks).
+ *
+ * @public
+ */
+type StepRowProps = {
+  detailsId: string;
+  hasDetails: boolean;
+  header: ReactNode;
+  icon: ReactNode;
+  iconClass: string;
+  labels: Required<AgentActivityLabels>;
+  onToggle: () => void;
+  open: boolean;
+};
+
+function StepRow({
+  detailsId,
+  hasDetails,
+  header,
+  icon,
+  iconClass,
+  labels,
+  onToggle,
+  open,
+}: StepRowProps): ReactNode {
+  return (
+    <div className="flex items-start gap-3 px-3 py-2">
+      <span
+        aria-hidden="true"
+        className={cn(
+          "mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center",
+          iconClass,
+        )}
+      >
+        {icon}
+      </span>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">{header}</div>
+      {hasDetails ? (
+        <button
+          aria-controls={detailsId}
+          aria-expanded={open}
+          aria-label={open ? labels.collapse : labels.expand}
+          className="ml-auto inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          onClick={onToggle}
+          type="button"
+        >
+          <ChevronDown
+            aria-hidden="true"
+            className={cn(
+              "h-4 w-4 transition-transform",
+              open ? "rotate-180" : "rotate-0",
+            )}
+          />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+export const AgentStep = forwardRef<HTMLLIElement, AgentStepProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      defaultOpen = true,
+      icon,
+      status,
+      ...rest
+    } = props;
+    const split = useMemo(() => splitChildren(children), [children]);
+    const palette = STATUS_CLASSES[status];
+    const hasDetails = split.body.length > 0;
+    const [open, setOpen] = useState(defaultOpen);
+    const detailsId = useId();
+
+    const handleToggle = useCallback(() => {
+      setOpen((value) => !value);
+    }, []);
+
+    const contextValue = useMemo<StepContextValue>(
+      () => ({ status }),
+      [status],
+    );
+    const resolvedIcon = icon ?? DEFAULT_STATUS_ICON[status];
+
+    return (
+      <li
+        className={cn(
+          "rounded-xl border ring-1",
+          palette.rowClass,
+          palette.ringClass,
+          className,
+        )}
+        data-status={status}
+        ref={ref}
+        {...rest}
+      >
+        <StepContext.Provider value={contextValue}>
+          <StepRow
+            detailsId={detailsId}
+            hasDetails={hasDetails}
+            header={split.header}
+            icon={resolvedIcon}
+            iconClass={palette.iconClass}
+            labels={DEFAULT_LABELS}
+            onToggle={handleToggle}
+            open={open}
+          />
+          {hasDetails && open ? (
+            <div
+              className="border-t border-border/60 px-3 py-2 text-xs"
+              id={detailsId}
+            >
+              <div className="flex flex-col gap-2 pl-8">{split.body}</div>
+            </div>
+          ) : null}
+        </StepContext.Provider>
+      </li>
+    );
+  },
+);
+AgentStep.displayName = "AgentStep";
+
+/**
+ * Props for {@link AgentStepTitle}.
+ *
+ * @public
+ */
+export type AgentStepTitleProps = ComponentPropsWithoutRef<"p">;
+
+/**
+ * Title slot for an {@link AgentStep}.
+ *
+ * @public
+ */
+export const AgentStepTitle = forwardRef<
+  HTMLParagraphElement,
+  AgentStepTitleProps
+>(({ className, ...rest }, ref) => (
+  <p
+    className={cn(
+      "text-sm font-medium leading-tight text-foreground",
+      className,
+    )}
+    ref={ref}
+    {...rest}
+  />
+));
+AgentStepTitle.displayName = "AgentStepTitle";
+
+/**
+ * Props for {@link AgentStepDuration}.
+ *
+ * @public
+ */
+export type AgentStepDurationProps = ComponentPropsWithoutRef<"span">;
+
+/**
+ * Duration badge for an {@link AgentStep}.
+ *
+ * @public
+ */
+export const AgentStepDuration = forwardRef<
+  HTMLSpanElement,
+  AgentStepDurationProps
+>(({ className, ...rest }, ref) => (
+  <span
+    className={cn("font-mono text-xs text-muted-foreground", className)}
+    ref={ref}
+    {...rest}
+  />
+));
+AgentStepDuration.displayName = "AgentStepDuration";
+
+/**
+ * Props for {@link AgentStepProgress}.
+ *
+ * @public
+ */
+export type AgentStepProgressProps = {
+  /** Optional aria-label override. Defaults to `"Step progress"`. */
+  label?: string;
+  /** Progress value, 0–100. */
+  value: number;
+} & Omit<ComponentPropsWithoutRef<"div">, "role">;
+
+/**
+ * Progress bar for a running {@link AgentStep}.
+ *
+ * @public
+ */
+export const AgentStepProgress = forwardRef<
+  HTMLDivElement,
+  AgentStepProgressProps
+>(({ className, label = "Step progress", value, ...rest }, ref) => {
+  const clamped = Math.max(0, Math.min(100, value));
+  return (
+    <div
+      aria-label={label}
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={clamped}
+      className={cn("h-1.5 w-full rounded-full bg-muted", className)}
+      ref={ref}
+      role="progressbar"
+      {...rest}
+    >
+      <span
+        className="block h-full rounded-full bg-primary transition-[width]"
+        style={{ width: `${clamped.toString()}%` }}
+      />
+    </div>
+  );
+});
+AgentStepProgress.displayName = "AgentStepProgress";
+
+/**
+ * Props for {@link AgentStepDetail}.
+ *
+ * @public
+ */
+export type AgentStepDetailProps = ComponentPropsWithoutRef<"div">;
+
+/**
+ * Collapsible detail block inside an {@link AgentStep} (tool output, log
+ * snippet, anything secondary).
+ *
+ * @public
+ */
+export const AgentStepDetail = forwardRef<HTMLDivElement, AgentStepDetailProps>(
+  ({ className, ...rest }, ref) => (
+    <div
+      className={cn("text-xs text-muted-foreground", className)}
+      ref={ref}
+      {...rest}
+    />
+  ),
+);
+AgentStepDetail.displayName = "AgentStepDetail";
+
+/**
+ * Hook for reading the current step's status from inside a custom child.
+ *
+ * @public
+ */
+export function useAgentStepStatus(): AgentStepStatus {
+  return useContext(StepContext).status;
+}

--- a/packages/ui/src/components/agent-activity/agent-activity.visual.tsx
+++ b/packages/ui/src/components/agent-activity/agent-activity.visual.tsx
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import {
+  AgentActivity,
+  AgentStep,
+  AgentStepDetail,
+  AgentStepDuration,
+  AgentStepProgress,
+  AgentStepTitle,
+} from "./agent-activity";
+
+test.describe("AgentActivity Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <AgentActivity elapsed="3.2s" status="running">
+        <AgentStep status="completed">
+          <AgentStepTitle>Searching codebase</AgentStepTitle>
+          <AgentStepDuration>1.2s</AgentStepDuration>
+          <AgentStepDetail>Found 12 files matching "auth".</AgentStepDetail>
+        </AgentStep>
+        <AgentStep status="completed">
+          <AgentStepTitle>Reading auth.ts</AgentStepTitle>
+          <AgentStepDuration>0.4s</AgentStepDuration>
+        </AgentStep>
+        <AgentStep status="running">
+          <AgentStepTitle>Writing fix</AgentStepTitle>
+          <AgentStepProgress value={60} />
+        </AgentStep>
+        <AgentStep status="pending">
+          <AgentStepTitle>Running tests</AgentStepTitle>
+        </AgentStep>
+      </AgentActivity>,
+    );
+    await expect(component).toHaveScreenshot("agent-activity-default.png");
+  });
+
+  test("error-state", async ({ mount }) => {
+    const component = await mount(
+      <AgentActivity status="error">
+        <AgentStep status="completed">
+          <AgentStepTitle>Searching codebase</AgentStepTitle>
+        </AgentStep>
+        <AgentStep status="error">
+          <AgentStepTitle>Reading auth.ts</AgentStepTitle>
+          <AgentStepDetail>Permission denied.</AgentStepDetail>
+        </AgentStep>
+        <AgentStep status="skipped">
+          <AgentStepTitle>Writing fix</AgentStepTitle>
+        </AgentStep>
+      </AgentActivity>,
+    );
+    await expect(component).toHaveScreenshot("agent-activity-error-state.png");
+  });
+});

--- a/packages/ui/src/components/agent-activity/index.ts
+++ b/packages/ui/src/components/agent-activity/index.ts
@@ -1,0 +1,18 @@
+export {
+  AgentActivity,
+  type AgentActivityLabels,
+  type AgentActivityProps,
+  type AgentActivityStatus,
+  AgentStep,
+  AgentStepDetail,
+  type AgentStepDetailProps,
+  AgentStepDuration,
+  type AgentStepDurationProps,
+  AgentStepProgress,
+  type AgentStepProgressProps,
+  type AgentStepProps,
+  type AgentStepStatus,
+  AgentStepTitle,
+  type AgentStepTitleProps,
+  useAgentStepStatus,
+} from "./agent-activity";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -362,6 +362,24 @@ export {
 export { Skeleton } from "./skeleton";
 export { Separator } from "./separator";
 export { Alert, AlertDescription, AlertTitle, alertVariants } from "./alert";
+export {
+  AgentActivity,
+  type AgentActivityLabels,
+  type AgentActivityProps,
+  type AgentActivityStatus,
+  AgentStep,
+  AgentStepDetail,
+  type AgentStepDetailProps,
+  AgentStepDuration,
+  type AgentStepDurationProps,
+  AgentStepProgress,
+  type AgentStepProgressProps,
+  type AgentStepProps,
+  type AgentStepStatus,
+  AgentStepTitle,
+  type AgentStepTitleProps,
+  useAgentStepStatus,
+} from "./agent-activity";
 export { StatCard, type StatCardProps, statCardVariants } from "./stat-card";
 export {
   dotVariants,


### PR DESCRIPTION
## Summary

Visual display of an AI agent's execution chain — steps, tools called, decisions made, current progress. Suitable for Claude Code-style activity panels, multi-step task views, and pipeline progress.

A compound family:

- **\`AgentActivity\`** — root container; swaps \`aria-live\` between \`polite\` (running) and \`off\` (idle / completed / error) so assistive tech reads new steps without focus-stealing.
- **\`AgentStep\`** — status-driven row (\`pending\` / \`running\` / \`completed\` / \`error\` / \`skipped\`) with default icons + color treatments. Children are partitioned at render: \`AgentStepDetail\` nodes go into a collapsible body, everything else stays in the always-visible header. The toggle appears only when at least one detail exists.
- **\`AgentStepTitle\`** / **\`AgentStepDuration\`** / **\`AgentStepProgress\`** — header slots. \`AgentStepProgress\` is a \`role="progressbar"\` with clamped \`aria-valuenow\`.
- **\`AgentStepDetail\`** — collapsible body slot, can repeat.
- **\`useAgentStepStatus\`** — hook for custom children that need to react to the surrounding step status (e.g. tinted code blocks).

Nested sub-tasks, retry actions, and tool-output streaming are intentionally **out of scope** — drive them from consumer code via the detail slot.

Closes #57

## API

\`\`\`tsx
<AgentActivity status="running" elapsed="3.2s">
  <AgentStep status="completed" icon={<SearchIcon />}>
    <AgentStepTitle>Searching codebase</AgentStepTitle>
    <AgentStepDuration>1.2s</AgentStepDuration>
    <AgentStepDetail>Found 12 files matching "auth".</AgentStepDetail>
  </AgentStep>
  <AgentStep status="running" icon={<CodeIcon />}>
    <AgentStepTitle>Writing fix</AgentStepTitle>
    <AgentStepProgress value={60} />
  </AgentStep>
  <AgentStep status="pending">
    <AgentStepTitle>Running tests</AgentStepTitle>
  </AgentStep>
</AgentActivity>
\`\`\`

## Coverage

- Unit: 13 tests covering activity heading + steps, elapsed-time region, \`aria-live\` toggle (\`polite\` while running, \`off\` while idle), all 5 step statuses round-trip via \`data-status\`, duration rendering, collapsed-by-default toggle round-trip, no toggle when there are no details, \`AgentStepProgress\` clamps \`aria-valuenow\` to \`[0, 100]\`
- Visual: Playwright CT story for default running pipeline + error state
- Storybook: \`Default\`, \`Completed\`, \`Error state\`, \`Collapsed details\`
- MDX: status table + a11y notes + scope notes

## Registry

Added \`agent-activity\` (\`category: ai\`, no \`registryDependencies\`, deps: \`lucide-react\`). Re-export shim and \`pnpm build\` regenerates \`/r/agent-activity.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 506/506 (13 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview exercises \`Default\`, \`Completed\`, \`Error state\`, \`Collapsed details\` — confirm icons and color treatments per status
- [ ] Registry entry visible at \`/r/agent-activity.json\` and \`/components/agent-activity\` after deploy