### PR TITLE
feat(ui): add AIArtifact compound family

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -49,6 +49,26 @@
       "category": "data"
     },
     {
+      "name": "ai-artifact",
+      "type": "registry:component",
+      "title": "AI Artifact",
+      "description": "Rendered output area for AI-generated content with toolbar, copy/edit/download/fullscreen actions, and version chips.",
+      "files": [
+        {
+          "path": "registry/default/ai-artifact/ai-artifact.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [
+        "badge",
+        "button"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "category": "ai"
+    },
+    {
       "name": "ai-chat-input",
       "type": "registry:component",
       "title": "AI Chat Input",

--- a/apps/registry/registry/default/ai-artifact/ai-artifact.tsx
+++ b/apps/registry/registry/default/ai-artifact/ai-artifact.tsx
@@ -1,0 +1,13 @@
+// Re-export from @vllnt/ui package
+export {
+  AIArtifact,
+  AIArtifactContent,
+  AIArtifactCopyButton,
+  AIArtifactDownloadButton,
+  AIArtifactEditButton,
+  AIArtifactFullscreenButton,
+  AIArtifactToolbar,
+  AIArtifactVersion,
+  AIArtifactVersions,
+  useAIArtifact,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/ai-artifact/ai-artifact.mdx
+++ b/packages/ui/src/components/ai-artifact/ai-artifact.mdx
@@ -1,0 +1,99 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './ai-artifact.stories'
+
+<Meta of={Stories} />
+
+# AIArtifact
+
+Rendered output area for AI-generated content — code previews, documents, diagrams, interactive widgets. Think Claude Artifacts or ChatGPT Canvas. Composes `Badge` + `Button`.
+
+A compound family driven by an internal context:
+
+- `AIArtifact` — root container; owns the copy state, fullscreen state, derived filename, and the consumer-supplied `onEdit` handler. Sets `data-fullscreen` and `data-type` on the section.
+- `AIArtifactToolbar` — wraps the action row (`role="toolbar"`).
+- `AIArtifactCopyButton` / `AIArtifactDownloadButton` — wired to `value` + `filename` automatically. Copy flips to a check after a successful clipboard write; download creates a Blob with the auto-derived (or overridden) filename.
+- `AIArtifactEditButton` — fires `onEdit`. Renders **nothing** when no `onEdit` handler is provided so consumers do not have to conditionally hide it.
+- `AIArtifactFullscreenButton` — toggles `data-fullscreen` on the root. Drive layout changes via CSS or via `useAIArtifact`.
+- `AIArtifactContent` — scrollable body slot for the actual payload (code block, MDX, mermaid output, sandboxed iframe, image, etc.).
+- `AIArtifactVersions` / `AIArtifactVersion` — version navigator chips at the bottom; each chip emits `onClick` so consumers drive the selected version externally.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ai-artifact.json
+```
+
+## Import
+
+```tsx
+import {
+  AIArtifact,
+  AIArtifactContent,
+  AIArtifactCopyButton,
+  AIArtifactDownloadButton,
+  AIArtifactEditButton,
+  AIArtifactFullscreenButton,
+  AIArtifactToolbar,
+  AIArtifactVersion,
+  AIArtifactVersions,
+  useAIArtifact,
+} from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<AIArtifact
+  type="code"
+  title="UserProfile.tsx"
+  language="tsx"
+  value={generatedCode}
+  onEdit={openEditor}
+>
+  <AIArtifactToolbar>
+    <AIArtifactCopyButton />
+    <AIArtifactEditButton />
+    <AIArtifactDownloadButton />
+    <AIArtifactFullscreenButton />
+  </AIArtifactToolbar>
+  <AIArtifactContent>
+    <CodeBlock language="tsx">{generatedCode}</CodeBlock>
+  </AIArtifactContent>
+  <AIArtifactVersions>
+    <AIArtifactVersion label="v1" onClick={() => setVersion('v1')} />
+    <AIArtifactVersion active label="v2" onClick={() => setVersion('v2')} />
+  </AIArtifactVersions>
+</AIArtifact>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Read-only
+
+Omit `onEdit` to hide the edit control without conditionally rendering it.
+
+<Canvas of={Stories.ReadOnly} sourceState="shown" />
+
+## Document type
+
+`type` drives the badge and the default download extension when no `language` is provided. Supported values: `code` / `document` / `diagram` / `table` / `html` / `image` / `custom`.
+
+<Canvas of={Stories.Document} sourceState="shown" />
+
+## Minimal
+
+Every prop except `value` (used for copy/download) is optional. The component still renders the type badge and a content slot ready for any payload.
+
+<Canvas of={Stories.Minimal} sourceState="shown" />
+
+## Notes
+
+- Type-aware payload rendering (code → CodeBlock, document → MDX, diagram → mermaid output, html → sandboxed iframe, etc.) is intentionally **out of scope** — pass the appropriate component or markup as the body of `AIArtifactContent`.
+- Streaming, side-by-side resize against the chat, mobile tab UI, and edit-in-place are kept out of scope. Use `useAIArtifact` and the consumer's own state if you need them.
+- The download flow uses a temporary `Blob` + anchor and falls back to a no-op when `document` is undefined (SSR-safe).

--- a/packages/ui/src/components/ai-artifact/ai-artifact.stories.tsx
+++ b/packages/ui/src/components/ai-artifact/ai-artifact.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  AIArtifact,
+  AIArtifactContent,
+  AIArtifactCopyButton,
+  AIArtifactDownloadButton,
+  AIArtifactEditButton,
+  AIArtifactFullscreenButton,
+  AIArtifactToolbar,
+  AIArtifactVersion,
+  AIArtifactVersions,
+} from "./ai-artifact";
+
+const SAMPLE = `export function UserProfile({ name }: { name: string }) {
+  return <div className="profile">Hello, {name}</div>;
+}`;
+
+const noop = (): void => {
+  return;
+};
+
+const meta = {
+  args: {
+    language: "tsx",
+    onEdit: noop,
+    subtitle: "Generated component",
+    title: "UserProfile.tsx",
+    type: "code",
+    value: SAMPLE,
+  },
+  argTypes: {
+    type: {
+      control: "select",
+      options: [
+        "code",
+        "document",
+        "diagram",
+        "table",
+        "html",
+        "image",
+        "custom",
+      ],
+    },
+  },
+  component: AIArtifact,
+  title: "AI/AIArtifact",
+} satisfies Meta<typeof AIArtifact>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <AIArtifact {...args}>
+      <AIArtifactToolbar>
+        <AIArtifactCopyButton />
+        <AIArtifactEditButton />
+        <AIArtifactDownloadButton />
+        <AIArtifactFullscreenButton />
+      </AIArtifactToolbar>
+      <AIArtifactContent>
+        <pre className="font-mono text-xs leading-relaxed">{SAMPLE}</pre>
+      </AIArtifactContent>
+      <AIArtifactVersions>
+        <AIArtifactVersion label="v1" />
+        <AIArtifactVersion active label="v2" />
+      </AIArtifactVersions>
+    </AIArtifact>
+  ),
+};
+
+export const ReadOnly: Story = {
+  args: {
+    onEdit: undefined,
+  },
+  render: (args) => (
+    <AIArtifact {...args}>
+      <AIArtifactToolbar>
+        <AIArtifactCopyButton />
+        <AIArtifactEditButton />
+        <AIArtifactDownloadButton />
+      </AIArtifactToolbar>
+      <AIArtifactContent>
+        <pre className="font-mono text-xs leading-relaxed">{SAMPLE}</pre>
+      </AIArtifactContent>
+    </AIArtifact>
+  ),
+};
+
+export const Document: Story = {
+  args: {
+    language: "md",
+    subtitle: "Generated brief",
+    title: "Project brief",
+    type: "document",
+    value: "# Project brief\n\nThis is a generated outline.",
+  },
+  render: (args) => (
+    <AIArtifact {...args}>
+      <AIArtifactToolbar>
+        <AIArtifactCopyButton />
+        <AIArtifactDownloadButton />
+        <AIArtifactFullscreenButton />
+      </AIArtifactToolbar>
+      <AIArtifactContent>
+        <article className="prose prose-sm dark:prose-invert">
+          <h1>Project brief</h1>
+          <p>This is a generated outline that the user can refine.</p>
+          <ul>
+            <li>Goal — articulate the problem</li>
+            <li>Scope — single-quarter</li>
+          </ul>
+        </article>
+      </AIArtifactContent>
+    </AIArtifact>
+  ),
+};
+
+export const Minimal: Story = {
+  args: {
+    language: undefined,
+    onEdit: undefined,
+    subtitle: undefined,
+    title: "Notes",
+    type: "document",
+    value: "",
+  },
+};

--- a/packages/ui/src/components/ai-artifact/ai-artifact.test.tsx
+++ b/packages/ui/src/components/ai-artifact/ai-artifact.test.tsx
@@ -1,0 +1,225 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AIArtifact,
+  AIArtifactContent,
+  AIArtifactCopyButton,
+  AIArtifactDownloadButton,
+  AIArtifactEditButton,
+  AIArtifactFullscreenButton,
+  AIArtifactToolbar,
+  AIArtifactVersion,
+  AIArtifactVersions,
+} from "./ai-artifact";
+
+type ClipboardLike = {
+  writeText: (value: string) => Promise<void>;
+};
+
+function setClipboard(clipboard: ClipboardLike): () => void {
+  const original = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: clipboard,
+    writable: true,
+  });
+  return () => {
+    if (original) {
+      Object.defineProperty(navigator, "clipboard", original);
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
+  };
+}
+
+const VALUE = "const greet = (name: string) => `Hello, ${name}`;";
+
+const noopRestoreClipboard = (): void => undefined;
+
+describe("AIArtifact", () => {
+  describe("rendering", () => {
+    it("renders the title and language badge", () => {
+      render(
+        <AIArtifact language="tsx" title="UserProfile.tsx" value={VALUE}>
+          <AIArtifactContent>{VALUE}</AIArtifactContent>
+        </AIArtifact>,
+      );
+
+      expect(
+        screen.getByRole("heading", { level: 3, name: "UserProfile.tsx" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("tsx")).toBeInTheDocument();
+    });
+
+    it("emits data-type and aria-label on the section", () => {
+      const { container } = render(
+        <AIArtifact title="Doc" type="document" value="" />,
+      );
+
+      const section = container.querySelector("section");
+      expect(section).toHaveAttribute("data-type", "document");
+      expect(section).toHaveAttribute("aria-label", "Doc");
+    });
+
+    it("falls back to the type when no language is provided", () => {
+      render(<AIArtifact title="Doc" type="document" value="" />);
+
+      expect(screen.getByText("document")).toBeInTheDocument();
+    });
+  });
+
+  describe("AIArtifactCopyButton", () => {
+    let restoreClipboard: () => void = noopRestoreClipboard;
+    const writeText = vi.fn<(value: string) => Promise<void>>();
+
+    beforeEach(() => {
+      writeText.mockReset();
+      writeText.mockResolvedValue();
+      restoreClipboard = setClipboard({ writeText });
+    });
+
+    afterEach(() => {
+      restoreClipboard();
+    });
+
+    it("writes the value to the clipboard and flips the label", async () => {
+      render(
+        <AIArtifact title="Doc" value={VALUE}>
+          <AIArtifactToolbar>
+            <AIArtifactCopyButton />
+          </AIArtifactToolbar>
+        </AIArtifact>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith(VALUE);
+      });
+      await screen.findByRole("button", { name: "Copied" });
+    });
+  });
+
+  describe("AIArtifactEditButton", () => {
+    it("renders nothing when no onEdit is provided", () => {
+      render(
+        <AIArtifact title="Doc" value="">
+          <AIArtifactToolbar>
+            <AIArtifactEditButton />
+          </AIArtifactToolbar>
+        </AIArtifact>,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: "Edit" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("invokes onEdit when clicked", () => {
+      const onEdit = vi.fn();
+      render(
+        <AIArtifact onEdit={onEdit} title="Doc" value="">
+          <AIArtifactToolbar>
+            <AIArtifactEditButton />
+          </AIArtifactToolbar>
+        </AIArtifact>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+      expect(onEdit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("AIArtifactDownloadButton", () => {
+    it("creates an object URL and clicks an anchor", () => {
+      const createObjectURL = vi.fn(() => "blob:mock");
+      const revokeObjectURL = vi.fn();
+      Object.defineProperty(URL, "createObjectURL", {
+        configurable: true,
+        value: createObjectURL,
+      });
+      Object.defineProperty(URL, "revokeObjectURL", {
+        configurable: true,
+        value: revokeObjectURL,
+      });
+
+      render(
+        <AIArtifact title="UserProfile" value={VALUE}>
+          <AIArtifactToolbar>
+            <AIArtifactDownloadButton />
+          </AIArtifactToolbar>
+        </AIArtifact>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Download" }));
+
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("AIArtifactFullscreenButton", () => {
+    it("toggles the data-fullscreen attribute", () => {
+      const { container } = render(
+        <AIArtifact title="Doc" value="">
+          <AIArtifactToolbar>
+            <AIArtifactFullscreenButton />
+          </AIArtifactToolbar>
+        </AIArtifact>,
+      );
+
+      expect(container.querySelector("section")).toHaveAttribute(
+        "data-fullscreen",
+        "false",
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Enter fullscreen" }));
+
+      expect(container.querySelector("section")).toHaveAttribute(
+        "data-fullscreen",
+        "true",
+      );
+      expect(
+        screen.getByRole("button", { name: "Exit fullscreen" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("AIArtifactVersion", () => {
+    it("marks the active version with aria-current", () => {
+      render(
+        <AIArtifact title="Doc" value="">
+          <AIArtifactVersions>
+            <AIArtifactVersion label="v1" />
+            <AIArtifactVersion active label="v2" />
+          </AIArtifactVersions>
+        </AIArtifact>,
+      );
+
+      expect(screen.getByRole("button", { name: "v1" })).not.toHaveAttribute(
+        "aria-current",
+      );
+      expect(screen.getByRole("button", { name: "v2" })).toHaveAttribute(
+        "aria-current",
+        "true",
+      );
+    });
+
+    it("forwards onClick", () => {
+      const onClick = vi.fn();
+      render(
+        <AIArtifact title="Doc" value="">
+          <AIArtifactVersions>
+            <AIArtifactVersion label="v1" onClick={onClick} />
+          </AIArtifactVersions>
+        </AIArtifact>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "v1" }));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/ui/src/components/ai-artifact/ai-artifact.tsx
+++ b/packages/ui/src/components/ai-artifact/ai-artifact.tsx
@@ -1,0 +1,702 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+import {
+  Check,
+  Copy,
+  Download,
+  Maximize2,
+  Minimize2,
+  Pencil,
+} from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Badge } from "../badge/badge";
+import { Button } from "../button/button";
+
+const COPIED_TIMEOUT_MS = 2000;
+
+/**
+ * Artifact rendering type for {@link AIArtifact}. Drives the visual badge
+ * but consumers render the actual content inside {@link AIArtifactContent}.
+ *
+ * @public
+ */
+export type AIArtifactType =
+  | "code"
+  | "custom"
+  | "diagram"
+  | "document"
+  | "html"
+  | "image"
+  | "table";
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type AIArtifactLabels = {
+  /** Aria-label after a successful copy. Defaults to `"Copied"`. */
+  copied?: string;
+  /** Aria-label for the copy control. Defaults to `"Copy"`. */
+  copy?: string;
+  /** Aria-label for the download control. Defaults to `"Download"`. */
+  download?: string;
+  /** Aria-label for the edit control. Defaults to `"Edit"`. */
+  edit?: string;
+  /** Aria-label for the fullscreen control when collapsed. Defaults to `"Enter fullscreen"`. */
+  enterFullscreen?: string;
+  /** Aria-label for the fullscreen control when expanded. Defaults to `"Exit fullscreen"`. */
+  exitFullscreen?: string;
+  /** Aria-label for the version list. Defaults to `"Versions"`. */
+  versions?: string;
+};
+
+const DEFAULT_LABELS = {
+  copied: "Copied",
+  copy: "Copy",
+  download: "Download",
+  edit: "Edit",
+  enterFullscreen: "Enter fullscreen",
+  exitFullscreen: "Exit fullscreen",
+  versions: "Versions",
+} as const satisfies Required<AIArtifactLabels>;
+
+type AIArtifactContextValue = {
+  copied: boolean;
+  copy: () => Promise<boolean>;
+  download: () => void;
+  filename: string;
+  fullscreen: boolean;
+  hasOnEdit: boolean;
+  labels: Required<AIArtifactLabels>;
+  onEdit: () => void;
+  toggleFullscreen: () => void;
+  type: AIArtifactType;
+  value: string;
+};
+
+const NO_OP = (): void => {
+  return;
+};
+
+const DEFAULT_CONTEXT: AIArtifactContextValue = {
+  copied: false,
+  copy: async () => false,
+  download: NO_OP,
+  filename: "artifact.txt",
+  fullscreen: false,
+  hasOnEdit: false,
+  labels: DEFAULT_LABELS,
+  onEdit: NO_OP,
+  toggleFullscreen: NO_OP,
+  type: "code",
+  value: "",
+};
+
+const AIArtifactContext =
+  createContext<AIArtifactContextValue>(DEFAULT_CONTEXT);
+
+/**
+ * Hook for reading the artifact's state from inside a custom child.
+ *
+ * @public
+ */
+export function useAIArtifact(): AIArtifactContextValue {
+  return useContext(AIArtifactContext);
+}
+
+function pickExtension(type: AIArtifactType, language: string): string {
+  if (language) return language;
+  switch (type) {
+    case "code":
+      return "txt";
+    case "custom":
+      return "txt";
+    case "diagram":
+      return "mmd";
+    case "document":
+      return "md";
+    case "html":
+      return "html";
+    case "image":
+      return "png";
+    case "table":
+      return "csv";
+  }
+}
+
+const SLUG_INVALID_CHARS = /[^\da-z]+/g;
+const SLUG_TRIM = /^-+|-+$/g;
+
+type FilenameInput = {
+  filename?: string;
+  language: string;
+  title: ReactNode;
+  type: AIArtifactType;
+};
+
+function buildFilename({
+  filename,
+  language,
+  title,
+  type,
+}: FilenameInput): string {
+  if (filename) return filename;
+  const base =
+    typeof title === "string" && title.length > 0 ? title : "artifact";
+  const slug = base
+    .toLowerCase()
+    .replaceAll(SLUG_INVALID_CHARS, "-")
+    .replaceAll(SLUG_TRIM, "");
+  const safeBase = slug.length > 0 ? slug : "artifact";
+  return `${safeBase}.${pickExtension(type, language)}`;
+}
+
+async function writeToClipboard(value: string): Promise<boolean> {
+  if (
+    typeof navigator === "undefined" ||
+    typeof navigator.clipboard?.writeText !== "function"
+  ) {
+    return false;
+  }
+  try {
+    await navigator.clipboard.writeText(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function downloadValueAsFile(value: string, filename: string): void {
+  if (typeof document === "undefined") return;
+  const blob = new Blob([value], { type: "text/plain;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.style.display = "none";
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Props for {@link AIArtifact}.
+ *
+ * @public
+ */
+export type AIArtifactProps = {
+  /** Initial fullscreen state. */
+  defaultFullscreen?: boolean;
+  /** Override the auto-derived filename for downloads. */
+  filename?: string;
+  /** Localizable strings. */
+  labels?: AIArtifactLabels;
+  /** Optional language tag rendered next to the title (e.g. `tsx`). */
+  language?: string;
+  /** Fires when the user clicks the edit control. */
+  onEdit?: () => void;
+  /** Subtitle / sub-headline. */
+  subtitle?: ReactNode;
+  /** Primary title. */
+  title?: ReactNode;
+  /** Artifact type — drives the badge and default download extension. */
+  type?: AIArtifactType;
+  /** Raw text content used by the copy + download controls. */
+  value?: string;
+} & ComponentPropsWithoutRef<"section">;
+
+type ArtifactHeaderProps = {
+  language: string;
+  subtitle?: ReactNode;
+  title?: ReactNode;
+  type: AIArtifactType;
+};
+
+function ArtifactHeader({
+  language,
+  subtitle,
+  title,
+  type,
+}: ArtifactHeaderProps): ReactNode {
+  if (!title && !subtitle && !language) return null;
+  return (
+    <header className="flex flex-col gap-1">
+      <div className="flex flex-wrap items-center gap-2">
+        {title ? (
+          <h3 className="text-sm font-semibold tracking-tight text-foreground">
+            {title}
+          </h3>
+        ) : null}
+        <Badge variant="secondary">{language || type}</Badge>
+      </div>
+      {subtitle ? (
+        <p className="text-xs text-muted-foreground">{subtitle}</p>
+      ) : null}
+    </header>
+  );
+}
+
+/**
+ * Rendered output area for AI-generated content — code previews, documents,
+ * diagrams, or any custom artifact. Composes {@link Badge} + {@link Button}.
+ *
+ * The compound family pairs a root context with action buttons and a
+ * content slot:
+ *
+ * - {@link AIArtifactToolbar} — wraps the action row.
+ * - {@link AIArtifactCopyButton} / {@link AIArtifactDownloadButton} —
+ *   wired to `value` + `filename` automatically.
+ * - {@link AIArtifactEditButton} — fires `onEdit`; hidden when no
+ *   handler exists.
+ * - {@link AIArtifactFullscreenButton} — toggles `data-fullscreen` on the
+ *   root so consumers can drive the layout via CSS.
+ * - {@link AIArtifactContent} — scrollable body slot for the actual
+ *   payload (code block, MDX, mermaid output, iframe, etc.).
+ * - {@link AIArtifactVersions} / {@link AIArtifactVersion} — version
+ *   navigator at the bottom.
+ *
+ * @example
+ * ```tsx
+ * <AIArtifact
+ *   type="code"
+ *   title="UserProfile.tsx"
+ *   language="tsx"
+ *   value={generatedCode}
+ *   onEdit={openEditor}
+ * >
+ *   <AIArtifactToolbar>
+ *     <AIArtifactCopyButton />
+ *     <AIArtifactEditButton />
+ *     <AIArtifactDownloadButton />
+ *     <AIArtifactFullscreenButton />
+ *   </AIArtifactToolbar>
+ *   <AIArtifactContent>
+ *     <CodeBlock language="tsx">{generatedCode}</CodeBlock>
+ *   </AIArtifactContent>
+ * </AIArtifact>
+ * ```
+ *
+ * @public
+ */
+type ControllerOptions = {
+  defaultFullscreen: boolean;
+  filename?: string;
+  labels: Required<AIArtifactLabels>;
+  language: string;
+  onEdit?: () => void;
+  title: ReactNode;
+  type: AIArtifactType;
+  value: string;
+};
+
+function useArtifactController(
+  options: ControllerOptions,
+): AIArtifactContextValue {
+  const {
+    defaultFullscreen,
+    filename,
+    labels,
+    language,
+    onEdit,
+    title,
+    type,
+    value,
+  } = options;
+  const [fullscreen, setFullscreen] = useState(defaultFullscreen);
+  const [copied, setCopied] = useState(false);
+  const resolvedFilename = useMemo(
+    () => buildFilename({ filename, language, title, type }),
+    [filename, language, title, type],
+  );
+
+  const copy = useCallback(async () => {
+    const ok = await writeToClipboard(value);
+    if (!ok) return false;
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, COPIED_TIMEOUT_MS);
+    return true;
+  }, [value]);
+
+  const download = useCallback(() => {
+    downloadValueAsFile(value, resolvedFilename);
+  }, [resolvedFilename, value]);
+
+  const toggleFullscreen = useCallback(() => {
+    setFullscreen((current) => !current);
+  }, []);
+
+  const triggerEdit = useCallback(() => {
+    onEdit?.();
+  }, [onEdit]);
+
+  return useMemo<AIArtifactContextValue>(
+    () => ({
+      copied,
+      copy,
+      download,
+      filename: resolvedFilename,
+      fullscreen,
+      hasOnEdit: onEdit !== undefined,
+      labels,
+      onEdit: triggerEdit,
+      toggleFullscreen,
+      type,
+      value,
+    }),
+    [
+      copied,
+      copy,
+      download,
+      fullscreen,
+      labels,
+      onEdit,
+      resolvedFilename,
+      toggleFullscreen,
+      triggerEdit,
+      type,
+      value,
+    ],
+  );
+}
+
+export const AIArtifact = forwardRef<HTMLElement, AIArtifactProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      defaultFullscreen = false,
+      filename,
+      labels,
+      language = "",
+      onEdit,
+      subtitle,
+      title,
+      type = "code",
+      value = "",
+      ...rest
+    } = props;
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const contextValue = useArtifactController({
+      defaultFullscreen,
+      filename,
+      labels: resolvedLabels,
+      language,
+      onEdit,
+      title,
+      type,
+      value,
+    });
+
+    return (
+      <AIArtifactContext.Provider value={contextValue}>
+        <section
+          aria-label={typeof title === "string" ? title : undefined}
+          className={cn(
+            "flex flex-col gap-3 rounded-2xl border bg-background p-4",
+            className,
+          )}
+          data-fullscreen={contextValue.fullscreen ? "true" : "false"}
+          data-type={type}
+          ref={ref}
+          {...rest}
+        >
+          <ArtifactHeader
+            language={language}
+            subtitle={subtitle}
+            title={title}
+            type={type}
+          />
+          {children}
+        </section>
+      </AIArtifactContext.Provider>
+    );
+  },
+);
+AIArtifact.displayName = "AIArtifact";
+
+/**
+ * Toolbar slot — wraps action buttons in a horizontal row.
+ *
+ * @public
+ */
+export const AIArtifactToolbar = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ className, ...rest }, ref) => (
+  <div
+    className={cn(
+      "flex flex-wrap items-center gap-1.5 border-b border-border pb-2",
+      className,
+    )}
+    ref={ref}
+    role="toolbar"
+    {...rest}
+  />
+));
+AIArtifactToolbar.displayName = "AIArtifactToolbar";
+
+type ToolbarButtonProps = Omit<
+  ComponentPropsWithoutRef<"button">,
+  "children" | "type"
+>;
+
+/**
+ * Copy-to-clipboard control for the artifact's `value`. Visually flips to
+ * a check after a successful copy.
+ *
+ * @public
+ */
+export const AIArtifactCopyButton = forwardRef<
+  HTMLButtonElement,
+  ToolbarButtonProps
+>(({ className, onClick, ...rest }, ref) => {
+  const { copied, copy, labels } = useAIArtifact();
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      void copy();
+    },
+    [copy, onClick],
+  );
+  return (
+    <Button
+      aria-label={copied ? labels.copied : labels.copy}
+      className={cn("h-8 w-8", className)}
+      onClick={handleClick}
+      ref={ref}
+      size="icon"
+      type="button"
+      variant="ghost"
+      {...rest}
+    >
+      {copied ? (
+        <Check aria-hidden="true" className="h-4 w-4" />
+      ) : (
+        <Copy aria-hidden="true" className="h-4 w-4" />
+      )}
+    </Button>
+  );
+});
+AIArtifactCopyButton.displayName = "AIArtifactCopyButton";
+
+/**
+ * Edit control. Renders nothing when the artifact has no `onEdit`
+ * handler so consumers do not have to conditionally hide it.
+ *
+ * @public
+ */
+export const AIArtifactEditButton = forwardRef<
+  HTMLButtonElement,
+  ToolbarButtonProps
+>(({ className, onClick, ...rest }, ref) => {
+  const { hasOnEdit, labels, onEdit } = useAIArtifact();
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      onEdit();
+    },
+    [onClick, onEdit],
+  );
+  if (!hasOnEdit) return null;
+  return (
+    <Button
+      aria-label={labels.edit}
+      className={cn("h-8 w-8", className)}
+      onClick={handleClick}
+      ref={ref}
+      size="icon"
+      type="button"
+      variant="ghost"
+      {...rest}
+    >
+      <Pencil aria-hidden="true" className="h-4 w-4" />
+    </Button>
+  );
+});
+AIArtifactEditButton.displayName = "AIArtifactEditButton";
+
+/**
+ * Download control — saves the artifact's `value` as a file with an
+ * auto-derived (or overridden) filename.
+ *
+ * @public
+ */
+export const AIArtifactDownloadButton = forwardRef<
+  HTMLButtonElement,
+  ToolbarButtonProps
+>(({ className, onClick, ...rest }, ref) => {
+  const { download, labels } = useAIArtifact();
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      download();
+    },
+    [download, onClick],
+  );
+  return (
+    <Button
+      aria-label={labels.download}
+      className={cn("h-8 w-8", className)}
+      onClick={handleClick}
+      ref={ref}
+      size="icon"
+      type="button"
+      variant="ghost"
+      {...rest}
+    >
+      <Download aria-hidden="true" className="h-4 w-4" />
+    </Button>
+  );
+});
+AIArtifactDownloadButton.displayName = "AIArtifactDownloadButton";
+
+/**
+ * Fullscreen toggle. Updates the root's `data-fullscreen` attribute so
+ * consumers can drive layout changes via CSS or React state on
+ * {@link useAIArtifact}.
+ *
+ * @public
+ */
+export const AIArtifactFullscreenButton = forwardRef<
+  HTMLButtonElement,
+  ToolbarButtonProps
+>(({ className, onClick, ...rest }, ref) => {
+  const { fullscreen, labels, toggleFullscreen } = useAIArtifact();
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      toggleFullscreen();
+    },
+    [onClick, toggleFullscreen],
+  );
+  return (
+    <Button
+      aria-label={fullscreen ? labels.exitFullscreen : labels.enterFullscreen}
+      aria-pressed={fullscreen}
+      className={cn("h-8 w-8", className)}
+      onClick={handleClick}
+      ref={ref}
+      size="icon"
+      type="button"
+      variant="ghost"
+      {...rest}
+    >
+      {fullscreen ? (
+        <Minimize2 aria-hidden="true" className="h-4 w-4" />
+      ) : (
+        <Maximize2 aria-hidden="true" className="h-4 w-4" />
+      )}
+    </Button>
+  );
+});
+AIArtifactFullscreenButton.displayName = "AIArtifactFullscreenButton";
+
+/**
+ * Scrollable body slot. Render the actual payload here (code block,
+ * markdown, mermaid output, sandboxed iframe, etc.).
+ *
+ * @public
+ */
+export const AIArtifactContent = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ className, ...rest }, ref) => (
+  <div
+    className={cn(
+      "min-h-[6rem] overflow-auto rounded-lg border border-border bg-muted/20 p-3 text-sm text-foreground",
+      className,
+    )}
+    ref={ref}
+    {...rest}
+  />
+));
+AIArtifactContent.displayName = "AIArtifactContent";
+
+/**
+ * Version navigator container.
+ *
+ * @public
+ */
+export const AIArtifactVersions = forwardRef<
+  HTMLElement,
+  ComponentPropsWithoutRef<"nav">
+>(({ children, className, ...rest }, ref) => {
+  const { labels } = useAIArtifact();
+  return (
+    <nav
+      aria-label={labels.versions}
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 border-t border-border pt-2",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      {children}
+    </nav>
+  );
+});
+AIArtifactVersions.displayName = "AIArtifactVersions";
+
+/**
+ * Props for {@link AIArtifactVersion}.
+ *
+ * @public
+ */
+export type AIArtifactVersionProps = {
+  /** When true, renders with active styling and `aria-current="true"`. */
+  active?: boolean;
+  /** Caption for the chip. */
+  label: ReactNode;
+} & Omit<ComponentPropsWithoutRef<"button">, "type">;
+
+/**
+ * Single chip inside an {@link AIArtifactVersions}. Emits `onClick` so
+ * consumers can drive version state externally.
+ *
+ * @public
+ */
+export const AIArtifactVersion = forwardRef<
+  HTMLButtonElement,
+  AIArtifactVersionProps
+>(({ active = false, className, label, ...rest }, ref) => (
+  <button
+    aria-current={active ? "true" : undefined}
+    className={cn(
+      "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      active
+        ? "border-primary bg-primary text-primary-foreground"
+        : "border-border bg-background text-muted-foreground hover:bg-accent",
+      className,
+    )}
+    ref={ref}
+    type="button"
+    {...rest}
+  >
+    {label}
+  </button>
+));
+AIArtifactVersion.displayName = "AIArtifactVersion";

--- a/packages/ui/src/components/ai-artifact/ai-artifact.visual.tsx
+++ b/packages/ui/src/components/ai-artifact/ai-artifact.visual.tsx
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import {
+  AIArtifact,
+  AIArtifactContent,
+  AIArtifactCopyButton,
+  AIArtifactDownloadButton,
+  AIArtifactEditButton,
+  AIArtifactFullscreenButton,
+  AIArtifactToolbar,
+  AIArtifactVersion,
+  AIArtifactVersions,
+} from "./ai-artifact";
+
+const noop = (): void => {
+  return;
+};
+
+const SAMPLE = `export function UserProfile({ name }: { name: string }) {
+  return <div className="profile">Hello, {name}</div>;
+}`;
+
+test.describe("AIArtifact Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <AIArtifact
+        language="tsx"
+        onEdit={noop}
+        subtitle="Generated component"
+        title="UserProfile.tsx"
+        type="code"
+        value={SAMPLE}
+      >
+        <AIArtifactToolbar>
+          <AIArtifactCopyButton />
+          <AIArtifactEditButton />
+          <AIArtifactDownloadButton />
+          <AIArtifactFullscreenButton />
+        </AIArtifactToolbar>
+        <AIArtifactContent>
+          <pre className="font-mono text-xs leading-relaxed">{SAMPLE}</pre>
+        </AIArtifactContent>
+        <AIArtifactVersions>
+          <AIArtifactVersion label="v1" />
+          <AIArtifactVersion active label="v2" />
+        </AIArtifactVersions>
+      </AIArtifact>,
+    );
+    await expect(component).toHaveScreenshot("ai-artifact-default.png");
+  });
+
+  test("minimal", async ({ mount }) => {
+    const component = await mount(
+      <AIArtifact title="Notes" type="document" value="" />,
+    );
+    await expect(component).toHaveScreenshot("ai-artifact-minimal.png");
+  });
+});

--- a/packages/ui/src/components/ai-artifact/index.ts
+++ b/packages/ui/src/components/ai-artifact/index.ts
@@ -1,0 +1,16 @@
+export {
+  AIArtifact,
+  AIArtifactContent,
+  AIArtifactCopyButton,
+  AIArtifactDownloadButton,
+  AIArtifactEditButton,
+  AIArtifactFullscreenButton,
+  type AIArtifactLabels,
+  type AIArtifactProps,
+  AIArtifactToolbar,
+  type AIArtifactType,
+  AIArtifactVersion,
+  type AIArtifactVersionProps,
+  AIArtifactVersions,
+  useAIArtifact,
+} from "./ai-artifact";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -101,6 +101,22 @@ export {
 } from "./toast";
 
 // AI components
+export {
+  AIArtifact,
+  AIArtifactContent,
+  AIArtifactCopyButton,
+  AIArtifactDownloadButton,
+  AIArtifactEditButton,
+  AIArtifactFullscreenButton,
+  type AIArtifactLabels,
+  type AIArtifactProps,
+  AIArtifactToolbar,
+  type AIArtifactType,
+  AIArtifactVersion,
+  type AIArtifactVersionProps,
+  AIArtifactVersions,
+  useAIArtifact,
+} from "./ai-artifact";
 export { AIChatInput, type AIChatInputProps } from "./ai-chat-input";
 export {
   AIMessageBubble,


### PR DESCRIPTION
## Summary

Rendered output area for AI-generated content — code previews, documents, diagrams, interactive widgets. Claude Artifacts / ChatGPT Canvas shape. Composes \`Badge\` + \`Button\`.

A compound family driven by an internal context:

- **\`AIArtifact\`** — root container; owns the copy state, fullscreen state, derived filename, and the consumer-supplied \`onEdit\` handler. Sets \`data-fullscreen\` and \`data-type\` on the section.
- **\`AIArtifactToolbar\`** — \`role="toolbar"\` action row.
- **\`AIArtifactCopyButton\`** / **\`AIArtifactDownloadButton\`** — wired to \`value\` + \`filename\` automatically. Copy flips to a check after a successful clipboard write (2 s); download creates a Blob with an auto-derived (or overridden) filename.
- **\`AIArtifactEditButton\`** — fires \`onEdit\`. Renders **nothing** when no \`onEdit\` handler exists so consumers do not have to conditionally hide it.
- **\`AIArtifactFullscreenButton\`** — toggles \`data-fullscreen\` on the root.
- **\`AIArtifactContent\`** — scrollable body slot for the actual payload (code block, MDX, mermaid output, sandboxed iframe, etc.).
- **\`AIArtifactVersions\`** / **\`AIArtifactVersion\`** — version chips at the bottom; each chip emits \`onClick\` so consumers drive the selected version externally.
- **\`useAIArtifact\`** — hook for any custom child that needs the artifact's state.

Type-aware payload rendering, streaming, side-by-side resize against the chat, mobile tab UI, and edit-in-place are intentionally **out of scope** — drive them from consumer code via the hook.

Closes #56

## API

\`\`\`tsx
<AIArtifact
  type="code"
  title="UserProfile.tsx"
  language="tsx"
  value={generatedCode}
  onEdit={openEditor}
>
  <AIArtifactToolbar>
    <AIArtifactCopyButton />
    <AIArtifactEditButton />
    <AIArtifactDownloadButton />
    <AIArtifactFullscreenButton />
  </AIArtifactToolbar>
  <AIArtifactContent>
    <CodeBlock language="tsx">{generatedCode}</CodeBlock>
  </AIArtifactContent>
  <AIArtifactVersions>
    <AIArtifactVersion label="v1" onClick={() => setVersion('v1')} />
    <AIArtifactVersion active label="v2" onClick={() => setVersion('v2')} />
  </AIArtifactVersions>
</AIArtifact>
\`\`\`

## Coverage

- Unit: 10 tests covering title/language badge rendering, \`data-type\` + \`aria-label\` on the section, type fallback when language is omitted, copy → clipboard write + label flip, edit button hides without \`onEdit\` and fires when present, download creates + revokes the object URL, fullscreen toggles \`data-fullscreen\`, version \`active\` → \`aria-current\` flag, \`AIArtifactVersion\` forwards \`onClick\`
- Visual: Playwright CT story for full toolbar + minimal layouts
- Storybook: \`Default\`, \`ReadOnly\`, \`Document\`, \`Minimal\`
- MDX: usage + read-only + document + minimal + scope notes

## Registry

Added \`ai-artifact\` (\`category: ai\`, \`registryDependencies: [badge, button]\`, deps: \`lucide-react\`). Re-export shim and \`pnpm build\` regenerates \`/r/ai-artifact.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 503/503 (10 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview exercises copy / edit / download / fullscreen + version chip switch
- [ ] Registry entry visible at \`/r/ai-artifact.json\` and \`/components/ai-artifact\` after deploy