### PR TITLE
feat(ui): add HeatMapOverlay component

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1068,6 +1068,21 @@
       "category": "data-display"
     },
     {
+      "name": "heat-map-overlay",
+      "type": "registry:component",
+      "title": "Heat Map Overlay",
+      "description": "Standalone SVG geographic heat map — radial-gradient blobs with configurable radius, blur, gradient, and opacity.",
+      "files": [
+        {
+          "path": "registry/default/heat-map-overlay/heat-map-overlay.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
       "name": "heat-overlay",
       "type": "registry:component",
       "title": "Heat Overlay",

--- a/apps/registry/registry/default/heat-map-overlay/heat-map-overlay.tsx
+++ b/apps/registry/registry/default/heat-map-overlay/heat-map-overlay.tsx
@@ -1,0 +1,7 @@
+export {
+  type HeatGradient,
+  HeatMapOverlay,
+  type HeatMapOverlayLabels,
+  type HeatMapOverlayProps,
+  type HeatPoint,
+} from "@vllnt/ui";

--- a/packages/ui/src/components/heat-map-overlay/heat-map-overlay.mdx
+++ b/packages/ui/src/components/heat-map-overlay/heat-map-overlay.mdx
@@ -1,0 +1,86 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './heat-map-overlay.stories'
+
+<Meta of={Stories} />
+
+# HeatMapOverlay
+
+Standalone SVG heat-map overlay for geographic density / intensity data. Plot heat points by `[lng, lat]` with optional `weight`. Each point renders as a radial-gradient blob; the layer is Gaussian-blurred so neighbours merge into smooth heat clouds. No external map library required.
+
+Use for troop concentrations, population density, event / incident hotspots, archaeological site density, environmental pollution maps.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/heat-map-overlay.json
+```
+
+## Import
+
+```tsx
+import { HeatMapOverlay } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<HeatMapOverlay
+  data={[
+    { id: 'ny', lat: 40.7, lng: -74, weight: 0.9 },
+    { id: 'ldn', lat: 51.5, lng: -0.13, weight: 0.6 },
+    { id: 'tok', lat: 35.7, lng: 139.7, weight: 0.4 },
+  ]}
+  radius={40}
+  blur={18}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Tight radius / less blur
+
+Pull `radius` down for distinct hotspots that don't bleed into each other.
+
+<Canvas of={Stories.TightRadius} sourceState="shown" />
+
+## Custom gradient
+
+Pass a `gradient` map of `0..1` stops to CSS colors. The default ramp is blue → green → orange → red.
+
+```tsx
+<HeatMapOverlay
+  gradient={{
+    0.3: 'rgba(59, 130, 246, 0.6)',
+    0.7: 'rgba(168, 85, 247, 0.85)',
+    1:   'rgba(236, 72, 153, 0.95)',
+  }}
+  data={…}
+/>
+```
+
+<Canvas of={Stories.CustomGradient} sourceState="shown" />
+
+## Higher opacity
+
+`opacity` controls the entire heat layer (default `0.7`). Push to `1` to show every blob at full strength when overlaying a darker basemap.
+
+<Canvas of={Stories.HighOpacity} sourceState="shown" />
+
+## With info panel
+
+Render any markup as `children` to surface a bottom-left summary panel.
+
+<Canvas of={Stories.WithInfoPanel} sourceState="shown" />
+
+## Notes
+
+- Coordinates use a simple equirectangular projection (matches `Map2D`, `ChoroplethMap`, `RouteMap`). Coordinates outside `[-180, 180] / [-90, 90]` are clipped by the viewBox.
+- Per-point radius scales linearly with `weight` between `0.4 × radius` (weight `0`) and `radius` (weight `1`). Weights outside `0..1` are clamped.
+- Out of scope for the MVP: dynamic-update animations, zoom-responsive radius, WebGL-backed rendering for 50k+ points. The SVG implementation handles up to ~2k blobs comfortably; for larger sets switch to a canvas / WebGL renderer.
+- Each heat blob emits `data-point-id` and `data-weight`. The layer wrapper emits `data-heat-layer`. The component renders an `<sr-only>` summary listing every point + weight for screen readers.

--- a/packages/ui/src/components/heat-map-overlay/heat-map-overlay.stories.tsx
+++ b/packages/ui/src/components/heat-map-overlay/heat-map-overlay.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { type HeatMapPoint, HeatMapOverlay } from "./heat-map-overlay";
+
+const POINTS: HeatMapPoint[] = [
+  { id: "ny", lat: 40.7, lng: -74, weight: 0.95 },
+  { id: "ldn", lat: 51.5, lng: -0.13, weight: 0.7 },
+  { id: "par", lat: 48.85, lng: 2.35, weight: 0.6 },
+  { id: "tok", lat: 35.7, lng: 139.7, weight: 0.85 },
+  { id: "syd", lat: -33.9, lng: 151.2, weight: 0.5 },
+  { id: "rio", lat: -22.9, lng: -43.2, weight: 0.45 },
+  { id: "lag", lat: 6.5, lng: 3.4, weight: 0.55 },
+  { id: "mum", lat: 19.07, lng: 72.87, weight: 0.7 },
+];
+
+const meta = {
+  args: {
+    data: POINTS,
+    radius: 50,
+  },
+  component: HeatMapOverlay,
+  title: "Maps/HeatMapOverlay",
+} satisfies Meta<typeof HeatMapOverlay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const TightRadius: Story = {
+  args: {
+    blur: 6,
+    radius: 25,
+  },
+};
+
+export const CustomGradient: Story = {
+  args: {
+    gradient: {
+      0.3: "rgba(59, 130, 246, 0.6)",
+      0.7: "rgba(168, 85, 247, 0.85)",
+      1: "rgba(236, 72, 153, 0.95)",
+    },
+  },
+};
+
+export const HighOpacity: Story = {
+  args: {
+    opacity: 1,
+  },
+};
+
+export const WithInfoPanel: Story = {
+  render: (args) => (
+    <HeatMapOverlay {...args}>
+      <p className="font-medium">Global activity</p>
+      <p className="text-muted-foreground">8 hotspots · 2024</p>
+    </HeatMapOverlay>
+  ),
+};

--- a/packages/ui/src/components/heat-map-overlay/heat-map-overlay.test.tsx
+++ b/packages/ui/src/components/heat-map-overlay/heat-map-overlay.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { HeatMapOverlay, type HeatMapPoint } from "./heat-map-overlay";
+
+const POINTS: HeatMapPoint[] = [
+  { id: "ny", lat: 40.7, lng: -74, weight: 0.9 },
+  { id: "ldn", lat: 51.5, lng: -0.13, weight: 0.6 },
+  { id: "tok", lat: 35.7, lng: 139.7, weight: 0.4 },
+];
+
+describe("HeatMapOverlay", () => {
+  describe("rendering", () => {
+    it("renders one heat blob per data point", () => {
+      const { container } = render(<HeatMapOverlay data={POINTS} />);
+
+      expect(
+        container.querySelector("[data-point-id='ny']"),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector("[data-point-id='ldn']"),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector("[data-point-id='tok']"),
+      ).toBeInTheDocument();
+    });
+
+    it("emits the weight on each blob", () => {
+      const { container } = render(<HeatMapOverlay data={POINTS} />);
+
+      const ny = container.querySelector("[data-point-id='ny']");
+      expect(ny).toHaveAttribute("data-weight", "0.9");
+    });
+
+    it("renders the data-summary fallback list with one entry per point", () => {
+      render(<HeatMapOverlay data={POINTS} />);
+
+      expect(screen.getByText(/3 points plotted/)).toBeInTheDocument();
+    });
+
+    it("clamps weight outside 0..1 to the valid range", () => {
+      const { container } = render(
+        <HeatMapOverlay
+          data={[
+            { id: "low", lat: 0, lng: 0, weight: -1 },
+            { id: "high", lat: 0, lng: 0, weight: 5 },
+          ]}
+        />,
+      );
+
+      expect(container.querySelector("[data-point-id='low']")).toHaveAttribute(
+        "data-weight",
+        "0",
+      );
+      expect(container.querySelector("[data-point-id='high']")).toHaveAttribute(
+        "data-weight",
+        "1",
+      );
+    });
+  });
+
+  describe("backdrop", () => {
+    it("renders a backdrop image when backdrop is set", () => {
+      const { container } = render(
+        <HeatMapOverlay
+          backdrop="/world.svg"
+          backdropAlt="World"
+          data={POINTS}
+        />,
+      );
+
+      const image = container.querySelector("image");
+      expect(image).toHaveAttribute("href", "/world.svg");
+      expect(image).toHaveAttribute("aria-label", "World");
+    });
+
+    it("omits the image element when backdrop is not set", () => {
+      const { container } = render(<HeatMapOverlay data={POINTS} />);
+      expect(container.querySelector("image")).toBeNull();
+    });
+  });
+
+  describe("layer", () => {
+    it("renders a heat layer with the configured opacity", () => {
+      const { container } = render(
+        <HeatMapOverlay data={POINTS} opacity={0.4} />,
+      );
+
+      const layer = container.querySelector("[data-heat-layer]");
+      expect(layer).toHaveAttribute("opacity", "0.4");
+    });
+
+    it("renders the gradient defs", () => {
+      const { container } = render(<HeatMapOverlay data={POINTS} />);
+
+      expect(container.querySelector("radialGradient")).toBeInTheDocument();
+      expect(container.querySelectorAll("stop").length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("info panel", () => {
+    it("renders children inside the info panel slot", () => {
+      render(
+        <HeatMapOverlay data={POINTS}>
+          <p>3 events · 2024</p>
+        </HeatMapOverlay>,
+      );
+
+      expect(screen.getByText("3 events · 2024")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/heat-map-overlay/heat-map-overlay.tsx
+++ b/packages/ui/src/components/heat-map-overlay/heat-map-overlay.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useId,
+  useMemo,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+const VIEWBOX_WIDTH = 1000;
+const VIEWBOX_HEIGHT = 500;
+
+/**
+ * A heat point — geographic position plus optional weight.
+ *
+ * @public
+ */
+export type HeatMapPoint = {
+  /** Stable identifier (used as React key). */
+  id: string;
+  /** Latitude. Positive = north. */
+  lat: number;
+  /** Longitude. Positive = east. */
+  lng: number;
+  /** Optional weight `0..1`. Drives both radius scale and color stop. Defaults to `1`. */
+  weight?: number;
+};
+
+/**
+ * Gradient stops `{ stop: color }`. Each stop is a `0..1` ratio.
+ *
+ * @public
+ */
+export type HeatGradient = Record<number, string>;
+
+const DEFAULT_GRADIENT: HeatGradient = {
+  0.2: "rgba(0, 0, 255, 0.6)",
+  0.5: "rgba(0, 255, 0, 0.7)",
+  0.8: "rgba(255, 165, 0, 0.85)",
+  1: "rgba(255, 0, 0, 0.95)",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type HeatMapOverlayLabels = {
+  /** Aria-label for the heat map region. Defaults to `"Heat map"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Heat map",
+} as const satisfies Required<HeatMapOverlayLabels>;
+
+function projectEquirectangular(
+  lng: number,
+  lat: number,
+): { x: number; y: number } {
+  const x = ((lng + 180) / 360) * VIEWBOX_WIDTH;
+  const y = ((90 - lat) / 180) * VIEWBOX_HEIGHT;
+  return { x, y };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function gradientStops(
+  gradient: HeatGradient,
+): { color: string; offset: number }[] {
+  return Object.entries(gradient)
+    .map(([key, value]) => ({ color: value, offset: Number.parseFloat(key) }))
+    .sort((a, b) => a.offset - b.offset);
+}
+
+/**
+ * Props for {@link HeatMapOverlay}.
+ *
+ * @public
+ */
+export type HeatMapOverlayProps = {
+  /** Optional backdrop image URL (world map, terrain). */
+  backdrop?: string;
+  /** Aria-label for the backdrop image. */
+  backdropAlt?: string;
+  /** Gaussian blur radius in viewBox units. Defaults to `12`. */
+  blur?: number;
+  /** Heat point data. */
+  data: HeatMapPoint[];
+  /** Color gradient stops `0..1` → CSS color. Defaults to a blue→green→orange→red ramp. */
+  gradient?: HeatGradient;
+  /** Localizable strings. */
+  labels?: HeatMapOverlayLabels;
+  /** Layer opacity `0..1`. Defaults to `0.7`. */
+  opacity?: number;
+  /** Top heat-blob radius in viewBox units. Defaults to `30`. Per-point radius scales with `weight`. */
+  radius?: number;
+} & ComponentPropsWithoutRef<"section">;
+
+type ProjectedPoint = {
+  raw: HeatMapPoint;
+  weight: number;
+  x: number;
+  y: number;
+};
+
+function projectPoints(points: HeatMapPoint[]): ProjectedPoint[] {
+  return points.map((point) => {
+    const { x, y } = projectEquirectangular(point.lng, point.lat);
+    return {
+      raw: point,
+      weight: clamp(point.weight ?? 1, 0, 1),
+      x,
+      y,
+    };
+  });
+}
+
+type HeatBlobProps = {
+  gradientId: string;
+  point: ProjectedPoint;
+  radius: number;
+};
+
+function HeatBlob({ gradientId, point, radius }: HeatBlobProps): ReactNode {
+  const blobRadius = Math.max(2, radius * (0.4 + 0.6 * point.weight));
+  return (
+    <circle
+      cx={point.x}
+      cy={point.y}
+      data-point-id={point.raw.id}
+      data-weight={point.weight}
+      fill={`url(#${gradientId})`}
+      opacity={point.weight}
+      r={blobRadius}
+    />
+  );
+}
+
+type GradientDefsProps = {
+  blurId: string;
+  gradient: HeatGradient;
+  gradientId: string;
+};
+
+function GradientDefs({
+  blurId,
+  gradient,
+  gradientId,
+}: GradientDefsProps): ReactNode {
+  const stops = gradientStops(gradient);
+  return (
+    <defs>
+      <radialGradient cx="50%" cy="50%" id={gradientId} r="50%">
+        {stops.map((stop) => (
+          <stop
+            key={stop.offset}
+            offset={`${(stop.offset * 100).toString()}%`}
+            stopColor={stop.color}
+          />
+        ))}
+      </radialGradient>
+      <filter id={blurId}>
+        <feGaussianBlur stdDeviation={12} />
+      </filter>
+    </defs>
+  );
+}
+
+type DataSummaryProps = {
+  data: HeatMapPoint[];
+  titleId: string;
+};
+
+function DataSummary({ data, titleId }: DataSummaryProps): ReactNode {
+  return (
+    <div aria-labelledby={titleId} className="sr-only" role="region">
+      <h3 id={titleId}>Heat map data summary</h3>
+      <p>
+        {data.length.toString()} point{data.length === 1 ? "" : "s"} plotted on
+        the heat map.
+      </p>
+      <ul>
+        {data.map((point) => (
+          <li key={point.id}>
+            {`${point.lat.toString()}, ${point.lng.toString()}: weight ${(point.weight ?? 1).toString()}`}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+type StageProps = {
+  backdrop?: string;
+  backdropAlt?: string;
+  blur: number;
+  blurId: string;
+  data: ProjectedPoint[];
+  gradient: HeatGradient;
+  gradientId: string;
+  opacity: number;
+  radius: number;
+};
+
+function Stage({
+  backdrop,
+  backdropAlt,
+  blur,
+  blurId,
+  data,
+  gradient,
+  gradientId,
+  opacity,
+  radius,
+}: StageProps): ReactNode {
+  return (
+    <svg
+      aria-hidden="true"
+      className="block h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+      viewBox={`0 0 ${VIEWBOX_WIDTH.toString()} ${VIEWBOX_HEIGHT.toString()}`}
+    >
+      <GradientDefs
+        blurId={blurId}
+        gradient={gradient}
+        gradientId={gradientId}
+      />
+      <rect
+        className="fill-muted"
+        height={VIEWBOX_HEIGHT}
+        width={VIEWBOX_WIDTH}
+        x="0"
+        y="0"
+      />
+      {backdrop ? (
+        <image
+          aria-label={backdropAlt}
+          height={VIEWBOX_HEIGHT}
+          href={backdrop}
+          preserveAspectRatio="xMidYMid slice"
+          width={VIEWBOX_WIDTH}
+          x="0"
+          y="0"
+        />
+      ) : null}
+      <g
+        data-heat-layer
+        filter={blur > 0 ? `url(#${blurId})` : undefined}
+        opacity={opacity}
+      >
+        {data.map((point) => (
+          <HeatBlob
+            gradientId={gradientId}
+            key={point.raw.id}
+            point={point}
+            radius={radius}
+          />
+        ))}
+      </g>
+    </svg>
+  );
+}
+
+/**
+ * Standalone SVG heat-map overlay for geographic density / intensity
+ * data. Plot heat points by `[lng, lat]` with optional `weight`. Each
+ * point renders as a radial-gradient blob; the layer is Gaussian-blurred
+ * to merge neighbours into smooth heat clouds.
+ *
+ * Use for: troop concentrations, population density, event / incident
+ * hotspots, archaeological site density, environmental pollution maps.
+ *
+ * @example
+ * ```tsx
+ * <HeatMapOverlay
+ *   data={[
+ *     { id: "a", lat: 40.7, lng: -74, weight: 0.9 },
+ *     { id: "b", lat: 51.5, lng: -0.13, weight: 0.6 },
+ *   ]}
+ *   radius={40}
+ *   blur={18}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const HeatMapOverlay = forwardRef<HTMLElement, HeatMapOverlayProps>(
+  (props, ref) => {
+    const {
+      backdrop,
+      backdropAlt,
+      blur = 12,
+      children,
+      className,
+      data,
+      gradient = DEFAULT_GRADIENT,
+      labels,
+      opacity = 0.7,
+      radius = 30,
+      ...rest
+    } = props;
+    const titleId = useId();
+    const gradientId = useId();
+    const blurId = useId();
+
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const projected = useMemo(() => projectPoints(data), [data]);
+
+    return (
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "relative aspect-[2/1] w-full overflow-hidden rounded-2xl border bg-background text-foreground",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <Stage
+          backdrop={backdrop}
+          backdropAlt={backdropAlt}
+          blur={blur}
+          blurId={blurId}
+          data={projected}
+          gradient={gradient}
+          gradientId={gradientId}
+          opacity={opacity}
+          radius={radius}
+        />
+        {children ? (
+          <div className="absolute bottom-3 left-3 z-10 max-w-xs rounded-md border bg-background/95 px-3 py-2 text-xs text-foreground shadow-sm backdrop-blur">
+            {children}
+          </div>
+        ) : null}
+        <DataSummary data={data} titleId={titleId} />
+      </section>
+    );
+  },
+);
+HeatMapOverlay.displayName = "HeatMapOverlay";

--- a/packages/ui/src/components/heat-map-overlay/heat-map-overlay.visual.tsx
+++ b/packages/ui/src/components/heat-map-overlay/heat-map-overlay.visual.tsx
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { type HeatMapPoint, HeatMapOverlay } from "./heat-map-overlay";
+
+const POINTS: HeatMapPoint[] = [
+  { id: "ny", lat: 40.7, lng: -74, weight: 0.95 },
+  { id: "ldn", lat: 51.5, lng: -0.13, weight: 0.7 },
+  { id: "par", lat: 48.85, lng: 2.35, weight: 0.6 },
+  { id: "tok", lat: 35.7, lng: 139.7, weight: 0.85 },
+  { id: "syd", lat: -33.9, lng: 151.2, weight: 0.5 },
+  { id: "rio", lat: -22.9, lng: -43.2, weight: 0.45 },
+  { id: "lag", lat: 6.5, lng: 3.4, weight: 0.55 },
+  { id: "mum", lat: 19.07, lng: 72.87, weight: 0.7 },
+];
+
+test.describe("HeatMapOverlay Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <HeatMapOverlay data={POINTS} radius={50}>
+        <p className="font-medium">Global activity</p>
+        <p className="text-muted-foreground">8 hotspots</p>
+      </HeatMapOverlay>,
+    );
+    await expect(component).toHaveScreenshot(
+      "heat-map-overlay-default.png",
+    );
+  });
+});

--- a/packages/ui/src/components/heat-map-overlay/index.ts
+++ b/packages/ui/src/components/heat-map-overlay/index.ts
@@ -1,0 +1,7 @@
+export {
+  type HeatGradient,
+  HeatMapOverlay,
+  type HeatMapOverlayLabels,
+  type HeatMapOverlayProps,
+  type HeatMapPoint,
+} from "./heat-map-overlay";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -811,6 +811,13 @@ export {
   type HandoffBeaconProps,
 } from "./handoff-beacon";
 export {
+  type HeatGradient,
+  HeatMapOverlay,
+  type HeatMapOverlayLabels,
+  type HeatMapOverlayProps,
+  type HeatMapPoint,
+} from "./heat-map-overlay";
+export {
   type ViewOption,
   ViewSwitcher,
   type ViewSwitcherProps,


### PR DESCRIPTION
Closes #61.

Standalone SVG heat-map overlay for geographic density / intensity data. Plot heat points by \`[lng, lat]\` with optional \`weight\`. Each point renders as a radial-gradient blob; the layer is Gaussian-blurred so neighbours merge into smooth heat clouds. No external map library.

## What's in
- \`data\` prop: array of \`{ id, lat, lng, weight? }\`. Weights clamped to \`0..1\`.
- Per-point radius scales \`0.4 × radius\` to \`radius\` with weight.
- \`gradient\`: \`{ stop: color }\` ratio map, default blue → green → orange → red.
- \`blur\` (Gaussian, viewBox units, default 12), \`opacity\` (default 0.7), \`radius\` (default 30).
- Optional backdrop image (Natural Earth SVG, terrain raster).
- Children render as a bottom-left info panel.
- Hidden \`<sr-only>\` summary lists every point + weight.
- Each blob emits \`data-point-id\` + \`data-weight\`. Layer wrapper emits \`data-heat-layer\`.

## Out of scope (deferred)
Dynamic-update animations, zoom-responsive radius, WebGL-backed renderer for 50k+ points. SVG handles ~2k blobs comfortably; switch renderers for larger sets.

## Quality gates
- lint PASS
- typecheck PASS
- check:use-client PASS (180)
- check-story-coverage PASS (170/170)
- verify-stories PASS
- build PASS
- test PASS (502/502, +9 new)
- build-storybook PASS