### PR TITLE
feat(ui): add Timeline + TimelineItem

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -2735,6 +2735,23 @@
       "category": "data"
     },
     {
+      "name": "timeline",
+      "type": "registry:component",
+      "title": "Timeline",
+      "description": "Vertical or horizontal timeline of sequential events with completed/active/upcoming statuses and connector lines.",
+      "files": [
+        {
+          "path": "registry/default/timeline/timeline.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "class-variance-authority"
+      ],
+      "category": "content"
+    },
+    {
       "name": "timeline-scrubber",
       "type": "registry:component",
       "title": "Timeline Scrubber",

--- a/apps/registry/registry/default/timeline/timeline.tsx
+++ b/apps/registry/registry/default/timeline/timeline.tsx
@@ -1,0 +1,7 @@
+// Re-export from @vllnt/ui package
+export {
+  Timeline,
+  TimelineItem,
+  timelineVariants,
+  useTimelineOrientation,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -287,6 +287,17 @@ export {
   TableHeader,
   TableRow,
 } from "./table";
+export {
+  Timeline,
+  type TimelineColor,
+  TimelineItem,
+  type TimelineItemProps,
+  type TimelineItemStatus,
+  type TimelineOrientation,
+  type TimelineProps,
+  timelineVariants,
+  useTimelineOrientation,
+} from "./timeline";
 export { Avatar, AvatarFallback, AvatarImage } from "./avatar";
 export {
   AvatarGroup,

--- a/packages/ui/src/components/timeline/index.ts
+++ b/packages/ui/src/components/timeline/index.ts
@@ -1,0 +1,11 @@
+export {
+  Timeline,
+  type TimelineColor,
+  TimelineItem,
+  type TimelineItemProps,
+  type TimelineItemStatus,
+  type TimelineOrientation,
+  type TimelineProps,
+  timelineVariants,
+  useTimelineOrientation,
+} from "./timeline";

--- a/packages/ui/src/components/timeline/timeline.mdx
+++ b/packages/ui/src/components/timeline/timeline.mdx
@@ -1,0 +1,81 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './timeline.stories'
+
+<Meta of={Stories} />
+
+# Timeline
+
+Vertical or horizontal timeline of sequential events. Renders an ordered list (`<ol>`), so the order matters semantically.
+
+A small compound family:
+
+- `Timeline` — root container; orientation drives the layout and the connector direction.
+- `TimelineItem` — one row; status (`completed` / `active` / `upcoming`) drives the marker fill and the connector style (solid for completed/active, dashed for upcoming). Set `isLast` on the trailing item to suppress its connector.
+- `useTimelineOrientation` — hook for any custom child that needs to adapt its layout to the surrounding orientation.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/timeline.json
+```
+
+## Import
+
+```tsx
+import { Timeline, TimelineItem } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<Timeline>
+  <TimelineItem
+    title="Project started"
+    date="Jan 2026"
+    status="completed"
+    description="Initial planning and team formation."
+  />
+  <TimelineItem
+    title="V2 release"
+    date="Jul 2026"
+    status="active"
+    description="Major redesign with new features."
+  />
+  <TimelineItem
+    title="Public release"
+    date="Q4 2026"
+    isLast
+    status="upcoming"
+  />
+</Timeline>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Horizontal
+
+<Canvas of={Stories.Horizontal} sourceState="shown" />
+
+## Rich content
+
+Pass children to a `TimelineItem` for rich content (lists, code blocks, embedded components).
+
+<Canvas of={Stories.WithRichContent} sourceState="shown" />
+
+## Color overrides
+
+`color` overrides the marker fill independent of `status` for cases where the status palette is not granular enough.
+
+<Canvas of={Stories.ColorOverrides} sourceState="shown" />
+
+## Notes
+
+- Set `isLast` on the trailing item to drop the connector line below / right of the marker.
+- Connectors render solid for `completed` / `active` and dashed for `upcoming` — this matches the prevailing pattern in Mantine and Chakra.
+- Alternating sides, collapsible content, and responsive horizontal → vertical reflow are intentionally **out of scope** — drive them from consumer CSS.

--- a/packages/ui/src/components/timeline/timeline.stories.tsx
+++ b/packages/ui/src/components/timeline/timeline.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Timeline, TimelineItem } from "./timeline";
+
+const meta = {
+  args: {
+    orientation: "vertical",
+  },
+  argTypes: {
+    orientation: {
+      control: "select",
+      options: ["vertical", "horizontal"],
+    },
+  },
+  component: Timeline,
+  title: "Content/Timeline",
+} satisfies Meta<typeof Timeline>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Timeline {...args}>
+      <TimelineItem
+        date="Jan 2026"
+        description="Initial planning and team formation."
+        status="completed"
+        title="Project started"
+      />
+      <TimelineItem
+        date="Mar 2026"
+        description="First version shipped to beta users."
+        status="completed"
+        title="MVP launch"
+      />
+      <TimelineItem
+        date="Jul 2026"
+        description="Major redesign with new features."
+        status="active"
+        title="V2 release"
+      />
+      <TimelineItem
+        date="Q4 2026"
+        description="General availability."
+        isLast
+        status="upcoming"
+        title="Public release"
+      />
+    </Timeline>
+  ),
+};
+
+export const Horizontal: Story = {
+  args: {
+    orientation: "horizontal",
+  },
+  render: (args) => (
+    <Timeline {...args}>
+      <TimelineItem date="Jan" status="completed" title="Plan" />
+      <TimelineItem date="Mar" status="completed" title="Build" />
+      <TimelineItem date="Jul" status="active" title="Test" />
+      <TimelineItem date="Oct" isLast status="upcoming" title="Ship" />
+    </Timeline>
+  ),
+};
+
+export const WithRichContent: Story = {
+  render: (args) => (
+    <Timeline {...args}>
+      <TimelineItem
+        date="Jan 2026"
+        description="Kicked off with a small core team."
+        status="completed"
+        title="Project started"
+      >
+        <ul className="list-disc pl-4 text-sm text-muted-foreground">
+          <li>Hired the founding designer</li>
+          <li>Locked the v1 scope</li>
+        </ul>
+      </TimelineItem>
+      <TimelineItem
+        date="Mar 2026"
+        description="Closed the design loop with the engineering team."
+        isLast
+        status="active"
+        title="Beta opens"
+      />
+    </Timeline>
+  ),
+};
+
+export const ColorOverrides: Story = {
+  render: (args) => (
+    <Timeline {...args}>
+      <TimelineItem color="emerald" status="completed" title="Discovery" />
+      <TimelineItem color="amber" status="completed" title="Design" />
+      <TimelineItem color="purple" status="active" title="Build" />
+      <TimelineItem
+        color="rose"
+        isLast
+        status="upcoming"
+        title="Launch"
+      />
+    </Timeline>
+  ),
+};

--- a/packages/ui/src/components/timeline/timeline.test.tsx
+++ b/packages/ui/src/components/timeline/timeline.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Timeline, TimelineItem } from "./timeline";
+
+describe("Timeline", () => {
+  describe("rendering", () => {
+    it("renders an ordered list with item titles", () => {
+      const { container } = render(
+        <Timeline>
+          <TimelineItem date="Jan 2026" status="completed" title="Started" />
+          <TimelineItem date="Mar 2026" status="active" title="MVP" />
+          <TimelineItem date="Jul 2026" isLast status="upcoming" title="V2" />
+        </Timeline>,
+      );
+
+      expect(container.querySelector("ol")).toBeInTheDocument();
+      expect(screen.getByText("Started")).toBeInTheDocument();
+      expect(screen.getByText("MVP")).toBeInTheDocument();
+      expect(screen.getByText("V2")).toBeInTheDocument();
+    });
+
+    it("emits data-orientation on the root and data-status on items", () => {
+      const { container } = render(
+        <Timeline orientation="horizontal">
+          <TimelineItem status="completed" title="A" />
+          <TimelineItem isLast status="upcoming" title="B" />
+        </Timeline>,
+      );
+
+      expect(container.querySelector("ol")).toHaveAttribute(
+        "data-orientation",
+        "horizontal",
+      );
+      const items = container.querySelectorAll("li[data-status]");
+      expect(items.length).toBe(2);
+      expect(items[0]).toHaveAttribute("data-status", "completed");
+      expect(items[1]).toHaveAttribute("data-status", "upcoming");
+    });
+
+    it("renders the date caption when provided", () => {
+      render(
+        <Timeline>
+          <TimelineItem date="Jan 2026" isLast title="Started" />
+        </Timeline>,
+      );
+
+      expect(screen.getByText("Jan 2026")).toBeInTheDocument();
+    });
+
+    it("renders the description when provided", () => {
+      render(
+        <Timeline>
+          <TimelineItem description="Initial planning" isLast title="Started" />
+        </Timeline>,
+      );
+
+      expect(screen.getByText("Initial planning")).toBeInTheDocument();
+    });
+
+    it("renders rich children inside the item body", () => {
+      render(
+        <Timeline>
+          <TimelineItem isLast title="Started">
+            <p data-testid="rich">Rich content</p>
+          </TimelineItem>
+        </Timeline>,
+      );
+
+      expect(screen.getByTestId("rich")).toHaveTextContent("Rich content");
+    });
+  });
+
+  describe("connector", () => {
+    it("renders a connector for non-last items", () => {
+      const { container } = render(
+        <Timeline>
+          <TimelineItem status="completed" title="A" />
+          <TimelineItem isLast status="upcoming" title="B" />
+        </Timeline>,
+      );
+
+      const items = container.querySelectorAll("li");
+      const firstHasConnector = items[0]?.querySelector(".border-l-2");
+      const lastHasConnector = items[1]?.querySelector(".border-l-2");
+      expect(firstHasConnector).not.toBeNull();
+      expect(lastHasConnector).toBeNull();
+    });
+
+    it("uses horizontal connector classes when orientation=horizontal", () => {
+      const { container } = render(
+        <Timeline orientation="horizontal">
+          <TimelineItem status="completed" title="A" />
+          <TimelineItem isLast status="upcoming" title="B" />
+        </Timeline>,
+      );
+
+      expect(container.querySelector("li .border-t-2")).not.toBeNull();
+    });
+  });
+
+  describe("status palette", () => {
+    it.each(["completed", "active", "upcoming"] as const)(
+      "renders the %s status",
+      (status) => {
+        render(
+          <Timeline>
+            <TimelineItem isLast status={status} title="A" />
+          </Timeline>,
+        );
+
+        expect(screen.getByText("A")).toBeInTheDocument();
+      },
+    );
+  });
+});

