### PR TITLE
feat(ui): add HistoricTimeline component

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1147,6 +1147,21 @@
       "category": "navigation"
     },
     {
+      "name": "historic-timeline",
+      "type": "registry:component",
+      "title": "Historic Timeline",
+      "description": "Specialized timeline for historical events spanning centuries or millennia, with era bands, period bars, and BCE/CE point markers.",
+      "files": [
+        {
+          "path": "registry/default/historic-timeline/historic-timeline.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
       "name": "hover-card",
       "type": "registry:component",
       "title": "Hover Card",

--- a/apps/registry/registry/default/historic-timeline/historic-timeline.tsx
+++ b/apps/registry/registry/default/historic-timeline/historic-timeline.tsx
@@ -1,0 +1,10 @@
+export {
+  type HistoricCategory,
+  type HistoricColor,
+  type HistoricEra,
+  type HistoricEvent,
+  type HistoricPeriod,
+  HistoricTimeline,
+  type HistoricTimelineLabels,
+  type HistoricTimelineProps,
+} from "@vllnt/ui";

--- a/packages/ui/src/components/historic-timeline/historic-timeline.mdx
+++ b/packages/ui/src/components/historic-timeline/historic-timeline.mdx
@@ -1,0 +1,92 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './historic-timeline.stories'
+
+<Meta of={Stories} />
+
+# HistoricTimeline
+
+Specialized timeline for historical events spanning centuries or millennia. Renders era bands as a background layer, period bars in a lane, and point events as markers. Negative years format as `BCE`, positive as `CE`.
+
+Data-driven — pass `eras`, `periods`, `events`, and an optional `categories` legend.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/historic-timeline.json
+```
+
+## Import
+
+```tsx
+import { HistoricTimeline } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<HistoricTimeline
+  startYear={-3000}
+  endYear={2025}
+  eras={[
+    { id: 'ancient', name: 'Ancient', startYear: -3000, endYear: 476, color: 'amber' },
+    { id: 'medieval', name: 'Medieval', startYear: 476, endYear: 1453, color: 'emerald' },
+    { id: 'modern', name: 'Modern', startYear: 1453, endYear: 2025, color: 'blue' },
+  ]}
+  periods={[
+    { id: '100yr', title: "Hundred Years' War", startYear: 1337, endYear: 1453, category: 'conflict' },
+  ]}
+  events={[
+    { id: 'olympics', year: -776, title: 'First Olympic Games', category: 'culture' },
+    { id: 'moon', year: 1969, title: 'Moon landing', category: 'science' },
+  ]}
+  categories={[
+    { id: 'culture', label: 'Culture', color: 'amber' },
+    { id: 'science', label: 'Science', color: 'blue' },
+    { id: 'conflict', label: 'Conflict', color: 'red' },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Categories drive colors + a legend
+
+Pass `categories` to assign each event/period a color and surface a labeled chip row beneath the timeline. Match category ids on `HistoricEvent.category` and `HistoricPeriod.category`.
+
+```tsx
+const categories = [
+  { id: 'culture', label: 'Culture', color: 'amber' },
+  { id: 'science', label: 'Science', color: 'blue' },
+]
+```
+
+## Tight window
+
+Narrow `startYear` / `endYear` to focus on a sub-range. Events outside the window are clipped automatically.
+
+<Canvas of={Stories.TightWindow} sourceState="shown" />
+
+## Without categories
+
+Skip the legend by leaving `categories` empty.
+
+<Canvas of={Stories.NoCategories} sourceState="shown" />
+
+## Periods only
+
+Render period spans without point events.
+
+<Canvas of={Stories.PeriodsOnly} sourceState="shown" />
+
+## Notes
+
+- Years use the proleptic calendar — pass negative integers for BCE, positive for CE.
+- Events outside the `startYear` / `endYear` window are hidden; eras and periods are clipped to the visible range.
+- Event markers emit `data-event-id="<id>"` and `data-event-year="<year>"` for analytics; period bars emit `data-period-id="<id>"`; era bands emit `data-era-id="<id>"`.
+- Zoom, pan, search, minimap, event clustering, click-to-detail, and print mode are intentionally **out of scope** — the component is a presentation primitive over a fixed window. Drive zoom by re-rendering with a narrower `startYear` / `endYear`.

--- a/packages/ui/src/components/historic-timeline/historic-timeline.stories.tsx
+++ b/packages/ui/src/components/historic-timeline/historic-timeline.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  type HistoricCategory,
+  type HistoricEra,
+  type HistoricEvent,
+  type HistoricPeriod,
+  HistoricTimeline,
+} from "./historic-timeline";
+
+const ERAS: HistoricEra[] = [
+  { color: "amber", endYear: 476, id: "ancient", name: "Ancient", startYear: -3000 },
+  { color: "emerald", endYear: 1453, id: "medieval", name: "Medieval", startYear: 476 },
+  { color: "blue", endYear: 2025, id: "modern", name: "Modern", startYear: 1453 },
+];
+
+const CATEGORIES: HistoricCategory[] = [
+  { color: "amber", id: "culture", label: "Culture" },
+  { color: "blue", id: "science", label: "Science" },
+  { color: "red", id: "conflict", label: "Conflict" },
+  { color: "purple", id: "politics", label: "Politics" },
+];
+
+const EVENTS: HistoricEvent[] = [
+  { category: "culture", id: "olympics", title: "First Olympics", year: -776 },
+  { category: "culture", id: "rome-founded", title: "Rome founded", year: -753 },
+  { category: "politics", id: "augustus", title: "Augustus crowned", year: -27 },
+  { category: "conflict", id: "fall-rome", title: "Fall of Western Rome", year: 476 },
+  { category: "science", id: "press", title: "Printing press", year: 1450 },
+  { category: "science", id: "telescope", title: "Telescope", year: 1608 },
+  { category: "science", id: "moon", title: "Moon landing", year: 1969 },
+];
+
+const PERIODS: HistoricPeriod[] = [
+  {
+    category: "conflict",
+    endYear: 1453,
+    id: "100yr",
+    startYear: 1337,
+    title: "Hundred Years' War",
+  },
+  {
+    category: "culture",
+    endYear: 1600,
+    id: "renaissance",
+    startYear: 1400,
+    title: "Renaissance",
+  },
+];
+
+const meta = {
+  args: {
+    categories: CATEGORIES,
+    endYear: 2025,
+    eras: ERAS,
+    events: EVENTS,
+    periods: PERIODS,
+    startYear: -3000,
+  },
+  component: HistoricTimeline,
+  title: "Educational/HistoricTimeline",
+} satisfies Meta<typeof HistoricTimeline>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const TightWindow: Story = {
+  args: {
+    endYear: 1800,
+    eras: [
+      { color: "emerald", endYear: 1453, id: "medieval", name: "Medieval", startYear: 476 },
+      { color: "blue", endYear: 1800, id: "early-modern", name: "Early Modern", startYear: 1453 },
+    ],
+    startYear: 0,
+  },
+};
+
+export const NoCategories: Story = {
+  args: {
+    categories: [],
+  },
+};
+
+export const PeriodsOnly: Story = {
+  args: {
+    events: [],
+  },
+};

--- a/packages/ui/src/components/historic-timeline/historic-timeline.test.tsx
+++ b/packages/ui/src/components/historic-timeline/historic-timeline.test.tsx
@@ -1,0 +1,178 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  type HistoricCategory,
+  type HistoricEra,
+  type HistoricEvent,
+  type HistoricPeriod,
+  HistoricTimeline,
+} from "./historic-timeline";
+
+const ERAS: HistoricEra[] = [
+  {
+    color: "amber",
+    endYear: 476,
+    id: "ancient",
+    name: "Ancient",
+    startYear: -3000,
+  },
+  {
+    color: "emerald",
+    endYear: 1453,
+    id: "medieval",
+    name: "Medieval",
+    startYear: 476,
+  },
+  {
+    color: "blue",
+    endYear: 2025,
+    id: "modern",
+    name: "Modern",
+    startYear: 1453,
+  },
+];
+
+const CATEGORIES: HistoricCategory[] = [
+  { color: "blue", id: "science", label: "Science" },
+  { color: "red", id: "conflict", label: "Conflict" },
+];
+
+const EVENTS: HistoricEvent[] = [
+  { category: "science", id: "olympics", title: "First Olympics", year: -776 },
+  { category: "science", id: "moon", title: "Moon landing", year: 1969 },
+];
+
+const PERIODS: HistoricPeriod[] = [
+  {
+    category: "conflict",
+    endYear: 1453,
+    id: "100yr",
+    startYear: 1337,
+    title: "Hundred Years' War",
+  },
+];
+
+describe("HistoricTimeline", () => {
+  describe("rendering", () => {
+    it("renders era labels and event titles", () => {
+      render(
+        <HistoricTimeline
+          endYear={2025}
+          eras={ERAS}
+          events={EVENTS}
+          startYear={-3000}
+        />,
+      );
+
+      expect(screen.getByText("Ancient")).toBeInTheDocument();
+      expect(screen.getByText("Medieval")).toBeInTheDocument();
+      expect(screen.getByText("First Olympics")).toBeInTheDocument();
+      expect(screen.getByText("Moon landing")).toBeInTheDocument();
+    });
+
+    it("renders period bars when provided", () => {
+      const { container } = render(
+        <HistoricTimeline endYear={2025} periods={PERIODS} startYear={-3000} />,
+      );
+
+      expect(
+        container.querySelector("[data-period-id='100yr']"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the category legend when categories are provided", () => {
+      render(
+        <HistoricTimeline
+          categories={CATEGORIES}
+          endYear={2025}
+          startYear={-3000}
+        />,
+      );
+
+      expect(screen.getByText("Science")).toBeInTheDocument();
+      expect(screen.getByText("Conflict")).toBeInTheDocument();
+    });
+
+    it("renders BCE on negative years and CE on positive years", () => {
+      render(
+        <HistoricTimeline endYear={2025} events={EVENTS} startYear={-3000} />,
+      );
+
+      expect(screen.getByText(/776 BCE/)).toBeInTheDocument();
+      expect(screen.getByText(/1969 CE/)).toBeInTheDocument();
+    });
+
+    it("renders an event title as a link when href is set", () => {
+      render(
+        <HistoricTimeline
+          endYear={2025}
+          events={[
+            {
+              category: "science",
+              href: "/events/moon",
+              id: "moon",
+              title: "Moon landing",
+              year: 1969,
+            },
+          ]}
+          startYear={-3000}
+        />,
+      );
+
+      const link = screen.getByRole("link", { name: "Moon landing" });
+      expect(link).toHaveAttribute("href", "/events/moon");
+    });
+  });
+
+  describe("clipping", () => {
+    it("hides events outside the visible window", () => {
+      const { container } = render(
+        <HistoricTimeline
+          endYear={500}
+          events={[
+            { id: "in", title: "In range", year: 0 },
+            { id: "out-before", title: "Too early", year: -1000 },
+            { id: "out-after", title: "Too late", year: 1000 },
+          ]}
+          startYear={-500}
+        />,
+      );
+
+      expect(
+        container.querySelector("[data-event-id='in']"),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector("[data-event-id='out-before']"),
+      ).toBeNull();
+      expect(container.querySelector("[data-event-id='out-after']")).toBeNull();
+    });
+
+    it("hides eras with non-positive width inside the visible window", () => {
+      const { container } = render(
+        <HistoricTimeline
+          endYear={500}
+          eras={[
+            { endYear: -200, id: "before", name: "Before", startYear: -1000 },
+          ]}
+          startYear={-500}
+        />,
+      );
+
+      expect(container.querySelector("[data-era-id]")).not.toBeNull();
+    });
+  });
+
+  describe("data attributes", () => {
+    it("emits data-event-id and data-event-year per marker", () => {
+      const { container } = render(
+        <HistoricTimeline endYear={2025} events={EVENTS} startYear={-3000} />,
+      );
+
+      const markers = container.querySelectorAll("[data-event-id]");
+      expect(markers.length).toBe(2);
+      expect(markers[0]).toHaveAttribute("data-event-year", "-776");
+      expect(markers[1]).toHaveAttribute("data-event-year", "1969");
+    });
+  });
+});

--- a/packages/ui/src/components/historic-timeline/historic-timeline.tsx
+++ b/packages/ui/src/components/historic-timeline/historic-timeline.tsx
@@ -1,0 +1,560 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useMemo,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+const DEFAULT_TICK_COUNT = 8;
+
+/**
+ * Color theme for eras and event categories.
+ *
+ * @public
+ */
+export type HistoricColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "neutral"
+  | "purple"
+  | "red"
+  | "rose";
+
+const COLOR_PALETTE: Record<
+  HistoricColor,
+  { band: string; chip: string; marker: string }
+> = {
+  amber: {
+    band: "bg-amber-500/15",
+    chip: "bg-amber-500/15 text-amber-700 dark:text-amber-300",
+    marker: "border-amber-500 bg-amber-500",
+  },
+  blue: {
+    band: "bg-blue-500/15",
+    chip: "bg-blue-500/15 text-blue-700 dark:text-blue-300",
+    marker: "border-blue-500 bg-blue-500",
+  },
+  emerald: {
+    band: "bg-emerald-500/15",
+    chip: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+    marker: "border-emerald-500 bg-emerald-500",
+  },
+  neutral: {
+    band: "bg-muted",
+    chip: "bg-muted text-muted-foreground",
+    marker: "border-muted-foreground bg-muted-foreground",
+  },
+  purple: {
+    band: "bg-purple-500/15",
+    chip: "bg-purple-500/15 text-purple-700 dark:text-purple-300",
+    marker: "border-purple-500 bg-purple-500",
+  },
+  red: {
+    band: "bg-red-500/15",
+    chip: "bg-red-500/15 text-red-700 dark:text-red-300",
+    marker: "border-red-500 bg-red-500",
+  },
+  rose: {
+    band: "bg-rose-500/15",
+    chip: "bg-rose-500/15 text-rose-700 dark:text-rose-300",
+    marker: "border-rose-500 bg-rose-500",
+  },
+};
+
+/**
+ * Background era band rendered behind the timeline.
+ *
+ * @public
+ */
+export type HistoricEra = {
+  /** Color theme. Defaults to `"neutral"`. */
+  color?: HistoricColor;
+  /** End year (inclusive). */
+  endYear: number;
+  /** Stable identifier. */
+  id: string;
+  /** Display name. */
+  name: ReactNode;
+  /** Start year (inclusive). */
+  startYear: number;
+};
+
+/**
+ * Mapping from category id to color theme + display label.
+ *
+ * @public
+ */
+export type HistoricCategory = {
+  /** Color theme. Defaults to `"neutral"`. */
+  color?: HistoricColor;
+  /** Stable identifier; matches {@link HistoricEvent.category}. */
+  id: string;
+  /** Display label. */
+  label: ReactNode;
+};
+
+/**
+ * Point-in-time event marker.
+ *
+ * @public
+ */
+export type HistoricEvent = {
+  /** Optional category id. Drives the marker color when provided. */
+  category?: string;
+  /** Optional description. */
+  description?: ReactNode;
+  /** Optional anchor href. Renders the event title as a link. */
+  href?: string;
+  /** Stable identifier. */
+  id: string;
+  /** Event title. */
+  title: ReactNode;
+  /** Year. Negative for BCE / positive for CE. */
+  year: number;
+};
+
+/**
+ * Span event (a period or duration).
+ *
+ * @public
+ */
+export type HistoricPeriod = {
+  /** Optional category id. Drives the band color when provided. */
+  category?: string;
+  /** End year (inclusive). */
+  endYear: number;
+  /** Stable identifier. */
+  id: string;
+  /** Start year (inclusive). */
+  startYear: number;
+  /** Display title. */
+  title: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type HistoricTimelineLabels = {
+  /** Aria-label for the timeline section. Defaults to `"Historic timeline"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Historic timeline",
+} as const satisfies Required<HistoricTimelineLabels>;
+
+/**
+ * Props for {@link HistoricTimeline}.
+ *
+ * @public
+ */
+export type HistoricTimelineProps = {
+  /** Optional category list — drives event marker colors and the legend. */
+  categories?: HistoricCategory[];
+  /** End year of the visible window. */
+  endYear: number;
+  /** Eras rendered as background bands. */
+  eras?: HistoricEra[];
+  /** Point-in-time event markers. */
+  events?: HistoricEvent[];
+  /** Localizable strings. */
+  labels?: HistoricTimelineLabels;
+  /** Span events (durations). */
+  periods?: HistoricPeriod[];
+  /** Start year of the visible window (negative for BCE). */
+  startYear: number;
+  /** Number of axis ticks. Defaults to `8`. */
+  tickCount?: number;
+} & ComponentPropsWithoutRef<"section">;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function formatYear(year: number): string {
+  if (year < 0) return `${Math.abs(year).toString()} BCE`;
+  return `${year.toString()} CE`;
+}
+
+function yearToPercent(year: number, start: number, end: number): number {
+  const span = end - start;
+  if (span <= 0) return 0;
+  return clamp(((year - start) / span) * 100, 0, 100);
+}
+
+function buildTicks(
+  start: number,
+  end: number,
+  count: number,
+): { label: string; offset: number }[] {
+  const safeCount = Math.max(2, count);
+  const span = end - start;
+  if (span <= 0) return [];
+  const step = span / (safeCount - 1);
+  return Array.from({ length: safeCount }).map((_, index) => {
+    const year = Math.round(start + step * index);
+    return {
+      label: formatYear(year),
+      offset: yearToPercent(year, start, end),
+    };
+  });
+}
+
+function resolveCategoryColor(
+  categoryId: string | undefined,
+  categories: HistoricCategory[],
+): HistoricColor {
+  if (!categoryId) return "neutral";
+  const match = categories.find((category) => category.id === categoryId);
+  return match?.color ?? "neutral";
+}
+
+type AxisProps = {
+  ticks: { label: string; offset: number }[];
+};
+
+function Axis({ ticks }: AxisProps): ReactNode {
+  return (
+    <div
+      aria-hidden="true"
+      className="relative h-7 border-b border-border text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+    >
+      {ticks.map((tick) => (
+        <span
+          className="absolute top-1 -translate-x-1/2"
+          key={tick.label}
+          style={{ left: `${tick.offset.toString()}%` }}
+        >
+          {tick.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+type EraBandsProps = {
+  endYear: number;
+  eras: HistoricEra[];
+  startYear: number;
+};
+
+function EraBands({ endYear, eras, startYear }: EraBandsProps): ReactNode {
+  if (eras.length === 0) return null;
+  return (
+    <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+      {eras.map((era) => {
+        const left = yearToPercent(era.startYear, startYear, endYear);
+        const right = yearToPercent(era.endYear, startYear, endYear);
+        const width = Math.max(0, right - left);
+        if (width <= 0) return null;
+        const palette = COLOR_PALETTE[era.color ?? "neutral"];
+        return (
+          <div
+            className={cn("absolute inset-y-0", palette.band)}
+            data-era-id={era.id}
+            key={era.id}
+            style={{
+              left: `${left.toString()}%`,
+              width: `${width.toString()}%`,
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+type EraLabelsProps = {
+  endYear: number;
+  eras: HistoricEra[];
+  startYear: number;
+};
+
+function EraLabels({ endYear, eras, startYear }: EraLabelsProps): ReactNode {
+  if (eras.length === 0) return null;
+  return (
+    <div className="relative flex h-6 border-b border-border">
+      {eras.map((era) => {
+        const left = yearToPercent(era.startYear, startYear, endYear);
+        const right = yearToPercent(era.endYear, startYear, endYear);
+        const width = Math.max(0, right - left);
+        if (width <= 0) return null;
+        const palette = COLOR_PALETTE[era.color ?? "neutral"];
+        return (
+          <span
+            className={cn(
+              "absolute top-1 truncate rounded px-1 text-[10px] font-semibold uppercase tracking-wide",
+              palette.chip,
+            )}
+            key={`${era.id}-label`}
+            style={{
+              left: `${left.toString()}%`,
+              width: `${width.toString()}%`,
+            }}
+          >
+            {era.name}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+type PeriodLaneProps = {
+  categories: HistoricCategory[];
+  endYear: number;
+  periods: HistoricPeriod[];
+  startYear: number;
+};
+
+function PeriodLane({
+  categories,
+  endYear,
+  periods,
+  startYear,
+}: PeriodLaneProps): ReactNode {
+  if (periods.length === 0) return null;
+  return (
+    <div className="relative flex h-7 items-center border-b border-border/60">
+      {periods.map((period) => {
+        const left = yearToPercent(period.startYear, startYear, endYear);
+        const right = yearToPercent(period.endYear, startYear, endYear);
+        const width = Math.max(0, right - left);
+        if (width <= 0) return null;
+        const color = resolveCategoryColor(period.category, categories);
+        const palette = COLOR_PALETTE[color];
+        const titleText = typeof period.title === "string" ? period.title : "";
+        return (
+          <div
+            aria-label={
+              titleText
+                ? `${titleText}, ${formatYear(period.startYear)} – ${formatYear(period.endYear)}`
+                : undefined
+            }
+            className={cn(
+              "absolute top-1 flex h-5 items-center overflow-hidden rounded-sm px-1 text-[10px] font-medium",
+              palette.chip,
+            )}
+            data-period-id={period.id}
+            key={period.id}
+            style={{
+              left: `${left.toString()}%`,
+              width: `${width.toString()}%`,
+            }}
+          >
+            <span className="truncate">{period.title}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+type EventMarkerProps = {
+  categories: HistoricCategory[];
+  endYear: number;
+  event: HistoricEvent;
+  startYear: number;
+};
+
+function EventMarker({
+  categories,
+  endYear,
+  event,
+  startYear,
+}: EventMarkerProps): ReactNode {
+  if (event.year < startYear || event.year > endYear) return null;
+  const left = yearToPercent(event.year, startYear, endYear);
+  const color = resolveCategoryColor(event.category, categories);
+  const palette = COLOR_PALETTE[color];
+  const titleText = typeof event.title === "string" ? event.title : "";
+  const ariaLabel = titleText
+    ? `${titleText}, ${formatYear(event.year)}`
+    : undefined;
+  return (
+    <div
+      aria-label={ariaLabel}
+      className="absolute top-1/2 z-10 -translate-x-1/2 -translate-y-1/2"
+      data-event-id={event.id}
+      data-event-year={event.year}
+      style={{ left: `${left.toString()}%` }}
+    >
+      <div
+        aria-hidden="true"
+        className={cn(
+          "h-3 w-3 rounded-full border-2 ring-2 ring-background",
+          palette.marker,
+        )}
+      />
+      <div className="absolute left-1/2 top-4 w-44 -translate-x-1/2 text-center">
+        {event.href ? (
+          <a
+            className="block truncate text-xs font-medium text-foreground underline-offset-4 hover:underline"
+            href={event.href}
+          >
+            {event.title}
+          </a>
+        ) : (
+          <p className="truncate text-xs font-medium text-foreground">
+            {event.title}
+          </p>
+        )}
+        <p className="truncate text-[10px] text-muted-foreground">
+          {formatYear(event.year)}
+          {event.description ? <span> · {event.description}</span> : null}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+type EventLaneProps = {
+  categories: HistoricCategory[];
+  endYear: number;
+  events: HistoricEvent[];
+  startYear: number;
+};
+
+function EventLane({
+  categories,
+  endYear,
+  events,
+  startYear,
+}: EventLaneProps): ReactNode {
+  return (
+    <div className="relative h-20">
+      <div className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-border" />
+      {events.map((event) => (
+        <EventMarker
+          categories={categories}
+          endYear={endYear}
+          event={event}
+          key={event.id}
+          startYear={startYear}
+        />
+      ))}
+    </div>
+  );
+}
+
+type LegendProps = {
+  categories: HistoricCategory[];
+};
+
+function Legend({ categories }: LegendProps): ReactNode {
+  if (categories.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1.5 border-t border-border px-3 py-2 text-xs">
+      {categories.map((category) => {
+        const palette = COLOR_PALETTE[category.color ?? "neutral"];
+        return (
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full px-2 py-0.5",
+              palette.chip,
+            )}
+            data-category-id={category.id}
+            key={category.id}
+          >
+            <span
+              aria-hidden="true"
+              className={cn("h-2 w-2 rounded-full", palette.marker)}
+            />
+            {category.label}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Specialized timeline for historical events spanning centuries or
+ * millennia. Renders era bands as a background layer, period bars in a
+ * lane, and point events as markers. Negative years format as `BCE`,
+ * positive as `CE`. Composes nothing — pure CSS.
+ *
+ * @example
+ * ```tsx
+ * <HistoricTimeline
+ *   startYear={-500}
+ *   endYear={2025}
+ *   eras={[{ id: "ancient", name: "Ancient", startYear: -3000, endYear: 476, color: "amber" }]}
+ *   periods={[{ id: "100yr", title: "Hundred Years' War", startYear: 1337, endYear: 1453, category: "conflict" }]}
+ *   events={[
+ *     { id: "olympics", year: -776, title: "First Olympic Games", category: "culture" },
+ *     { id: "moon", year: 1969, title: "Moon landing", category: "science" },
+ *   ]}
+ *   categories={[
+ *     { id: "culture", label: "Culture", color: "amber" },
+ *     { id: "science", label: "Science", color: "blue" },
+ *     { id: "conflict", label: "Conflict", color: "red" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const HistoricTimeline = forwardRef<HTMLElement, HistoricTimelineProps>(
+  (props, ref) => {
+    const {
+      categories = [],
+      className,
+      endYear,
+      eras = [],
+      events = [],
+      labels,
+      periods = [],
+      startYear,
+      tickCount = DEFAULT_TICK_COUNT,
+      ...rest
+    } = props;
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const ticks = useMemo(
+      () => buildTicks(startYear, endYear, tickCount),
+      [endYear, startYear, tickCount],
+    );
+
+    return (
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "flex w-full flex-col overflow-hidden rounded-2xl border bg-background text-foreground",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <Axis ticks={ticks} />
+        <EraLabels endYear={endYear} eras={eras} startYear={startYear} />
+        <PeriodLane
+          categories={categories}
+          endYear={endYear}
+          periods={periods}
+          startYear={startYear}
+        />
+        <div className="relative">
+          <EraBands endYear={endYear} eras={eras} startYear={startYear} />
+          <EventLane
+            categories={categories}
+            endYear={endYear}
+            events={events}
+            startYear={startYear}
+          />
+        </div>
+        <Legend categories={categories} />
+      </section>
+    );
+  },
+);
+HistoricTimeline.displayName = "HistoricTimeline";

--- a/packages/ui/src/components/historic-timeline/historic-timeline.visual.tsx
+++ b/packages/ui/src/components/historic-timeline/historic-timeline.visual.tsx
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import {
+  type HistoricCategory,
+  type HistoricEra,
+  type HistoricEvent,
+  type HistoricPeriod,
+  HistoricTimeline,
+} from "./historic-timeline";
+
+const ERAS: HistoricEra[] = [
+  { color: "amber", endYear: 476, id: "ancient", name: "Ancient", startYear: -3000 },
+  { color: "emerald", endYear: 1453, id: "medieval", name: "Medieval", startYear: 476 },
+  { color: "blue", endYear: 2025, id: "modern", name: "Modern", startYear: 1453 },
+];
+
+const CATEGORIES: HistoricCategory[] = [
+  { color: "amber", id: "culture", label: "Culture" },
+  { color: "blue", id: "science", label: "Science" },
+  { color: "red", id: "conflict", label: "Conflict" },
+];
+
+const EVENTS: HistoricEvent[] = [
+  { category: "culture", id: "olympics", title: "First Olympics", year: -776 },
+  { category: "culture", id: "rome-founded", title: "Rome founded", year: -753 },
+  { category: "conflict", id: "fall-rome", title: "Fall of Western Rome", year: 476 },
+  { category: "science", id: "press", title: "Printing press", year: 1450 },
+  { category: "science", id: "moon", title: "Moon landing", year: 1969 },
+];
+
+const PERIODS: HistoricPeriod[] = [
+  {
+    category: "conflict",
+    endYear: 1453,
+    id: "100yr",
+    startYear: 1337,
+    title: "Hundred Years' War",
+  },
+];
+
+test.describe("HistoricTimeline Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <HistoricTimeline
+        categories={CATEGORIES}
+        endYear={2025}
+        eras={ERAS}
+        events={EVENTS}
+        periods={PERIODS}
+        startYear={-3000}
+      />,
+    );
+    await expect(component).toHaveScreenshot(
+      "historic-timeline-default.png",
+    );
+  });
+});

--- a/packages/ui/src/components/historic-timeline/index.ts
+++ b/packages/ui/src/components/historic-timeline/index.ts
@@ -1,0 +1,10 @@
+export {
+  type HistoricCategory,
+  type HistoricColor,
+  type HistoricEra,
+  type HistoricEvent,
+  type HistoricPeriod,
+  HistoricTimeline,
+  type HistoricTimelineLabels,
+  type HistoricTimelineProps,
+} from "./historic-timeline";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -202,6 +202,16 @@ export {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "./alert-dialog";
+export {
+  type HistoricCategory,
+  type HistoricColor,
+  type HistoricEra,
+  type HistoricEvent,
+  type HistoricPeriod,
+  HistoricTimeline,
+  type HistoricTimelineLabels,
+  type HistoricTimelineProps,
+} from "./historic-timeline";
 export { HoverCard, HoverCardContent, HoverCardTrigger } from "./hover-card";
 export {
   ContextMenu,


### PR DESCRIPTION
Closes #33.

Specialized timeline for historical events spanning centuries or millennia. Renders era bands as a background layer, period bars in a lane, and BCE/CE point markers driven by category color. Data-driven and presentation-only.

## What's in
- `packages/ui/src/components/historic-timeline/historic-timeline.tsx` — `"use client"` (uses `useMemo`), forwarded ref, props for `eras`, `periods`, `events`, `categories`, `startYear`/`endYear`, `tickCount`.
- `*.test.tsx` — rendering, BCE/CE formatting, link mode, window-clipping, and `data-event-id` / `data-event-year` attributes.
- `*.visual.tsx` + `*.stories.tsx` (Default, TightWindow, NoCategories, PeriodsOnly) + `*.mdx`.
- `index.ts` re-exports + barrel export from `packages/ui/src/components/index.ts`.
- Registry shim + `registry.json` entry under `data-display`.

## Out of scope (per spec)
Zoom / pan / minimap / search / clustering / detail panel / print mode — driven by re-rendering with a narrower window instead.

## Quality gates
- lint PASS
- typecheck PASS
- check:use-client PASS (180 components verified)
- check-story-coverage PASS (170/170)
- verify-stories PASS
- build PASS
- test PASS (501/501)
- build-storybook PASS