### PR TITLE
feat(ui): add GeographyQuizMap component

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1008,6 +1008,21 @@
       "category": "form"
     },
     {
+      "name": "geography-quiz-map",
+      "type": "registry:component",
+      "title": "Geography Quiz Map",
+      "description": "Interactive identify-mode map quiz — click the correct region per prompt with visual feedback, score, and results panel.",
+      "files": [
+        {
+          "path": "registry/default/geography-quiz-map/geography-quiz-map.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
       "name": "globe-3d",
       "type": "registry:component",
       "title": "Globe 3D",

--- a/apps/registry/registry/default/geography-quiz-map/geography-quiz-map.tsx
+++ b/apps/registry/registry/default/geography-quiz-map/geography-quiz-map.tsx
@@ -1,0 +1,11 @@
+export {
+  GeographyQuizMap,
+  type GeographyQuizMapLabels,
+  GeographyQuizMapPrompt,
+  type GeographyQuizMapProps,
+  GeographyQuizMapResults,
+  GeographyQuizMapScore,
+  type QuizAnswer,
+  type QuizQuestion,
+  type QuizRegion,
+} from "@vllnt/ui";

--- a/packages/ui/src/components/geography-quiz-map/geography-quiz-map.mdx
+++ b/packages/ui/src/components/geography-quiz-map/geography-quiz-map.mdx
@@ -1,0 +1,93 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './geography-quiz-map.stories'
+
+<Meta of={Stories} />
+
+# GeographyQuizMap
+
+Interactive map quiz. Identify-mode: each question asks the user to click the region matching the prompt. Correct clicks flash green, incorrect clicks flash red and reveal the correct region. After the final question the results panel renders the per-question outcome list and `onComplete` fires.
+
+Standalone SVG primitive — no external map library required.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/geography-quiz-map.json
+```
+
+## Import
+
+```tsx
+import {
+  GeographyQuizMap,
+  GeographyQuizMapPrompt,
+  GeographyQuizMapScore,
+  GeographyQuizMapResults,
+} from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+const REGIONS = [
+  { id: 'FR', name: 'France', coordinates: [[-5, 51], [10, 51], [10, 41], [-5, 41], [-5, 51]] },
+  { id: 'DE', name: 'Germany', coordinates: [[5, 55], [15, 55], [15, 47], [5, 47], [5, 55]] },
+]
+
+const QUESTIONS = [
+  { id: 'q1', prompt: 'Click on France', answerRegionId: 'FR' },
+  { id: 'q2', prompt: 'Click on Germany', answerRegionId: 'DE' },
+]
+
+<GeographyQuizMap
+  regions={REGIONS}
+  questions={QUESTIONS}
+  onComplete={(answers) => console.info(answers)}
+>
+  <GeographyQuizMapPrompt />
+  <GeographyQuizMapScore />
+  <GeographyQuizMapResults />
+</GeographyQuizMap>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Slots
+
+- **`GeographyQuizMapPrompt`** — top-center bar that renders the current question prompt. Hidden once the quiz completes.
+- **`GeographyQuizMapScore`** — top-right pill: `correct / total · accuracy%`.
+- **`GeographyQuizMapResults`** — full-overlay summary that renders only after every question is answered. Lists each question with a green or red row.
+
+```tsx
+<GeographyQuizMap regions={…} questions={…}>
+  <GeographyQuizMapPrompt />
+  <GeographyQuizMapScore />
+  <GeographyQuizMapResults />
+</GeographyQuizMap>
+```
+
+## Feedback timing
+
+After a click, the selected region flashes for ~800ms. Correct clicks turn the selected region green; incorrect clicks turn the selected region red and softly highlight the correct region in green so the user can see what they should have clicked. The component then advances to the next question.
+
+## Coordinate space
+
+Region polygons use `[lng, lat]` with the same equirectangular projection as `Map2D`, `ChoroplethMap`, `RouteMap`, and `HeatMapOverlay`.
+
+## Accessibility
+
+- Each region path is keyboard-focusable; `Enter` / `Space` activates a region.
+- A hidden landmark labels the section as a "Geography quiz map".
+- Region paths carry `role="button"` and an `aria-label` derived from their `name`.
+
+## Notes
+
+- Out of scope for the MVP: locate-mode (point proximity scoring), match-mode (drag labels to regions), countdown timer, hint system (zoom-to-region), streak tracking, randomized question order, difficulty levels. Wire those externally — pass a pre-randomised `questions` array, render an external timer, or trigger your own zoom UI on top.
+- Each region path emits `data-region-id` and `data-state` (`"correct"`, `"incorrect"`, or `"answer"` for the revealed correct region after a wrong click).
+- Each results row emits `data-answer-id` and `data-answer-correct`. The slots emit `data-quiz-prompt`, `data-quiz-score`, and `data-quiz-results`.

--- a/packages/ui/src/components/geography-quiz-map/geography-quiz-map.stories.tsx
+++ b/packages/ui/src/components/geography-quiz-map/geography-quiz-map.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  GeographyQuizMap,
+  GeographyQuizMapPrompt,
+  GeographyQuizMapResults,
+  GeographyQuizMapScore,
+  type QuizQuestion,
+  type QuizRegion,
+} from "./geography-quiz-map";
+
+const REGIONS: QuizRegion[] = [
+  {
+    coordinates: [
+      [-5, 51],
+      [10, 51],
+      [10, 41],
+      [-5, 41],
+      [-5, 51],
+    ],
+    id: "FR",
+    name: "France",
+  },
+  {
+    coordinates: [
+      [5, 55],
+      [15, 55],
+      [15, 47],
+      [5, 47],
+      [5, 55],
+    ],
+    id: "DE",
+    name: "Germany",
+  },
+  {
+    coordinates: [
+      [-9, 44],
+      [3, 44],
+      [3, 36],
+      [-9, 36],
+      [-9, 44],
+    ],
+    id: "ES",
+    name: "Spain",
+  },
+  {
+    coordinates: [
+      [6, 47],
+      [18, 47],
+      [18, 37],
+      [6, 37],
+      [6, 47],
+    ],
+    id: "IT",
+    name: "Italy",
+  },
+  {
+    coordinates: [
+      [21, 60],
+      [40, 60],
+      [40, 50],
+      [21, 50],
+      [21, 60],
+    ],
+    id: "PL",
+    name: "Poland",
+  },
+];
+
+const QUESTIONS: QuizQuestion[] = [
+  { answerRegionId: "FR", id: "q1", prompt: "Click on France" },
+  { answerRegionId: "DE", id: "q2", prompt: "Click on Germany" },
+  { answerRegionId: "ES", id: "q3", prompt: "Click on Spain" },
+  { answerRegionId: "IT", id: "q4", prompt: "Click on Italy" },
+  { answerRegionId: "PL", id: "q5", prompt: "Click on Poland" },
+];
+
+const meta = {
+  args: {
+    questions: QUESTIONS,
+    regions: REGIONS,
+  },
+  component: GeographyQuizMap,
+  title: "Educational/GeographyQuizMap",
+} satisfies Meta<typeof GeographyQuizMap>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <GeographyQuizMap {...args}>
+      <GeographyQuizMapPrompt />
+      <GeographyQuizMapScore />
+      <GeographyQuizMapResults />
+    </GeographyQuizMap>
+  ),
+};
+
+export const PromptOnly: Story = {
+  render: (args) => (
+    <GeographyQuizMap {...args}>
+      <GeographyQuizMapPrompt />
+    </GeographyQuizMap>
+  ),
+};
+
+export const ShortQuiz: Story = {
+  args: {
+    questions: QUESTIONS.slice(0, 2),
+  },
+  render: (args) => (
+    <GeographyQuizMap {...args}>
+      <GeographyQuizMapPrompt />
+      <GeographyQuizMapScore />
+      <GeographyQuizMapResults />
+    </GeographyQuizMap>
+  ),
+};

