### PR TITLE
feat(ui): add TransactionList compound family

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -2836,6 +2836,23 @@
       "category": "form"
     },
     {
+      "name": "transaction-list",
+      "type": "registry:component",
+      "title": "Transaction List",
+      "description": "Chronological credit/debit history with locale-aware currency formatting and a pinned subscription row.",
+      "files": [
+        {
+          "path": "registry/default/transaction-list/transaction-list.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [
+        "badge"
+      ],
+      "dependencies": [],
+      "category": "billing"
+    },
+    {
       "name": "tldr-section",
       "type": "registry:component",
       "title": "TLDR Section",

--- a/apps/registry/registry/default/transaction-list/transaction-list.tsx
+++ b/apps/registry/registry/default/transaction-list/transaction-list.tsx
@@ -1,0 +1,8 @@
+// Re-export from @vllnt/ui package
+export {
+  formatTransactionAmount,
+  formatTransactionDate,
+  TransactionList,
+  TransactionListPinned,
+  TransactionListSubscriptionRow,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -304,6 +304,21 @@ export {
   timelineVariants,
   useTimelineOrientation,
 } from "./timeline";
+export {
+  formatTransactionAmount,
+  formatTransactionDate,
+  type SubscriptionInterval,
+  type SubscriptionStatus,
+  type Transaction,
+  TransactionList,
+  type TransactionListLabels,
+  TransactionListPinned,
+  type TransactionListPinnedProps,
+  type TransactionListProps,
+  TransactionListSubscriptionRow,
+  type TransactionListSubscriptionRowProps,
+  type TransactionType,
+} from "./transaction-list";
 export { Avatar, AvatarFallback, AvatarImage } from "./avatar";
 export {
   AvatarGroup,

--- a/packages/ui/src/components/transaction-list/index.ts
+++ b/packages/ui/src/components/transaction-list/index.ts
@@ -1,0 +1,15 @@
+export {
+  formatTransactionAmount,
+  formatTransactionDate,
+  type SubscriptionInterval,
+  type SubscriptionStatus,
+  type Transaction,
+  TransactionList,
+  type TransactionListLabels,
+  TransactionListPinned,
+  type TransactionListPinnedProps,
+  type TransactionListProps,
+  TransactionListSubscriptionRow,
+  type TransactionListSubscriptionRowProps,
+  type TransactionType,
+} from "./transaction-list";

--- a/packages/ui/src/components/transaction-list/transaction-list.mdx
+++ b/packages/ui/src/components/transaction-list/transaction-list.mdx
@@ -1,0 +1,112 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './transaction-list.stories'
+
+<Meta of={Stories} />
+
+# TransactionList
+
+Chronological list of financial transactions with credit / debit color coding, locale-aware currency + date formatting, and an optional pinned section for the active subscription. Composes `Badge`.
+
+A compound family:
+
+- `TransactionList` — root container; renders pinned children first, then the transactions array. Falls back to `emptyMessage` when both are empty.
+- `TransactionList.Pinned` — wrapper for the pinned section (typically the active subscription row).
+- `TransactionList.SubscriptionRow` — green-border card with plan name, status badge, amount per interval, and an optional renewal date. Status drives both the badge variant and the border treatment.
+
+The component also exports two helper functions for callers that want to format amounts / dates outside the component (e.g. inside CSV exports or PDF receipts):
+
+- `formatTransactionAmount(cents, { currency?, locale? })`
+- `formatTransactionDate(timestampMs, locale?)`
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/transaction-list.json
+```
+
+## Import
+
+```tsx
+import {
+  type Transaction,
+  TransactionList,
+  formatTransactionAmount,
+  formatTransactionDate,
+} from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<TransactionList
+  currency="USD"
+  locale="en-US"
+  emptyMessage="No transactions yet"
+  transactions={[
+    {
+      id: '1',
+      type: 'credit',
+      description: 'Credit reload',
+      amountCents: 2000,
+      createdAt: 1710547200000,
+    },
+    {
+      id: '2',
+      type: 'debit',
+      description: 'API usage',
+      amountCents: 150,
+      createdAt: 1710460800000,
+    },
+  ]}
+>
+  <TransactionList.Pinned>
+    <TransactionList.SubscriptionRow
+      plan="AI OS Pro"
+      status="active"
+      amountCents={1200}
+      interval="month"
+      renewsAt={1713139200000}
+      meta="VAT incl."
+    />
+  </TransactionList.Pinned>
+</TransactionList>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Transaction types
+
+| Type | Sign | Color |
+| ---- | ---- | ----- |
+| `credit` | `+` | emerald |
+| `initial` | `+` | emerald |
+| `refund` | `+` | emerald |
+| `debit` | `−` | destructive |
+
+## With subscription
+
+Pass `TransactionList.SubscriptionRow` inside `TransactionList.Pinned` to render the active subscription above the history.
+
+<Canvas of={Stories.WithSubscription} sourceState="shown" />
+
+## Trial + past-due
+
+Subscription `status` accepts `active` / `trialing` / `past_due` / `canceled`. The badge variant and the row border treatment follow.
+
+<Canvas of={Stories.TrialAndPastDue} sourceState="shown" />
+
+## Empty state
+
+<Canvas of={Stories.Empty} sourceState="shown" />
+
+## Notes
+
+- Amounts are accepted in **minor units** (cents) — pass an integer; the component handles the divide-by-100 + currency formatting.
+- Sorting is the consumer's responsibility — pass the array in display order.
+- Pagination, server-driven filtering, and CSV export are intentionally **out of scope** — drive them from the consumer's data layer and pass the resulting slice as `transactions`.

--- a/packages/ui/src/components/transaction-list/transaction-list.stories.tsx
+++ b/packages/ui/src/components/transaction-list/transaction-list.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { type Transaction, TransactionList } from "./transaction-list";
+
+const TRANSACTIONS: Transaction[] = [
+  {
+    amountCents: 2000,
+    createdAt: Date.UTC(2025, 2, 10),
+    description: "Credit reload",
+    id: "1",
+    type: "credit",
+  },
+  {
+    amountCents: 150,
+    createdAt: Date.UTC(2025, 2, 8),
+    description: "API usage - March",
+    id: "2",
+    type: "debit",
+  },
+  {
+    amountCents: 500,
+    createdAt: Date.UTC(2025, 2, 4),
+    description: "Refund — duplicate charge",
+    id: "3",
+    meta: "Reference R-117",
+    type: "refund",
+  },
+  {
+    amountCents: 1500,
+    createdAt: Date.UTC(2025, 1, 28),
+    description: "Initial credit",
+    id: "4",
+    type: "initial",
+  },
+];
+
+const meta = {
+  args: {
+    currency: "USD",
+    emptyMessage: "No transactions yet",
+    locale: "en-US",
+    transactions: TRANSACTIONS,
+  },
+  component: TransactionList,
+  title: "Billing/TransactionList",
+} satisfies Meta<typeof TransactionList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithSubscription: Story = {
+  args: {
+    currency: "EUR",
+    locale: "en-IE",
+  },
+  render: (args) => (
+    <TransactionList {...args}>
+      <TransactionList.Pinned>
+        <TransactionList.SubscriptionRow
+          amountCents={1200}
+          currency="EUR"
+          interval="month"
+          locale="en-IE"
+          meta="VAT incl."
+          plan="AI OS Pro"
+          renewsAt={Date.UTC(2025, 3, 15)}
+          status="active"
+        />
+      </TransactionList.Pinned>
+    </TransactionList>
+  ),
+};
+
+export const TrialAndPastDue: Story = {
+  args: {
+    transactions: [],
+  },
+  render: (args) => (
+    <TransactionList {...args}>
+      <TransactionList.Pinned>
+        <TransactionList.SubscriptionRow
+          amountCents={1900}
+          interval="month"
+          plan="Pro Trial"
+          renewsAt={Date.UTC(2025, 2, 25)}
+          status="trialing"
+        />
+        <TransactionList.SubscriptionRow
+          amountCents={4900}
+          interval="year"
+          plan="Team"
+          renewsAt={Date.UTC(2025, 3, 1)}
+          status="past_due"
+        />
+      </TransactionList.Pinned>
+    </TransactionList>
+  ),
+};
+
+export const Empty: Story = {
+  args: {
+    transactions: [],
+  },
+};

--- a/packages/ui/src/components/transaction-list/transaction-list.test.tsx
+++ b/packages/ui/src/components/transaction-list/transaction-list.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  formatTransactionAmount,
+  formatTransactionDate,
+  type Transaction,
+  TransactionList,
+} from "./transaction-list";
+
+const FIXED_DATE = Date.UTC(2025, 2, 10);
+const FIXED_DATE_LATER = Date.UTC(2025, 2, 8);
+
+const TRANSACTIONS: Transaction[] = [
+  {
+    amountCents: 2000,
+    createdAt: FIXED_DATE,
+    description: "Credit reload",
+    id: "1",
+    type: "credit",
+  },
+  {
+    amountCents: 150,
+    createdAt: FIXED_DATE_LATER,
+    description: "API usage - March",
+    id: "2",
+    type: "debit",
+  },
+];
+
+describe("formatTransactionAmount", () => {
+  it("formats with the default locale and currency", () => {
+    expect(formatTransactionAmount(2000)).toBe("$20.00");
+  });
+
+  it("respects the locale + currency overrides", () => {
+    expect(
+      formatTransactionAmount(2000, { currency: "EUR", locale: "en-IE" }),
+    ).toMatch(/€20\.00/);
+  });
+});
+
+describe("formatTransactionDate", () => {
+  it("formats with the default locale", () => {
+    expect(formatTransactionDate(FIXED_DATE)).toMatch(/2025/);
+  });
+});
+
+describe("TransactionList", () => {
+  describe("rendering", () => {
+    it("renders all transactions in order", () => {
+      render(<TransactionList transactions={TRANSACTIONS} />);
+
+      expect(screen.getByText("Credit reload")).toBeInTheDocument();
+      expect(screen.getByText("API usage - March")).toBeInTheDocument();
+    });
+
+    it("emits data-transaction-type per row", () => {
+      const { container } = render(
+        <TransactionList transactions={TRANSACTIONS} />,
+      );
+
+      const items = container.querySelectorAll("li[data-transaction-type]");
+      expect(items.length).toBe(2);
+      expect(items[0]).toHaveAttribute("data-transaction-type", "credit");
+      expect(items[1]).toHaveAttribute("data-transaction-type", "debit");
+    });
+
+    it("formats amounts with sign prefixes", () => {
+      render(<TransactionList transactions={TRANSACTIONS} />);
+
+      expect(screen.getByText("+$20.00")).toBeInTheDocument();
+      expect(screen.getByText("-$1.50")).toBeInTheDocument();
+    });
+
+    it("renders the empty message when no transactions and no children", () => {
+      render(
+        <TransactionList
+          emptyMessage="No transactions yet"
+          transactions={[]}
+        />,
+      );
+
+      expect(screen.getByText("No transactions yet")).toBeInTheDocument();
+    });
+
+    it("hides the empty message when pinned children are rendered", () => {
+      render(
+        <TransactionList emptyMessage="No txn" transactions={[]}>
+          <TransactionList.Pinned>
+            <TransactionList.SubscriptionRow
+              amountCents={1200}
+              interval="month"
+              plan="AI OS Pro"
+              status="active"
+            />
+          </TransactionList.Pinned>
+        </TransactionList>,
+      );
+
+      expect(screen.queryByText("No txn")).not.toBeInTheDocument();
+      expect(screen.getByText("AI OS Pro")).toBeInTheDocument();
+    });
+  });
+
+  describe("TransactionListSubscriptionRow", () => {
+    it("renders the active badge and active-border style", () => {
+      const { container } = render(
+        <TransactionList transactions={[]}>
+          <TransactionList.Pinned>
+            <TransactionList.SubscriptionRow
+              amountCents={1200}
+              interval="month"
+              plan="AI OS Pro"
+              status="active"
+            />
+          </TransactionList.Pinned>
+        </TransactionList>,
+      );
+
+      expect(screen.getByText("Active")).toBeInTheDocument();
+      const subscriptionRow = container.querySelector("[data-status]");
+      expect(subscriptionRow).toHaveAttribute("data-status", "active");
+    });
+
+    it("renders the renewal date when provided", () => {
+      render(
+        <TransactionList transactions={[]}>
+          <TransactionList.Pinned>
+            <TransactionList.SubscriptionRow
+              amountCents={1200}
+              interval="month"
+              plan="AI OS Pro"
+              renewsAt={Date.UTC(2025, 3, 15)}
+              status="active"
+            />
+          </TransactionList.Pinned>
+        </TransactionList>,
+      );
+
+      expect(screen.getByText(/Renews/)).toBeInTheDocument();
+      expect(screen.getByText(/2025/)).toBeInTheDocument();
+    });
+
+    it("formats the per-interval amount", () => {
+      render(
+        <TransactionList transactions={[]}>
+          <TransactionList.Pinned>
+            <TransactionList.SubscriptionRow
+              amountCents={1200}
+              currency="EUR"
+              interval="month"
+              locale="en-IE"
+              plan="AI OS Pro"
+              status="active"
+            />
+          </TransactionList.Pinned>
+        </TransactionList>,
+      );
+
+      expect(screen.getByText(/€12\.00\/mo/)).toBeInTheDocument();
+    });
+
+    it.each([
+      ["active", "Active"],
+      ["trialing", "Trial"],
+      ["past_due", "Past due"],
+      ["canceled", "Canceled"],
+    ] as const)(
+      "renders status=%s with badge label %s",
+      (status, expectedLabel) => {
+        render(
+          <TransactionList transactions={[]}>
+            <TransactionList.Pinned>
+              <TransactionList.SubscriptionRow
+                amountCents={1200}
+                interval="month"
+                plan="Plan"
+                status={status}
+              />
+            </TransactionList.Pinned>
+          </TransactionList>,
+        );
+
+        expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+      },
+    );
+  });
+});

--- a/packages/ui/src/components/transaction-list/transaction-list.tsx
+++ b/packages/ui/src/components/transaction-list/transaction-list.tsx
@@ -1,0 +1,449 @@
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+import { Badge } from "../badge/badge";
+
+const CENTS_PER_UNIT = 100;
+const DEFAULT_LOCALE = "en-US";
+const DEFAULT_CURRENCY = "USD";
+
+/**
+ * Transaction type for {@link TransactionListItem}.
+ *
+ * @public
+ */
+export type TransactionType = "credit" | "debit" | "initial" | "refund";
+
+/**
+ * Renewal interval for {@link TransactionListSubscriptionRow}.
+ *
+ * @public
+ */
+export type SubscriptionInterval = "day" | "month" | "week" | "year";
+
+/**
+ * Subscription status for {@link TransactionListSubscriptionRow}.
+ *
+ * @public
+ */
+export type SubscriptionStatus =
+  | "active"
+  | "canceled"
+  | "past_due"
+  | "trialing";
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type TransactionListLabels = {
+  /** Caption for the active subscription badge. Defaults to `"Active"`. */
+  active?: string;
+  /** Caption for the canceled subscription badge. Defaults to `"Canceled"`. */
+  canceled?: string;
+  /** Caption for the past-due subscription badge. Defaults to `"Past due"`. */
+  pastDue?: string;
+  /** Renewal label prefix. Defaults to `"Renews"`. */
+  renews?: string;
+  /** Caption for the trial subscription badge. Defaults to `"Trial"`. */
+  trialing?: string;
+};
+
+const DEFAULT_LABELS = {
+  active: "Active",
+  canceled: "Canceled",
+  pastDue: "Past due",
+  renews: "Renews",
+  trialing: "Trial",
+} as const satisfies Required<TransactionListLabels>;
+
+/**
+ * One transaction entry.
+ *
+ * @public
+ */
+export type Transaction = {
+  /** Amount in minor units (cents). Always positive — `type` decides the sign. */
+  amountCents: number;
+  /** Unix timestamp (ms) for the transaction. */
+  createdAt: number;
+  /** Free-form description. */
+  description: ReactNode;
+  /** Stable identifier. */
+  id: string;
+  /** Optional secondary line (e.g. `"VAT incl."`). */
+  meta?: ReactNode;
+  /** Transaction type. */
+  type: TransactionType;
+};
+
+const SIGN_BY_TYPE: Record<TransactionType, "negative" | "positive"> = {
+  credit: "positive",
+  debit: "negative",
+  initial: "positive",
+  refund: "positive",
+};
+
+const AMOUNT_CLASS: Record<"negative" | "positive", string> = {
+  negative: "text-destructive",
+  positive: "text-emerald-600 dark:text-emerald-400",
+};
+
+const STATUS_VARIANT: Record<
+  SubscriptionStatus,
+  "default" | "destructive" | "outline" | "secondary"
+> = {
+  active: "default",
+  canceled: "secondary",
+  past_due: "destructive",
+  trialing: "outline",
+};
+
+const STATUS_LABEL_KEY: Record<
+  SubscriptionStatus,
+  keyof Required<TransactionListLabels>
+> = {
+  active: "active",
+  canceled: "canceled",
+  past_due: "pastDue",
+  trialing: "trialing",
+};
+
+const INTERVAL_LABEL: Record<SubscriptionInterval, string> = {
+  day: "day",
+  month: "mo",
+  week: "wk",
+  year: "yr",
+};
+
+/**
+ * Format an amount in minor units as a localized currency string. Use the
+ * locale + currency from {@link TransactionListProps} to drive the output.
+ *
+ * @public
+ */
+export function formatTransactionAmount(
+  amountCents: number,
+  options: {
+    currency?: string;
+    locale?: string;
+  } = {},
+): string {
+  const { currency = DEFAULT_CURRENCY, locale = DEFAULT_LOCALE } = options;
+  return new Intl.NumberFormat(locale, {
+    currency,
+    style: "currency",
+  }).format(amountCents / CENTS_PER_UNIT);
+}
+
+/**
+ * Format a Unix timestamp (ms) as a short locale-aware date.
+ *
+ * @public
+ */
+export function formatTransactionDate(
+  timestamp: number,
+  locale: string = DEFAULT_LOCALE,
+): string {
+  return new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(new Date(timestamp));
+}
+
+/**
+ * Props for {@link TransactionList}.
+ *
+ * @public
+ */
+export type TransactionListProps = {
+  /** Currency code (ISO 4217). Defaults to `"USD"`. */
+  currency?: string;
+  /** Caption shown when the list is empty and no pinned children exist. */
+  emptyMessage?: ReactNode;
+  /** Localizable strings. */
+  labels?: TransactionListLabels;
+  /** BCP-47 locale tag. Defaults to `"en-US"`. */
+  locale?: string;
+  /** Transaction array (rendered after pinned children). */
+  transactions: Transaction[];
+} & ComponentPropsWithoutRef<"div">;
+
+type TransactionListComponent = ReturnType<
+  typeof forwardRef<HTMLDivElement, TransactionListProps>
+> & {
+  Pinned: typeof TransactionListPinned;
+  SubscriptionRow: typeof TransactionListSubscriptionRow;
+};
+
+const TransactionListBase = forwardRef<HTMLDivElement, TransactionListProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      currency,
+      emptyMessage,
+      labels,
+      locale,
+      transactions,
+      ...rest
+    } = props;
+    const isEmpty = transactions.length === 0;
+    const hasPinned = Boolean(children);
+    return (
+      <div
+        className={cn(
+          "flex w-full flex-col gap-2 rounded-2xl border bg-background p-3",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+        {isEmpty && !hasPinned && emptyMessage ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            {emptyMessage}
+          </p>
+        ) : null}
+        {isEmpty ? null : (
+          <ul className="flex flex-col gap-1.5">
+            {transactions.map((transaction) => (
+              <TransactionListItem
+                currency={currency}
+                key={transaction.id}
+                labels={labels}
+                locale={locale}
+                transaction={transaction}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  },
+);
+TransactionListBase.displayName = "TransactionList";
+
+/**
+ * Props for {@link TransactionListPinned}.
+ *
+ * @public
+ */
+export type TransactionListPinnedProps = ComponentPropsWithoutRef<"div">;
+
+/**
+ * Wrapper that renders pinned content (typically the active subscription
+ * row) above the main transaction list.
+ *
+ * @public
+ */
+export const TransactionListPinned = forwardRef<
+  HTMLDivElement,
+  TransactionListPinnedProps
+>(({ children, className, ...rest }, ref) => (
+  <div className={cn("flex flex-col gap-1.5", className)} ref={ref} {...rest}>
+    {children}
+  </div>
+));
+TransactionListPinned.displayName = "TransactionList.Pinned";
+
+type TransactionListItemProps = {
+  currency?: string;
+  labels?: TransactionListLabels;
+  locale?: string;
+  transaction: Transaction;
+};
+
+function TransactionListItem({
+  currency,
+  locale,
+  transaction,
+}: TransactionListItemProps): ReactNode {
+  const sign = SIGN_BY_TYPE[transaction.type];
+  const formatted = formatTransactionAmount(transaction.amountCents, {
+    currency,
+    locale,
+  });
+  const display = sign === "negative" ? `-${formatted}` : `+${formatted}`;
+  const ariaLabel =
+    typeof transaction.description === "string"
+      ? `${sign === "negative" ? "Debit" : "Credit"} ${display} for ${transaction.description}`
+      : undefined;
+  return (
+    <li
+      className="flex items-start justify-between gap-3 rounded-lg border border-border bg-muted/20 px-3 py-2"
+      data-transaction-type={transaction.type}
+    >
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <p className="truncate text-sm font-medium text-foreground">
+          {transaction.description}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {formatTransactionDate(transaction.createdAt, locale)}
+          {transaction.meta ? <span> · {transaction.meta}</span> : null}
+        </p>
+      </div>
+      <span
+        aria-label={ariaLabel}
+        className={cn(
+          "shrink-0 font-mono text-sm font-semibold",
+          AMOUNT_CLASS[sign],
+        )}
+      >
+        {display}
+      </span>
+    </li>
+  );
+}
+
+/**
+ * Props for {@link TransactionListSubscriptionRow}.
+ *
+ * @public
+ */
+export type TransactionListSubscriptionRowProps = {
+  /** Subscription amount per interval, in minor units. */
+  amountCents: number;
+  /** Currency code (ISO 4217). Defaults to `"USD"`. */
+  currency?: string;
+  /** Renewal interval. */
+  interval: SubscriptionInterval;
+  /** Localizable strings. */
+  labels?: TransactionListLabels;
+  /** BCP-47 locale tag. Defaults to `"en-US"`. */
+  locale?: string;
+  /** Optional secondary metadata (e.g. `"VAT incl."`). */
+  meta?: ReactNode;
+  /** Plan display name. */
+  plan: ReactNode;
+  /** Optional renewal timestamp (ms). */
+  renewsAt?: number;
+  /** Subscription status. */
+  status: SubscriptionStatus;
+} & ComponentPropsWithoutRef<"div">;
+
+type SubscriptionMetaProps = {
+  locale?: string;
+  meta?: ReactNode;
+  renewsAt?: number;
+  renewsLabel: string;
+};
+
+function SubscriptionMeta({
+  locale,
+  meta,
+  renewsAt,
+  renewsLabel,
+}: SubscriptionMetaProps): ReactNode {
+  if (renewsAt === undefined && !meta) return null;
+  return (
+    <p className="text-xs text-muted-foreground">
+      {renewsAt === undefined
+        ? null
+        : `${renewsLabel} ${formatTransactionDate(renewsAt, locale)}`}
+      {renewsAt !== undefined && meta ? <span> · {meta}</span> : null}
+      {renewsAt === undefined && meta ? meta : null}
+    </p>
+  );
+}
+
+/**
+ * Active-subscription row for the pinned section. Renders a green-border
+ * card with plan name, status badge, amount/interval, and optional
+ * renewal date.
+ *
+ * @public
+ */
+export const TransactionListSubscriptionRow = forwardRef<
+  HTMLDivElement,
+  TransactionListSubscriptionRowProps
+>((props, ref) => {
+  const {
+    amountCents,
+    className,
+    currency,
+    interval,
+    labels,
+    locale,
+    meta,
+    plan,
+    renewsAt,
+    status,
+    ...rest
+  } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const formatted = formatTransactionAmount(amountCents, { currency, locale });
+  const intervalSuffix = INTERVAL_LABEL[interval];
+  const isActive = status === "active";
+
+  return (
+    <div
+      className={cn(
+        "flex items-start justify-between gap-3 rounded-lg border px-3 py-2",
+        isActive
+          ? "border-emerald-500/40 bg-emerald-500/5"
+          : "border-border bg-muted/20",
+        className,
+      )}
+      data-status={status}
+      ref={ref}
+      {...rest}
+    >
+      <div className="flex min-w-0 flex-col gap-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="text-sm font-semibold text-foreground">{plan}</p>
+          <Badge variant={STATUS_VARIANT[status]}>
+            {resolvedLabels[STATUS_LABEL_KEY[status]]}
+          </Badge>
+        </div>
+        <SubscriptionMeta
+          locale={locale}
+          meta={meta}
+          renewsAt={renewsAt}
+          renewsLabel={resolvedLabels.renews}
+        />
+      </div>
+      <span className="shrink-0 font-mono text-sm font-semibold text-foreground">
+        {formatted}/{intervalSuffix}
+      </span>
+    </div>
+  );
+});
+TransactionListSubscriptionRow.displayName = "TransactionList.SubscriptionRow";
+
+/**
+ * Chronological list of financial transactions with credit/debit color
+ * coding, locale-aware currency / date formatting, and an optional pinned
+ * section for the active subscription.
+ *
+ * @example
+ * ```tsx
+ * <TransactionList
+ *   transactions={transactions}
+ *   currency="EUR"
+ *   locale="en-IE"
+ *   emptyMessage="No transactions yet"
+ * >
+ *   <TransactionList.Pinned>
+ *     <TransactionList.SubscriptionRow
+ *       plan="AI OS Pro"
+ *       status="active"
+ *       amountCents={1200}
+ *       renewsAt={1713139200000}
+ *       interval="month"
+ *     />
+ *   </TransactionList.Pinned>
+ * </TransactionList>
+ * ```
+ *
+ * @public
+ */
+export const TransactionList = TransactionListBase as TransactionListComponent;
+TransactionList.Pinned = TransactionListPinned;
+TransactionList.SubscriptionRow = TransactionListSubscriptionRow;

--- a/packages/ui/src/components/transaction-list/transaction-list.visual.tsx
+++ b/packages/ui/src/components/transaction-list/transaction-list.visual.tsx
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { type Transaction, TransactionList } from "./transaction-list";
+
+const TRANSACTIONS: Transaction[] = [
+  {
+    amountCents: 2000,
+    createdAt: Date.UTC(2025, 2, 10),
+    description: "Credit reload",
+    id: "1",
+    type: "credit",
+  },
+  {
+    amountCents: 150,
+    createdAt: Date.UTC(2025, 2, 8),
+    description: "API usage - March",
+    id: "2",
+    type: "debit",
+  },
+  {
+    amountCents: 500,
+    createdAt: Date.UTC(2025, 2, 4),
+    description: "Refund — duplicate charge",
+    id: "3",
+    meta: "Reference R-117",
+    type: "refund",
+  },
+];
+
+test.describe("TransactionList Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <TransactionList currency="EUR" locale="en-IE" transactions={TRANSACTIONS}>
+        <TransactionList.Pinned>
+          <TransactionList.SubscriptionRow
+            amountCents={1200}
+            currency="EUR"
+            interval="month"
+            locale="en-IE"
+            meta="VAT incl."
+            plan="AI OS Pro"
+            renewsAt={Date.UTC(2025, 3, 15)}
+            status="active"
+          />
+        </TransactionList.Pinned>
+      </TransactionList>,
+    );
+    await expect(component).toHaveScreenshot("transaction-list-default.png");
+  });
+
+  test("empty", async ({ mount }) => {
+    const component = await mount(
+      <TransactionList emptyMessage="No transactions yet" transactions={[]} />,
+    );
+    await expect(component).toHaveScreenshot("transaction-list-empty.png");
+  });
+});


### PR DESCRIPTION
## Summary

Chronological credit/debit history with locale-aware currency + date formatting, color-coded transaction types, and an optional pinned section for the active subscription. Composes \`Badge\`.

A compound family:

- **\`TransactionList\`** — root container; accepts \`transactions: Transaction[]\`, \`currency\`, \`locale\`, and an \`emptyMessage\`. Falls back to the empty message when both the array and the pinned children are empty.
- **\`TransactionList.Pinned\`** — wrapper for the pinned section (typically the active subscription row).
- **\`TransactionList.SubscriptionRow\`** — green-border card with plan name, status badge (\`active\` / \`trialing\` / \`past_due\` / \`canceled\`), per-interval amount, and an optional renewal date. Status drives both the badge variant and the border treatment.

Two helper functions are also exported for callers that want to format outside the component (CSV exports, PDF receipts):

- \`formatTransactionAmount(cents, { currency?, locale? })\`
- \`formatTransactionDate(timestampMs, locale?)\`

Transaction types — \`credit\` / \`initial\` / \`refund\` render as positive (emerald), \`debit\` renders as negative (destructive). Amounts are accepted in **minor units** (cents) — the component handles divide-by-100 + \`Intl.NumberFormat\`.

Pagination, server-driven filtering, and CSV export are intentionally **out of scope** — drive them from the consumer's data layer.

Closes #90

## API

\`\`\`tsx
<TransactionList
  currency="USD"
  locale="en-US"
  emptyMessage="No transactions yet"
  transactions={[
    { id: '1', type: 'credit', description: 'Credit reload', amountCents: 2000, createdAt: 1710547200000 },
    { id: '2', type: 'debit', description: 'API usage', amountCents: 150, createdAt: 1710460800000 },
  ]}
>
  <TransactionList.Pinned>
    <TransactionList.SubscriptionRow
      plan="AI OS Pro"
      status="active"
      amountCents={1200}
      interval="month"
      renewsAt={1713139200000}
      meta="VAT incl."
    />
  </TransactionList.Pinned>
</TransactionList>
\`\`\`

## Coverage

- Unit: 15 tests covering \`formatTransactionAmount\` (default + locale/currency override), \`formatTransactionDate\`, ordered rendering, \`data-transaction-type\` per row, sign-prefixed amounts, empty-state caption, pinned children suppress the empty caption, all 4 status badges (\`active\` / \`trialing\` / \`past_due\` / \`canceled\`), per-interval amount formatting, renewal date rendering, active-status border treatment
- Visual: Playwright CT story for default + empty layouts
- Storybook: \`Default\`, \`WithSubscription\`, \`TrialAndPastDue\`, \`Empty\`
- MDX: usage + transaction type table + with-subscription + trial+past-due + empty + scope notes

## Registry

Added \`transaction-list\` (\`category: billing\`, \`registryDependencies: [badge]\`, no extra deps). Re-export shim and \`pnpm build\` regenerates \`/r/transaction-list.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 508/508 (15 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview renders all four stories with correct currency formatting per locale
- [ ] Registry entry visible at \`/r/transaction-list.json\` and \`/components/transaction-list\` after deploy