### PR TITLE
feat(ui): add AutoReload toggle + form

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -253,6 +253,25 @@
       "category": "utility"
     },
     {
+      "name": "auto-reload",
+      "type": "registry:component",
+      "title": "Auto Reload",
+      "description": "Toggle + collapsible threshold/amount form for automatic credit reloading with locale-aware currency.",
+      "files": [
+        {
+          "path": "registry/default/auto-reload/auto-reload.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [
+        "button",
+        "input",
+        "switch"
+      ],
+      "dependencies": [],
+      "category": "billing"
+    },
+    {
       "name": "avatar",
       "type": "registry:component",
       "title": "Avatar",

--- a/apps/registry/registry/default/auto-reload/auto-reload.tsx
+++ b/apps/registry/registry/default/auto-reload/auto-reload.tsx
@@ -1,0 +1,2 @@
+// Re-export from @vllnt/ui package
+export { AutoReload } from '@vllnt/ui'

--- a/packages/ui/src/components/auto-reload/auto-reload.mdx
+++ b/packages/ui/src/components/auto-reload/auto-reload.mdx
@@ -1,0 +1,75 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './auto-reload.stories'
+
+<Meta of={Stories} />
+
+# AutoReload
+
+Toggle + collapsible configuration form for automatic credit reloading. When enabled, reveals a threshold input and a reload-amount input. Composes `Switch`, `Input`, and `Button`.
+
+Values flow through in **minor units** (cents). The inputs display the corresponding currency unit; the consumer receives the cents value via `onSave`.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/auto-reload.json
+```
+
+## Import
+
+```tsx
+import { AutoReload } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<AutoReload
+  enabled={settings.autoReloadEnabled}
+  thresholdCents={settings.thresholdCents}
+  reloadAmountCents={settings.reloadAmountCents}
+  currency="EUR"
+  onToggle={handleToggle}
+  onSave={handleSave}
+  isSaving={isSaving}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Enabled
+
+The form expands when the toggle is on. The same component handles both controlled and uncontrolled state — pass `enabled` (controlled) or `defaultEnabled` (uncontrolled).
+
+<Canvas of={Stories.Enabled} sourceState="shown" />
+
+## Localized currency
+
+Pass `currency` (ISO 4217) and `locale` (BCP-47). The component derives the symbol via `Intl.NumberFormat`. Use `currencySymbol` to override the derived value.
+
+<Canvas of={Stories.Euro} sourceState="shown" />
+
+## Saving state
+
+Set `isSaving` to render the save button as loading + disabled.
+
+<Canvas of={Stories.Saving} sourceState="shown" />
+
+## Disabled (no access)
+
+Set `disabled` to render a banner instead of the form. Useful before the user has subscribed or completed onboarding.
+
+<Canvas of={Stories.DisabledForUnsubscribed} sourceState="shown" />
+
+## Notes
+
+- Values are accepted in minor units (cents) — pass an integer, the component handles the divide-by-100 + currency formatting in the inputs.
+- `minAmountCents` defaults to 100 (one currency unit). Set `maxAmountCents` to enforce a ceiling.
+- Persistence (HTTP write, optimistic update, error toast) is intentionally out of scope — drive it from the consumer's `onSave`.
+- The component does not currently throttle saves. Pass a debounced handler if your write path needs it.

--- a/packages/ui/src/components/auto-reload/auto-reload.stories.tsx
+++ b/packages/ui/src/components/auto-reload/auto-reload.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { AutoReload } from "./auto-reload";
+
+const meta = {
+  args: {
+    currency: "USD",
+    defaultEnabled: false,
+    defaultReloadAmountCents: 2000,
+    defaultThresholdCents: 1000,
+    locale: "en-US",
+  },
+  component: AutoReload,
+  title: "Billing/AutoReload",
+} satisfies Meta<typeof AutoReload>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Enabled: Story = {
+  args: {
+    defaultEnabled: true,
+  },
+};
+
+export const Euro: Story = {
+  args: {
+    currency: "EUR",
+    defaultEnabled: true,
+    locale: "en-IE",
+  },
+};
+
+export const Saving: Story = {
+  args: {
+    defaultEnabled: true,
+    isSaving: true,
+  },
+};
+
+export const DisabledForUnsubscribed: Story = {
+  args: {
+    disabled: true,
+    disabledMessage: "Subscribe to enable auto-reload settings.",
+  },
+  name: "Disabled (no subscription)",
+};

--- a/packages/ui/src/components/auto-reload/auto-reload.test.tsx
+++ b/packages/ui/src/components/auto-reload/auto-reload.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AutoReload } from "./auto-reload";
+
+describe("AutoReload", () => {
+  describe("rendering", () => {
+    it("renders the heading and helper text", () => {
+      render(<AutoReload />);
+
+      expect(screen.getByText("Auto-reload")).toBeInTheDocument();
+      expect(
+        screen.getByText(/Automatically reload credits/),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the form when enabled", () => {
+      render(<AutoReload defaultEnabled />);
+
+      expect(screen.getByLabelText(/Threshold/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Reload amount/)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Save settings" }),
+      ).toBeInTheDocument();
+    });
+
+    it("hides the form when disabled-by-toggle", () => {
+      render(<AutoReload />);
+
+      expect(screen.queryByLabelText(/Threshold/)).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Save settings" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders the disabled banner when disabled is set", () => {
+      render(<AutoReload disabled disabledMessage="Subscribe first." />);
+
+      expect(screen.getByText("Subscribe first.")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Save settings" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders the saving label when isSaving is true", () => {
+      render(<AutoReload defaultEnabled isSaving />);
+
+      expect(
+        screen.getByRole("button", { name: "Saving…" }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Saving…" })).toBeDisabled();
+    });
+  });
+
+  describe("toggle", () => {
+    it("invokes onToggle when the switch is clicked", () => {
+      const onToggle = vi.fn();
+      render(<AutoReload onToggle={onToggle} />);
+
+      fireEvent.click(screen.getByRole("switch"));
+
+      expect(onToggle).toHaveBeenCalledWith(true);
+    });
+
+    it("flips uncontrolled state when toggled", () => {
+      render(<AutoReload />);
+
+      expect(screen.queryByLabelText(/Threshold/)).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole("switch"));
+      expect(screen.getByLabelText(/Threshold/)).toBeInTheDocument();
+    });
+
+    it("controlled mode flows through onToggle without flipping internal state", () => {
+      const onToggle = vi.fn();
+      render(<AutoReload enabled={false} onToggle={onToggle} />);
+
+      fireEvent.click(screen.getByRole("switch"));
+
+      expect(onToggle).toHaveBeenCalledWith(true);
+      expect(screen.queryByLabelText(/Threshold/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("save", () => {
+    it("invokes onSave with the current values in cents", () => {
+      const onSave = vi.fn();
+      render(
+        <AutoReload
+          defaultEnabled
+          defaultReloadAmountCents={2500}
+          defaultThresholdCents={1500}
+          onSave={onSave}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+
+      expect(onSave).toHaveBeenCalledWith({
+        reloadAmountCents: 2500,
+        thresholdCents: 1500,
+      });
+    });
+
+    it("reflects user input in the next save payload", () => {
+      const onSave = vi.fn();
+      render(<AutoReload defaultEnabled onSave={onSave} />);
+
+      fireEvent.change(screen.getByLabelText(/Threshold/), {
+        target: { value: "5.50" },
+      });
+      fireEvent.change(screen.getByLabelText(/Reload amount/), {
+        target: { value: "30" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+
+      expect(onSave).toHaveBeenCalledWith({
+        reloadAmountCents: 3000,
+        thresholdCents: 550,
+      });
+    });
+  });
+
+  describe("currency", () => {
+    it("uses the currencySymbol override when provided", () => {
+      render(<AutoReload currencySymbol="₿" defaultEnabled />);
+
+      expect(screen.getAllByText(/₿/).length).toBeGreaterThan(0);
+    });
+
+    it("derives a symbol from the locale + currency", () => {
+      render(<AutoReload currency="EUR" defaultEnabled locale="en-IE" />);
+
+      expect(screen.getAllByText(/€/).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/ui/src/components/auto-reload/auto-reload.tsx
+++ b/packages/ui/src/components/auto-reload/auto-reload.tsx
@@ -1,0 +1,572 @@
+"use client";
+
+import {
+  type ChangeEvent,
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+
+import { cn } from "../../lib/utils";
+import { Button } from "../button/button";
+import { Input } from "../input/input";
+import { Switch } from "../switch/switch";
+
+const CENTS_PER_UNIT = 100;
+const DEFAULT_LOCALE = "en-US";
+const DEFAULT_CURRENCY = "USD";
+const DEFAULT_STEP_CENTS = 100;
+
+/**
+ * Snapshot passed to {@link AutoReloadProps.onSave}.
+ *
+ * @public
+ */
+export type AutoReloadSavePayload = {
+  reloadAmountCents: number;
+  thresholdCents: number;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type AutoReloadLabels = {
+  /** Caption for the disabled banner. */
+  disabledFallback?: string;
+  /** Caption for the toggle headline. Defaults to `"Auto-reload"`. */
+  heading?: string;
+  /** Helper line under the toggle headline. Defaults to `"Automatically reload credits when balance is low."`. */
+  helper?: string;
+  /** Helper line under the reload-amount input. */
+  reloadHelper?: string;
+  /** Caption for the reload-amount input. Defaults to `"Reload amount"`. */
+  reloadLabel?: string;
+  /** Caption for the save button. Defaults to `"Save settings"`. */
+  save?: string;
+  /** Caption for the save button while saving. Defaults to `"Saving…"`. */
+  saving?: string;
+  /** Helper line under the threshold input. */
+  thresholdHelper?: string;
+  /** Caption for the threshold input. Defaults to `"Threshold"`. */
+  thresholdLabel?: string;
+};
+
+const DEFAULT_LABELS = {
+  disabledFallback: "Auto-reload is unavailable for this account.",
+  heading: "Auto-reload",
+  helper: "Automatically reload credits when balance is low.",
+  reloadHelper: "Amount to add when the threshold is hit.",
+  reloadLabel: "Reload amount",
+  save: "Save settings",
+  saving: "Saving…",
+  thresholdHelper: "Reload when the balance drops below this.",
+  thresholdLabel: "Threshold",
+} as const satisfies Required<AutoReloadLabels>;
+
+/**
+ * Props for {@link AutoReload}.
+ *
+ * @public
+ */
+export type AutoReloadProps = {
+  /** Currency code (ISO 4217). Defaults to `"USD"`. */
+  currency?: string;
+  /** Override the symbol displayed inside the inputs (e.g. `"€"`). */
+  currencySymbol?: string;
+  /** Initial enabled state when uncontrolled. */
+  defaultEnabled?: boolean;
+  /** Initial reload-amount value (cents) when uncontrolled. */
+  defaultReloadAmountCents?: number;
+  /** Initial threshold value (cents) when uncontrolled. */
+  defaultThresholdCents?: number;
+  /** When true, the consumer cannot interact with the control. */
+  disabled?: boolean;
+  /** Caption rendered with `disabled`. */
+  disabledMessage?: ReactNode;
+  /** Controlled enabled state. */
+  enabled?: boolean;
+  /** When true, the save button renders as loading + disabled. */
+  isSaving?: boolean;
+  /** Localizable strings. */
+  labels?: AutoReloadLabels;
+  /** BCP-47 locale tag. Defaults to `"en-US"`. */
+  locale?: string;
+  /** Highest allowed amount (cents). */
+  maxAmountCents?: number;
+  /** Lowest allowed amount (cents). Defaults to `100`. */
+  minAmountCents?: number;
+  /** Fires when the user clicks save. */
+  onSave?: (payload: AutoReloadSavePayload) => void;
+  /** Fires when the toggle changes. */
+  onToggle?: (enabled: boolean) => void;
+  /** Controlled reload-amount value (cents). */
+  reloadAmountCents?: number;
+  /** Step granularity for the inputs (cents). Defaults to `100`. */
+  stepCents?: number;
+  /** Controlled threshold value (cents). */
+  thresholdCents?: number;
+} & ComponentPropsWithoutRef<"div">;
+
+function centsToValue(cents: number): string {
+  return (cents / CENTS_PER_UNIT).toFixed(2);
+}
+
+function valueToCents(value: string): number {
+  const parsed = Number.parseFloat(value);
+  if (Number.isNaN(parsed)) return 0;
+  return Math.round(parsed * CENTS_PER_UNIT);
+}
+
+function getCurrencySymbol(locale: string, currency: string): string {
+  const formatted = new Intl.NumberFormat(locale, {
+    currency,
+    style: "currency",
+  }).format(0);
+  const symbol = formatted.replaceAll(/[\d\s,.]/g, "");
+  return symbol.length > 0 ? symbol : currency;
+}
+
+type ReloadFormProps = {
+  currencyDisplay: string;
+  isSaving: boolean;
+  labels: Required<AutoReloadLabels>;
+  maxAmountCents?: number;
+  minAmountCents: number;
+  onSave: () => void;
+  reloadAmount: number;
+  reloadAmountId: string;
+  setReloadAmount: (value: number) => void;
+  setThreshold: (value: number) => void;
+  stepCents: number;
+  threshold: number;
+  thresholdId: string;
+};
+
+function ReloadFormFields({
+  currencyDisplay,
+  isSaving,
+  labels,
+  maxAmountCents,
+  minAmountCents,
+  onSave,
+  reloadAmount,
+  reloadAmountId,
+  setReloadAmount,
+  setThreshold,
+  stepCents,
+  threshold,
+  thresholdId,
+}: ReloadFormProps): ReactNode {
+  const handleThreshold = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setThreshold(valueToCents(event.target.value));
+    },
+    [setThreshold],
+  );
+  const handleReload = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setReloadAmount(valueToCents(event.target.value));
+    },
+    [setReloadAmount],
+  );
+  const step = (stepCents / CENTS_PER_UNIT).toFixed(2);
+  const min = (minAmountCents / CENTS_PER_UNIT).toFixed(2);
+  const max =
+    maxAmountCents === undefined
+      ? undefined
+      : (maxAmountCents / CENTS_PER_UNIT).toFixed(2);
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <NumericField
+          currencyDisplay={currencyDisplay}
+          helper={labels.thresholdHelper}
+          id={thresholdId}
+          label={labels.thresholdLabel}
+          max={max}
+          min={min}
+          onChange={handleThreshold}
+          step={step}
+          value={centsToValue(threshold)}
+        />
+        <NumericField
+          currencyDisplay={currencyDisplay}
+          helper={labels.reloadHelper}
+          id={reloadAmountId}
+          label={labels.reloadLabel}
+          max={max}
+          min={min}
+          onChange={handleReload}
+          step={step}
+          value={centsToValue(reloadAmount)}
+        />
+      </div>
+      <div>
+        <Button disabled={isSaving} onClick={onSave} type="button">
+          {isSaving ? labels.saving : labels.save}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+type NumericFieldProps = {
+  currencyDisplay: string;
+  helper?: string;
+  id: string;
+  label: string;
+  max?: string;
+  min?: string;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  step: string;
+  value: string;
+};
+
+function NumericField({
+  currencyDisplay,
+  helper,
+  id,
+  label,
+  max,
+  min,
+  onChange,
+  step,
+  value,
+}: NumericFieldProps): ReactNode {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-sm font-medium text-foreground" htmlFor={id}>
+        {label} ({currencyDisplay})
+      </label>
+      <Input
+        id={id}
+        inputMode="decimal"
+        max={max}
+        min={min}
+        onChange={onChange}
+        step={step}
+        type="number"
+        value={value}
+      />
+      {helper ? (
+        <p className="text-xs text-muted-foreground">{helper}</p>
+      ) : null}
+    </div>
+  );
+}
+
+type ToggleHeaderProps = {
+  enabled: boolean;
+  heading: string;
+  helper: string;
+  id: string;
+  onCheckedChange: (next: boolean) => void;
+};
+
+function ToggleHeader({
+  enabled,
+  heading,
+  helper,
+  id,
+  onCheckedChange,
+}: ToggleHeaderProps): ReactNode {
+  const helperId = `${id}-helper`;
+  return (
+    <header className="flex items-start justify-between gap-3">
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-semibold text-foreground" id={id}>
+          {heading}
+        </span>
+        <span className="text-xs text-muted-foreground" id={helperId}>
+          {helper}
+        </span>
+      </div>
+      <Switch
+        aria-describedby={helperId}
+        aria-labelledby={id}
+        checked={enabled}
+        onCheckedChange={onCheckedChange}
+      />
+    </header>
+  );
+}
+
+type ControllerOptions = {
+  defaultEnabled: boolean;
+  defaultReloadAmountCents: number;
+  defaultThresholdCents: number;
+  enabled?: boolean;
+  onToggle?: (enabled: boolean) => void;
+  reloadAmountCents?: number;
+  thresholdCents?: number;
+};
+
+type ControllerState = {
+  enabled: boolean;
+  handleToggle: (next: boolean) => void;
+  reloadAmount: number;
+  setReloadAmount: (value: number) => void;
+  setThreshold: (value: number) => void;
+  threshold: number;
+};
+
+function useAutoReloadController(options: ControllerOptions): ControllerState {
+  const {
+    defaultEnabled,
+    defaultReloadAmountCents,
+    defaultThresholdCents,
+    enabled: controlledEnabled,
+    onToggle,
+    reloadAmountCents: controlledReload,
+    thresholdCents: controlledThreshold,
+  } = options;
+  const [uncontrolledEnabled, setUncontrolledEnabled] =
+    useState(defaultEnabled);
+  const [threshold, setThreshold] = useState(defaultThresholdCents);
+  const [reloadAmount, setReloadAmount] = useState(defaultReloadAmountCents);
+  const enabled = controlledEnabled ?? uncontrolledEnabled;
+
+  const handleToggle = useCallback(
+    (next: boolean) => {
+      if (controlledEnabled === undefined) setUncontrolledEnabled(next);
+      onToggle?.(next);
+    },
+    [controlledEnabled, onToggle],
+  );
+
+  return {
+    enabled,
+    handleToggle,
+    reloadAmount: controlledReload ?? reloadAmount,
+    setReloadAmount,
+    setThreshold,
+    threshold: controlledThreshold ?? threshold,
+  };
+}
+
+/**
+ * Toggle + collapsible configuration form for automatic credit reloading.
+ * Composes {@link Switch}, {@link Input}, and {@link Button}. Renders a
+ * disabled banner when the consumer passes `disabled` so the control can
+ * advertise itself before the user has access (e.g. before subscribing).
+ *
+ * Values flow through the component in **minor units** (cents). Inputs
+ * display the corresponding currency unit; consumers receive the cents
+ * value from `onSave`.
+ *
+ * @example
+ * ```tsx
+ * <AutoReload
+ *   enabled={settings.autoReloadEnabled}
+ *   thresholdCents={settings.thresholdCents}
+ *   reloadAmountCents={settings.reloadAmountCents}
+ *   currency="EUR"
+ *   onToggle={handleToggle}
+ *   onSave={handleSave}
+ *   isSaving={isSaving}
+ * />
+ * ```
+ *
+ * @public
+ */
+type DisabledBannerProps = {
+  className?: string;
+  message: ReactNode;
+} & ComponentPropsWithoutRef<"div">;
+
+const DisabledBanner = forwardRef<HTMLDivElement, DisabledBannerProps>(
+  ({ className, message, ...rest }, ref) => (
+    <div
+      aria-disabled="true"
+      className={cn(
+        "flex items-start gap-3 rounded-2xl border border-dashed border-border bg-muted/30 p-4 text-sm text-muted-foreground",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      {message}
+    </div>
+  ),
+);
+DisabledBanner.displayName = "AutoReload.DisabledBanner";
+
+type ActivePanelProps = {
+  className?: string;
+  controller: ControllerState;
+  currencyDisplay: string;
+  isSaving: boolean;
+  labels: Required<AutoReloadLabels>;
+  maxAmountCents?: number;
+  minAmountCents: number;
+  onSave: () => void;
+  reloadAmountId: string;
+  stepCents: number;
+  thresholdId: string;
+  toggleId: string;
+} & ComponentPropsWithoutRef<"div">;
+
+const ActivePanel = forwardRef<HTMLDivElement, ActivePanelProps>(
+  (props, ref) => {
+    const {
+      className,
+      controller,
+      currencyDisplay,
+      isSaving,
+      labels,
+      maxAmountCents,
+      minAmountCents,
+      onSave,
+      reloadAmountId,
+      stepCents,
+      thresholdId,
+      toggleId,
+      ...rest
+    } = props;
+    return (
+      <div
+        className={cn(
+          "flex flex-col gap-4 rounded-2xl border bg-background p-4",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <ToggleHeader
+          enabled={controller.enabled}
+          heading={labels.heading}
+          helper={labels.helper}
+          id={toggleId}
+          onCheckedChange={controller.handleToggle}
+        />
+        {controller.enabled ? (
+          <ReloadFormFields
+            currencyDisplay={currencyDisplay}
+            isSaving={isSaving}
+            labels={labels}
+            maxAmountCents={maxAmountCents}
+            minAmountCents={minAmountCents}
+            onSave={onSave}
+            reloadAmount={controller.reloadAmount}
+            reloadAmountId={reloadAmountId}
+            setReloadAmount={controller.setReloadAmount}
+            setThreshold={controller.setThreshold}
+            stepCents={stepCents}
+            threshold={controller.threshold}
+            thresholdId={thresholdId}
+          />
+        ) : null}
+      </div>
+    );
+  },
+);
+ActivePanel.displayName = "AutoReload.ActivePanel";
+
+type AutoReloadInternalState = {
+  controller: ControllerState;
+  currencyDisplay: string;
+  handleSave: () => void;
+  reloadAmountId: string;
+  resolvedLabels: Required<AutoReloadLabels>;
+  thresholdId: string;
+  toggleId: string;
+};
+
+function useAutoReloadInternals(
+  props: AutoReloadProps,
+): AutoReloadInternalState {
+  const {
+    currency = DEFAULT_CURRENCY,
+    currencySymbol,
+    defaultEnabled = false,
+    defaultReloadAmountCents = 2000,
+    defaultThresholdCents = 1000,
+    enabled: controlledEnabled,
+    labels,
+    locale = DEFAULT_LOCALE,
+    onSave,
+    onToggle,
+    reloadAmountCents: controlledReload,
+    thresholdCents: controlledThreshold,
+  } = props;
+  const resolvedLabels = useMemo(
+    () => ({ ...DEFAULT_LABELS, ...labels }),
+    [labels],
+  );
+  const toggleId = useId();
+  const thresholdId = useId();
+  const reloadAmountId = useId();
+  const controller = useAutoReloadController({
+    defaultEnabled,
+    defaultReloadAmountCents,
+    defaultThresholdCents,
+    enabled: controlledEnabled,
+    onToggle,
+    reloadAmountCents: controlledReload,
+    thresholdCents: controlledThreshold,
+  });
+  const currencyDisplay = currencySymbol ?? getCurrencySymbol(locale, currency);
+  const handleSave = useCallback(() => {
+    onSave?.({
+      reloadAmountCents: controller.reloadAmount,
+      thresholdCents: controller.threshold,
+    });
+  }, [controller.reloadAmount, controller.threshold, onSave]);
+  return {
+    controller,
+    currencyDisplay,
+    handleSave,
+    reloadAmountId,
+    resolvedLabels,
+    thresholdId,
+    toggleId,
+  };
+}
+
+export const AutoReload = forwardRef<HTMLDivElement, AutoReloadProps>(
+  (props, ref) => {
+    const {
+      className,
+      disabled = false,
+      disabledMessage,
+      isSaving = false,
+      maxAmountCents,
+      minAmountCents = 100,
+      stepCents = DEFAULT_STEP_CENTS,
+    } = props;
+    const internals = useAutoReloadInternals(props);
+    if (disabled) {
+      return (
+        <DisabledBanner
+          className={className}
+          message={disabledMessage ?? internals.resolvedLabels.disabledFallback}
+          ref={ref}
+        />
+      );
+    }
+    return (
+      <ActivePanel
+        className={className}
+        controller={internals.controller}
+        currencyDisplay={internals.currencyDisplay}
+        isSaving={isSaving}
+        labels={internals.resolvedLabels}
+        maxAmountCents={maxAmountCents}
+        minAmountCents={minAmountCents}
+        onSave={internals.handleSave}
+        ref={ref}
+        reloadAmountId={internals.reloadAmountId}
+        stepCents={stepCents}
+        thresholdId={internals.thresholdId}
+        toggleId={internals.toggleId}
+      />
+    );
+  },
+);
+AutoReload.displayName = "AutoReload";

--- a/packages/ui/src/components/auto-reload/auto-reload.visual.tsx
+++ b/packages/ui/src/components/auto-reload/auto-reload.visual.tsx
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { AutoReload } from "./auto-reload";
+
+test.describe("AutoReload Visual", () => {
+  test("disabled-by-toggle", async ({ mount }) => {
+    const component = await mount(<AutoReload currency="EUR" locale="en-IE" />);
+    await expect(component).toHaveScreenshot("auto-reload-toggle-off.png");
+  });
+
+  test("enabled", async ({ mount }) => {
+    const component = await mount(
+      <AutoReload
+        currency="EUR"
+        defaultEnabled
+        defaultReloadAmountCents={2000}
+        defaultThresholdCents={1000}
+        locale="en-IE"
+      />,
+    );
+    await expect(component).toHaveScreenshot("auto-reload-toggle-on.png");
+  });
+
+  test("disabled-banner", async ({ mount }) => {
+    const component = await mount(
+      <AutoReload
+        disabled
+        disabledMessage="Subscribe to enable auto-reload settings."
+      />,
+    );
+    await expect(component).toHaveScreenshot("auto-reload-disabled.png");
+  });
+});

--- a/packages/ui/src/components/auto-reload/index.ts
+++ b/packages/ui/src/components/auto-reload/index.ts
@@ -1,0 +1,6 @@
+export {
+  AutoReload,
+  type AutoReloadLabels,
+  type AutoReloadProps,
+  type AutoReloadSavePayload,
+} from "./auto-reload";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -288,6 +288,12 @@ export {
   TableRow,
 } from "./table";
 export {
+  AutoReload,
+  type AutoReloadLabels,
+  type AutoReloadProps,
+  type AutoReloadSavePayload,
+} from "./auto-reload";
+export {
   Timeline,
   type TimelineColor,
   TimelineItem,


### PR DESCRIPTION
## Summary

Toggle + collapsible configuration form for automatic credit reloading. Composes \`Switch\`, \`Input\`, and \`Button\`.

- **Toggle** — enable / disable; controlled (\`enabled\` + \`onToggle\`) or uncontrolled (\`defaultEnabled\`).
- **Form** — appears when enabled; locale-aware threshold + reload-amount inputs (currency symbol derived from \`Intl.NumberFormat\`, overridable via \`currencySymbol\`).
- **Save** — emits \`onSave({ thresholdCents, reloadAmountCents })\`. The save button supports an \`isSaving\` loading state.
- **Disabled banner** — when \`disabled\` is set, renders a dashed-border banner with the consumer's \`disabledMessage\` instead of the form. Useful before the user has subscribed.

Values flow through in **minor units** (cents); the inputs display the corresponding currency unit; consumers receive cents from \`onSave\`.

Persistence (HTTP write, optimistic update, error toast) is intentionally **out of scope** — drive it from the consumer's \`onSave\`.

Closes #89

## API

\`\`\`tsx
<AutoReload
  enabled={settings.autoReloadEnabled}
  thresholdCents={settings.thresholdCents}
  reloadAmountCents={settings.reloadAmountCents}
  currency="EUR"
  locale="en-IE"
  onToggle={handleToggle}
  onSave={handleSave}
  isSaving={isSaving}
/>

{/* Before subscription */}
<AutoReload
  disabled
  disabledMessage="Subscribe to enable auto-reload settings."
/>
\`\`\`

## Coverage

- Unit: 12 tests covering heading + helper rendering, expanded form on enabled, hidden form when disabled-by-toggle, disabled banner, saving state (label flip + disabled), \`onToggle\` invocation, uncontrolled flip, controlled-mode flow without internal state change, \`onSave\` payload (defaults + after user input), \`currencySymbol\` override, locale-derived symbol
- Visual: Playwright CT story for toggle-off, toggle-on, and disabled banner
- Storybook: \`Default\`, \`Enabled\`, \`Euro\`, \`Saving\`, \`Disabled (no subscription)\`
- MDX: usage + enabled / localized / saving / disabled / scope notes

## Registry

Added \`auto-reload\` (\`category: billing\`, \`registryDependencies: [button, input, switch]\`, no extra deps). Re-export shim and \`pnpm build\` regenerates \`/r/auto-reload.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean
- \`check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 505/505 (12 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview exercises toggle / save / saving / disabled flows
- [ ] Registry entry visible at \`/r/auto-reload.json\` and \`/components/auto-reload\` after deploy