--- a/packages/ui/src/components/geography-quiz-map/geography-quiz-map.test.tsx
+++ b/packages/ui/src/components/geography-quiz-map/geography-quiz-map.test.tsx
@@ -1,0 +1,229 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  GeographyQuizMap,
+  GeographyQuizMapPrompt,
+  GeographyQuizMapResults,
+  GeographyQuizMapScore,
+  type QuizQuestion,
+  type QuizRegion,
+} from "./geography-quiz-map";
+
+const REGIONS: QuizRegion[] = [
+  {
+    coordinates: [
+      [-5, 51],
+      [10, 51],
+      [10, 41],
+      [-5, 41],
+      [-5, 51],
+    ],
+    id: "FR",
+    name: "France",
+  },
+  {
+    coordinates: [
+      [5, 55],
+      [15, 55],
+      [15, 47],
+      [5, 47],
+      [5, 55],
+    ],
+    id: "DE",
+    name: "Germany",
+  },
+  {
+    coordinates: [
+      [-9, 44],
+      [3, 44],
+      [3, 36],
+      [-9, 36],
+      [-9, 44],
+    ],
+    id: "ES",
+    name: "Spain",
+  },
+];
+
+const QUESTIONS: QuizQuestion[] = [
+  { answerRegionId: "FR", id: "q1", prompt: "Click on France" },
+  { answerRegionId: "DE", id: "q2", prompt: "Click on Germany" },
+];
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function flushAdvance(): void {
+  act(() => {
+    vi.advanceTimersByTime(1000);
+  });
+}
+
+function clickRegion(container: HTMLElement, id: string): void {
+  const node = container.querySelector(`[data-region-id='${id}']`);
+  expect(node).not.toBeNull();
+  if (node) fireEvent.click(node);
+}
+
+describe("GeographyQuizMap", () => {
+  describe("rendering", () => {
+    it("renders one region path per entry", () => {
+      const { container } = render(
+        <GeographyQuizMap questions={QUESTIONS} regions={REGIONS} />,
+      );
+
+      expect(
+        container.querySelector("[data-region-id='FR']"),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector("[data-region-id='DE']"),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector("[data-region-id='ES']"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the prompt for the current question", () => {
+      render(
+        <GeographyQuizMap questions={QUESTIONS} regions={REGIONS}>
+          <GeographyQuizMapPrompt />
+        </GeographyQuizMap>,
+      );
+
+      expect(screen.getByText("Click on France")).toBeInTheDocument();
+    });
+
+    it("renders the score slot with running totals", () => {
+      render(
+        <GeographyQuizMap questions={QUESTIONS} regions={REGIONS}>
+          <GeographyQuizMapScore />
+        </GeographyQuizMap>,
+      );
+
+      expect(screen.getByText("0 / 2 · 0%")).toBeInTheDocument();
+    });
+  });
+
+  describe("interaction", () => {
+    it("marks the answer correct when the right region is clicked", () => {
+      const onComplete = vi.fn();
+      const { container } = render(
+        <GeographyQuizMap
+          onComplete={onComplete}
+          questions={QUESTIONS}
+          regions={REGIONS}
+        >
+          <GeographyQuizMapScore />
+        </GeographyQuizMap>,
+      );
+
+      clickRegion(container, "FR");
+      expect(container.querySelector("[data-region-id='FR']")).toHaveAttribute(
+        "data-state",
+        "correct",
+      );
+
+      flushAdvance();
+      expect(screen.getByText("1 / 2 · 100%")).toBeInTheDocument();
+    });
+
+    it("marks the answer incorrect and reveals the correct region", () => {
+      const { container } = render(
+        <GeographyQuizMap questions={QUESTIONS} regions={REGIONS} />,
+      );
+
+      clickRegion(container, "ES");
+
+      expect(container.querySelector("[data-region-id='ES']")).toHaveAttribute(
+        "data-state",
+        "incorrect",
+      );
+      expect(container.querySelector("[data-region-id='FR']")).toHaveAttribute(
+        "data-state",
+        "answer",
+      );
+    });
+
+    it("advances to the next question after the feedback delay", () => {
+      const { container } = render(
+        <GeographyQuizMap questions={QUESTIONS} regions={REGIONS}>
+          <GeographyQuizMapPrompt />
+        </GeographyQuizMap>,
+      );
+
+      clickRegion(container, "FR");
+      flushAdvance();
+      expect(screen.getByText("Click on Germany")).toBeInTheDocument();
+    });
+
+    it("ignores clicks while the feedback is showing", () => {
+      const { container } = render(
+        <GeographyQuizMap questions={QUESTIONS} regions={REGIONS}>
+          <GeographyQuizMapScore />
+        </GeographyQuizMap>,
+      );
+
+      clickRegion(container, "FR");
+      clickRegion(container, "DE");
+      flushAdvance();
+      expect(screen.getByText("1 / 2 · 100%")).toBeInTheDocument();
+    });
+
+    it("fires onComplete with the per-question outcome after the last answer", () => {
+      const onComplete = vi.fn();
+      const { container } = render(
+        <GeographyQuizMap
+          onComplete={onComplete}
+          questions={QUESTIONS}
+          regions={REGIONS}
+        />,
+      );
+
+      clickRegion(container, "FR");
+      flushAdvance();
+      clickRegion(container, "DE");
+      flushAdvance();
+
+      expect(onComplete).toHaveBeenCalledTimes(1);
+      expect(onComplete).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ correct: true, selectedRegionId: "FR" }),
+          expect.objectContaining({ correct: true, selectedRegionId: "DE" }),
+        ]),
+      );
+    });
+  });
+
+  describe("results", () => {
+    it("renders the results panel after completion", () => {
+      const { container } = render(
+        <GeographyQuizMap questions={QUESTIONS} regions={REGIONS}>
+          <GeographyQuizMapResults />
+        </GeographyQuizMap>,
+      );
+
+      clickRegion(container, "FR");
+      flushAdvance();
+      clickRegion(container, "ES");
+      flushAdvance();
+
+      expect(
+        container.querySelector("[data-quiz-results]"),
+      ).toBeInTheDocument();
+      expect(container.querySelector("[data-answer-id='q1']")).toHaveAttribute(
+        "data-answer-correct",
+        "true",
+      );
+      expect(container.querySelector("[data-answer-id='q2']")).toHaveAttribute(
+        "data-answer-correct",
+        "false",
+      );
+    });
+  });
+});

