### PR TITLE
feat(ui): add RouteMap component

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1917,6 +1917,21 @@
       "category": "content"
     },
     {
+      "name": "route-map",
+      "type": "registry:component",
+      "title": "Route Map",
+      "description": "Standalone SVG map with animated route paths, waypoints, and progress indicator. For trade routes, voyages, migrations, delivery tracking.",
+      "files": [
+        {
+          "path": "registry/default/route-map/route-map.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
       "name": "routing-assignment-panel",
       "type": "registry:component",
       "title": "Routing Assignment Panel",

--- a/apps/registry/registry/default/route-map/route-map.tsx
+++ b/apps/registry/registry/default/route-map/route-map.tsx
@@ -1,0 +1,8 @@
+export {
+  type RouteColor,
+  type RouteLineStyle,
+  RouteMap,
+  type RouteMapLabels,
+  type RouteMapProps,
+  type RouteWaypoint,
+} from "@vllnt/ui";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -513,6 +513,14 @@ export {
   type RoleBadgeRole,
 } from "./role-badge";
 export {
+  type RouteColor,
+  type RouteLineStyle,
+  RouteMap,
+  type RouteMapLabels,
+  type RouteMapProps,
+  type RouteWaypoint,
+} from "./route-map";
+export {
   SparklineGrid,
   type SparklineGridItem,
   type SparklineGridProps,

--- a/packages/ui/src/components/route-map/index.ts
+++ b/packages/ui/src/components/route-map/index.ts
@@ -1,0 +1,9 @@
+export {
+  type GeoPosition,
+  type RouteColor,
+  type RouteLineStyle,
+  RouteMap,
+  type RouteMapLabels,
+  type RouteMapProps,
+  type RouteWaypoint,
+} from "./route-map";

--- a/packages/ui/src/components/route-map/route-map.mdx
+++ b/packages/ui/src/components/route-map/route-map.mdx
@@ -1,0 +1,76 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './route-map.stories'
+
+<Meta of={Stories} />
+
+# RouteMap
+
+Map for animated route paths, waypoints, and journey progression. Use for trade routes, military campaigns, exploration voyages, migration paths, and delivery tracking. Standalone SVG — no external map library required. Drop in a backdrop image (Natural Earth SVG, terrain raster) to add geographic context.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/route-map.json
+```
+
+## Import
+
+```tsx
+import { RouteMap } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<RouteMap
+  animated
+  showProgressIndicator
+  color="red"
+  waypoints={[
+    { id: "chang", label: "Chang'an", position: [108.94, 34.34] },
+    { id: "kashgar", label: "Kashgar", position: [75.99, 39.47] },
+    { id: "samarkand", label: "Samarkand", position: [66.97, 39.65] },
+    { id: "constantinople", label: "Constantinople", position: [28.98, 41.01] },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Animation
+
+Set `animated` to draw the route line progressively from start to end. `animationDurationSeconds` controls speed (default: 4 seconds). Add `showProgressIndicator` to render a moving dot that travels along the path on a continuous loop.
+
+<Canvas of={Stories.Animated} sourceState="shown" />
+
+## Line styles
+
+`lineStyle="solid"` (default), `"dashed"`, or `"dotted"`. Dashed reads well for trade routes and historical journeys; solid reads well for delivery / current paths.
+
+<Canvas of={Stories.Dotted} sourceState="shown" />
+
+## Waypoint ordering
+
+Each waypoint exposes a 1-based `data-waypoint-ordinal` attribute. By default it follows array index; pass an explicit `order` to override (useful when stitching multiple data sets together).
+
+## Info panel
+
+Pass `children` to render an optional bottom-left info panel. Common content: route name, total distance, duration estimates, current waypoint highlight.
+
+<Canvas of={Stories.WithInfoPanel} sourceState="shown" />
+
+## Accessibility
+
+The component renders a hidden ordered list of waypoint coordinates alongside the SVG. Screen readers can read the route in order without losing fidelity.
+
+## Notes
+
+- Coordinates use a simple equirectangular projection (matches `Map2D` and `ChoroplethMap`). Coordinates outside `[-180, 180] / [-90, 90]` are clipped by the viewBox.
+- Out of scope for the MVP: multiple routes per canvas, elevation profile, playback controls, click-waypoint detail popups, route-info panels with live distance computations. Wire those externally — this primitive stays focused on rendering.
+- Each waypoint emits `data-waypoint-id` and `data-waypoint-ordinal`. The route line emits `data-route-line`; the progress indicator emits `data-route-progress`.

--- a/packages/ui/src/components/route-map/route-map.stories.tsx
+++ b/packages/ui/src/components/route-map/route-map.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { type RouteWaypoint, RouteMap } from "./route-map";
+
+const SILK_ROAD: RouteWaypoint[] = [
+  { id: "chang", label: "Chang'an", position: [108.94, 34.34] },
+  { id: "kashgar", label: "Kashgar", position: [75.99, 39.47] },
+  { id: "samarkand", label: "Samarkand", position: [66.97, 39.65] },
+  { id: "baghdad", label: "Baghdad", position: [44.36, 33.31] },
+  { id: "constantinople", label: "Constantinople", position: [28.98, 41.01] },
+];
+
+const COLUMBUS: RouteWaypoint[] = [
+  { id: "palos", label: "Palos", position: [-6.89, 37.23] },
+  { id: "canary", label: "Canary Islands", position: [-15.42, 28.29] },
+  { id: "san-salvador", label: "San Salvador", position: [-74.5, 24] },
+  { id: "cuba", label: "Cuba", position: [-78, 21.5] },
+];
+
+const meta = {
+  args: {
+    color: "red",
+    lineStyle: "dashed",
+    waypoints: SILK_ROAD,
+  },
+  component: RouteMap,
+  title: "Maps/RouteMap",
+} satisfies Meta<typeof RouteMap>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Animated: Story = {
+  args: {
+    animated: true,
+    showProgressIndicator: true,
+  },
+};
+
+export const ColumbusVoyage: Story = {
+  args: {
+    color: "blue",
+    lineStyle: "solid",
+    waypoints: COLUMBUS,
+  },
+};
+
+export const WithInfoPanel: Story = {
+  render: (args) => (
+    <RouteMap {...args}>
+      <p className="font-medium">Silk Road</p>
+      <p className="text-muted-foreground">5 waypoints · 7,500 km</p>
+    </RouteMap>
+  ),
+};
+
+export const Dotted: Story = {
+  args: {
+    color: "emerald",
+    lineStyle: "dotted",
+  },
+};

--- a/packages/ui/src/components/route-map/route-map.test.tsx
+++ b/packages/ui/src/components/route-map/route-map.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RouteMap, type RouteWaypoint } from "./route-map";
+
+const SILK_ROAD: RouteWaypoint[] = [
+  { id: "chang", label: "Chang'an", position: [108.94, 34.34] },
+  { id: "kashgar", label: "Kashgar", position: [75.99, 39.47] },
+  { id: "samarkand", label: "Samarkand", position: [66.97, 39.65] },
+  { id: "constantinople", label: "Constantinople", position: [28.98, 41.01] },
+];
+
+describe("RouteMap", () => {
+  describe("rendering", () => {
+    it("renders one waypoint dot per entry with label", () => {
+      const { container } = render(<RouteMap waypoints={SILK_ROAD} />);
+
+      expect(
+        container.querySelector("[data-waypoint-id='chang']"),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector("[data-waypoint-id='constantinople']"),
+      ).toBeInTheDocument();
+      expect(screen.getAllByText("Chang'an").length).toBeGreaterThan(0);
+    });
+
+    it("emits 1-based ordinal when order is omitted", () => {
+      const { container } = render(<RouteMap waypoints={SILK_ROAD} />);
+
+      const first = container.querySelector("[data-waypoint-id='chang']");
+      const last = container.querySelector(
+        "[data-waypoint-id='constantinople']",
+      );
+      expect(first).toHaveAttribute("data-waypoint-ordinal", "1");
+      expect(last).toHaveAttribute("data-waypoint-ordinal", "4");
+    });
+
+    it("uses the provided order when set", () => {
+      const { container } = render(
+        <RouteMap
+          waypoints={[
+            { id: "a", label: "Start", order: 10, position: [0, 0] },
+            { id: "b", label: "End", order: 20, position: [10, 10] },
+          ]}
+        />,
+      );
+
+      expect(container.querySelector("[data-waypoint-id='a']")).toHaveAttribute(
+        "data-waypoint-ordinal",
+        "10",
+      );
+      expect(container.querySelector("[data-waypoint-id='b']")).toHaveAttribute(
+        "data-waypoint-ordinal",
+        "20",
+      );
+    });
+
+    it("renders the route polyline", () => {
+      const { container } = render(<RouteMap waypoints={SILK_ROAD} />);
+
+      const line = container.querySelector("[data-route-line]");
+      expect(line).toBeInTheDocument();
+      const path = line?.querySelector("path");
+      expect(path?.getAttribute("d")).toMatch(/^M/);
+    });
+
+    it("renders the backdrop image when set", () => {
+      const { container } = render(
+        <RouteMap
+          backdrop="/world.svg"
+          backdropAlt="World"
+          waypoints={SILK_ROAD}
+        />,
+      );
+
+      const image = container.querySelector("image");
+      expect(image).toHaveAttribute("href", "/world.svg");
+      expect(image).toHaveAttribute("aria-label", "World");
+    });
+  });
+
+  describe("animation + progress", () => {
+    it("does not render the progress indicator by default", () => {
+      const { container } = render(<RouteMap waypoints={SILK_ROAD} />);
+
+      expect(container.querySelector("[data-route-progress]")).toBeNull();
+    });
+
+    it("renders the progress indicator when showProgressIndicator is true", () => {
+      const { container } = render(
+        <RouteMap showProgressIndicator waypoints={SILK_ROAD} />,
+      );
+
+      expect(
+        container.querySelector("[data-route-progress]"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the SVG <animate> element when animated is true", () => {
+      const { container } = render(<RouteMap animated waypoints={SILK_ROAD} />);
+
+      expect(container.querySelector("animate")).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("renders the data-summary fallback list with every waypoint", () => {
+      render(<RouteMap waypoints={SILK_ROAD} />);
+
+      expect(screen.getAllByText(/Chang'an/).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/Kashgar/).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/Samarkand/).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/Constantinople/).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("info panel", () => {
+    it("renders children inside the info panel slot", () => {
+      render(
+        <RouteMap waypoints={SILK_ROAD}>
+          <p>4 waypoints · 7,500 km</p>
+        </RouteMap>,
+      );
+
+      expect(screen.getByText("4 waypoints · 7,500 km")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/route-map/route-map.tsx
+++ b/packages/ui/src/components/route-map/route-map.tsx
@@ -1,0 +1,512 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useId,
+  useMemo,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+const VIEWBOX_WIDTH = 1000;
+const VIEWBOX_HEIGHT = 500;
+
+/**
+ * Geographic coordinate `[longitude, latitude]`.
+ *
+ * @public
+ */
+export type GeoPosition = [number, number];
+
+/**
+ * A single waypoint along the route.
+ *
+ * @public
+ */
+export type RouteWaypoint = {
+  /** Stable identifier. */
+  id: string;
+  /** Human-readable label rendered next to the marker. */
+  label: ReactNode;
+  /** Optional 1-based ordinal. Defaults to the array index + 1. */
+  order?: number;
+  /** Geographic position. */
+  position: GeoPosition;
+};
+
+/**
+ * Color theme for the route line + waypoint markers.
+ *
+ * @public
+ */
+export type RouteColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "purple"
+  | "red"
+  | "rose";
+
+const ROUTE_PALETTE: Record<
+  RouteColor,
+  { dot: string; line: string; text: string }
+> = {
+  amber: {
+    dot: "fill-amber-500",
+    line: "stroke-amber-500",
+    text: "text-amber-600",
+  },
+  blue: {
+    dot: "fill-blue-500",
+    line: "stroke-blue-500",
+    text: "text-blue-600",
+  },
+  emerald: {
+    dot: "fill-emerald-500",
+    line: "stroke-emerald-500",
+    text: "text-emerald-600",
+  },
+  purple: {
+    dot: "fill-purple-500",
+    line: "stroke-purple-500",
+    text: "text-purple-600",
+  },
+  red: { dot: "fill-red-500", line: "stroke-red-500", text: "text-red-600" },
+  rose: {
+    dot: "fill-rose-500",
+    line: "stroke-rose-500",
+    text: "text-rose-600",
+  },
+};
+
+/**
+ * Line drawing style.
+ *
+ * @public
+ */
+export type RouteLineStyle = "dashed" | "dotted" | "solid";
+
+const LINE_DASH: Record<RouteLineStyle, string> = {
+  dashed: "10,8",
+  dotted: "2,6",
+  solid: "0",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type RouteMapLabels = {
+  /** Aria-label for the route region. Defaults to `"Route map"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Route map",
+} as const satisfies Required<RouteMapLabels>;
+
+function projectEquirectangular(position: GeoPosition): {
+  x: number;
+  y: number;
+} {
+  const [lng, lat] = position;
+  const x = ((lng + 180) / 360) * VIEWBOX_WIDTH;
+  const y = ((90 - lat) / 180) * VIEWBOX_HEIGHT;
+  return { x, y };
+}
+
+/**
+ * Props for {@link RouteMap}.
+ *
+ * @public
+ */
+export type RouteMapProps = {
+  /** When `true`, the route line draws progressively from start to end. */
+  animated?: boolean;
+  /** Animation duration in seconds. Defaults to `4`. */
+  animationDurationSeconds?: number;
+  /** Optional URL of a backdrop image (world map, terrain). */
+  backdrop?: string;
+  /** Aria-label for the backdrop image when set. */
+  backdropAlt?: string;
+  /** Color theme. Defaults to `"red"`. */
+  color?: RouteColor;
+  /** Localizable strings. */
+  labels?: RouteMapLabels;
+  /** Line drawing style. Defaults to `"solid"`. */
+  lineStyle?: RouteLineStyle;
+  /** When `true`, renders a moving indicator that travels along the route. */
+  showProgressIndicator?: boolean;
+  /** Ordered list of waypoints along the route. */
+  waypoints: RouteWaypoint[];
+} & ComponentPropsWithoutRef<"section">;
+
+type ProjectedWaypoint = {
+  ordinal: number;
+  raw: RouteWaypoint;
+  x: number;
+  y: number;
+};
+
+function projectWaypoints(waypoints: RouteWaypoint[]): ProjectedWaypoint[] {
+  return waypoints.map((waypoint, index) => {
+    const point = projectEquirectangular(waypoint.position);
+    return {
+      ordinal: waypoint.order ?? index + 1,
+      raw: waypoint,
+      x: point.x,
+      y: point.y,
+    };
+  });
+}
+
+function pathFor(points: ProjectedWaypoint[]): string {
+  if (points.length === 0) return "";
+  return points
+    .map(
+      (point, index) =>
+        `${index === 0 ? "M" : "L"}${point.x.toString()},${point.y.toString()}`,
+    )
+    .join(" ");
+}
+
+function pathLength(points: ProjectedWaypoint[]): number {
+  if (points.length < 2) return 0;
+  const total = points.reduce<{ length: number; previous?: ProjectedWaypoint }>(
+    (accumulator, point) => {
+      if (!accumulator.previous) return { length: 0, previous: point };
+      const dx = point.x - accumulator.previous.x;
+      const dy = point.y - accumulator.previous.y;
+      return {
+        length: accumulator.length + Math.hypot(dx, dy),
+        previous: point,
+      };
+    },
+    { length: 0 },
+  );
+  return total.length;
+}
+
+type RouteLineProps = {
+  animated: boolean;
+  animationDurationSeconds: number;
+  color: RouteColor;
+  lineStyle: RouteLineStyle;
+  pathDefinition: string;
+  pathId: string;
+  totalLength: number;
+};
+
+function RouteLine({
+  animated,
+  animationDurationSeconds,
+  color,
+  lineStyle,
+  pathDefinition,
+  pathId,
+  totalLength,
+}: RouteLineProps): ReactNode {
+  if (!pathDefinition) return null;
+  const palette = ROUTE_PALETTE[color];
+  const dashArray = animated
+    ? totalLength > 0
+      ? `${totalLength.toString()} ${totalLength.toString()}`
+      : LINE_DASH[lineStyle]
+    : LINE_DASH[lineStyle];
+
+  return (
+    <g data-route-line>
+      <path
+        className={cn("fill-none stroke-[3]", palette.line)}
+        d={pathDefinition}
+        id={pathId}
+        strokeDasharray={dashArray}
+        strokeDashoffset={animated ? totalLength : 0}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        {animated ? (
+          <animate
+            attributeName="stroke-dashoffset"
+            dur={`${animationDurationSeconds.toString()}s`}
+            fill="freeze"
+            from={totalLength}
+            to="0"
+          />
+        ) : null}
+      </path>
+    </g>
+  );
+}
+
+type ProgressIndicatorProps = {
+  animationDurationSeconds: number;
+  color: RouteColor;
+  pathId: string;
+  visible: boolean;
+};
+
+function ProgressIndicator({
+  animationDurationSeconds,
+  color,
+  pathId,
+  visible,
+}: ProgressIndicatorProps): ReactNode {
+  if (!visible) return null;
+  const palette = ROUTE_PALETTE[color];
+  return (
+    <g data-route-progress>
+      <circle
+        className={cn("stroke-background", palette.dot)}
+        r="6"
+        strokeWidth="2"
+      >
+        <animateMotion
+          dur={`${animationDurationSeconds.toString()}s`}
+          repeatCount="indefinite"
+          rotate="auto"
+        >
+          <mpath href={`#${pathId}`} />
+        </animateMotion>
+      </circle>
+    </g>
+  );
+}
+
+type WaypointDotsProps = {
+  color: RouteColor;
+  waypoints: ProjectedWaypoint[];
+};
+
+function WaypointDots({ color, waypoints }: WaypointDotsProps): ReactNode {
+  const palette = ROUTE_PALETTE[color];
+  return (
+    <g data-route-waypoints>
+      {waypoints.map((point) => {
+        const labelText =
+          typeof point.raw.label === "string" ? point.raw.label : undefined;
+        return (
+          <g
+            data-waypoint-id={point.raw.id}
+            data-waypoint-ordinal={point.ordinal}
+            key={point.raw.id}
+            transform={`translate(${point.x.toString()}, ${point.y.toString()})`}
+          >
+            <circle
+              className={cn(
+                "stroke-background outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                palette.dot,
+              )}
+              r="6"
+              strokeWidth="2"
+            >
+              {labelText ? <title>{labelText}</title> : null}
+            </circle>
+            <text
+              className={cn(
+                "select-none text-[10px] font-semibold",
+                palette.text,
+              )}
+              dominantBaseline="middle"
+              textAnchor="middle"
+              y="-12"
+            >
+              {point.raw.label}
+            </text>
+            <text
+              className="select-none fill-background text-[8px] font-bold"
+              dominantBaseline="central"
+              textAnchor="middle"
+              y="0"
+            >
+              {point.ordinal}
+            </text>
+          </g>
+        );
+      })}
+    </g>
+  );
+}
+
+type DataSummaryProps = {
+  titleId: string;
+  waypoints: RouteWaypoint[];
+};
+
+function DataSummary({ titleId, waypoints }: DataSummaryProps): ReactNode {
+  return (
+    <div aria-labelledby={titleId} className="sr-only" role="region">
+      <h3 id={titleId}>Route waypoint summary</h3>
+      <ol>
+        {waypoints.map((waypoint) => (
+          <li key={waypoint.id}>
+            {typeof waypoint.label === "string"
+              ? waypoint.label
+              : `Waypoint ${waypoint.id}`}
+            {`: ${waypoint.position[0].toString()}, ${waypoint.position[1].toString()}`}
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+type StageProps = {
+  animated: boolean;
+  animationDurationSeconds: number;
+  backdrop?: string;
+  backdropAlt?: string;
+  color: RouteColor;
+  lineStyle: RouteLineStyle;
+  pathDefinition: string;
+  pathId: string;
+  showProgressIndicator: boolean;
+  totalLength: number;
+  waypoints: ProjectedWaypoint[];
+};
+
+function Stage(props: StageProps): ReactNode {
+  const {
+    animated,
+    animationDurationSeconds,
+    backdrop,
+    backdropAlt,
+    color,
+    lineStyle,
+    pathDefinition,
+    pathId,
+    showProgressIndicator,
+    totalLength,
+    waypoints,
+  } = props;
+  const showProgress: boolean = showProgressIndicator && totalLength > 0;
+  return (
+    <svg
+      aria-hidden="true"
+      className="block h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+      viewBox={`0 0 ${VIEWBOX_WIDTH.toString()} ${VIEWBOX_HEIGHT.toString()}`}
+    >
+      <rect
+        className="fill-muted"
+        height={VIEWBOX_HEIGHT}
+        width={VIEWBOX_WIDTH}
+        x="0"
+        y="0"
+      />
+      {backdrop ? (
+        <image
+          aria-label={backdropAlt}
+          height={VIEWBOX_HEIGHT}
+          href={backdrop}
+          preserveAspectRatio="xMidYMid slice"
+          width={VIEWBOX_WIDTH}
+          x="0"
+          y="0"
+        />
+      ) : null}
+      <RouteLine
+        animated={animated}
+        animationDurationSeconds={animationDurationSeconds}
+        color={color}
+        lineStyle={lineStyle}
+        pathDefinition={pathDefinition}
+        pathId={pathId}
+        totalLength={totalLength}
+      />
+      <WaypointDots color={color} waypoints={waypoints} />
+      <ProgressIndicator
+        animationDurationSeconds={animationDurationSeconds}
+        color={color}
+        pathId={pathId}
+        visible={showProgress}
+      />
+    </svg>
+  );
+}
+
+/**
+ * Map for animated route paths, waypoints, and journey progression.
+ * Use for trade routes, military campaigns, exploration voyages,
+ * migration paths, and delivery tracking. Standalone SVG primitive —
+ * no external map library or tile provider required. Drop in a backdrop
+ * image (Natural Earth SVG, terrain raster) to add geographic context.
+ *
+ * @example
+ * ```tsx
+ * <RouteMap
+ *   animated
+ *   showProgressIndicator
+ *   color="red"
+ *   waypoints={[
+ *     { id: "chang", label: "Chang'an", position: [108.94, 34.34] },
+ *     { id: "kashgar", label: "Kashgar", position: [75.99, 39.47] },
+ *     { id: "samarkand", label: "Samarkand", position: [66.97, 39.65] },
+ *     { id: "constantinople", label: "Constantinople", position: [28.98, 41.01] },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const RouteMap = forwardRef<HTMLElement, RouteMapProps>((props, ref) => {
+  const {
+    animated = false,
+    animationDurationSeconds = 4,
+    backdrop,
+    backdropAlt,
+    children,
+    className,
+    color = "red",
+    labels,
+    lineStyle = "solid",
+    showProgressIndicator = false,
+    waypoints,
+    ...rest
+  } = props;
+  const titleId = useId();
+  const pathId = useId();
+  const resolvedLabels = useMemo(
+    () => ({ ...DEFAULT_LABELS, ...labels }),
+    [labels],
+  );
+  const projected = useMemo(() => projectWaypoints(waypoints), [waypoints]);
+  const pathDefinition = useMemo(() => pathFor(projected), [projected]);
+  const totalLength = useMemo(() => pathLength(projected), [projected]);
+
+  return (
+    <section
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "relative aspect-[2/1] w-full overflow-hidden rounded-2xl border bg-background text-foreground",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      <Stage
+        animated={animated}
+        animationDurationSeconds={animationDurationSeconds}
+        backdrop={backdrop}
+        backdropAlt={backdropAlt}
+        color={color}
+        lineStyle={lineStyle}
+        pathDefinition={pathDefinition}
+        pathId={pathId}
+        showProgressIndicator={showProgressIndicator}
+        totalLength={totalLength}
+        waypoints={projected}
+      />
+      {children ? (
+        <div className="absolute bottom-3 left-3 z-10 max-w-xs rounded-md border bg-background/95 px-3 py-2 text-xs text-foreground shadow-sm backdrop-blur">
+          {children}
+        </div>
+      ) : null}
+      <DataSummary titleId={titleId} waypoints={waypoints} />
+    </section>
+  );
+});
+RouteMap.displayName = "RouteMap";

--- a/packages/ui/src/components/route-map/route-map.visual.tsx
+++ b/packages/ui/src/components/route-map/route-map.visual.tsx
@@ -1,0 +1,22 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { type RouteWaypoint, RouteMap } from "./route-map";
+
+const SILK_ROAD: RouteWaypoint[] = [
+  { id: "chang", label: "Chang'an", position: [108.94, 34.34] },
+  { id: "kashgar", label: "Kashgar", position: [75.99, 39.47] },
+  { id: "samarkand", label: "Samarkand", position: [66.97, 39.65] },
+  { id: "constantinople", label: "Constantinople", position: [28.98, 41.01] },
+];
+
+test.describe("RouteMap Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <RouteMap color="red" lineStyle="dashed" waypoints={SILK_ROAD}>
+        <p className="font-medium">Silk Road</p>
+        <p className="text-muted-foreground">4 waypoints · 7,500 km</p>
+      </RouteMap>,
+    );
+    await expect(component).toHaveScreenshot("route-map-default.png");
+  });
+});


### PR DESCRIPTION
Closes #62.

Standalone SVG route/journey map. Use for trade routes, voyages, military campaigns, migration paths, delivery tracking. No external map library required.

## What's in
- \`waypoints\` prop: array of \`{ id, label, position: [lng, lat], order? }\`.
- Polyline path drawn through waypoints in array order.
- \`animated\` — progressive line reveal via SVG \`<animate>\` on \`stroke-dashoffset\`.
- \`showProgressIndicator\` — moving dot along the path via \`<animateMotion>\` + \`<mpath>\`.
- \`color\` (6-stop palette) + \`lineStyle\` (\`solid\`/\`dashed\`/\`dotted\`).
- Optional backdrop image (Natural Earth SVG, terrain raster).
- Children render as a bottom-left info panel.
- Hidden ordered list summarises every waypoint for screen readers.
- Each waypoint emits \`data-waypoint-id\` + \`data-waypoint-ordinal\`. Line emits \`data-route-line\`; progress indicator emits \`data-route-progress\`.

## Out of scope (deferred)
Multiple routes per canvas, elevation profile, playback controls (play/pause), click-waypoint detail popups, route-info panels with live distance computations. The primitive stays focused on rendering.

## Quality gates
- lint PASS
- typecheck PASS
- check:use-client PASS (180)
- check-story-coverage PASS (170/170)
- verify-stories PASS
- build PASS
- test PASS (503/503, +10 new)
- build-storybook PASS