--- a/packages/ui/src/components/timeline/timeline.tsx
+++ b/packages/ui/src/components/timeline/timeline.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useContext,
+  useMemo,
+} from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Visual orientation for a {@link Timeline}.
+ *
+ * @public
+ */
+export type TimelineOrientation = "horizontal" | "vertical";
+
+/**
+ * Status for a {@link TimelineItem}.
+ *
+ * @public
+ */
+export type TimelineItemStatus = "active" | "completed" | "upcoming";
+
+/**
+ * Color theme for a {@link TimelineItem} marker.
+ *
+ * @public
+ */
+export type TimelineColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "neutral"
+  | "purple"
+  | "red"
+  | "rose";
+
+const STATUS_CLASSES: Record<
+  TimelineItemStatus,
+  { connector: string; markerBorder: string; markerFill: string }
+> = {
+  active: {
+    connector: "border-solid border-primary",
+    markerBorder: "border-primary",
+    markerFill: "bg-background ring-2 ring-primary",
+  },
+  completed: {
+    connector: "border-solid border-primary",
+    markerBorder: "border-primary",
+    markerFill: "bg-primary",
+  },
+  upcoming: {
+    connector: "border-dashed border-muted-foreground/40",
+    markerBorder: "border-muted-foreground/40",
+    markerFill: "bg-background",
+  },
+};
+
+const COLOR_OVERRIDES: Record<TimelineColor, { border: string; fill: string }> =
+  {
+    amber: {
+      border: "border-amber-500",
+      fill: "bg-amber-500",
+    },
+    blue: {
+      border: "border-blue-500",
+      fill: "bg-blue-500",
+    },
+    emerald: {
+      border: "border-emerald-500",
+      fill: "bg-emerald-500",
+    },
+    neutral: {
+      border: "border-muted-foreground",
+      fill: "bg-muted-foreground",
+    },
+    purple: {
+      border: "border-purple-500",
+      fill: "bg-purple-500",
+    },
+    red: {
+      border: "border-red-500",
+      fill: "bg-red-500",
+    },
+    rose: {
+      border: "border-rose-500",
+      fill: "bg-rose-500",
+    },
+  };
+
+type TimelineContextValue = {
+  orientation: TimelineOrientation;
+};
+
+const TimelineContext = createContext<TimelineContextValue>({
+  orientation: "vertical",
+});
+
+/**
+ * Hook for reading the surrounding {@link Timeline}'s orientation. Useful
+ * for custom children that need to adapt their layout.
+ *
+ * @public
+ */
+export function useTimelineOrientation(): TimelineOrientation {
+  return useContext(TimelineContext).orientation;
+}
+
+const timelineVariants = cva("flex", {
+  defaultVariants: {
+    orientation: "vertical",
+  },
+  variants: {
+    orientation: {
+      horizontal: "flex-row gap-0 overflow-x-auto",
+      vertical: "flex-col gap-0",
+    },
+  },
+});
+
+/**
+ * Props for {@link Timeline}.
+ *
+ * @public
+ */
+export type TimelineProps = ComponentPropsWithoutRef<"ol"> &
+  VariantProps<typeof timelineVariants>;
+
+/**
+ * Vertical or horizontal timeline of sequential events. Renders an
+ * ordered list (`<ol>`) so the order matters semantically. Children
+ * should be {@link TimelineItem}s.
+ *
+ * The component injects connector styling per child via context — the
+ * last item drops its trailing connector automatically.
+ *
+ * @example
+ * ```tsx
+ * <Timeline>
+ *   <TimelineItem title="Project started" date="Jan 2026" status="completed" />
+ *   <TimelineItem title="MVP launch" date="Mar 2026" status="completed" />
+ *   <TimelineItem title="V2" date="Jul 2026" status="active" />
+ *   <TimelineItem title="Public release" date="Q4 2026" status="upcoming" />
+ * </Timeline>
+ * ```
+ *
+ * @public
+ */
+export const Timeline = forwardRef<HTMLOListElement, TimelineProps>(
+  ({ children, className, orientation, ...rest }, ref) => {
+    const resolvedOrientation: TimelineOrientation = orientation ?? "vertical";
+    const contextValue = useMemo<TimelineContextValue>(
+      () => ({ orientation: resolvedOrientation }),
+      [resolvedOrientation],
+    );
+    return (
+      <TimelineContext.Provider value={contextValue}>
+        <ol
+          className={cn(timelineVariants({ orientation }), className)}
+          data-orientation={resolvedOrientation}
+          ref={ref}
+          {...rest}
+        >
+          {children}
+        </ol>
+      </TimelineContext.Provider>
+    );
+  },
+);
+Timeline.displayName = "Timeline";
+
+/**
+ * Props for {@link TimelineItem}.
+ *
+ * @public
+ */
+export type TimelineItemProps = {
+  /** Optional color override for the marker. Falls back to the status palette. */
+  color?: TimelineColor;
+  /** Optional date / time caption rendered alongside the title. */
+  date?: ReactNode;
+  /** Optional sub-headline rendered under the title. */
+  description?: ReactNode;
+  /** Optional icon rendered inside the marker. */
+  icon?: ReactNode;
+  /** When true, suppresses the trailing connector. Defaults to `false`. */
+  isLast?: boolean;
+  /** Status drives marker fill and connector style. Defaults to `"upcoming"`. */
+  status?: TimelineItemStatus;
+  /** Item title. */
+  title: ReactNode;
+} & ComponentPropsWithoutRef<"li">;
+
+type MarkerProps = {
+  color?: TimelineColor;
+  icon?: ReactNode;
+  status: TimelineItemStatus;
+};
+
+function Marker({ color, icon, status }: MarkerProps): ReactNode {
+  const palette = STATUS_CLASSES[status];
+  const override = color ? COLOR_OVERRIDES[color] : undefined;
+  const borderClass = override?.border ?? palette.markerBorder;
+  const fillClass = override?.fill ?? palette.markerFill;
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "relative z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 bg-background text-[10px]",
+        borderClass,
+      )}
+    >
+      {icon ? (
+        <span
+          className={cn(
+            "flex h-full w-full items-center justify-center text-foreground [&>svg]:h-3 [&>svg]:w-3",
+            status === "completed" ? "text-primary-foreground" : "",
+          )}
+        >
+          {icon}
+        </span>
+      ) : (
+        <span
+          className={cn(
+            "h-2.5 w-2.5 rounded-full",
+            override ? fillClass : palette.markerFill,
+          )}
+        />
+      )}
+    </span>
+  );
+}
+
+type ConnectorProps = {
+  orientation: TimelineOrientation;
+  status: TimelineItemStatus;
+};
+
+function Connector({ orientation, status }: ConnectorProps): ReactNode {
+  const palette = STATUS_CLASSES[status];
+  if (orientation === "horizontal") {
+    return (
+      <span
+        aria-hidden="true"
+        className={cn(
+          "absolute top-3 h-0 w-full border-t-2",
+          palette.connector,
+        )}
+        style={{ left: "calc(50% + 0.75rem)" }}
+      />
+    );
+  }
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "absolute left-3 top-6 h-full w-0 -translate-x-1/2 border-l-2",
+        palette.connector,
+      )}
+    />
+  );
+}
+
+type ItemBodyProps = {
+  children?: ReactNode;
+  date?: ReactNode;
+  description?: ReactNode;
+  orientation: TimelineOrientation;
+  title: ReactNode;
+};
+
+function ItemBody({
+  children,
+  date,
+  description,
+  orientation,
+  title,
+}: ItemBodyProps): ReactNode {
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 flex-col gap-0.5",
+        orientation === "horizontal" ? "items-center text-center" : "",
+      )}
+    >
+      <div
+        className={cn(
+          "flex flex-wrap items-baseline gap-x-2 gap-y-0.5",
+          orientation === "horizontal" ? "justify-center" : "",
+        )}
+      >
+        <p className="text-sm font-semibold tracking-tight text-foreground">
+          {title}
+        </p>
+        {date ? (
+          <span className="font-mono text-xs text-muted-foreground">
+            {date}
+          </span>
+        ) : null}
+      </div>
+      {description ? (
+        <p className="text-sm text-muted-foreground">{description}</p>
+      ) : null}
+      {children ? (
+        <div className="mt-1 text-sm text-foreground">{children}</div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * One row inside a {@link Timeline}. Renders the marker, connector, title,
+ * date, description, and any rich-content children.
+ *
+ * @public
+ */
+export const TimelineItem = forwardRef<HTMLLIElement, TimelineItemProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      color,
+      date,
+      description,
+      icon,
+      isLast = false,
+      status = "upcoming",
+      title,
+      ...rest
+    } = props;
+    const orientation = useTimelineOrientation();
+    return (
+      <li
+        className={cn(
+          "relative",
+          orientation === "horizontal"
+            ? "flex flex-1 flex-col items-center gap-2 px-3 pt-1"
+            : "flex items-start gap-3 pb-6 last:pb-0",
+          className,
+        )}
+        data-status={status}
+        ref={ref}
+        {...rest}
+      >
+        {isLast ? null : (
+          <Connector orientation={orientation} status={status} />
+        )}
+        <Marker color={color} icon={icon} status={status} />
+        <ItemBody
+          date={date}
+          description={description}
+          orientation={orientation}
+          title={title}
+        >
+          {children}
+        </ItemBody>
+      </li>
+    );
+  },
+);
+TimelineItem.displayName = "TimelineItem";
+
+export { timelineVariants };