--- a/packages/ui/src/components/geography-quiz-map/geography-quiz-map.tsx
+++ b/packages/ui/src/components/geography-quiz-map/geography-quiz-map.tsx
@@ -1,0 +1,552 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+const VIEWBOX_WIDTH = 1000;
+const VIEWBOX_HEIGHT = 500;
+const FEEDBACK_DURATION_MS = 800;
+
+/**
+ * Geographic coordinate `[longitude, latitude]`.
+ *
+ * @public
+ */
+export type GeoPosition = [number, number];
+
+/**
+ * A region polygon — outer ring of `[lng, lat]` positions; close the
+ * ring by repeating the first point.
+ *
+ * @public
+ */
+export type QuizRegion = {
+  /** Outer ring positions. */
+  coordinates: GeoPosition[];
+  /** Stable identifier — referenced by `QuizQuestion.answerRegionId`. */
+  id: string;
+  /** Human-readable name (used in the prompt and results panel). */
+  name: string;
+};
+
+/**
+ * Identify-mode question. The user clicks the region matching `answerRegionId`.
+ *
+ * @public
+ */
+export type QuizQuestion = {
+  /** Region id of the correct answer. */
+  answerRegionId: string;
+  /** Stable identifier. */
+  id: string;
+  /** Human-readable prompt rendered above the map. */
+  prompt: ReactNode;
+};
+
+/**
+ * Outcome for a single answered question.
+ *
+ * @public
+ */
+export type QuizAnswer = {
+  /** `true` when the selected region matches the answer. */
+  correct: boolean;
+  /** The original question. */
+  question: QuizQuestion;
+  /** Region id the user clicked. */
+  selectedRegionId: string;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type GeographyQuizMapLabels = {
+  /** Aria-label for the quiz region. Defaults to `"Geography quiz map"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Geography quiz map",
+} as const satisfies Required<GeographyQuizMapLabels>;
+
+type Phase = "complete" | "playing";
+type Feedback = "correct" | "incorrect";
+
+type QuizCtx = {
+  answers: QuizAnswer[];
+  current?: QuizQuestion;
+  feedback?: Feedback;
+  phase: Phase;
+  questionIndex: number;
+  totalQuestions: number;
+};
+
+const QuizContext = createContext<null | QuizCtx>(null);
+
+function useQuizContext(): QuizCtx {
+  const ctx = useContext(QuizContext);
+  if (!ctx) {
+    throw new Error("GeographyQuizMap subcomponent used outside its root.");
+  }
+  return ctx;
+}
+
+function projectEquirectangular(position: GeoPosition): {
+  x: number;
+  y: number;
+} {
+  const [lng, lat] = position;
+  const x = ((lng + 180) / 360) * VIEWBOX_WIDTH;
+  const y = ((90 - lat) / 180) * VIEWBOX_HEIGHT;
+  return { x, y };
+}
+
+function regionPath(region: QuizRegion): string {
+  const points = region.coordinates
+    .map((coord, index) => {
+      const projected = projectEquirectangular(coord);
+      return `${index === 0 ? "M" : "L"}${projected.x.toString()},${projected.y.toString()}`;
+    })
+    .join(" ");
+  return `${points} Z`;
+}
+
+/**
+ * Props for {@link GeographyQuizMap}.
+ *
+ * @public
+ */
+export type GeographyQuizMapProps = {
+  /** Optional backdrop image URL. */
+  backdrop?: string;
+  /** Aria-label for the backdrop image. */
+  backdropAlt?: string;
+  /** Localizable strings. */
+  labels?: GeographyQuizMapLabels;
+  /** Fires once the user finishes every question. */
+  onComplete?: (answers: QuizAnswer[]) => void;
+  /** Quiz questions in order. */
+  questions: QuizQuestion[];
+  /** Region polygons. */
+  regions: QuizRegion[];
+} & ComponentPropsWithoutRef<"section">;
+
+type RegionPathProps = {
+  disabled: boolean;
+  feedback?: Feedback;
+  isAnswerForCurrent: boolean;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+  region: QuizRegion;
+  showAnswerFlash: boolean;
+};
+
+function RegionShape({
+  disabled,
+  feedback,
+  isAnswerForCurrent,
+  isSelected,
+  onSelect,
+  region,
+  showAnswerFlash,
+}: RegionPathProps): ReactNode {
+  let fill = "rgb(226, 232, 240)";
+  if (isSelected && feedback === "correct") fill = "rgb(34, 197, 94)";
+  else if (isSelected && feedback === "incorrect") fill = "rgb(239, 68, 68)";
+  else if (showAnswerFlash && isAnswerForCurrent && !isSelected)
+    fill = "rgba(34, 197, 94, 0.4)";
+  return (
+    <path
+      aria-label={region.name}
+      className={cn(
+        "stroke-background outline-none transition-colors",
+        disabled
+          ? "cursor-not-allowed"
+          : "cursor-pointer hover:opacity-90 focus-visible:opacity-90",
+      )}
+      d={regionPath(region)}
+      data-region-id={region.id}
+      data-state={
+        isSelected
+          ? feedback === "correct"
+            ? "correct"
+            : "incorrect"
+          : showAnswerFlash && isAnswerForCurrent
+            ? "answer"
+            : undefined
+      }
+      fill={fill}
+      onClick={() => {
+        if (!disabled) onSelect(region.id);
+      }}
+      onKeyDown={(event) => {
+        if (disabled) return;
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        onSelect(region.id);
+      }}
+      role="button"
+      strokeWidth={1}
+      tabIndex={disabled ? -1 : 0}
+    />
+  );
+}
+
+type StageProps = {
+  backdrop?: string;
+  backdropAlt?: string;
+  current?: QuizQuestion;
+  disabled: boolean;
+  feedback?: Feedback;
+  onSelect: (id: string) => void;
+  regions: QuizRegion[];
+  selectedRegionId?: string;
+};
+
+function Stage({
+  backdrop,
+  backdropAlt,
+  current,
+  disabled,
+  feedback,
+  onSelect,
+  regions,
+  selectedRegionId,
+}: StageProps): ReactNode {
+  return (
+    <svg
+      className="block h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      viewBox={`0 0 ${VIEWBOX_WIDTH.toString()} ${VIEWBOX_HEIGHT.toString()}`}
+    >
+      <rect
+        className="fill-muted"
+        height={VIEWBOX_HEIGHT}
+        width={VIEWBOX_WIDTH}
+        x="0"
+        y="0"
+      />
+      {backdrop ? (
+        <image
+          aria-label={backdropAlt}
+          height={VIEWBOX_HEIGHT}
+          href={backdrop}
+          preserveAspectRatio="xMidYMid slice"
+          width={VIEWBOX_WIDTH}
+          x="0"
+          y="0"
+        />
+      ) : null}
+      {regions.map((region) => (
+        <RegionShape
+          disabled={disabled}
+          feedback={feedback}
+          isAnswerForCurrent={current?.answerRegionId === region.id}
+          isSelected={selectedRegionId === region.id}
+          key={region.id}
+          onSelect={onSelect}
+          region={region}
+          showAnswerFlash={feedback === "incorrect"}
+        />
+      ))}
+    </svg>
+  );
+}
+
+/**
+ * Prompt slot. Renders the current question text on top of the map.
+ *
+ * @public
+ */
+export const GeographyQuizMapPrompt = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ className, ...rest }, ref) => {
+  const { current, phase } = useQuizContext();
+  if (phase !== "playing" || !current) return null;
+  return (
+    <div
+      className={cn(
+        "absolute inset-x-3 top-3 z-10 rounded-md border bg-background/95 px-3 py-2 text-center text-sm font-medium text-foreground shadow-sm backdrop-blur",
+        className,
+      )}
+      data-quiz-prompt
+      ref={ref}
+      {...rest}
+    >
+      {current.prompt}
+    </div>
+  );
+});
+GeographyQuizMapPrompt.displayName = "GeographyQuizMapPrompt";
+
+/**
+ * Score slot. Renders `correct / total · streak%`.
+ *
+ * @public
+ */
+export const GeographyQuizMapScore = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ className, ...rest }, ref) => {
+  const { answers, totalQuestions } = useQuizContext();
+  const correct = answers.filter((entry) => entry.correct).length;
+  const accuracy =
+    answers.length === 0 ? 0 : Math.round((correct / answers.length) * 100);
+  return (
+    <div
+      className={cn(
+        "absolute right-3 top-3 z-10 rounded-md border bg-background/95 px-2 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur",
+        className,
+      )}
+      data-quiz-score
+      ref={ref}
+      {...rest}
+    >
+      {`${correct.toString()} / ${totalQuestions.toString()} · ${accuracy.toString()}%`}
+    </div>
+  );
+});
+GeographyQuizMapScore.displayName = "GeographyQuizMapScore";
+
+/**
+ * Results slot. Renders the per-question outcome list once the
+ * user finishes every question.
+ *
+ * @public
+ */
+export const GeographyQuizMapResults = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ className, ...rest }, ref) => {
+  const { answers, phase, totalQuestions } = useQuizContext();
+  if (phase !== "complete") return null;
+  const correct = answers.filter((entry) => entry.correct).length;
+  return (
+    <div
+      className={cn(
+        "absolute inset-3 z-20 flex flex-col gap-3 overflow-auto rounded-md border bg-background/95 p-4 text-sm text-foreground shadow-md backdrop-blur",
+        className,
+      )}
+      data-quiz-results
+      ref={ref}
+      {...rest}
+    >
+      <h3 className="text-base font-semibold">
+        {`Results · ${correct.toString()} / ${totalQuestions.toString()}`}
+      </h3>
+      <ol className="space-y-1">
+        {answers.map((entry) => (
+          <li
+            className={cn(
+              "flex items-center gap-2 rounded-md border px-2 py-1",
+              entry.correct
+                ? "border-emerald-300 bg-emerald-500/10"
+                : "border-red-300 bg-red-500/10",
+            )}
+            data-answer-correct={entry.correct ? "true" : "false"}
+            data-answer-id={entry.question.id}
+            key={entry.question.id}
+          >
+            <span aria-hidden="true">{entry.correct ? "✓" : "✗"}</span>
+            <span className="flex-1">{entry.question.prompt}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+});
+GeographyQuizMapResults.displayName = "GeographyQuizMapResults";
+
+type QuizState = {
+  answers: QuizAnswer[];
+  feedback?: Feedback;
+  questionIndex: number;
+  selectedRegionId?: string;
+};
+
+function useQuizState(arguments_: {
+  onComplete?: (answers: QuizAnswer[]) => void;
+  questions: QuizQuestion[];
+}): {
+  handleSelect: (regionId: string) => void;
+  state: QuizState;
+} {
+  const { onComplete, questions } = arguments_;
+  const [state, setState] = useState<QuizState>({
+    answers: [],
+    feedback: undefined,
+    questionIndex: 0,
+    selectedRegionId: undefined,
+  });
+
+  const handleSelect = useCallback(
+    (regionId: string) => {
+      setState((current) => {
+        if (current.feedback) return current;
+        const question = questions[current.questionIndex];
+        if (!question) return current;
+        const correct = question.answerRegionId === regionId;
+        const next: QuizState = {
+          ...current,
+          answers: [
+            ...current.answers,
+            { correct, question, selectedRegionId: regionId },
+          ],
+          feedback: correct ? "correct" : "incorrect",
+          selectedRegionId: regionId,
+        };
+        scheduleAdvance(setState, onComplete, questions);
+        return next;
+      });
+    },
+    [onComplete, questions],
+  );
+
+  return { handleSelect, state };
+}
+
+function scheduleAdvance(
+  setState: React.Dispatch<React.SetStateAction<QuizState>>,
+  onComplete: ((answers: QuizAnswer[]) => void) | undefined,
+  questions: QuizQuestion[],
+): void {
+  if (typeof window === "undefined") return;
+  window.setTimeout(() => {
+    setState((current) => {
+      const nextIndex = current.questionIndex + 1;
+      if (nextIndex >= questions.length) {
+        onComplete?.(current.answers);
+        return {
+          ...current,
+          feedback: undefined,
+          questionIndex: questions.length,
+          selectedRegionId: undefined,
+        };
+      }
+      return {
+        ...current,
+        feedback: undefined,
+        questionIndex: nextIndex,
+        selectedRegionId: undefined,
+      };
+    });
+  }, FEEDBACK_DURATION_MS);
+}
+
+/**
+ * Interactive map quiz. Identify-mode: each question asks the user to
+ * click the region matching the prompt. Correct clicks flash green,
+ * incorrect clicks flash red and reveal the correct region. After the
+ * final question the {@link GeographyQuizMapResults} slot renders the
+ * per-question outcome list and `onComplete` fires.
+ *
+ * Compose with {@link GeographyQuizMapPrompt}, {@link GeographyQuizMapScore},
+ * and {@link GeographyQuizMapResults} as children.
+ *
+ * @example
+ * ```tsx
+ * <GeographyQuizMap
+ *   regions={countries}
+ *   questions={[
+ *     { id: "q1", prompt: "Click on France", answerRegionId: "FR" },
+ *     { id: "q2", prompt: "Click on Germany", answerRegionId: "DE" },
+ *   ]}
+ *   onComplete={(answers) => console.info(answers)}
+ * >
+ *   <GeographyQuizMapPrompt />
+ *   <GeographyQuizMapScore />
+ *   <GeographyQuizMapResults />
+ * </GeographyQuizMap>
+ * ```
+ *
+ * @public
+ */
+export const GeographyQuizMap = forwardRef<HTMLElement, GeographyQuizMapProps>(
+  (props, ref) => {
+    const {
+      backdrop,
+      backdropAlt,
+      children,
+      className,
+      labels,
+      onComplete,
+      questions,
+      regions,
+      ...rest
+    } = props;
+    const titleId = useId();
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const { handleSelect, state } = useQuizState({ onComplete, questions });
+
+    const phase: Phase =
+      state.questionIndex >= questions.length ? "complete" : "playing";
+    const current = questions[state.questionIndex];
+
+    const ctx = useMemo<QuizCtx>(
+      () => ({
+        answers: state.answers,
+        current,
+        feedback: state.feedback,
+        phase,
+        questionIndex: state.questionIndex,
+        totalQuestions: questions.length,
+      }),
+      [
+        current,
+        phase,
+        questions.length,
+        state.answers,
+        state.feedback,
+        state.questionIndex,
+      ],
+    );
+
+    return (
+      <QuizContext.Provider value={ctx}>
+        <section
+          aria-labelledby={titleId}
+          className={cn(
+            "relative aspect-[2/1] w-full overflow-hidden rounded-2xl border bg-background text-foreground",
+            className,
+          )}
+          ref={ref}
+          {...rest}
+        >
+          <span className="sr-only" id={titleId}>
+            {resolvedLabels.region}
+          </span>
+          <Stage
+            backdrop={backdrop}
+            backdropAlt={backdropAlt}
+            current={current}
+            disabled={phase === "complete" || Boolean(state.feedback)}
+            feedback={state.feedback}
+            onSelect={handleSelect}
+            regions={regions}
+            selectedRegionId={state.selectedRegionId}
+          />
+          {children}
+        </section>
+      </QuizContext.Provider>
+    );
+  },
+);
+GeographyQuizMap.displayName = "GeographyQuizMap";

--- a/packages/ui/src/components/geography-quiz-map/geography-quiz-map.visual.tsx
+++ b/packages/ui/src/components/geography-quiz-map/geography-quiz-map.visual.tsx
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import {
+  GeographyQuizMap,
+  GeographyQuizMapPrompt,
+  GeographyQuizMapScore,
+  type QuizQuestion,
+  type QuizRegion,
+} from "./geography-quiz-map";
+
+const REGIONS: QuizRegion[] = [
+  {
+    coordinates: [
+      [-5, 51],
+      [10, 51],
+      [10, 41],
+      [-5, 41],
+      [-5, 51],
+    ],
+    id: "FR",
+    name: "France",
+  },
+  {
+    coordinates: [
+      [5, 55],
+      [15, 55],
+      [15, 47],
+      [5, 47],
+      [5, 55],
+    ],
+    id: "DE",
+    name: "Germany",
+  },
+  {
+    coordinates: [
+      [-9, 44],
+      [3, 44],
+      [3, 36],
+      [-9, 36],
+      [-9, 44],
+    ],
+    id: "ES",
+    name: "Spain",
+  },
+  {
+    coordinates: [
+      [6, 47],
+      [18, 47],
+      [18, 37],
+      [6, 37],
+      [6, 47],
+    ],
+    id: "IT",
+    name: "Italy",
+  },
+];
+
+const QUESTIONS: QuizQuestion[] = [
+  { answerRegionId: "FR", id: "q1", prompt: "Click on France" },
+  { answerRegionId: "DE", id: "q2", prompt: "Click on Germany" },
+  { answerRegionId: "ES", id: "q3", prompt: "Click on Spain" },
+];
+
+test.describe("GeographyQuizMap Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <GeographyQuizMap questions={QUESTIONS} regions={REGIONS}>
+        <GeographyQuizMapPrompt />
+        <GeographyQuizMapScore />
+      </GeographyQuizMap>,
+    );
+    await expect(component).toHaveScreenshot(
+      "geography-quiz-map-default.png",
+    );
+  });
+});

