### PR TITLE
feat(ui): add AISidebar compound family

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -135,6 +135,25 @@
       "category": "learning"
     },
     {
+      "name": "ai-sidebar",
+      "type": "registry:component",
+      "title": "AI Sidebar",
+      "description": "Slide-out AI assistant panel with provider, header / content / footer slots, and a standalone trigger.",
+      "files": [
+        {
+          "path": "registry/default/ai-sidebar/ai-sidebar.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [
+        "button"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "category": "ai"
+    },
+    {
       "name": "ai-tool-call-display",
       "type": "registry:component",
       "title": "AI Tool Call Display",

--- a/apps/registry/registry/default/ai-sidebar/ai-sidebar.tsx
+++ b/apps/registry/registry/default/ai-sidebar/ai-sidebar.tsx
@@ -1,0 +1,12 @@
+// Re-export from @vllnt/ui package
+export {
+  AISidebar,
+  AISidebarClose,
+  AISidebarContent,
+  AISidebarFooter,
+  AISidebarHeader,
+  AISidebarProvider,
+  AISidebarTitle,
+  AISidebarTrigger,
+  useAISidebar,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/ai-sidebar/ai-sidebar.mdx
+++ b/packages/ui/src/components/ai-sidebar/ai-sidebar.mdx
@@ -1,0 +1,108 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './ai-sidebar.stories'
+
+<Meta of={Stories} />
+
+# AISidebar
+
+Slide-out AI assistant panel anchored to the left or right edge — Copilot Chat / Cursor / Notion AI shape. Composes Button.
+
+A compound family driven by `AISidebarProvider`:
+
+- `AISidebarProvider` — owns the open/closed state (controlled or uncontrolled), default position, default width, and labels. Wrap your app shell.
+- `AISidebar` — the panel itself. `aside role="complementary"` with `aria-hidden` toggling on close.
+- `AISidebarHeader` / `AISidebarTitle` / `AISidebarClose` — header slots.
+- `AISidebarContent` — scrollable middle section.
+- `AISidebarFooter` — bottom slot, typically the composer.
+- `AISidebarTrigger` — standalone open/toggle control.
+- `useAISidebar` — hook for any custom child that needs the open state, position, or width.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ai-sidebar.json
+```
+
+## Import
+
+```tsx
+import {
+  AISidebar,
+  AISidebarClose,
+  AISidebarContent,
+  AISidebarFooter,
+  AISidebarHeader,
+  AISidebarProvider,
+  AISidebarTitle,
+  AISidebarTrigger,
+  useAISidebar,
+} from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<AISidebarProvider defaultOpen={false}>
+  <AISidebar>
+    <AISidebarHeader>
+      <AISidebarTitle>AI Assistant</AISidebarTitle>
+      <ModelSelector models={models} />
+      <AISidebarClose />
+    </AISidebarHeader>
+    <AISidebarContent>
+      <ConversationThread messages={messages} />
+    </AISidebarContent>
+    <AISidebarFooter>
+      <ChatInput onSubmit={handleSend} />
+    </AISidebarFooter>
+  </AISidebar>
+
+  <AISidebarTrigger />
+  <main>{children}</main>
+</AISidebarProvider>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Position
+
+`defaultPosition` selects the anchor edge — `"right"` (default) or `"left"`. The panel slides in from that edge.
+
+<Canvas of={Stories.LeftSide} sourceState="shown" />
+
+## Closed by default
+
+<Canvas of={Stories.Closed} sourceState="shown" />
+
+## State
+
+`AISidebarProvider` accepts both controlled (`open` + `onOpenChange`) and uncontrolled (`defaultOpen` + `onOpenChange`) shapes.
+
+```tsx
+const [open, setOpen] = useState(false)
+
+<AISidebarProvider open={open} onOpenChange={setOpen}>
+  ...
+</AISidebarProvider>
+```
+
+The `useAISidebar` hook exposes `{ openState, open, close, toggle, position, width, labels }` for any custom child.
+
+## Accessibility
+
+- `<aside role="complementary">` with `aria-label` from `labels.defaultTitle`
+- `aria-hidden` toggled with the open state so assistive tech skips the panel when closed
+- Escape closes the sidebar by default; opt out per panel with `closeOnEscape={false}`
+- The trigger emits `aria-expanded` so screen readers announce the disclosure state
+
+## Notes
+
+- The panel uses `position: fixed` by default. Override the wrapper class to anchor it inside an absolute container (the stories use `className="!absolute"` for the demo frame).
+- Drag-resize, persistence, focus trap, mobile overlay, and keyboard shortcuts beyond Escape are intentionally **out of scope** — drive them from consumer code via `useAISidebar` and the provider's controlled API.
+- Width is clamped between 280 and 720 px to keep the layout sensible on common viewports.

--- a/packages/ui/src/components/ai-sidebar/ai-sidebar.stories.tsx
+++ b/packages/ui/src/components/ai-sidebar/ai-sidebar.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  AISidebar,
+  AISidebarClose,
+  AISidebarContent,
+  AISidebarFooter,
+  AISidebarHeader,
+  AISidebarProvider,
+  AISidebarTitle,
+  AISidebarTrigger,
+} from "./ai-sidebar";
+
+const meta = {
+  args: {
+    defaultOpen: true,
+    defaultPosition: "right",
+  },
+  argTypes: {
+    defaultPosition: {
+      control: "select",
+      options: ["left", "right"],
+    },
+  },
+  component: AISidebarProvider,
+  title: "AI/AISidebar",
+} satisfies Meta<typeof AISidebarProvider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Frame = ({ children }: { children: React.ReactNode }): JSX.Element => (
+  <div className="relative h-[480px] w-full overflow-hidden rounded-xl border bg-muted/30">
+    {children}
+  </div>
+);
+
+export const Default: Story = {
+  render: (args) => (
+    <AISidebarProvider {...args}>
+      <Frame>
+        <AISidebarTrigger />
+        <AISidebar className="!absolute">
+          <AISidebarHeader>
+            <AISidebarTitle>AI Assistant</AISidebarTitle>
+            <AISidebarClose />
+          </AISidebarHeader>
+          <AISidebarContent>
+            <p className="text-sm text-muted-foreground">
+              Ask anything about this document.
+            </p>
+            <p className="text-sm text-foreground">
+              I can help you summarize, draft, or refactor.
+            </p>
+          </AISidebarContent>
+          <AISidebarFooter>
+            <p className="text-xs text-muted-foreground">Composer goes here…</p>
+          </AISidebarFooter>
+        </AISidebar>
+      </Frame>
+    </AISidebarProvider>
+  ),
+};
+
+export const LeftSide: Story = {
+  args: {
+    defaultPosition: "left",
+  },
+  render: (args) => (
+    <AISidebarProvider {...args}>
+      <Frame>
+        <AISidebar className="!absolute">
+          <AISidebarHeader>
+            <AISidebarTitle>AI Assistant</AISidebarTitle>
+            <AISidebarClose />
+          </AISidebarHeader>
+          <AISidebarContent>
+            <p className="text-sm text-muted-foreground">Anchored to the left edge.</p>
+          </AISidebarContent>
+        </AISidebar>
+      </Frame>
+    </AISidebarProvider>
+  ),
+};
+
+export const Closed: Story = {
+  args: {
+    defaultOpen: false,
+  },
+  render: (args) => (
+    <AISidebarProvider {...args}>
+      <Frame>
+        <AISidebarTrigger />
+        <AISidebar className="!absolute">
+          <AISidebarHeader>
+            <AISidebarTitle>AI Assistant</AISidebarTitle>
+            <AISidebarClose />
+          </AISidebarHeader>
+          <AISidebarContent>
+            <p className="text-sm text-muted-foreground">
+              Click the trigger to open.
+            </p>
+          </AISidebarContent>
+        </AISidebar>
+      </Frame>
+    </AISidebarProvider>
+  ),
+};

--- a/packages/ui/src/components/ai-sidebar/ai-sidebar.test.tsx
+++ b/packages/ui/src/components/ai-sidebar/ai-sidebar.test.tsx
@@ -1,0 +1,191 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  AISidebar,
+  AISidebarClose,
+  AISidebarContent,
+  AISidebarFooter,
+  AISidebarHeader,
+  AISidebarProvider,
+  AISidebarTitle,
+  AISidebarTrigger,
+} from "./ai-sidebar";
+
+describe("AISidebar", () => {
+  describe("rendering", () => {
+    it("renders the title and content", () => {
+      render(
+        <AISidebarProvider defaultOpen>
+          <AISidebar>
+            <AISidebarHeader>
+              <AISidebarTitle>Assistant</AISidebarTitle>
+              <AISidebarClose />
+            </AISidebarHeader>
+            <AISidebarContent>
+              <p>Hello</p>
+            </AISidebarContent>
+            <AISidebarFooter>
+              <button type="button">Send</button>
+            </AISidebarFooter>
+          </AISidebar>
+        </AISidebarProvider>,
+      );
+
+      expect(
+        screen.getByRole("heading", { level: 2, name: /Assistant/ }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Hello")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
+    });
+
+    it("falls back to the default title when no children are passed", () => {
+      render(
+        <AISidebarProvider defaultOpen>
+          <AISidebar>
+            <AISidebarHeader>
+              <AISidebarTitle />
+            </AISidebarHeader>
+          </AISidebar>
+        </AISidebarProvider>,
+      );
+
+      expect(
+        screen.getByRole("heading", { level: 2, name: /AI Assistant/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("uses aria-hidden=false when open and aria-hidden=true when closed", () => {
+      const { container, rerender } = render(
+        <AISidebarProvider open>
+          <AISidebar>
+            <AISidebarTitle>Assistant</AISidebarTitle>
+          </AISidebar>
+        </AISidebarProvider>,
+      );
+
+      expect(container.querySelector("aside")).toHaveAttribute(
+        "aria-hidden",
+        "false",
+      );
+
+      rerender(
+        <AISidebarProvider open={false}>
+          <AISidebar>
+            <AISidebarTitle>Assistant</AISidebarTitle>
+          </AISidebar>
+        </AISidebarProvider>,
+      );
+
+      expect(container.querySelector("aside")).toHaveAttribute(
+        "aria-hidden",
+        "true",
+      );
+    });
+  });
+
+  describe("toggle", () => {
+    it("the trigger toggles open state", () => {
+      const onOpenChange = vi.fn();
+      render(
+        <AISidebarProvider onOpenChange={onOpenChange}>
+          <AISidebar>
+            <AISidebarTitle>Assistant</AISidebarTitle>
+          </AISidebar>
+          <AISidebarTrigger />
+        </AISidebarProvider>,
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Open AI assistant" }),
+      );
+
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+
+    it("AISidebarClose closes the sidebar", () => {
+      const onOpenChange = vi.fn();
+      render(
+        <AISidebarProvider defaultOpen onOpenChange={onOpenChange}>
+          <AISidebar>
+            <AISidebarHeader>
+              <AISidebarTitle>Assistant</AISidebarTitle>
+              <AISidebarClose />
+            </AISidebarHeader>
+          </AISidebar>
+        </AISidebarProvider>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Close assistant" }));
+
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it("Escape closes the sidebar when closeOnEscape is the default", () => {
+      const onOpenChange = vi.fn();
+      render(
+        <AISidebarProvider defaultOpen onOpenChange={onOpenChange}>
+          <AISidebar>
+            <AISidebarTitle>Assistant</AISidebarTitle>
+          </AISidebar>
+        </AISidebarProvider>,
+      );
+
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it("Escape is ignored when closeOnEscape is false", () => {
+      const onOpenChange = vi.fn();
+      render(
+        <AISidebarProvider defaultOpen onOpenChange={onOpenChange}>
+          <AISidebar closeOnEscape={false}>
+            <AISidebarTitle>Assistant</AISidebarTitle>
+          </AISidebar>
+        </AISidebarProvider>,
+      );
+
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it("controlled mode flows through onOpenChange without changing internal state", () => {
+      const onOpenChange = vi.fn();
+      render(
+        <AISidebarProvider onOpenChange={onOpenChange} open={false}>
+          <AISidebar>
+            <AISidebarTitle>Assistant</AISidebarTitle>
+          </AISidebar>
+          <AISidebarTrigger />
+        </AISidebarProvider>,
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Open AI assistant" }),
+      );
+
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+      const aside = document.querySelector("aside");
+      expect(aside).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+
+  describe("position", () => {
+    it("emits data-state and position-driven classes", () => {
+      const { container } = render(
+        <AISidebarProvider defaultOpen defaultPosition="left">
+          <AISidebar>
+            <AISidebarTitle>Assistant</AISidebarTitle>
+          </AISidebar>
+        </AISidebarProvider>,
+      );
+
+      const aside = container.querySelector("aside");
+      expect(aside).toHaveAttribute("data-state", "open");
+      expect(aside?.className).toContain("left-0");
+      expect(aside?.className).toContain("border-r");
+    });
+  });
+});

--- a/packages/ui/src/components/ai-sidebar/ai-sidebar.tsx
+++ b/packages/ui/src/components/ai-sidebar/ai-sidebar.tsx
@@ -1,0 +1,441 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import { Bot, MessageSquarePlus, X } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Button } from "../button/button";
+
+const DEFAULT_WIDTH = 400;
+const MIN_WIDTH = 280;
+const MAX_WIDTH = 720;
+
+/**
+ * Side of the viewport the sidebar attaches to.
+ *
+ * @public
+ */
+export type AISidebarPosition = "left" | "right";
+
+/**
+ * Localizable strings for {@link AISidebar} subcomponents.
+ *
+ * @public
+ */
+export type AISidebarLabels = {
+  /** Aria-label for the close control. Defaults to `"Close assistant"`. */
+  close?: string;
+  /** Default heading text for {@link AISidebarTitle}. */
+  defaultTitle?: string;
+  /** Aria-label for the open trigger. Defaults to `"Open AI assistant"`. */
+  open?: string;
+};
+
+const DEFAULT_LABELS = {
+  close: "Close assistant",
+  defaultTitle: "AI Assistant",
+  open: "Open AI assistant",
+} as const satisfies Required<AISidebarLabels>;
+
+type AISidebarContextValue = {
+  close: () => void;
+  labels: Required<AISidebarLabels>;
+  open: () => void;
+  openState: boolean;
+  position: AISidebarPosition;
+  setOpen: (next: boolean) => void;
+  toggle: () => void;
+  width: number;
+};
+
+const NO_OP = (): void => {
+  return;
+};
+
+const DEFAULT_CONTEXT: AISidebarContextValue = {
+  close: NO_OP,
+  labels: DEFAULT_LABELS,
+  open: NO_OP,
+  openState: false,
+  position: "right",
+  setOpen: NO_OP,
+  toggle: NO_OP,
+  width: DEFAULT_WIDTH,
+};
+
+const AISidebarContext = createContext<AISidebarContextValue>(DEFAULT_CONTEXT);
+
+/**
+ * Hook for reading sidebar state from anywhere inside an
+ * {@link AISidebarProvider}.
+ *
+ * @public
+ */
+export function useAISidebar(): AISidebarContextValue {
+  return useContext(AISidebarContext);
+}
+
+/**
+ * Props for {@link AISidebarProvider}.
+ *
+ * @public
+ */
+export type AISidebarProviderProps = {
+  children?: ReactNode;
+  /** Initial open state when uncontrolled. Defaults to `false`. */
+  defaultOpen?: boolean;
+  /** Initial position. Defaults to `"right"`. */
+  defaultPosition?: AISidebarPosition;
+  /** Initial width in px. Defaults to `400`. */
+  defaultWidth?: number;
+  /** Localizable strings. */
+  labels?: AISidebarLabels;
+  /** Fires when the open state changes (controlled or uncontrolled). */
+  onOpenChange?: (open: boolean) => void;
+  /** Controlled open state. */
+  open?: boolean;
+};
+
+function clampWidth(value: number): number {
+  return Math.min(Math.max(value, MIN_WIDTH), MAX_WIDTH);
+}
+
+/**
+ * Provider for the AI sidebar context. Wrap your app shell with this so
+ * {@link AISidebar}, {@link AISidebarTrigger}, and {@link useAISidebar}
+ * share the same state.
+ *
+ * @public
+ */
+export function AISidebarProvider({
+  children,
+  defaultOpen = false,
+  defaultPosition = "right",
+  defaultWidth = DEFAULT_WIDTH,
+  labels,
+  onOpenChange,
+  open: controlledOpen,
+}: AISidebarProviderProps): ReactNode {
+  const resolvedLabels = useMemo(
+    () => ({ ...DEFAULT_LABELS, ...labels }),
+    [labels],
+  );
+  const [uncontrolled, setUncontrolled] = useState(defaultOpen);
+  const isControlled = controlledOpen !== undefined;
+  const openState = isControlled ? controlledOpen : uncontrolled;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlled) setUncontrolled(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  const open = useCallback(() => {
+    setOpen(true);
+  }, [setOpen]);
+  const close = useCallback(() => {
+    setOpen(false);
+  }, [setOpen]);
+  const toggle = useCallback(() => {
+    setOpen(!openState);
+  }, [openState, setOpen]);
+
+  const value = useMemo<AISidebarContextValue>(
+    () => ({
+      close,
+      labels: resolvedLabels,
+      open,
+      openState,
+      position: defaultPosition,
+      setOpen,
+      toggle,
+      width: clampWidth(defaultWidth),
+    }),
+    [
+      close,
+      defaultPosition,
+      defaultWidth,
+      open,
+      openState,
+      resolvedLabels,
+      setOpen,
+      toggle,
+    ],
+  );
+
+  return (
+    <AISidebarContext.Provider value={value}>
+      {children}
+    </AISidebarContext.Provider>
+  );
+}
+
+/**
+ * Props for {@link AISidebar}.
+ *
+ * @public
+ */
+export type AISidebarProps = {
+  /** When true, pressing Escape closes the sidebar. Defaults to `true`. */
+  closeOnEscape?: boolean;
+} & ComponentPropsWithoutRef<"aside">;
+
+function useEscapeToClose(
+  enabled: boolean,
+  isOpen: boolean,
+  onClose: () => void,
+): void {
+  useEffect(() => {
+    if (!enabled || !isOpen) return;
+    const handler = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+
+    return () => {
+      document.removeEventListener("keydown", handler);
+    };
+  }, [enabled, isOpen, onClose]);
+}
+
+/**
+ * Slide-out AI assistant panel anchored to the left or right edge. Renders
+ * an `<aside role="complementary">` so screen readers announce it as a
+ * complementary region. Sets `aria-hidden` on close so its content is
+ * skipped by assistive tech.
+ *
+ * @example
+ * ```tsx
+ * <AISidebarProvider defaultOpen={false}>
+ *   <AISidebar>
+ *     <AISidebarHeader>
+ *       <AISidebarTitle>AI Assistant</AISidebarTitle>
+ *       <AISidebarClose />
+ *     </AISidebarHeader>
+ *     <AISidebarContent>{messages}</AISidebarContent>
+ *     <AISidebarFooter>{composer}</AISidebarFooter>
+ *   </AISidebar>
+ *   <AISidebarTrigger />
+ *   <main>{children}</main>
+ * </AISidebarProvider>
+ * ```
+ *
+ * @public
+ */
+export const AISidebar = forwardRef<HTMLElement, AISidebarProps>(
+  (props, ref) => {
+    const { children, className, closeOnEscape = true, ...rest } = props;
+    const { close, labels, openState, position, width } = useAISidebar();
+    useEscapeToClose(closeOnEscape, openState, close);
+
+    return (
+      <aside
+        aria-hidden={!openState}
+        aria-label={labels.defaultTitle}
+        className={cn(
+          "fixed top-0 z-40 flex h-full flex-col border-border bg-background shadow-lg transition-transform duration-200 ease-out",
+          position === "right" ? "right-0 border-l" : "left-0 border-r",
+          openState
+            ? "translate-x-0"
+            : position === "right"
+              ? "translate-x-full"
+              : "-translate-x-full",
+          "max-w-full",
+          className,
+        )}
+        data-state={openState ? "open" : "closed"}
+        ref={ref}
+        style={{ width: `${width.toString()}px` }}
+        {...rest}
+      >
+        {children}
+      </aside>
+    );
+  },
+);
+AISidebar.displayName = "AISidebar";
+
+/**
+ * Header slot for an {@link AISidebar}. Use to host the title, model
+ * selector, and the close control.
+ *
+ * @public
+ */
+export const AISidebarHeader = forwardRef<
+  HTMLElement,
+  ComponentPropsWithoutRef<"header">
+>(({ children, className, ...rest }, ref) => (
+  <header
+    className={cn(
+      "flex items-center gap-2 border-b border-border px-4 py-3",
+      className,
+    )}
+    ref={ref}
+    {...rest}
+  >
+    {children}
+  </header>
+));
+AISidebarHeader.displayName = "AISidebarHeader";
+
+/**
+ * Title slot for {@link AISidebarHeader}. Defaults to the localized title
+ * from the provider whenever the consumer omits children.
+ *
+ * @public
+ */
+export const AISidebarTitle = forwardRef<
+  HTMLHeadingElement,
+  ComponentPropsWithoutRef<"h2">
+>(({ children, className, ...rest }, ref) => {
+  const { labels } = useAISidebar();
+  return (
+    <h2
+      className={cn(
+        "flex flex-1 items-center gap-2 text-sm font-semibold tracking-tight text-foreground",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      <Bot aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
+      {children ?? labels.defaultTitle}
+    </h2>
+  );
+});
+AISidebarTitle.displayName = "AISidebarTitle";
+
+/**
+ * Close-button slot for {@link AISidebarHeader}.
+ *
+ * @public
+ */
+export const AISidebarClose = forwardRef<
+  HTMLButtonElement,
+  Omit<ComponentPropsWithoutRef<"button">, "type">
+>(({ className, onClick, ...rest }, ref) => {
+  const { close, labels } = useAISidebar();
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      close();
+    },
+    [close, onClick],
+  );
+  return (
+    <Button
+      aria-label={labels.close}
+      className={cn("h-8 w-8", className)}
+      onClick={handleClick}
+      ref={ref}
+      size="icon"
+      type="button"
+      variant="ghost"
+      {...rest}
+    >
+      <X aria-hidden="true" className="h-4 w-4" />
+    </Button>
+  );
+});
+AISidebarClose.displayName = "AISidebarClose";
+
+/**
+ * Scrollable middle section of {@link AISidebar}.
+ *
+ * @public
+ */
+export const AISidebarContent = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ children, className, ...rest }, ref) => (
+  <div
+    className={cn("flex flex-1 flex-col gap-2 overflow-y-auto p-4", className)}
+    ref={ref}
+    {...rest}
+  >
+    {children}
+  </div>
+));
+AISidebarContent.displayName = "AISidebarContent";
+
+/**
+ * Bottom slot of {@link AISidebar}, typically the chat composer.
+ *
+ * @public
+ */
+export const AISidebarFooter = forwardRef<
+  HTMLElement,
+  ComponentPropsWithoutRef<"footer">
+>(({ children, className, ...rest }, ref) => (
+  <footer
+    className={cn("border-t border-border bg-background px-4 py-3", className)}
+    ref={ref}
+    {...rest}
+  >
+    {children}
+  </footer>
+));
+AISidebarFooter.displayName = "AISidebarFooter";
+
+/**
+ * Props for {@link AISidebarTrigger}.
+ *
+ * @public
+ */
+export type AISidebarTriggerProps = Omit<
+  ComponentPropsWithoutRef<"button">,
+  "type"
+>;
+
+/**
+ * Standalone control that opens the sidebar. Place anywhere inside an
+ * {@link AISidebarProvider}. Falls back to the default icon + label when
+ * the consumer omits children.
+ *
+ * @public
+ */
+export const AISidebarTrigger = forwardRef<
+  HTMLButtonElement,
+  AISidebarTriggerProps
+>(({ children, className, onClick, ...rest }, ref) => {
+  const { labels, openState, toggle } = useAISidebar();
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      toggle();
+    },
+    [onClick, toggle],
+  );
+  return (
+    <Button
+      aria-expanded={openState}
+      aria-label={children ? undefined : labels.open}
+      className={cn(className)}
+      data-state={openState ? "open" : "closed"}
+      onClick={handleClick}
+      ref={ref}
+      size={children ? "sm" : "icon"}
+      type="button"
+      variant="outline"
+      {...rest}
+    >
+      {children ?? <MessageSquarePlus aria-hidden="true" className="h-4 w-4" />}
+    </Button>
+  );
+});
+AISidebarTrigger.displayName = "AISidebarTrigger";

--- a/packages/ui/src/components/ai-sidebar/ai-sidebar.visual.tsx
+++ b/packages/ui/src/components/ai-sidebar/ai-sidebar.visual.tsx
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import {
+  AISidebar,
+  AISidebarClose,
+  AISidebarContent,
+  AISidebarFooter,
+  AISidebarHeader,
+  AISidebarProvider,
+  AISidebarTitle,
+} from "./ai-sidebar";
+
+test.describe("AISidebar Visual", () => {
+  test("default-open", async ({ mount }) => {
+    const component = await mount(
+      <div className="relative h-[480px] w-[600px] bg-muted/30">
+        <AISidebarProvider defaultOpen>
+          <AISidebar className="!relative">
+            <AISidebarHeader>
+              <AISidebarTitle>AI Assistant</AISidebarTitle>
+              <AISidebarClose />
+            </AISidebarHeader>
+            <AISidebarContent>
+              <p className="text-sm text-muted-foreground">
+                Ask anything about this document.
+              </p>
+              <p className="text-sm text-foreground">
+                I can help you summarize, draft, or refactor.
+              </p>
+            </AISidebarContent>
+            <AISidebarFooter>
+              <p className="text-xs text-muted-foreground">
+                Composer goes here…
+              </p>
+            </AISidebarFooter>
+          </AISidebar>
+        </AISidebarProvider>
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("ai-sidebar-default-open.png");
+  });
+});

--- a/packages/ui/src/components/ai-sidebar/index.ts
+++ b/packages/ui/src/components/ai-sidebar/index.ts
@@ -1,0 +1,16 @@
+export {
+  AISidebar,
+  AISidebarClose,
+  AISidebarContent,
+  AISidebarFooter,
+  AISidebarHeader,
+  type AISidebarLabels,
+  type AISidebarPosition,
+  type AISidebarProps,
+  AISidebarProvider,
+  type AISidebarProviderProps,
+  AISidebarTitle,
+  AISidebarTrigger,
+  type AISidebarTriggerProps,
+  useAISidebar,
+} from "./ai-sidebar";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -135,6 +135,22 @@ export {
   type AIToolCallDisplayProps,
   type AIToolCallStatus,
 } from "./ai-tool-call-display";
+export {
+  AISidebar,
+  AISidebarClose,
+  AISidebarContent,
+  AISidebarFooter,
+  AISidebarHeader,
+  type AISidebarLabels,
+  type AISidebarPosition,
+  type AISidebarProps,
+  AISidebarProvider,
+  type AISidebarProviderProps,
+  AISidebarTitle,
+  AISidebarTrigger,
+  type AISidebarTriggerProps,
+  useAISidebar,
+} from "./ai-sidebar";
 
 // New shadcn primitives - Form
 export { Textarea, type TextareaProps } from "./textarea";


### PR DESCRIPTION
## Summary

Slide-out AI assistant panel — Copilot Chat / Cursor / Notion AI shape. Composable family driven by \`AISidebarProvider\`.

- **\`AISidebarProvider\`** — owns open/closed state (controlled or uncontrolled via \`open\`/\`onOpenChange\` or \`defaultOpen\`), default position (\`left\`/\`right\`), default width (clamped 280–720), and labels.
- **\`AISidebar\`** — \`aside role="complementary"\`; toggles \`aria-hidden\` with the open state so assistive tech skips the panel when closed. Slides in from the configured edge with \`translate-x\`. Escape closes by default; opt out per panel with \`closeOnEscape={false}\`.
- **\`AISidebarHeader\`** / **\`AISidebarTitle\`** / **\`AISidebarClose\`** — header slots. \`AISidebarTitle\` falls back to \`labels.defaultTitle\` whenever the consumer omits children.
- **\`AISidebarContent\`** — scrollable middle section.
- **\`AISidebarFooter\`** — bottom slot, typically the composer.
- **\`AISidebarTrigger\`** — standalone open/toggle control with \`aria-expanded\`.
- **\`useAISidebar\`** — hook for any custom child that needs the open state, position, or width.

Drag-resize, persistence, focus trap, mobile overlay, and keyboard shortcuts beyond Escape are intentionally **out of scope** — drive them from consumer code via \`useAISidebar\` + the provider's controlled API.

Closes #55

## API

\`\`\`tsx
<AISidebarProvider defaultOpen={false}>
  <AISidebar>
    <AISidebarHeader>
      <AISidebarTitle>AI Assistant</AISidebarTitle>
      <ModelSelector models={models} />
      <AISidebarClose />
    </AISidebarHeader>
    <AISidebarContent>
      <ConversationThread messages={messages} />
    </AISidebarContent>
    <AISidebarFooter>
      <ChatInput onSubmit={handleSend} />
    </AISidebarFooter>
  </AISidebar>

  <AISidebarTrigger />
  <main>{children}</main>
</AISidebarProvider>
\`\`\`

## Coverage

- Unit: 9 tests covering rendering all slots, default-title fallback, \`aria-hidden\` controlled flip, trigger \`onOpenChange\` invocation, close button \`onOpenChange\` invocation, Escape close path, \`closeOnEscape={false}\` opt-out, controlled-mode flow (callback fires, internal state stays put), \`data-state\` + position-driven classes
- Visual: Playwright CT story for default-open right-anchored panel
- Storybook: \`Default\`, \`LeftSide\`, \`Closed\` (interactive trigger)
- MDX: usage + position + state model + a11y notes + scope notes

## Registry

Added \`ai-sidebar\` (\`category: ai\`, \`registryDependencies: [button]\`, deps: \`lucide-react\`). Re-export shim and \`pnpm build\` regenerates \`/r/ai-sidebar.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 502/502 (9 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview opens / closes the panel via trigger and close, exercises Escape, and renders the left-anchored variant
- [ ] Registry entry visible at \`/r/ai-sidebar.json\` and \`/components/ai-sidebar\` after deploy