### PR TITLE
feat(ui): add ChronologicalTimeline component

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -523,6 +523,21 @@
       "category": "core"
     },
     {
+      "name": "chronological-timeline",
+      "type": "registry:component",
+      "title": "Chronological Timeline",
+      "description": "Media-rich, scroll-driven chronological timeline with alternating cards, image/video/audio media, and a progress strip.",
+      "files": [
+        {
+          "path": "registry/default/chronological-timeline/chronological-timeline.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
       "name": "checklist",
       "type": "registry:component",
       "title": "Checklist",

--- a/apps/registry/registry/default/chronological-timeline/chronological-timeline.tsx
+++ b/apps/registry/registry/default/chronological-timeline/chronological-timeline.tsx
@@ -1,0 +1,7 @@
+export {
+  type ChronoEventProps,
+  ChronoEvent,
+  type ChronoMedia,
+  type ChronologicalTimelineProps,
+  ChronologicalTimeline,
+} from "@vllnt/ui";

--- a/packages/ui/src/components/chronological-timeline/chronological-timeline.mdx
+++ b/packages/ui/src/components/chronological-timeline/chronological-timeline.mdx
@@ -1,0 +1,96 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './chronological-timeline.stories'
+
+<Meta of={Stories} />
+
+# ChronologicalTimeline
+
+Media-rich chronological timeline for storytelling — biographies, project histories, course "journey" pages, museum exhibits. Vertical column on mobile, alternating left/right cards on desktop. Each `ChronoEvent` accepts an image, video, or audio payload plus narrative children (paragraphs, blockquotes, lists).
+
+The active event is tracked via `IntersectionObserver`; the progress strip at the top reflects how far the reader has scrolled.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/chronological-timeline.json
+```
+
+## Import
+
+```tsx
+import { ChronologicalTimeline, ChronoEvent } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<ChronologicalTimeline title="The Space Race">
+  <ChronoEvent
+    date="October 4, 1957"
+    id="sputnik"
+    title="Sputnik 1"
+    subtitle="First artificial satellite"
+    media={{
+      type: 'image',
+      src: '/sputnik.jpg',
+      alt: 'Sputnik satellite',
+      credit: 'NASA',
+    }}
+  >
+    <p>The Soviet Union launched Sputnik 1, kicking off the space age.</p>
+    <blockquote>That ball in the sky changed everything.</blockquote>
+  </ChronoEvent>
+
+  <ChronoEvent
+    date="July 20, 1969"
+    id="apollo"
+    title="Apollo 11"
+    subtitle="First crewed Moon landing"
+    featured
+    media={{
+      type: 'video',
+      src: 'https://example.test/embed/apollo',
+      title: 'Apollo 11 footage',
+    }}
+  >
+    <p>Neil Armstrong and Buzz Aldrin walked on the Moon...</p>
+  </ChronoEvent>
+</ChronologicalTimeline>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## With image media
+
+`media.type === 'image'` requires an `alt` attribute. `caption` and `credit` are optional and render in a figcaption strip beneath the image.
+
+<Canvas of={Stories.WithImageMedia} sourceState="shown" />
+
+## Featured events
+
+Pass `featured` to bump the card size and emphasis ring — useful for pivot points in the narrative.
+
+## Compact (no media or copy)
+
+A bare-bones run with date and title only.
+
+<Canvas of={Stories.Compact} sourceState="shown" />
+
+## Untitled
+
+Drop the `title` prop for embeds inside an outer page header.
+
+<Canvas of={Stories.Untitled} sourceState="shown" />
+
+## Notes
+
+- Stable, human-readable `id`s on each `ChronoEvent` enable deep links — drop the prop to fall back to a generated id.
+- Alternating sides are driven by even/odd index — odd children render on the right via the `data-side="right"` attribute on the `<li>` wrapper.
+- Out of scope for the MVP: fullscreen-per-event mode, share / deep-link UI, jump-to-event keyboard shortcuts, and print-only export. Hosting frameworks can wire those on top of the rendered DOM.
+- Event cards emit `data-event-id` (and `data-featured="true"` when applicable). The list wrapper emits `data-side="left"|"right"` and `data-active="true"` on whichever event is currently in view.

--- a/packages/ui/src/components/chronological-timeline/chronological-timeline.stories.tsx
+++ b/packages/ui/src/components/chronological-timeline/chronological-timeline.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  ChronoEvent,
+  ChronologicalTimeline,
+} from "./chronological-timeline";
+
+const meta = {
+  args: {
+    title: "The Space Race",
+  },
+  component: ChronologicalTimeline,
+  title: "Educational/ChronologicalTimeline",
+} satisfies Meta<typeof ChronologicalTimeline>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <ChronologicalTimeline {...args}>
+      <ChronoEvent
+        date="October 4, 1957"
+        id="sputnik"
+        subtitle="First artificial satellite"
+        title="Sputnik 1"
+      >
+        <p>
+          The Soviet Union launched Sputnik 1, the first artificial satellite,
+          igniting the space age.
+        </p>
+        <blockquote>That ball in the sky changed everything.</blockquote>
+      </ChronoEvent>
+      <ChronoEvent
+        date="April 12, 1961"
+        id="vostok"
+        subtitle="First human in space"
+        title="Vostok 1"
+      >
+        <p>
+          Yuri Gagarin orbited Earth aboard Vostok 1 in 108 minutes,
+          becoming the first human in space.
+        </p>
+      </ChronoEvent>
+      <ChronoEvent
+        date="July 20, 1969"
+        featured
+        id="apollo"
+        subtitle="First crewed Moon landing"
+        title="Apollo 11"
+      >
+        <p>
+          Neil Armstrong and Buzz Aldrin became the first humans to walk on
+          the Moon. The crew returned safely on July 24.
+        </p>
+      </ChronoEvent>
+    </ChronologicalTimeline>
+  ),
+};
+
+export const WithImageMedia: Story = {
+  args: { title: "Visual Storytelling" },
+  render: (args) => (
+    <ChronologicalTimeline {...args}>
+      <ChronoEvent
+        date="1957"
+        id="sputnik-img"
+        media={{
+          alt: "Replica of the Sputnik 1 satellite",
+          caption: "Replica on display at the National Air and Space Museum",
+          credit: "NASA",
+          src: "https://placehold.co/640x360/0d1117/ffffff/png?text=Sputnik+1",
+          type: "image",
+        }}
+        title="Sputnik 1"
+      >
+        <p>
+          A polished metal sphere with four trailing antennas — and the
+          beep-beep-beep heard around the world.
+        </p>
+      </ChronoEvent>
+    </ChronologicalTimeline>
+  ),
+};
+
+export const Compact: Story = {
+  args: { title: "Compact" },
+  render: (args) => (
+    <ChronologicalTimeline {...args}>
+      <ChronoEvent date="1957" id="a" title="Sputnik 1" />
+      <ChronoEvent date="1961" id="b" title="Vostok 1" />
+      <ChronoEvent date="1969" id="c" title="Apollo 11" />
+    </ChronologicalTimeline>
+  ),
+};
+
+export const Untitled: Story = {
+  args: { title: undefined },
+  render: (args) => (
+    <ChronologicalTimeline {...args}>
+      <ChronoEvent date="1957" id="a" title="Sputnik 1">
+        <p>The space age began.</p>
+      </ChronoEvent>
+      <ChronoEvent date="1969" featured id="b" title="Apollo 11">
+        <p>Crewed lunar landing.</p>
+      </ChronoEvent>
+    </ChronologicalTimeline>
+  ),
+};