--- a/packages/ui/src/components/geography-quiz-map/index.ts
+++ b/packages/ui/src/components/geography-quiz-map/index.ts
@@ -1,0 +1,11 @@
+export {
+  GeographyQuizMap,
+  type GeographyQuizMapLabels,
+  GeographyQuizMapPrompt,
+  type GeographyQuizMapProps,
+  GeographyQuizMapResults,
+  GeographyQuizMapScore,
+  type QuizAnswer,
+  type QuizQuestion,
+  type QuizRegion,
+} from "./geography-quiz-map";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -385,6 +385,17 @@ export {
 } from "./globe-3d";
 export { GlassPanel, type GlassPanelProps } from "./glass-panel";
 export {
+  GeographyQuizMap,
+  type GeographyQuizMapLabels,
+  GeographyQuizMapPrompt,
+  type GeographyQuizMapProps,
+  GeographyQuizMapResults,
+  GeographyQuizMapScore,
+  type QuizAnswer,
+  type QuizQuestion,
+  type QuizRegion,
+} from "./geography-quiz-map";
+export {
   InfinitePlane,
   type InfinitePlaneLabels,
   type InfinitePlanePattern,


### PR DESCRIPTION
Closes #68.

Interactive map quiz. Identify-mode: each question asks the user to click the region matching the prompt. Correct clicks flash green, incorrect clicks flash red and reveal the correct region. After the final question, the results panel renders the per-question outcome list and \`onComplete\` fires. Standalone SVG — no external map library.

## What's in
- \`regions\` + \`questions\` props.
- Compound slots: \`GeographyQuizMapPrompt\`, \`GeographyQuizMapScore\`, \`GeographyQuizMapResults\`.
- ~800ms feedback delay between answer and advancing.
- \`onComplete(answers)\` fires once the final answer is recorded.
- Click + keyboard activation (Enter / Space) on each region path; aria-label from region name; role="button".
- Each region path emits \`data-region-id\` + \`data-state\` (\`"correct"\`, \`"incorrect"\`, or \`"answer"\` for the revealed correct region after a wrong click).

## Out of scope (deferred)
Locate-mode (point proximity scoring), match-mode (drag labels to regions), countdown timer, hint system (zoom-to-region), streak tracking, randomized question order, difficulty levels.

## Quality gates
- lint PASS
- typecheck PASS
- check:use-client PASS (180)
- check-story-coverage PASS (170/170)
- verify-stories PASS
- build PASS
- test PASS (502/502, +9 new)
- build-storybook PASS