--- a/packages/ui/src/components/timeline/timeline.visual.tsx
+++ b/packages/ui/src/components/timeline/timeline.visual.tsx
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { Timeline, TimelineItem } from "./timeline";
+
+test.describe("Timeline Visual", () => {
+  test("vertical", async ({ mount }) => {
+    const component = await mount(
+      <div style={{ width: 320 }}>
+        <Timeline>
+          <TimelineItem
+            date="Jan 2026"
+            description="Initial planning and team formation."
+            status="completed"
+            title="Project started"
+          />
+          <TimelineItem
+            date="Mar 2026"
+            description="First version shipped to beta users."
+            status="completed"
+            title="MVP launch"
+          />
+          <TimelineItem
+            date="Jul 2026"
+            description="Major redesign with new features."
+            status="active"
+            title="V2 release"
+          />
+          <TimelineItem
+            date="Q4 2026"
+            description="General availability."
+            isLast
+            status="upcoming"
+            title="Public release"
+          />
+        </Timeline>
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("timeline-vertical.png");
+  });
+
+  test("horizontal", async ({ mount }) => {
+    const component = await mount(
+      <div style={{ width: 720 }}>
+        <Timeline orientation="horizontal">
+          <TimelineItem date="Jan" status="completed" title="Plan" />
+          <TimelineItem date="Mar" status="completed" title="Build" />
+          <TimelineItem date="Jul" status="active" title="Test" />
+          <TimelineItem date="Oct" isLast status="upcoming" title="Ship" />
+        </Timeline>
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("timeline-horizontal.png");
+  });
+});


### PR DESCRIPTION
## Summary

Vertical or horizontal timeline of sequential events. Renders an ordered list (\`<ol>\`) so order matters semantically. Status drives the marker fill and the connector line style: solid for completed/active, dashed for upcoming. Set \`isLast\` on the trailing item to drop the trailing connector.

A small compound family:

- **\`Timeline\`** — root container, orientation context (\`vertical\` default / \`horizontal\`).
- **\`TimelineItem\`** — row with title, date, description, optional icon, \`status\` (completed / active / upcoming), \`color\` override, and rich children body.
- **\`useTimelineOrientation\`** — hook for custom children that need to adapt to the surrounding orientation.

Alternating sides, collapsible content, and responsive \`horizontal\` → \`vertical\` reflow are intentionally **out of scope** — drive them from consumer CSS.

Closes #32

## API

\`\`\`tsx
<Timeline>
  <TimelineItem
    title="Project started"
    date="Jan 2026"
    status="completed"
    description="Initial planning and team formation."
  />
  <TimelineItem
    title="V2 release"
    date="Jul 2026"
    status="active"
    description="Major redesign with new features."
  >
    <ul>...</ul>
  </TimelineItem>
  <TimelineItem
    title="Public release"
    date="Q4 2026"
    isLast
    status="upcoming"
  />
</Timeline>
\`\`\`

## Coverage

- Unit: 10 tests covering \`<ol>\` semantic + item titles, \`data-orientation\` on root + \`data-status\` on items, date caption, description, rich children body, connector renders for non-last items + drops on last item, horizontal-orientation connector class, all three statuses (\`completed\` / \`active\` / \`upcoming\`)
- Visual: Playwright CT story for vertical + horizontal layouts
- Storybook: \`Default\`, \`Horizontal\`, \`WithRichContent\`, \`ColorOverrides\`
- MDX: usage + horizontal + rich content + color overrides + scope notes

## Registry

Added \`timeline\` (\`category: content\`, no \`registryDependencies\`, deps: \`class-variance-authority\`). Re-export shim and \`pnpm build\` regenerates \`/r/timeline.json\`.

## Local validation

- \`pnpm -F @vllnt/ui lint\` — clean
- \`pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json\` — clean
- \`pnpm -F @vllnt/ui check:use-client\` — clean (\`"use client";\` present; component imports \`useContext\` + \`useMemo\`)
- \`check-story-coverage.ts\` + \`verify-stories.ts\` — clean
- \`pnpm test:once\` — 503/503 (10 new in this PR)
- \`pnpm build\` — green
- \`pnpm -F @vllnt/ui build-storybook\` — green

## Test plan

- [ ] CI green
- [ ] Storybook preview renders all four stories with correct connector solid/dashed treatment per status
- [ ] Registry entry visible at \`/r/timeline.json\` and \`/components/timeline\` after deploy