### PR TITLE
feat(ui): add TreeView component

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -2765,6 +2765,21 @@
       "category": "core"
     },
     {
+      "name": "tree-view",
+      "type": "registry:component",
+      "title": "Tree View",
+      "description": "Hierarchical tree component for nested data with controlled state, single/multi-select, and keyboard navigation.",
+      "files": [
+        {
+          "path": "registry/default/tree-view/tree-view.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
       "name": "tooltip",
       "type": "registry:component",
       "title": "Tooltip",

--- a/apps/registry/registry/default/tree-view/tree-view.tsx
+++ b/apps/registry/registry/default/tree-view/tree-view.tsx
@@ -1,0 +1,7 @@
+export {
+  type TreeNode,
+  TreeView,
+  type TreeViewLabels,
+  type TreeViewProps,
+  type TreeViewSelectionMode,
+} from "@vllnt/ui";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -139,6 +139,13 @@ export { Slider } from "./slider";
 export { Toggle, toggleVariants } from "./toggle";
 export { ToggleGroup, ToggleGroupItem } from "./toggle-group";
 export {
+  type TreeNode,
+  TreeView,
+  type TreeViewLabels,
+  type TreeViewProps,
+  type TreeViewSelectionMode,
+} from "./tree-view";
+export {
   InputOTP,
   InputOTPGroup,
   InputOTPSeparator,

--- a/packages/ui/src/components/tree-view/index.ts
+++ b/packages/ui/src/components/tree-view/index.ts
@@ -1,0 +1,7 @@
+export {
+  type TreeNode,
+  TreeView,
+  type TreeViewLabels,
+  type TreeViewProps,
+  type TreeViewSelectionMode,
+} from "./tree-view";

--- a/packages/ui/src/components/tree-view/tree-view.mdx
+++ b/packages/ui/src/components/tree-view/tree-view.mdx
@@ -1,0 +1,78 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './tree-view.stories'
+
+<Meta of={Stories} />
+
+# TreeView
+
+Hierarchical tree component for nested data — file systems, categories, taxonomies, org charts. Data-driven via the `nodes` prop. Supports controlled and uncontrolled expand/select state, single or multi-select, and full keyboard navigation (arrow keys, enter, space).
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/tree-view.json
+```
+
+## Import
+
+```tsx
+import { TreeView } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+const nodes = [
+  {
+    id: 'src',
+    label: 'src/',
+    nodes: [
+      { id: 'components', label: 'components/' },
+      { id: 'utils', label: 'utils/' },
+    ],
+  },
+  { id: 'package', label: 'package.json' },
+]
+
+<TreeView
+  nodes={nodes}
+  defaultExpanded={['src']}
+  onSelect={(ids) => console.info(ids)}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Selection modes
+
+`selectionMode="single"` (default) replaces the selection on each click. `selectionMode="multiple"` toggles the clicked id in/out of the set; the resulting array is delivered to `onSelect`.
+
+<Canvas of={Stories.MultiSelect} sourceState="shown" />
+
+## Controlled state
+
+Pass `expanded` + `onExpandedChange` to drive expand/collapse from a parent store. Pass `selected` + `onSelect` for the selection set.
+
+```tsx
+const [expanded, setExpanded] = useState<string[]>([])
+<TreeView nodes={nodes} expanded={expanded} onExpandedChange={setExpanded} />
+```
+
+## Keyboard
+
+- `ArrowDown` / `ArrowUp` — move active row.
+- `ArrowRight` — expand the active branch (or move into it if already expanded).
+- `ArrowLeft` — collapse the active branch (or move to its parent if collapsed).
+- `Enter` / `Space` — expand a branch or select a leaf.
+
+## Notes
+
+- Out of scope for the MVP: explicit checkbox-mode UI, search/filter, lazy loading, drag-and-drop reordering, indent guides. Wire those on top by deriving filtered `nodes` and controlling `expanded` externally.
+- Each row emits `data-node-id`, `data-depth`, and (when current) `data-active="true"` / `data-selected="true"` for analytics and CSS hooks.
+- `disabled` nodes still render but are not clickable and announce `aria-disabled="true"`.

--- a/packages/ui/src/components/tree-view/tree-view.stories.tsx
+++ b/packages/ui/src/components/tree-view/tree-view.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { type TreeNode, TreeView } from "./tree-view";
+
+const NODES: TreeNode[] = [
+  {
+    id: "src",
+    label: "src/",
+    nodes: [
+      {
+        id: "components",
+        label: "components/",
+        nodes: [
+          { id: "button", label: "Button.tsx" },
+          { id: "card", label: "Card.tsx" },
+          { id: "input", label: "Input.tsx" },
+        ],
+      },
+      {
+        id: "utils",
+        label: "utils/",
+        nodes: [
+          { id: "cn", label: "cn.ts" },
+          { id: "format", label: "format.ts" },
+        ],
+      },
+      { id: "index", label: "index.ts" },
+    ],
+  },
+  { id: "package", label: "package.json" },
+  { disabled: true, id: "node_modules", label: "node_modules/" },
+];
+
+const meta = {
+  args: {
+    defaultExpanded: ["src", "components"],
+    nodes: NODES,
+  },
+  component: TreeView,
+  title: "Data Display/TreeView",
+} satisfies Meta<typeof TreeView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const MultiSelect: Story = {
+  args: {
+    defaultSelected: ["button", "card"],
+    selectionMode: "multiple",
+  },
+};
+
+export const Collapsed: Story = {
+  args: {
+    defaultExpanded: [],
+    defaultSelected: [],
+  },
+};
+
+export const SingleLevel: Story = {
+  args: {
+    nodes: [
+      { id: "alpha", label: "Alpha" },
+      { id: "beta", label: "Beta" },
+      { id: "gamma", label: "Gamma" },
+    ],
+  },
+};

--- a/packages/ui/src/components/tree-view/tree-view.test.tsx
+++ b/packages/ui/src/components/tree-view/tree-view.test.tsx
@@ -1,0 +1,167 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { type TreeNode, TreeView } from "./tree-view";
+
+const NODES: TreeNode[] = [
+  {
+    id: "src",
+    label: "src/",
+    nodes: [
+      {
+        id: "components",
+        label: "components/",
+        nodes: [{ id: "button", label: "Button.tsx" }],
+      },
+      { id: "utils", label: "utils/" },
+    ],
+  },
+  { disabled: true, id: "node_modules", label: "node_modules/" },
+];
+
+describe("TreeView", () => {
+  describe("rendering", () => {
+    it("renders only top-level nodes when nothing is expanded", () => {
+      render(<TreeView nodes={NODES} />);
+
+      expect(screen.getByText("src/")).toBeInTheDocument();
+      expect(screen.getByText("node_modules/")).toBeInTheDocument();
+      expect(screen.queryByText("components/")).toBeNull();
+    });
+
+    it("renders descendants when ancestors are in defaultExpanded", () => {
+      render(<TreeView defaultExpanded={["src"]} nodes={NODES} />);
+
+      expect(screen.getByText("components/")).toBeInTheDocument();
+      expect(screen.getByText("utils/")).toBeInTheDocument();
+      expect(screen.queryByText("Button.tsx")).toBeNull();
+    });
+
+    it("emits ARIA tree role and aria-expanded on branches", () => {
+      render(<TreeView nodes={NODES} />);
+
+      const tree = screen.getByRole("tree");
+      expect(tree).toBeInTheDocument();
+      const branch = screen.getByText("src/").closest("li");
+      expect(branch).toHaveAttribute("aria-expanded", "false");
+    });
+  });
+
+  describe("interaction", () => {
+    it("toggles expand on branch click", () => {
+      render(<TreeView nodes={NODES} />);
+
+      fireEvent.click(screen.getByText("src/"));
+      expect(screen.getByText("components/")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("src/"));
+      expect(screen.queryByText("components/")).toBeNull();
+    });
+
+    it("fires onSelect with the leaf id on click (single mode)", () => {
+      const onSelect = vi.fn();
+      render(
+        <TreeView
+          defaultExpanded={["src", "components"]}
+          nodes={NODES}
+          onSelect={onSelect}
+        />,
+      );
+
+      fireEvent.click(screen.getByText("Button.tsx"));
+      expect(onSelect).toHaveBeenCalledWith(["button"]);
+    });
+
+    it("toggles selection per-id when selectionMode is multiple", () => {
+      const onSelect = vi.fn();
+      render(
+        <TreeView
+          defaultExpanded={["src", "components"]}
+          nodes={NODES}
+          onSelect={onSelect}
+          selectionMode="multiple"
+        />,
+      );
+
+      fireEvent.click(screen.getByText("Button.tsx"));
+      fireEvent.click(screen.getByText("utils/"));
+      expect(onSelect).toHaveBeenLastCalledWith(["button", "utils"]);
+
+      fireEvent.click(screen.getByText("Button.tsx"));
+      expect(onSelect).toHaveBeenLastCalledWith(["utils"]);
+    });
+
+    it("ignores clicks on disabled nodes", () => {
+      const onSelect = vi.fn();
+      render(<TreeView nodes={NODES} onSelect={onSelect} />);
+
+      fireEvent.click(screen.getByText("node_modules/"));
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("controlled state", () => {
+    it("respects controlled expanded prop", () => {
+      const onExpandedChange = vi.fn();
+      const { rerender } = render(
+        <TreeView
+          expanded={[]}
+          nodes={NODES}
+          onExpandedChange={onExpandedChange}
+        />,
+      );
+
+      fireEvent.click(screen.getByText("src/"));
+      expect(onExpandedChange).toHaveBeenCalledWith(["src"]);
+      expect(screen.queryByText("components/")).toBeNull();
+
+      rerender(
+        <TreeView
+          expanded={["src"]}
+          nodes={NODES}
+          onExpandedChange={onExpandedChange}
+        />,
+      );
+      expect(screen.getByText("components/")).toBeInTheDocument();
+    });
+  });
+
+  describe("keyboard navigation", () => {
+    it("ArrowDown moves the active row", () => {
+      const { container } = render(<TreeView nodes={NODES} />);
+      const tree = container.querySelector("ul[role='tree']");
+      expect(tree).not.toBeNull();
+      if (!tree) return;
+
+      expect(
+        container.querySelector("[data-node-id='src'][data-active='true']"),
+      ).toBeInTheDocument();
+
+      fireEvent.keyDown(tree, { key: "ArrowDown" });
+      expect(
+        container.querySelector(
+          "[data-node-id='node_modules'][data-active='true']",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("Enter expands a branch and selects a leaf", () => {
+      const onSelect = vi.fn();
+      const { container } = render(
+        <TreeView
+          defaultExpanded={["src", "components"]}
+          nodes={NODES}
+          onSelect={onSelect}
+        />,
+      );
+      const tree = container.querySelector("ul[role='tree']");
+      if (!tree) return;
+
+      fireEvent.keyDown(tree, { key: "ArrowDown" });
+      fireEvent.keyDown(tree, { key: "ArrowDown" });
+      fireEvent.keyDown(tree, { key: "Enter" });
+
+      expect(onSelect).toHaveBeenCalledWith(["button"]);
+    });
+  });
+});

--- a/packages/ui/src/components/tree-view/tree-view.tsx
+++ b/packages/ui/src/components/tree-view/tree-view.tsx
@@ -1,0 +1,465 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Selection mode for {@link TreeView}.
+ *
+ * @public
+ */
+export type TreeViewSelectionMode = "multiple" | "single";
+
+/**
+ * A node in the tree.
+ *
+ * @public
+ */
+export type TreeNode = {
+  /** When `true`, the node renders dimmed and ignores clicks. */
+  disabled?: boolean;
+  /** Optional leading icon. */
+  icon?: ReactNode;
+  /** Stable identifier. */
+  id: string;
+  /** Visible label. */
+  label: ReactNode;
+  /** Child nodes; the node renders as a branch when present. */
+  nodes?: TreeNode[];
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type TreeViewLabels = {
+  /** Aria-label for the tree. Defaults to `"Tree"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Tree",
+} as const satisfies Required<TreeViewLabels>;
+
+/**
+ * Props for {@link TreeView}.
+ *
+ * @public
+ */
+export type TreeViewProps = {
+  /** Default expanded ids (uncontrolled). */
+  defaultExpanded?: string[];
+  /** Default selected ids (uncontrolled). */
+  defaultSelected?: string[];
+  /** Controlled expanded ids. */
+  expanded?: string[];
+  /** Localizable strings. */
+  labels?: TreeViewLabels;
+  /** Tree data. */
+  nodes: TreeNode[];
+  /** Fires when expanded ids change. */
+  onExpandedChange?: (next: string[]) => void;
+  /** Fires when selection changes. */
+  onSelect?: (next: string[]) => void;
+  /** Controlled selected ids. */
+  selected?: string[];
+  /** Selection mode. Defaults to `"single"`. */
+  selectionMode?: TreeViewSelectionMode;
+} & Omit<ComponentPropsWithoutRef<"ul">, "onSelect">;
+
+type FlatNode = {
+  depth: number;
+  hasChildren: boolean;
+  node: TreeNode;
+  parentId?: string;
+};
+
+type FlattenArguments = {
+  depth?: number;
+  expanded: ReadonlySet<string>;
+  nodes: TreeNode[];
+  parentId?: string;
+};
+
+function flattenVisible(arguments_: FlattenArguments): FlatNode[] {
+  const { depth = 0, expanded, nodes, parentId } = arguments_;
+  return nodes.flatMap((node) => {
+    const hasChildren = (node.nodes?.length ?? 0) > 0;
+    const head: FlatNode = { depth, hasChildren, node, parentId };
+    if (!hasChildren || !expanded.has(node.id)) return [head];
+    return [
+      head,
+      ...flattenVisible({
+        depth: depth + 1,
+        expanded,
+        nodes: node.nodes ?? [],
+        parentId: node.id,
+      }),
+    ];
+  });
+}
+
+function useControlled<T>(
+  controlled: T | undefined,
+  defaultValue: T,
+): readonly [T, (next: T) => void, boolean] {
+  const [internal, setInternal] = useState<T>(defaultValue);
+  const isControlled = controlled !== undefined;
+  const value = isControlled ? controlled : internal;
+  const setValue = useCallback(
+    (next: T) => {
+      if (!isControlled) setInternal(next);
+    },
+    [isControlled],
+  );
+  return [value, setValue, isControlled];
+}
+
+function toggleSet(set: ReadonlySet<string>, id: string): string[] {
+  const next = new Set(set);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  return [...next];
+}
+
+type TreeRowProps = {
+  active: boolean;
+  expanded: boolean;
+  flat: FlatNode;
+  onActivate: (id: string) => void;
+  onExpand: (id: string) => void;
+  onSelect: (id: string) => void;
+  selected: boolean;
+};
+
+function TreeRow({
+  active,
+  expanded,
+  flat,
+  onActivate,
+  onExpand,
+  onSelect,
+  selected,
+}: TreeRowProps): ReactNode {
+  const { depth, hasChildren, node } = flat;
+  const activate = (): void => {
+    if (node.disabled) return;
+    onActivate(node.id);
+    if (hasChildren) onExpand(node.id);
+    else onSelect(node.id);
+  };
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLLIElement>): void => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    activate();
+  };
+  return (
+    <li
+      aria-disabled={node.disabled || undefined}
+      aria-expanded={hasChildren ? expanded : undefined}
+      aria-selected={selected || undefined}
+      className={cn(
+        "flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-sm focus:outline-none",
+        active ? "bg-accent text-accent-foreground" : "hover:bg-accent/60",
+        selected ? "ring-1 ring-primary" : "",
+        node.disabled ? "cursor-not-allowed opacity-50" : "",
+      )}
+      data-active={active ? "true" : undefined}
+      data-depth={depth}
+      data-node-id={node.id}
+      data-selected={selected ? "true" : undefined}
+      onClick={activate}
+      onKeyDown={handleKeyDown}
+      role="treeitem"
+      style={{ paddingLeft: `${(depth * 16 + 8).toString()}px` }}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "inline-flex h-4 w-4 shrink-0 items-center justify-center text-xs text-muted-foreground transition-transform",
+          hasChildren ? "" : "opacity-0",
+          expanded ? "rotate-90" : "",
+        )}
+      >
+        ▸
+      </span>
+      {node.icon ? (
+        <span aria-hidden="true" className="inline-flex h-4 w-4 shrink-0">
+          {node.icon}
+        </span>
+      ) : null}
+      <span className="truncate">{node.label}</span>
+    </li>
+  );
+}
+
+function nextActiveId(
+  flat: FlatNode[],
+  delta: number,
+  current?: string,
+): string | undefined {
+  if (flat.length === 0) return undefined;
+  if (!current) return flat[0]?.node.id;
+  const index = flat.findIndex((entry) => entry.node.id === current);
+  if (index < 0) return flat[0]?.node.id;
+  const nextIndex = Math.min(Math.max(index + delta, 0), flat.length - 1);
+  return flat[nextIndex]?.node.id;
+}
+
+function findFlat(flat: FlatNode[], id?: string): FlatNode | undefined {
+  if (!id) return undefined;
+  return flat.find((entry) => entry.node.id === id);
+}
+
+function useTreeState(arguments_: {
+  defaultExpanded?: string[];
+  defaultSelected?: string[];
+  expanded?: string[];
+  onExpandedChange?: (next: string[]) => void;
+  onSelect?: (next: string[]) => void;
+  selected?: string[];
+  selectionMode: TreeViewSelectionMode;
+}): {
+  applyExpand: (id: string) => void;
+  applySelect: (id: string) => void;
+  expandedSet: ReadonlySet<string>;
+  selectedSet: ReadonlySet<string>;
+} {
+  const {
+    defaultExpanded = [],
+    defaultSelected = [],
+    expanded,
+    onExpandedChange,
+    onSelect,
+    selected,
+    selectionMode,
+  } = arguments_;
+  const [expandedState, setExpandedState] = useControlled<string[]>(
+    expanded,
+    defaultExpanded,
+  );
+  const [selectedState, setSelectedState] = useControlled<string[]>(
+    selected,
+    defaultSelected,
+  );
+  const expandedSet = useMemo(() => new Set(expandedState), [expandedState]);
+  const selectedSet = useMemo(() => new Set(selectedState), [selectedState]);
+
+  const applyExpand = useCallback(
+    (id: string) => {
+      const next = toggleSet(expandedSet, id);
+      setExpandedState(next);
+      onExpandedChange?.(next);
+    },
+    [expandedSet, onExpandedChange, setExpandedState],
+  );
+
+  const applySelect = useCallback(
+    (id: string) => {
+      const next =
+        selectionMode === "single" ? [id] : toggleSet(selectedSet, id);
+      setSelectedState(next);
+      onSelect?.(next);
+    },
+    [onSelect, selectedSet, selectionMode, setSelectedState],
+  );
+
+  return { applyExpand, applySelect, expandedSet, selectedSet };
+}
+
+function useKeyboardHandler(arguments_: {
+  activeId?: string;
+  applyExpand: (id: string) => void;
+  applySelect: (id: string) => void;
+  expandedSet: ReadonlySet<string>;
+  flat: FlatNode[];
+  setActiveId: (id?: string) => void;
+}): (event: ReactKeyboardEvent<HTMLUListElement>) => void {
+  const { activeId, applyExpand, applySelect, expandedSet, flat, setActiveId } =
+    arguments_;
+  return useCallback(
+    (event) => {
+      const current = findFlat(flat, activeId);
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setActiveId(nextActiveId(flat, 1, activeId));
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setActiveId(nextActiveId(flat, -1, activeId));
+        return;
+      }
+      if (event.key === "ArrowRight" && current?.hasChildren) {
+        event.preventDefault();
+        if (!expandedSet.has(current.node.id)) applyExpand(current.node.id);
+        return;
+      }
+      if (event.key === "ArrowLeft" && current) {
+        event.preventDefault();
+        if (current.hasChildren && expandedSet.has(current.node.id)) {
+          applyExpand(current.node.id);
+        } else if (current.parentId) {
+          setActiveId(current.parentId);
+        }
+        return;
+      }
+      if (event.key === "Enter" || event.key === " ") {
+        if (!current || current.node.disabled) return;
+        event.preventDefault();
+        if (current.hasChildren) applyExpand(current.node.id);
+        else applySelect(current.node.id);
+      }
+    },
+    [activeId, applyExpand, applySelect, expandedSet, flat, setActiveId],
+  );
+}
+
+type TreeRowsProps = {
+  activeId?: string;
+  applyExpand: (id: string) => void;
+  applySelect: (id: string) => void;
+  expandedSet: ReadonlySet<string>;
+  flat: FlatNode[];
+  selectedSet: ReadonlySet<string>;
+  setActiveId: (id?: string) => void;
+};
+
+function TreeRows({
+  activeId,
+  applyExpand,
+  applySelect,
+  expandedSet,
+  flat,
+  selectedSet,
+  setActiveId,
+}: TreeRowsProps): ReactNode {
+  return (
+    <>
+      {flat.map((entry) => (
+        <TreeRow
+          active={entry.node.id === activeId}
+          expanded={expandedSet.has(entry.node.id)}
+          flat={entry}
+          key={entry.node.id}
+          onActivate={setActiveId}
+          onExpand={applyExpand}
+          onSelect={applySelect}
+          selected={selectedSet.has(entry.node.id)}
+        />
+      ))}
+    </>
+  );
+}
+
+/**
+ * Hierarchical tree component for nested data (file systems, categories,
+ * org charts). Pass {@link TreeNode} data via `nodes`. Supports controlled
+ * and uncontrolled expand/select state, single or multi-select, and full
+ * keyboard navigation (arrows expand/collapse and traverse, enter/space
+ * activates).
+ *
+ * @example
+ * ```tsx
+ * <TreeView
+ *   nodes={[
+ *     { id: "src", label: "src/", nodes: [
+ *       { id: "components", label: "components/" },
+ *       { id: "utils", label: "utils/" },
+ *     ]},
+ *   ]}
+ *   defaultExpanded={["src"]}
+ *   onSelect={(ids) => console.info(ids)}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const TreeView = forwardRef<HTMLUListElement, TreeViewProps>(
+  (props, ref) => {
+    const {
+      className,
+      defaultExpanded,
+      defaultSelected,
+      expanded,
+      labels,
+      nodes,
+      onExpandedChange,
+      onSelect,
+      selected,
+      selectionMode = "single",
+      ...rest
+    } = props;
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+
+    const { applyExpand, applySelect, expandedSet, selectedSet } = useTreeState(
+      {
+        defaultExpanded,
+        defaultSelected,
+        expanded,
+        onExpandedChange,
+        onSelect,
+        selected,
+        selectionMode,
+      },
+    );
+
+    const flat = useMemo(
+      () => flattenVisible({ expanded: expandedSet, nodes }),
+      [expandedSet, nodes],
+    );
+
+    const [activeId, setActiveId] = useState<string | undefined>(
+      () => flat[0]?.node.id,
+    );
+
+    const handleKeyDown = useKeyboardHandler({
+      activeId,
+      applyExpand,
+      applySelect,
+      expandedSet,
+      flat,
+      setActiveId,
+    });
+
+    return (
+      <ul
+        aria-label={resolvedLabels.region}
+        aria-multiselectable={selectionMode === "multiple" || undefined}
+        className={cn(
+          "flex flex-col gap-0.5 rounded-2xl border bg-background p-2 text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          className,
+        )}
+        onKeyDown={handleKeyDown}
+        ref={ref}
+        role="tree"
+        tabIndex={0}
+        {...rest}
+      >
+        <TreeRows
+          activeId={activeId}
+          applyExpand={applyExpand}
+          applySelect={applySelect}
+          expandedSet={expandedSet}
+          flat={flat}
+          selectedSet={selectedSet}
+          setActiveId={setActiveId}
+        />
+      </ul>
+    );
+  },
+);
+TreeView.displayName = "TreeView";

--- a/packages/ui/src/components/tree-view/tree-view.visual.tsx
+++ b/packages/ui/src/components/tree-view/tree-view.visual.tsx
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { type TreeNode, TreeView } from "./tree-view";
+
+const NODES: TreeNode[] = [
+  {
+    id: "src",
+    label: "src/",
+    nodes: [
+      {
+        id: "components",
+        label: "components/",
+        nodes: [
+          { id: "button", label: "Button.tsx" },
+          { id: "card", label: "Card.tsx" },
+        ],
+      },
+      { id: "utils", label: "utils/" },
+    ],
+  },
+  { id: "package", label: "package.json" },
+];
+
+test.describe("TreeView Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <TreeView
+        defaultExpanded={["src", "components"]}
+        defaultSelected={["button"]}
+        nodes={NODES}
+      />,
+    );
+    await expect(component).toHaveScreenshot("tree-view-default.png");
+  });
+});


### PR DESCRIPTION
Closes #40.

Hierarchical tree component for nested data — file systems, categories, taxonomies, org charts. Data-driven via the \`nodes\` prop with full controlled/uncontrolled state, single/multi-select, custom icons, and ARIA tree semantics.

## What's in
- \`nodes\` prop: \`{ id, label, icon?, disabled?, nodes? }\` recursively.
- Controlled \`expanded\` + \`onExpandedChange\`; uncontrolled \`defaultExpanded\`.
- Controlled \`selected\` + \`onSelect\`; uncontrolled \`defaultSelected\`.
- \`selectionMode: "single" | "multiple"\` (default \`single\`).
- Keyboard nav: ArrowDown/Up move active row, ArrowRight expands, ArrowLeft collapses or moves to parent, Enter/Space activates (expand a branch or select a leaf). Each row also handles Enter/Space directly for assistive tech.
- ARIA tree role, \`aria-expanded\`, \`aria-selected\`, \`aria-disabled\`, \`aria-multiselectable\`.
- \`disabled\` nodes render dimmed and ignore clicks.
- Each row emits \`data-node-id\`, \`data-depth\`, \`data-active\`, \`data-selected\`.

## Out of scope (per spec, deferred)
Explicit checkbox-mode UI, search/filter, lazy loading, drag-and-drop, indent guide lines. Wire those externally — controlled \`expanded\` and a derived \`nodes\` array cover the search/lazy cases.

## Quality gates
- lint PASS
- typecheck PASS
- check:use-client PASS (180)
- check-story-coverage PASS (170/170)
- verify-stories PASS
- build PASS
- test PASS (503/503, +10 new)
- build-storybook PASS