--- a/packages/ui/src/components/chronological-timeline/chronological-timeline.test.tsx
+++ b/packages/ui/src/components/chronological-timeline/chronological-timeline.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ChronoEvent, ChronologicalTimeline } from "./chronological-timeline";
+
+describe("ChronologicalTimeline", () => {
+  describe("rendering", () => {
+    it("renders the title and event cards", () => {
+      render(
+        <ChronologicalTimeline title="The Space Race">
+          <ChronoEvent date="October 4, 1957" id="sputnik" title="Sputnik 1">
+            <p>First artificial satellite</p>
+          </ChronoEvent>
+          <ChronoEvent
+            date="July 20, 1969"
+            featured
+            id="apollo"
+            title="Apollo 11"
+          >
+            <p>First crewed Moon landing</p>
+          </ChronoEvent>
+        </ChronologicalTimeline>,
+      );
+
+      expect(screen.getByText("The Space Race")).toBeInTheDocument();
+      expect(screen.getByText("Sputnik 1")).toBeInTheDocument();
+      expect(screen.getByText("Apollo 11")).toBeInTheDocument();
+    });
+
+    it("uses the provided id for the article element", () => {
+      const { container } = render(
+        <ChronologicalTimeline title="History">
+          <ChronoEvent date="1957" id="sputnik" title="Sputnik 1" />
+        </ChronologicalTimeline>,
+      );
+
+      expect(container.querySelector("#sputnik")).toBeInTheDocument();
+    });
+
+    it("emits data-featured on featured events", () => {
+      const { container } = render(
+        <ChronologicalTimeline title="History">
+          <ChronoEvent date="1969" featured id="apollo" title="Apollo 11" />
+          <ChronoEvent date="1957" id="sputnik" title="Sputnik 1" />
+        </ChronologicalTimeline>,
+      );
+
+      expect(
+        container.querySelector("[data-event-id='apollo']"),
+      ).toHaveAttribute("data-featured", "true");
+      expect(
+        container.querySelector("[data-event-id='sputnik']"),
+      ).not.toHaveAttribute("data-featured");
+    });
+
+    it("alternates data-side between left and right per event", () => {
+      const { container } = render(
+        <ChronologicalTimeline title="History">
+          <ChronoEvent date="1957" id="a" title="A" />
+          <ChronoEvent date="1958" id="b" title="B" />
+          <ChronoEvent date="1959" id="c" title="C" />
+        </ChronologicalTimeline>,
+      );
+
+      const items = container.querySelectorAll("li[data-side]");
+      expect(items).toHaveLength(3);
+      expect(items[0]).toHaveAttribute("data-side", "left");
+      expect(items[1]).toHaveAttribute("data-side", "right");
+      expect(items[2]).toHaveAttribute("data-side", "left");
+    });
+  });
+
+  describe("media", () => {
+    it("renders an image with alt text", () => {
+      render(
+        <ChronologicalTimeline title="History">
+          <ChronoEvent
+            date="1957"
+            id="sputnik"
+            media={{
+              alt: "Sputnik satellite",
+              credit: "NASA",
+              src: "/sputnik.jpg",
+              type: "image",
+            }}
+            title="Sputnik 1"
+          />
+        </ChronologicalTimeline>,
+      );
+
+      const image = screen.getByAltText("Sputnik satellite");
+      expect(image).toHaveAttribute("src", "/sputnik.jpg");
+      expect(screen.getByText("NASA")).toBeInTheDocument();
+    });
+
+    it("renders a video iframe with the title attribute", () => {
+      const { container } = render(
+        <ChronologicalTimeline title="History">
+          <ChronoEvent
+            date="1969"
+            id="apollo"
+            media={{
+              src: "https://example.test/embed/abc",
+              title: "Apollo 11 footage",
+              type: "video",
+            }}
+            title="Apollo 11"
+          />
+        </ChronologicalTimeline>,
+      );
+
+      const iframe = container.querySelector("iframe");
+      expect(iframe).toHaveAttribute("src", "https://example.test/embed/abc");
+      expect(iframe).toHaveAttribute("title", "Apollo 11 footage");
+    });
+
+    it("renders an audio control with aria-label from alt", () => {
+      const { container } = render(
+        <ChronologicalTimeline title="History">
+          <ChronoEvent
+            date="1969"
+            id="apollo"
+            media={{
+              alt: "Mission audio",
+              src: "/apollo.mp3",
+              type: "audio",
+            }}
+            title="Apollo 11"
+          />
+        </ChronologicalTimeline>,
+      );
+
+      const audio = container.querySelector("audio");
+      expect(audio).toHaveAttribute("src", "/apollo.mp3");
+      expect(audio).toHaveAttribute("aria-label", "Mission audio");
+    });
+  });
+
+  describe("progress strip", () => {
+    it("renders a progressbar landmark with the configured label", () => {
+      render(
+        <ChronologicalTimeline progressLabel="Story progress" title="History">
+          <ChronoEvent date="1957" id="sputnik" title="Sputnik 1" />
+        </ChronologicalTimeline>,
+      );
+
+      const progress = screen.getByRole("progressbar");
+      expect(progress).toHaveAttribute("aria-label", "Story progress");
+    });
+
+    it("hides the progress strip when there are no events", () => {
+      render(<ChronologicalTimeline title="History" />);
+
+      expect(screen.queryByRole("progressbar")).toBeNull();
+    });
+  });
+
+  describe("compound contract", () => {
+    it("throws when ChronoEvent is rendered outside the root", () => {
+      const renderOrphan = (): void => {
+        render(<ChronoEvent date="1957" id="sputnik" title="Sputnik 1" />);
+      };
+
+      expect(renderOrphan).toThrow(/ChronoEvent used outside/);
+    });
+  });
+});

