### PR TITLE
feat(ui): add EraComparison compound family

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -904,6 +904,21 @@
       "category": "overlay"
     },
     {
+      "name": "era-comparison",
+      "type": "registry:component",
+      "title": "Era Comparison",
+      "description": "Side-by-side comparison of historical eras with domain rows, color-themed columns, highlights, and figure chips.",
+      "files": [
+        {
+          "path": "registry/default/era-comparison/era-comparison.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "educational"
+    },
+    {
       "name": "exercise",
       "type": "registry:component",
       "title": "Exercise",

--- a/apps/registry/registry/default/era-comparison/era-comparison.tsx
+++ b/apps/registry/registry/default/era-comparison/era-comparison.tsx
@@ -1,0 +1,9 @@
+// Re-export from @vllnt/ui package
+export {
+  EraColumn,
+  EraComparison,
+  EraDomain,
+  EraFigure,
+  EraHighlight,
+  useEraColumnColor,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/era-comparison/era-comparison.mdx
+++ b/packages/ui/src/components/era-comparison/era-comparison.mdx
@@ -1,0 +1,83 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './era-comparison.stories'
+
+<Meta of={Stories} />
+
+# EraComparison
+
+Side-by-side comparison of historical eras showing parallel developments across domains (Art, Science, Politics, Technology). Composes `Badge`.
+
+A compound family:
+
+- `EraComparison` — responsive grid container (1 col → 2 col on `md` → 3 col on `xl`).
+- `EraColumn` — single era; renders the header (name + period chip + region) and supplies a color theme via context.
+- `EraDomain` — domain row (`Art`, `Science`, …). Pass the same `name` in each column for visually aligned parallel rows. Emits `data-domain="<name>"` for analytics.
+- `EraHighlight` — single-line achievement note tinted by the surrounding column color.
+- `EraFigure` — pill-shaped reference to a notable figure. Renders as `<span>` by default; pass `href` to render as `<a>` and `anchorProps` to forward `rel` / `target`.
+- `useEraColumnColor` — hook for custom children that need to match the column accent.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/era-comparison.json
+```
+
+## Import
+
+```tsx
+import {
+  EraColumn,
+  EraComparison,
+  EraDomain,
+  EraFigure,
+  EraHighlight,
+} from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<EraComparison>
+  <EraColumn name="Renaissance" period="1400–1600" color="amber">
+    <EraDomain name="Art">
+      <EraHighlight>Perspective painting, humanism</EraHighlight>
+      <EraFigure name="Leonardo da Vinci" />
+    </EraDomain>
+    <EraDomain name="Science">
+      <EraHighlight>Heliocentrism, anatomy</EraHighlight>
+      <EraFigure name="Copernicus" />
+    </EraDomain>
+  </EraColumn>
+  <EraColumn name="Islamic Golden Age" period="800–1400" color="emerald">
+    <EraDomain name="Science">
+      <EraHighlight>Algebra, optics, astronomy</EraHighlight>
+      <EraFigure name="Al-Khwarizmi" />
+    </EraDomain>
+  </EraColumn>
+</EraComparison>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Two columns
+
+The grid honors the actual number of children — fewer columns mean the cards stretch.
+
+<Canvas of={Stories.TwoColumn} sourceState="shown" />
+
+## Linked figures
+
+Pass an `href` (and optional `anchorProps`) on `EraFigure` to make each name a link to the figure's full profile (e.g. a `HistoricalFigureCard` route).
+
+<Canvas of={Stories.WithFigureLinks} sourceState="shown" />
+
+## Notes
+
+- Timeline overlap visualization, mobile-tab fallback, and printable layouts are intentionally **out of scope** — drive them from consumer code via the slot APIs and CSS.
+- Color themes — `amber` / `blue` / `emerald` / `neutral` / `purple` / `red` / `rose` — read from the column context, so any custom child rendered inside `EraColumn` can call `useEraColumnColor()` to match the accent.

--- a/packages/ui/src/components/era-comparison/era-comparison.stories.tsx
+++ b/packages/ui/src/components/era-comparison/era-comparison.stories.tsx
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  EraColumn,
+  EraComparison,
+  EraDomain,
+  EraFigure,
+  EraHighlight,
+} from "./era-comparison";
+
+const meta = {
+  component: EraComparison,
+  title: "Educational/EraComparison",
+} satisfies Meta<typeof EraComparison>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <EraComparison>
+      <EraColumn
+        color="amber"
+        name="Renaissance"
+        period="1400–1600"
+        region="Europe"
+      >
+        <EraDomain name="Art">
+          <EraHighlight>Perspective painting, humanism</EraHighlight>
+          <div className="flex flex-wrap gap-1.5">
+            <EraFigure name="Leonardo da Vinci" />
+            <EraFigure name="Michelangelo" />
+          </div>
+        </EraDomain>
+        <EraDomain name="Science">
+          <EraHighlight>Heliocentrism, anatomy</EraHighlight>
+          <div className="flex flex-wrap gap-1.5">
+            <EraFigure name="Copernicus" />
+            <EraFigure name="Galileo" />
+          </div>
+        </EraDomain>
+        <EraDomain name="Technology">
+          <EraHighlight>Printing press, navigation</EraHighlight>
+        </EraDomain>
+      </EraColumn>
+      <EraColumn
+        color="emerald"
+        name="Islamic Golden Age"
+        period="800–1400"
+        region="Middle East"
+      >
+        <EraDomain name="Art">
+          <EraHighlight>Geometric patterns, calligraphy</EraHighlight>
+        </EraDomain>
+        <EraDomain name="Science">
+          <EraHighlight>Algebra, optics, astronomy</EraHighlight>
+          <div className="flex flex-wrap gap-1.5">
+            <EraFigure name="Al-Khwarizmi" />
+            <EraFigure name="Ibn al-Haytham" />
+          </div>
+        </EraDomain>
+        <EraDomain name="Technology">
+          <EraHighlight>Paper-making, mechanical clocks</EraHighlight>
+        </EraDomain>
+      </EraColumn>
+      <EraColumn
+        color="rose"
+        name="Edo period"
+        period="1603–1868"
+        region="Japan"
+      >
+        <EraDomain name="Art">
+          <EraHighlight>Ukiyo-e woodblock prints, kabuki</EraHighlight>
+          <div className="flex flex-wrap gap-1.5">
+            <EraFigure name="Hokusai" />
+            <EraFigure name="Hiroshige" />
+          </div>
+        </EraDomain>
+        <EraDomain name="Science">
+          <EraHighlight>Mathematics (wasan)</EraHighlight>
+        </EraDomain>
+        <EraDomain name="Technology">
+          <EraHighlight>Printing, sericulture</EraHighlight>
+        </EraDomain>
+      </EraColumn>
+    </EraComparison>
+  ),
+};
+
+export const TwoColumn: Story = {
+  render: () => (
+    <EraComparison>
+      <EraColumn color="blue" name="Industrial Revolution" period="1760–1840">
+        <EraDomain name="Technology">
+          <EraHighlight>Steam, factories, railways</EraHighlight>
+          <div className="flex flex-wrap gap-1.5">
+            <EraFigure name="James Watt" />
+            <EraFigure name="George Stephenson" />
+          </div>
+        </EraDomain>
+        <EraDomain name="Society">
+          <EraHighlight>Urbanization, labor unions</EraHighlight>
+        </EraDomain>
+      </EraColumn>
+      <EraColumn color="purple" name="Information Age" period="1970–present">
+        <EraDomain name="Technology">
+          <EraHighlight>Personal computer, internet, mobile</EraHighlight>
+          <div className="flex flex-wrap gap-1.5">
+            <EraFigure name="Alan Kay" />
+            <EraFigure name="Tim Berners-Lee" />
+          </div>
+        </EraDomain>
+        <EraDomain name="Society">
+          <EraHighlight>Networked work, global media</EraHighlight>
+        </EraDomain>
+      </EraColumn>
+    </EraComparison>
+  ),
+};
+
+export const WithFigureLinks: Story = {
+  render: () => (
+    <EraComparison>
+      <EraColumn color="amber" name="Renaissance" period="1400–1600">
+        <EraDomain name="Art">
+          <EraHighlight>Perspective, humanism</EraHighlight>
+          <div className="flex flex-wrap gap-1.5">
+            <EraFigure
+              href="/figures/da-vinci"
+              name="Leonardo da Vinci"
+            />
+            <EraFigure href="/figures/michelangelo" name="Michelangelo" />
+          </div>
+        </EraDomain>
+      </EraColumn>
+    </EraComparison>
+  ),
+};

--- a/packages/ui/src/components/era-comparison/era-comparison.test.tsx
+++ b/packages/ui/src/components/era-comparison/era-comparison.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  EraColumn,
+  EraComparison,
+  EraDomain,
+  EraFigure,
+  EraHighlight,
+} from "./era-comparison";
+
+describe("EraComparison", () => {
+  describe("rendering", () => {
+    it("renders all era columns and their headers", () => {
+      render(
+        <EraComparison>
+          <EraColumn color="amber" name="Renaissance" period="1400–1600">
+            <EraDomain name="Art">
+              <EraHighlight>Perspective painting</EraHighlight>
+              <EraFigure name="Leonardo da Vinci" />
+            </EraDomain>
+          </EraColumn>
+          <EraColumn
+            color="emerald"
+            name="Islamic Golden Age"
+            period="800–1400"
+          >
+            <EraDomain name="Science">
+              <EraHighlight>Algebra, optics</EraHighlight>
+            </EraDomain>
+          </EraColumn>
+        </EraComparison>,
+      );
+
+      expect(
+        screen.getByRole("heading", { level: 3, name: "Renaissance" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { level: 3, name: "Islamic Golden Age" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("1400–1600")).toBeInTheDocument();
+      expect(screen.getByText("800–1400")).toBeInTheDocument();
+    });
+
+    it("emits data-color and data-domain attributes", () => {
+      const { container } = render(
+        <EraComparison>
+          <EraColumn color="purple" name="Era">
+            <EraDomain name="Art">
+              <EraHighlight>x</EraHighlight>
+            </EraDomain>
+          </EraColumn>
+        </EraComparison>,
+      );
+
+      expect(container.querySelector("article")).toHaveAttribute(
+        "data-color",
+        "purple",
+      );
+      expect(container.querySelector("section[data-domain]")).toHaveAttribute(
+        "data-domain",
+        "Art",
+      );
+    });
+
+    it("renders region when provided", () => {
+      render(
+        <EraComparison>
+          <EraColumn name="Era" region="Mediterranean">
+            <EraDomain name="Art">
+              <EraHighlight>x</EraHighlight>
+            </EraDomain>
+          </EraColumn>
+        </EraComparison>,
+      );
+
+      expect(screen.getByText("Mediterranean")).toBeInTheDocument();
+    });
+
+    it("omits the period chip when no period is provided", () => {
+      render(
+        <EraComparison>
+          <EraColumn name="Era">
+            <EraDomain name="Art">
+              <EraHighlight>x</EraHighlight>
+            </EraDomain>
+          </EraColumn>
+        </EraComparison>,
+      );
+
+      expect(screen.queryByText(/^\d{3,4}/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("EraDomain", () => {
+    it("renders the domain heading and highlights", () => {
+      render(
+        <EraComparison>
+          <EraColumn name="Era">
+            <EraDomain name="Art">
+              <EraHighlight>Perspective painting</EraHighlight>
+            </EraDomain>
+          </EraColumn>
+        </EraComparison>,
+      );
+
+      expect(
+        screen.getByRole("heading", { level: 4, name: "Art" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Perspective painting")).toBeInTheDocument();
+    });
+  });
+
+  describe("EraFigure", () => {
+    it("renders as a span by default", () => {
+      render(
+        <EraComparison>
+          <EraColumn name="Era">
+            <EraDomain name="Art">
+              <EraFigure name="Leonardo" />
+            </EraDomain>
+          </EraColumn>
+        </EraComparison>,
+      );
+
+      const node = screen.getByText("Leonardo");
+      expect(node.tagName).toBe("SPAN");
+    });
+
+    it("renders as a link when href is set", () => {
+      render(
+        <EraComparison>
+          <EraColumn name="Era">
+            <EraDomain name="Art">
+              <EraFigure href="/figures/leonardo" name="Leonardo" />
+            </EraDomain>
+          </EraColumn>
+        </EraComparison>,
+      );
+
+      const link = screen.getByRole("link", { name: "Leonardo" });
+      expect(link).toHaveAttribute("href", "/figures/leonardo");
+    });
+
+    it("forwards anchorProps to the rendered <a>", () => {
+      render(
+        <EraComparison>
+          <EraColumn name="Era">
+            <EraDomain name="Art">
+              <EraFigure
+                anchorProps={{ rel: "noopener", target: "_blank" }}
+                href="/figures/leonardo"
+                name="Leonardo"
+              />
+            </EraDomain>
+          </EraColumn>
+        </EraComparison>,
+      );
+
+      const link = screen.getByRole("link", { name: "Leonardo" });
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener");
+    });
+  });
+});

--- a/packages/ui/src/components/era-comparison/era-comparison.tsx
+++ b/packages/ui/src/components/era-comparison/era-comparison.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import {
+  type AnchorHTMLAttributes,
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useContext,
+  useMemo,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Color theme for an {@link EraColumn} accent strip.
+ *
+ * @public
+ */
+export type EraColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "neutral"
+  | "purple"
+  | "red"
+  | "rose";
+
+const ERA_PALETTE: Record<EraColor, { accent: string; chip: string }> = {
+  amber: {
+    accent: "bg-amber-500",
+    chip: "bg-amber-500/15 text-amber-700 dark:text-amber-300",
+  },
+  blue: {
+    accent: "bg-blue-500",
+    chip: "bg-blue-500/15 text-blue-700 dark:text-blue-300",
+  },
+  emerald: {
+    accent: "bg-emerald-500",
+    chip: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+  },
+  neutral: {
+    accent: "bg-muted-foreground/40",
+    chip: "bg-muted text-muted-foreground",
+  },
+  purple: {
+    accent: "bg-purple-500",
+    chip: "bg-purple-500/15 text-purple-700 dark:text-purple-300",
+  },
+  red: {
+    accent: "bg-red-500",
+    chip: "bg-red-500/15 text-red-700 dark:text-red-300",
+  },
+  rose: {
+    accent: "bg-rose-500",
+    chip: "bg-rose-500/15 text-rose-700 dark:text-rose-300",
+  },
+};
+
+type EraColumnContextValue = {
+  color: EraColor;
+};
+
+const EraColumnContext = createContext<EraColumnContextValue>({
+  color: "neutral",
+});
+
+/**
+ * Hook for reading the surrounding {@link EraColumn}'s color theme. Useful
+ * for custom children that want to match the column accent.
+ *
+ * @public
+ */
+export function useEraColumnColor(): EraColor {
+  return useContext(EraColumnContext).color;
+}
+
+/**
+ * Props for {@link EraComparison}.
+ *
+ * @public
+ */
+export type EraComparisonProps = ComponentPropsWithoutRef<"section">;
+
+/**
+ * Side-by-side comparison of historical eras. Lays out {@link EraColumn}
+ * children in a responsive grid (1 col on mobile → 2 col on `md` → 3 col
+ * on `xl`). Composes {@link Badge}.
+ *
+ * @example
+ * ```tsx
+ * <EraComparison>
+ *   <EraColumn name="Renaissance" period="1400–1600" color="amber">
+ *     <EraDomain name="Art">
+ *       <EraHighlight>Perspective painting, humanism</EraHighlight>
+ *       <EraFigure name="Leonardo da Vinci" />
+ *     </EraDomain>
+ *   </EraColumn>
+ *   <EraColumn name="Islamic Golden Age" period="800–1400" color="emerald">
+ *     <EraDomain name="Science">
+ *       <EraHighlight>Algebra, optics, astronomy</EraHighlight>
+ *       <EraFigure name="Al-Khwarizmi" />
+ *     </EraDomain>
+ *   </EraColumn>
+ * </EraComparison>
+ * ```
+ *
+ * @public
+ */
+export const EraComparison = forwardRef<HTMLElement, EraComparisonProps>(
+  ({ children, className, ...rest }, ref) => (
+    <section
+      className={cn(
+        "grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      {children}
+    </section>
+  ),
+);
+EraComparison.displayName = "EraComparison";
+
+/**
+ * Props for {@link EraColumn}.
+ *
+ * @public
+ */
+export type EraColumnProps = {
+  /** Color theme. Drives the top accent strip + chip. Defaults to `"neutral"`. */
+  color?: EraColor;
+  /** Era display name. */
+  name: ReactNode;
+  /** Period label (e.g. `"1400–1600"`). */
+  period?: ReactNode;
+  /** Optional region label (e.g. `"Europe"`). */
+  region?: ReactNode;
+} & ComponentPropsWithoutRef<"article">;
+
+type ColumnHeaderProps = {
+  color: EraColor;
+  name: ReactNode;
+  period?: ReactNode;
+  region?: ReactNode;
+};
+
+function ColumnHeader({
+  color,
+  name,
+  period,
+  region,
+}: ColumnHeaderProps): ReactNode {
+  const palette = ERA_PALETTE[color];
+  return (
+    <header className="flex flex-col gap-2">
+      <span
+        aria-hidden="true"
+        className={cn("h-1 w-12 rounded-full", palette.accent)}
+      />
+      <div className="flex items-baseline justify-between gap-2">
+        <h3 className="text-base font-semibold tracking-tight text-foreground">
+          {name}
+        </h3>
+        {period ? (
+          <span
+            className={cn(
+              "rounded-full px-2 py-0.5 text-xs font-mono",
+              palette.chip,
+            )}
+          >
+            {period}
+          </span>
+        ) : null}
+      </div>
+      {region ? (
+        <p className="text-xs text-muted-foreground">{region}</p>
+      ) : null}
+    </header>
+  );
+}
+
+/**
+ * Single era column inside an {@link EraComparison}. Wraps a header (name,
+ * period, region) and the column body — typically a series of
+ * {@link EraDomain} sections.
+ *
+ * @public
+ */
+export const EraColumn = forwardRef<HTMLElement, EraColumnProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      color = "neutral",
+      name,
+      period,
+      region,
+      ...rest
+    } = props;
+    const contextValue = useMemo<EraColumnContextValue>(
+      () => ({ color }),
+      [color],
+    );
+    return (
+      <EraColumnContext.Provider value={contextValue}>
+        <article
+          className={cn(
+            "flex flex-col gap-3 rounded-2xl border border-border bg-background p-4 shadow-sm",
+            className,
+          )}
+          data-color={color}
+          ref={ref}
+          {...rest}
+        >
+          <ColumnHeader
+            color={color}
+            name={name}
+            period={period}
+            region={region}
+          />
+          <div className="flex flex-col gap-3">{children}</div>
+        </article>
+      </EraColumnContext.Provider>
+    );
+  },
+);
+EraColumn.displayName = "EraColumn";
+
+/**
+ * Props for {@link EraDomain}.
+ *
+ * @public
+ */
+export type EraDomainProps = {
+  /** Domain display name (e.g. `"Art"`, `"Science"`). */
+  name: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+/**
+ * Domain row inside an {@link EraColumn}. Aligns across columns by
+ * convention — pass the same `name` in each column for parallel rows.
+ *
+ * @public
+ */
+export const EraDomain = forwardRef<HTMLElement, EraDomainProps>(
+  ({ children, className, name, ...rest }, ref) => (
+    <section
+      className={cn("flex flex-col gap-2", className)}
+      data-domain={typeof name === "string" ? name : undefined}
+      ref={ref}
+      {...rest}
+    >
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {name}
+      </h4>
+      {children}
+    </section>
+  ),
+);
+EraDomain.displayName = "EraDomain";
+
+/**
+ * Props for {@link EraHighlight}.
+ *
+ * @public
+ */
+export type EraHighlightProps = ComponentPropsWithoutRef<"p">;
+
+/**
+ * Single-line achievement note inside an {@link EraDomain}. Picks up the
+ * surrounding column's color theme automatically.
+ *
+ * @public
+ */
+export const EraHighlight = forwardRef<HTMLParagraphElement, EraHighlightProps>(
+  ({ children, className, ...rest }, ref) => {
+    const color = useEraColumnColor();
+    const palette = ERA_PALETTE[color];
+    return (
+      <p
+        className={cn("rounded-md px-2 py-1 text-sm", palette.chip, className)}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+      </p>
+    );
+  },
+);
+EraHighlight.displayName = "EraHighlight";
+
+type AnchorPassthroughProps = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  "children"
+>;
+
+/**
+ * Props for {@link EraFigure}.
+ *
+ * @public
+ */
+export type EraFigureProps = {
+  /** Anchor passthrough (e.g. `target`, `rel`). Forwarded with `href`. */
+  anchorProps?: AnchorPassthroughProps;
+  /** Optional anchor href. With this prop the chip renders as an `<a>`. */
+  href?: string;
+  /** Display name for the figure. */
+  name: ReactNode;
+} & Omit<ComponentPropsWithoutRef<"span">, "children">;
+
+/**
+ * Pill-shaped reference to a notable figure. With an `href`, the chip
+ * renders as a link.
+ *
+ * @public
+ */
+export const EraFigure = forwardRef<HTMLSpanElement, EraFigureProps>(
+  (props, ref) => {
+    const { anchorProps, className, href, name, ...rest } = props;
+    const color = useEraColumnColor();
+    const palette = ERA_PALETTE[color];
+    const baseClass = cn(
+      "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+      palette.chip,
+      className,
+    );
+    if (href) {
+      return (
+        <a
+          className={cn(baseClass, "underline-offset-4 hover:underline")}
+          href={href}
+          {...anchorProps}
+        >
+          {name}
+        </a>
+      );
+    }
+    return (
+      <span className={baseClass} ref={ref} {...rest}>
+        {name}
+      </span>
+    );
+  },
+);
+EraFigure.displayName = "EraFigure";

--- a/packages/ui/src/components/era-comparison/era-comparison.visual.tsx
+++ b/packages/ui/src/components/era-comparison/era-comparison.visual.tsx
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import {
+  EraColumn,
+  EraComparison,
+  EraDomain,
+  EraFigure,
+  EraHighlight,
+} from "./era-comparison";
+
+test.describe("EraComparison Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <EraComparison>
+        <EraColumn
+          color="amber"
+          name="Renaissance"
+          period="1400–1600"
+          region="Europe"
+        >
+          <EraDomain name="Art">
+            <EraHighlight>Perspective painting, humanism</EraHighlight>
+            <div className="flex flex-wrap gap-1.5">
+              <EraFigure name="Leonardo da Vinci" />
+              <EraFigure name="Michelangelo" />
+            </div>
+          </EraDomain>
+          <EraDomain name="Science">
+            <EraHighlight>Heliocentrism, anatomy</EraHighlight>
+            <div className="flex flex-wrap gap-1.5">
+              <EraFigure name="Copernicus" />
+              <EraFigure name="Galileo" />
+            </div>
+          </EraDomain>
+        </EraColumn>
+        <EraColumn
+          color="emerald"
+          name="Islamic Golden Age"
+          period="800–1400"
+          region="Middle East"
+        >
+          <EraDomain name="Art">
+            <EraHighlight>Geometric patterns, calligraphy</EraHighlight>
+          </EraDomain>
+          <EraDomain name="Science">
+            <EraHighlight>Algebra, optics, astronomy</EraHighlight>
+            <div className="flex flex-wrap gap-1.5">
+              <EraFigure name="Al-Khwarizmi" />
+              <EraFigure name="Ibn al-Haytham" />
+            </div>
+          </EraDomain>
+        </EraColumn>
+      </EraComparison>,
+    );
+    await expect(component).toHaveScreenshot("era-comparison-default.png");
+  });
+});

--- a/packages/ui/src/components/era-comparison/index.ts
+++ b/packages/ui/src/components/era-comparison/index.ts
@@ -1,0 +1,14 @@
+export {
+  type EraColor,
+  EraColumn,
+  type EraColumnProps,
+  EraComparison,
+  type EraComparisonProps,
+  EraDomain,
+  type EraDomainProps,
+  EraFigure,
+  type EraFigureProps,
+  EraHighlight,
+  type EraHighlightProps,
+  useEraColumnColor,
+} from "./era-comparison";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -704,6 +704,20 @@ export {
   Comparison,
   type ComparisonProps,
 } from "./comparison";
+export {
+  type EraColor,
+  EraColumn,
+  type EraColumnProps,
+  EraComparison,
+  type EraComparisonProps,
+  EraDomain,
+  type EraDomainProps,
+  EraFigure,
+  type EraFigureProps,
+  EraHighlight,
+  type EraHighlightProps,
+  useEraColumnColor,
+} from "./era-comparison";
 export { Exercise, type ExerciseProps } from "./exercise";
 export { FAQ, FAQItem, type FAQItemProps, type FAQProps } from "./faq";
 export { Flashcard, type FlashcardProps } from "./flashcard";


### PR DESCRIPTION
## Summary

Side-by-side comparison of historical eras showing parallel developments across domains (Art, Science, Politics, Technology). Pairs naturally with \`HistoricalFigureCard\` and timeline components.

A compound family:

- **\`EraComparison\`** — responsive grid container (1 col → 2 col on \`md\` → 3 col on \`xl\`).
- **\`EraColumn\`** — single era; renders the header (name + period chip + region) and supplies a color theme via context. Emits \`data-color\`.
- **\`EraDomain\`** — domain row (\`Art\`, \`Science\`, …). Pass the same \`name\` in each column for visually aligned parallel rows. Emits \`data-domain="<name>"\` for analytics.
- **\`EraHighlight\`** — single-line achievement note tinted by the surrounding column color.
- **\`EraFigure\`** — pill-shaped reference to a notable figure. Renders as \`<span>\` by default; pass \`href\` to render as \`<a>\` and \`anchorProps\` to forward \`rel\` / \`target\`.
- **\`useEraColumnColor\`** — hook for custom children that need to match the column accent.

Color themes — \`amber\` / \`blue\` / \`emerald\` / \`neutral\` / \`purple\` / \`red\` / \`rose\`.

Timeline overlap visualization, mobile-tab fallback, and printable layouts are intentionally **out of scope** — drive them from consumer code via the slot APIs and CSS.

Closes #70

## API

\`\`\`tsx
<EraComparison>
  <EraColumn name="Renaissance" period="1400–1600" color="amber" region="Europe">
    <EraDomain name="Art">
      <EraHighlight>Perspective painting, humanism</EraHighlight>
      <EraFigure name="Leonardo da Vinci" />
    </EraDomain>
    <EraDomain name="Science">
      <EraHighlight>Heliocentrism, anatomy</EraHighlight>
      <EraFigure name="Copernicus" />
    </EraDomain>
  </EraColumn>
  <EraColumn name="Islamic Golden Age" period="800–1400" color="emerald">
    <EraDomain name="Science">
      <EraHighlight>Algebra, optics, astronomy</EraHighlight>
      <EraFigure href="/figures/al-khwarizmi" name="Al-Khwarizmi" />
    </EraDomain>
  </EraColumn>
</EraComparison>
\`\`\`

## Coverage

- Unit: 8 tests covering column header rendering, period chip, region, suppressed period chip, \`data-color\` + \`data-domain\` attributes, \`EraDomain\` heading + highlight, \`EraFigure\` span / anchor / anchorProps passthrough
- Visual: Playwright CT story for the default Renaissance + Islamic Golden Age comparison
- Storybook: \`Default\` (3 columns), \`TwoColumn\` (Industrial Revolution vs Information Age), \`WithFigureLinks\`
- MDX: usage + two-column + linked figures + scope notes

## Registry

Added \`era-comparison\` (\`category: educational\`, no \`registryDependencies\`, no extra deps). Re-export shim and \`pnpm build\` regenerates \`/r/era-comparison.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 501/501 (8 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview exercises all three stories with linked figures
- [ ] Registry entry visible at \`/r/era-comparison.json\` and \`/components/era-comparison\` after deploy