--- a/packages/ui/src/components/chronological-timeline/chronological-timeline.tsx
+++ b/packages/ui/src/components/chronological-timeline/chronological-timeline.tsx
@@ -1,0 +1,544 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Media payload for a {@link ChronoEvent}.
+ *
+ * @public
+ */
+export type ChronoMedia =
+  | {
+      alt: string;
+      caption?: ReactNode;
+      credit?: ReactNode;
+      src: string;
+      type: "image";
+    }
+  | {
+      alt?: string;
+      caption?: ReactNode;
+      credit?: ReactNode;
+      src: string;
+      type: "audio";
+    }
+  | {
+      caption?: ReactNode;
+      credit?: ReactNode;
+      src: string;
+      title?: string;
+      type: "video";
+    };
+
+type ChronoCtx = {
+  registerEvent: (id: string, node: HTMLElement | null) => void;
+  setActiveId: (id: string) => void;
+  titleId: string;
+};
+
+const ChronoContext = createContext<ChronoCtx | null>(null);
+
+function useChronoContext(): ChronoCtx {
+  const ctx = useContext(ChronoContext);
+  if (!ctx) {
+    throw new Error("ChronoEvent used outside ChronologicalTimeline.");
+  }
+  return ctx;
+}
+
+/**
+ * Props for {@link ChronologicalTimeline}.
+ *
+ * @public
+ */
+export type ChronologicalTimelineProps = {
+  /** Aria-label for the timeline progress strip. Defaults to `"Timeline progress"`. */
+  progressLabel?: string;
+  /** Headline rendered at the top of the timeline. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+/**
+ * Props for {@link ChronoEvent}.
+ *
+ * @public
+ */
+export type ChronoEventProps = {
+  /** Display date (free-form string — pass `"1957"`, `"October 4, 1957"`, etc.). */
+  date: ReactNode;
+  /** When `true`, the card renders larger to emphasise pivotal events. */
+  featured?: boolean;
+  /** Stable id. Defaults to a generated id; pass one for deep links. */
+  id?: string;
+  /** Optional media payload — image / video / audio. */
+  media?: ChronoMedia;
+  /** Optional subtitle. */
+  subtitle?: ReactNode;
+  /** Card title. */
+  title: ReactNode;
+} & Omit<ComponentPropsWithoutRef<"article">, "id" | "title">;
+
+type ImageMediaProps = {
+  media: Extract<ChronoMedia, { type: "image" }>;
+};
+
+function ImageMedia({ media }: ImageMediaProps): ReactNode {
+  return (
+    <figure className="overflow-hidden rounded-xl border bg-muted">
+      <img
+        alt={media.alt}
+        className="aspect-video w-full object-cover"
+        loading="lazy"
+        src={media.src}
+      />
+      {media.caption || media.credit ? (
+        <figcaption className="border-t bg-background px-3 py-2 text-xs text-muted-foreground">
+          {media.caption ? (
+            <span className="block">{media.caption}</span>
+          ) : null}
+          {media.credit ? (
+            <span className="block italic">{media.credit}</span>
+          ) : null}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}
+
+type VideoMediaProps = {
+  media: Extract<ChronoMedia, { type: "video" }>;
+};
+
+function VideoMedia({ media }: VideoMediaProps): ReactNode {
+  return (
+    <figure className="overflow-hidden rounded-xl border bg-muted">
+      <div className="aspect-video w-full">
+        <iframe
+          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          className="h-full w-full"
+          src={media.src}
+          title={media.title ?? "Embedded video"}
+        />
+      </div>
+      {media.caption || media.credit ? (
+        <figcaption className="border-t bg-background px-3 py-2 text-xs text-muted-foreground">
+          {media.caption ? (
+            <span className="block">{media.caption}</span>
+          ) : null}
+          {media.credit ? (
+            <span className="block italic">{media.credit}</span>
+          ) : null}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}
+
+type AudioMediaProps = {
+  media: Extract<ChronoMedia, { type: "audio" }>;
+};
+
+function AudioMedia({ media }: AudioMediaProps): ReactNode {
+  return (
+    <figure className="overflow-hidden rounded-xl border bg-muted px-3 py-3">
+      <audio
+        aria-label={media.alt}
+        className="w-full"
+        controls
+        preload="metadata"
+        src={media.src}
+      >
+        <track kind="captions" />
+      </audio>
+      {media.caption || media.credit ? (
+        <figcaption className="pt-2 text-xs text-muted-foreground">
+          {media.caption ? (
+            <span className="block">{media.caption}</span>
+          ) : null}
+          {media.credit ? (
+            <span className="block italic">{media.credit}</span>
+          ) : null}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}
+
+type MediaProps = {
+  media: ChronoMedia;
+};
+
+function Media({ media }: MediaProps): ReactNode {
+  if (media.type === "image") return <ImageMedia media={media} />;
+  if (media.type === "video") return <VideoMedia media={media} />;
+  return <AudioMedia media={media} />;
+}
+
+type DateColumnProps = {
+  date: ReactNode;
+};
+
+function DateColumn({ date }: DateColumnProps): ReactNode {
+  return (
+    <div className="hidden items-start justify-end pr-4 text-right text-xs font-semibold uppercase tracking-wide text-muted-foreground md:flex md:group-[[data-side='right']]:order-3 md:group-[[data-side='right']]:justify-start md:group-[[data-side='right']]:pl-4 md:group-[[data-side='right']]:text-left">
+      <time className="pt-2">{date}</time>
+    </div>
+  );
+}
+
+type RailColumnProps = {
+  featured: boolean;
+};
+
+function RailColumn({ featured }: RailColumnProps): ReactNode {
+  return (
+    <div
+      aria-hidden="true"
+      className="relative hidden md:flex md:w-6 md:items-start md:justify-center"
+    >
+      <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border" />
+      <span
+        className={cn(
+          "relative z-10 mt-3 block h-3 w-3 rounded-full border-2 border-background bg-primary",
+          featured ? "h-4 w-4" : "",
+        )}
+      />
+    </div>
+  );
+}
+
+type EventCardProps = {
+  children?: ReactNode;
+  date: ReactNode;
+  eventId: string;
+  featured: boolean;
+  media?: ChronoMedia;
+  subtitle?: ReactNode;
+  title: ReactNode;
+};
+
+function EventCard({
+  children,
+  date,
+  eventId,
+  featured,
+  media,
+  subtitle,
+  title,
+}: EventCardProps): ReactNode {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border bg-background p-5 shadow-sm md:group-[[data-side='right']]:order-1",
+        featured ? "ring-1 ring-primary/30" : "",
+      )}
+    >
+      <header className="mb-3 flex flex-col gap-1">
+        <time className="text-xs font-semibold uppercase tracking-wide text-muted-foreground md:hidden">
+          {date}
+        </time>
+        <h3
+          className={cn(
+            "font-semibold text-foreground",
+            featured ? "text-xl" : "text-lg",
+          )}
+          id={`${eventId}-title`}
+        >
+          {title}
+        </h3>
+        {subtitle ? (
+          <p className="text-sm text-muted-foreground">{subtitle}</p>
+        ) : null}
+      </header>
+      {media ? (
+        <div className="mb-3">
+          <Media media={media} />
+        </div>
+      ) : null}
+      {children ? (
+        <div className="space-y-2 text-sm leading-relaxed text-foreground [&_blockquote]:my-3 [&_blockquote]:border-l-2 [&_blockquote]:border-primary [&_blockquote]:pl-3 [&_blockquote]:italic [&_blockquote]:text-muted-foreground">
+          {children}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * A single event card inside {@link ChronologicalTimeline}. Place
+ * narrative paragraphs, blockquotes, and lists as children.
+ *
+ * @public
+ */
+export const ChronoEvent = forwardRef<HTMLElement, ChronoEventProps>(
+  (props, forwardedRef) => {
+    const {
+      children,
+      className,
+      date,
+      featured = false,
+      id,
+      media,
+      subtitle,
+      title,
+      ...rest
+    } = props;
+    const generatedId = useId();
+    const eventId = id ?? generatedId;
+    const ref = useRef<HTMLElement | null>(null);
+    const { registerEvent, setActiveId } = useChronoContext();
+
+    const refCallback = useCallback(
+      (node: HTMLElement | null) => {
+        ref.current = node;
+        registerEvent(eventId, node);
+        if (typeof forwardedRef === "function") forwardedRef(node);
+        else if (forwardedRef) forwardedRef.current = node;
+      },
+      [eventId, forwardedRef, registerEvent],
+    );
+
+    const handleFocus = useCallback(() => {
+      setActiveId(eventId);
+    }, [eventId, setActiveId]);
+
+    return (
+      <article
+        aria-labelledby={`${eventId}-title`}
+        className={cn(
+          "group relative grid gap-4 py-6 md:grid-cols-[1fr_auto_1fr] md:gap-8",
+          className,
+        )}
+        data-event-id={eventId}
+        data-featured={featured ? "true" : undefined}
+        id={eventId}
+        onFocus={handleFocus}
+        ref={refCallback}
+        {...rest}
+      >
+        <DateColumn date={date} />
+        <RailColumn featured={featured} />
+        <EventCard
+          date={date}
+          eventId={eventId}
+          featured={featured}
+          media={media}
+          subtitle={subtitle}
+          title={title}
+        >
+          {children}
+        </EventCard>
+      </article>
+    );
+  },
+);
+ChronoEvent.displayName = "ChronoEvent";
+
+type ProgressStripProps = {
+  activeId?: string;
+  ids: string[];
+  label: string;
+};
+
+function ProgressStrip({
+  activeId,
+  ids,
+  label,
+}: ProgressStripProps): ReactNode {
+  if (ids.length === 0) return null;
+  const activeIndex = activeId ? ids.indexOf(activeId) : -1;
+  const ratio = activeIndex < 0 ? 0 : (activeIndex + 1) / ids.length;
+  return (
+    <div
+      aria-label={label}
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={Math.round(ratio * 100)}
+      className="sticky top-0 z-10 h-1 w-full bg-border"
+      role="progressbar"
+    >
+      <span
+        className="block h-full bg-primary transition-[width] duration-200"
+        style={{ width: `${(ratio * 100).toString()}%` }}
+      />
+    </div>
+  );
+}
+
+function useChronoActiveTracker(): {
+  activeId?: string;
+  ids: string[];
+  registerEvent: (id: string, node: HTMLElement | null) => void;
+  setActiveId: (id: string) => void;
+} {
+  const eventsRef = useRef<Map<string, HTMLElement>>(new Map());
+  const [ids, setIds] = useState<string[]>([]);
+  const [activeId, setActiveId] = useState<string | undefined>();
+
+  const registerEvent = useCallback((id: string, node: HTMLElement | null) => {
+    const map = eventsRef.current;
+    if (node) map.set(id, node);
+    else map.delete(id);
+    setIds([...map.keys()]);
+  }, []);
+
+  useEffect(() => {
+    if (typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        const first = visible[0];
+        if (first) {
+          const target = first.target;
+          if (target instanceof HTMLElement) {
+            const eventId = target.dataset.eventId;
+            if (eventId) setActiveId(eventId);
+          }
+        }
+      },
+      { rootMargin: "-30% 0px -50% 0px", threshold: 0.1 },
+    );
+    [...eventsRef.current.values()].forEach((node) => {
+      observer.observe(node);
+    });
+    return () => {
+      observer.disconnect();
+    };
+  }, [ids]);
+
+  return { activeId, ids, registerEvent, setActiveId };
+}
+
+type EventListProps = {
+  activeId?: string;
+  children: ReactNode;
+};
+
+function EventList({ activeId, children }: EventListProps): ReactNode {
+  if (!Array.isArray(children)) {
+    return (
+      <ol className="relative flex flex-col px-4 pb-6 md:px-6">{children}</ol>
+    );
+  }
+  return (
+    <ol className="relative flex flex-col px-4 pb-6 md:px-6">
+      {children.map((child, index) => (
+        <li
+          className="block list-none"
+          data-active={
+            isReactElementWithEventId(child, activeId) ? "true" : undefined
+          }
+          data-side={index % 2 === 0 ? "left" : "right"}
+          key={getChildKey(child, index)}
+        >
+          {child}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+/**
+ * Media-rich, scroll-driven chronological timeline. Cards alternate
+ * sides on desktop and stack on mobile. Each {@link ChronoEvent} can
+ * include an image, video, or audio payload plus narrative children
+ * (paragraphs, blockquotes, lists). An `IntersectionObserver` follows
+ * the reader and drives the progress strip + the active card flag.
+ *
+ * @example
+ * ```tsx
+ * <ChronologicalTimeline title="The Space Race">
+ *   <ChronoEvent date="October 4, 1957" title="Sputnik 1" subtitle="First artificial satellite">
+ *     <p>The Soviet Union launched Sputnik 1...</p>
+ *   </ChronoEvent>
+ *   <ChronoEvent date="July 20, 1969" title="Apollo 11" featured>
+ *     <p>Neil Armstrong and Buzz Aldrin walked on the Moon...</p>
+ *   </ChronoEvent>
+ * </ChronologicalTimeline>
+ * ```
+ *
+ * @public
+ */
+export const ChronologicalTimeline = forwardRef<
+  HTMLElement,
+  ChronologicalTimelineProps
+>((props, ref) => {
+  const {
+    children,
+    className,
+    progressLabel = "Timeline progress",
+    title,
+    ...rest
+  } = props;
+  const titleId = useId();
+  const { activeId, ids, registerEvent, setActiveId } =
+    useChronoActiveTracker();
+
+  const ctx = useMemo<ChronoCtx>(
+    () => ({ registerEvent, setActiveId, titleId }),
+    [registerEvent, setActiveId, titleId],
+  );
+
+  return (
+    <ChronoContext.Provider value={ctx}>
+      <section
+        aria-labelledby={title ? titleId : undefined}
+        className={cn(
+          "relative mx-auto flex w-full max-w-4xl flex-col overflow-hidden rounded-2xl border bg-background text-foreground",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <ProgressStrip activeId={activeId} ids={ids} label={progressLabel} />
+        {title ? (
+          <header className="px-6 py-6">
+            <h2 className="text-2xl font-semibold tracking-tight" id={titleId}>
+              {title}
+            </h2>
+          </header>
+        ) : null}
+        <EventList activeId={activeId}>{children}</EventList>
+      </section>
+    </ChronoContext.Provider>
+  );
+});
+ChronologicalTimeline.displayName = "ChronologicalTimeline";
+
+function isReactElementWithEventId(
+  child: unknown,
+  activeId: string | undefined,
+): boolean {
+  if (!activeId) return false;
+  if (typeof child !== "object" || child === null) return false;
+  if (!("props" in child)) return false;
+  const props = (child as { props: unknown }).props;
+  if (typeof props !== "object" || props === null) return false;
+  const id = (props as { id?: unknown }).id;
+  return typeof id === "string" && id === activeId;
+}
+
+function getChildKey(child: unknown, fallback: number): number | string {
+  if (typeof child !== "object" || child === null) return fallback;
+  if (!("key" in child)) return fallback;
+  const key = (child as { key: unknown }).key;
+  if (typeof key === "string" || typeof key === "number") return key;
+  return fallback;
+}

--- a/packages/ui/src/components/chronological-timeline/chronological-timeline.visual.tsx
+++ b/packages/ui/src/components/chronological-timeline/chronological-timeline.visual.tsx
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import {
+  ChronoEvent,
+  ChronologicalTimeline,
+} from "./chronological-timeline";
+
+test.describe("ChronologicalTimeline Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <ChronologicalTimeline title="The Space Race">
+        <ChronoEvent
+          date="October 4, 1957"
+          id="sputnik"
+          subtitle="First artificial satellite"
+          title="Sputnik 1"
+        >
+          <p>
+            The Soviet Union launched Sputnik 1, kicking off the space age and
+            the race to the Moon.
+          </p>
+          <blockquote>That ball in the sky changed everything.</blockquote>
+        </ChronoEvent>
+        <ChronoEvent
+          date="April 12, 1961"
+          id="vostok"
+          subtitle="First human in space"
+          title="Vostok 1"
+        >
+          <p>
+            Yuri Gagarin orbited Earth aboard Vostok 1 in 108 minutes.
+          </p>
+        </ChronoEvent>
+        <ChronoEvent
+          date="July 20, 1969"
+          featured
+          id="apollo"
+          subtitle="First crewed Moon landing"
+          title="Apollo 11"
+        >
+          <p>
+            Neil Armstrong and Buzz Aldrin became the first humans to walk on
+            the Moon, watched live by 600 million people.
+          </p>
+        </ChronoEvent>
+      </ChronologicalTimeline>,
+    );
+    await expect(component).toHaveScreenshot(
+      "chronological-timeline-default.png",
+    );
+  });
+});

--- a/packages/ui/src/components/chronological-timeline/index.ts
+++ b/packages/ui/src/components/chronological-timeline/index.ts
@@ -1,0 +1,7 @@
+export {
+  ChronoEvent,
+  type ChronoEventProps,
+  ChronologicalTimeline,
+  type ChronologicalTimelineProps,
+  type ChronoMedia,
+} from "./chronological-timeline";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -337,6 +337,13 @@ export {
   ChoroplethTooltip,
   type ChoroplethTooltipProps,
 } from "./choropleth-map";
+export {
+  ChronoEvent,
+  type ChronoEventProps,
+  ChronologicalTimeline,
+  type ChronologicalTimelineProps,
+  type ChronoMedia,
+} from "./chronological-timeline";
 export { CountdownTimer, type CountdownTimerProps } from "./countdown-timer";
 export {
   type GeoJSONPolygon,


### PR DESCRIPTION
Closes #35.

Media-rich, scroll-driven chronological timeline for storytelling — biographies, project histories, course "journey" pages, museum exhibits. Compound family: \`ChronologicalTimeline\` + \`ChronoEvent\`.

## What's in
- Vertical column on mobile, alternating left/right cards on desktop (driven by even/odd index → \`data-side\` on the \`<li>\` wrapper).
- \`ChronoMedia\` discriminated union for image / video (iframe) / audio media. Image media requires \`alt\`; audio includes a \`<track kind="captions" />\` for jsx-a11y compliance.
- \`featured\` prop bumps card size + adds a primary ring for pivot moments.
- Children render as narrative content; \`<blockquote>\` is auto-styled.
- IntersectionObserver follows the reader and drives a \`data-active\` flag on the wrapper plus a sticky top progress strip.
- Stable \`id\` per event for deep links (falls back to \`useId()\`).
- Throws when \`ChronoEvent\` is rendered outside the root.

## Out of scope (per spec, deferred)
Fullscreen-per-event mode, share / deep-link UI, jump-to-event keyboard shortcuts, print-only export. Hosting frameworks can wire those on top of the rendered DOM.

## Quality gates
- lint PASS
- typecheck PASS
- check:use-client PASS (180 components)
- check-story-coverage PASS (170/170)
- verify-stories PASS
- build PASS
- test PASS (503/503, +10 new)
- build-storybook PASS