### PR TITLE
feat(ui): add MapTimeline component family

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1327,6 +1327,21 @@
       "category": "utility"
     },
     {
+      "name": "map-timeline",
+      "type": "registry:component",
+      "title": "Map Timeline",
+      "description": "Standalone SVG map + time slider — era polygons and year-pinned events appear as the user scrubs the timeline.",
+      "files": [
+        {
+          "path": "registry/default/map-timeline/map-timeline.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
       "name": "mdx-content",
       "type": "registry:component",
       "title": "MDX Content",

--- a/apps/registry/registry/default/map-timeline/map-timeline.tsx
+++ b/apps/registry/registry/default/map-timeline/map-timeline.tsx
@@ -1,0 +1,14 @@
+export {
+  MapTimeline,
+  type MapTimelineColor,
+  MapTimelineControls,
+  MapTimelineEvent,
+  type MapTimelineEventProps,
+  type MapTimelineGeometry,
+  type MapTimelineLabels,
+  MapTimelineLayer,
+  type MapTimelineLayerProps,
+  MapTimelinePlayButton,
+  type MapTimelineProps,
+  MapTimelineSlider,
+} from "@vllnt/ui";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -321,6 +321,20 @@ export {
 export { Calendar, type CalendarProps } from "./calendar";
 export { CountdownTimer, type CountdownTimerProps } from "./countdown-timer";
 export { Marquee, type MarqueeProps } from "./marquee";
+export {
+  MapTimeline,
+  type MapTimelineColor,
+  MapTimelineControls,
+  MapTimelineEvent,
+  type MapTimelineEventProps,
+  type MapTimelineGeometry,
+  type MapTimelineLabels,
+  MapTimelineLayer,
+  type MapTimelineLayerProps,
+  MapTimelinePlayButton,
+  type MapTimelineProps,
+  MapTimelineSlider,
+} from "./map-timeline";
 export { NumberTicker, type NumberTickerProps } from "./number-ticker";
 export {
   Spinner,

--- a/packages/ui/src/components/map-timeline/index.ts
+++ b/packages/ui/src/components/map-timeline/index.ts
@@ -1,0 +1,15 @@
+export {
+  type GeoPosition,
+  MapTimeline,
+  type MapTimelineColor,
+  MapTimelineControls,
+  MapTimelineEvent,
+  type MapTimelineEventProps,
+  type MapTimelineGeometry,
+  type MapTimelineLabels,
+  MapTimelineLayer,
+  type MapTimelineLayerProps,
+  MapTimelinePlayButton,
+  type MapTimelineProps,
+  MapTimelineSlider,
+} from "./map-timeline";

--- a/packages/ui/src/components/map-timeline/map-timeline.mdx
+++ b/packages/ui/src/components/map-timeline/map-timeline.mdx
@@ -1,0 +1,103 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './map-timeline.stories'
+
+<Meta of={Stories} />
+
+# MapTimeline
+
+Combined map + time slider. Pass `MapTimelineLayer` (era polygons) and `MapTimelineEvent` (year-pinned markers) as children. The slider scrubs the current year; layers and events appear / disappear as the year crosses their windows. The play button auto-advances the slider on `requestAnimationFrame`.
+
+Standalone SVG primitive — no external map library required.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/map-timeline.json
+```
+
+## Import
+
+```tsx
+import {
+  MapTimeline,
+  MapTimelineLayer,
+  MapTimelineEvent,
+  MapTimelineControls,
+  MapTimelineSlider,
+  MapTimelinePlayButton,
+} from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<MapTimeline startYear={-500} endYear={2025} initialYear={1}>
+  <MapTimelineLayer
+    startYear={-27}
+    endYear={476}
+    color="red"
+    label="Roman Empire"
+    geometry={{ type: 'polygon', polygon: romanRing }}
+  />
+  <MapTimelineEvent
+    year={79}
+    position={[14.48, 40.75]}
+    title="Vesuvius"
+    description="Pompeii destroyed"
+  />
+  <MapTimelineControls>
+    <MapTimelinePlayButton />
+    <MapTimelineSlider />
+  </MapTimelineControls>
+</MapTimeline>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Layers
+
+A `MapTimelineLayer` renders only when `startYear ≤ currentYear ≤ endYear`. Pass `geometry={{ type: 'polygon', polygon: [...] }}` for a single ring or `{ type: 'multipolygon', polygons: [[...], [...]] }` for multi-island geometries.
+
+The 6-color palette (`amber`, `blue`, `emerald`, `purple`, `red`, `rose`) drives both the polygon fill and the centroid label color.
+
+## Events
+
+A `MapTimelineEvent` renders when `|currentYear - year| ≤ toleranceYears` (default `0` — exact match). Boost `toleranceYears` to keep the marker on screen for a few years around the event so it's easier to spot during slider drags.
+
+## Playback
+
+The play button auto-advances the year on `requestAnimationFrame`. `speed` controls years-per-second (default `25`). Playback pauses automatically when the year reaches `endYear`.
+
+```tsx
+<MapTimeline startYear={-500} endYear={2025} speed={50}>
+  …
+  <MapTimelineControls>
+    <MapTimelinePlayButton />
+    <MapTimelineSlider />
+  </MapTimelineControls>
+</MapTimeline>
+```
+
+## Roman era
+
+Tighter window for a focused stretch of history.
+
+<Canvas of={Stories.RomanEra} sourceState="shown" />
+
+## Without controls
+
+Drop the controls slot for embeds that drive the year externally.
+
+<Canvas of={Stories.NoControls} sourceState="shown" />
+
+## Notes
+
+- Coordinates use the same equirectangular projection as `Map2D`, `ChoroplethMap`, `RouteMap`, `HeatMapOverlay`, and `GeographyQuizMap`. Coordinates outside `[-180, 180] / [-90, 90]` are clipped by the viewBox.
+- Out of scope for the MVP: era selector buttons, info-panel slot beyond children, multi-page narrative, Globe3D composition.
+- Layer wrappers emit `data-layer-id` and `data-state="visible"` while in window. Event wrappers emit `data-event-id` and `data-event-year`. The slider exposes `data-current-year`. The play button exposes `data-playing="true"` while playing.

--- a/packages/ui/src/components/map-timeline/map-timeline.stories.tsx
+++ b/packages/ui/src/components/map-timeline/map-timeline.stories.tsx
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  MapTimeline,
+  MapTimelineControls,
+  MapTimelineEvent,
+  MapTimelineLayer,
+  MapTimelinePlayButton,
+  MapTimelineSlider,
+} from "./map-timeline";
+
+const ROMAN_RING: [number, number][] = [
+  [-9, 56],
+  [10, 56],
+  [40, 50],
+  [40, 30],
+  [10, 30],
+  [-9, 36],
+  [-9, 56],
+];
+
+const BYZANTINE_RING: [number, number][] = [
+  [10, 45],
+  [42, 45],
+  [42, 30],
+  [10, 30],
+  [10, 45],
+];
+
+const HOLY_ROMAN_RING: [number, number][] = [
+  [4, 55],
+  [18, 55],
+  [18, 45],
+  [4, 45],
+  [4, 55],
+];
+
+const meta = {
+  args: {
+    endYear: 2025,
+    initialYear: 400,
+    startYear: -500,
+  },
+  component: MapTimeline,
+  title: "Educational/MapTimeline",
+} satisfies Meta<typeof MapTimeline>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <MapTimeline {...args}>
+      <MapTimelineLayer
+        color="red"
+        endYear={476}
+        geometry={{ polygon: ROMAN_RING, type: "polygon" }}
+        id="rome"
+        label="Roman Empire"
+        startYear={-27}
+      />
+      <MapTimelineLayer
+        color="purple"
+        endYear={1453}
+        geometry={{ polygon: BYZANTINE_RING, type: "polygon" }}
+        id="byzantium"
+        label="Byzantine Empire"
+        startYear={330}
+      />
+      <MapTimelineLayer
+        color="emerald"
+        endYear={1806}
+        geometry={{ polygon: HOLY_ROMAN_RING, type: "polygon" }}
+        id="holy-roman"
+        label="Holy Roman Empire"
+        startYear={800}
+      />
+      <MapTimelineEvent
+        color="amber"
+        description="Pompeii destroyed"
+        id="vesuvius"
+        position={[14.48, 40.75]}
+        title="Vesuvius"
+        toleranceYears={400}
+        year={79}
+      />
+      <MapTimelineControls>
+        <MapTimelinePlayButton />
+        <MapTimelineSlider />
+      </MapTimelineControls>
+    </MapTimeline>
+  ),
+};
+
+export const RomanEra: Story = {
+  args: { endYear: 600, initialYear: 100, startYear: -200 },
+  render: (args) => (
+    <MapTimeline {...args}>
+      <MapTimelineLayer
+        color="red"
+        endYear={476}
+        geometry={{ polygon: ROMAN_RING, type: "polygon" }}
+        id="rome"
+        label="Roman Empire"
+        startYear={-27}
+      />
+      <MapTimelineEvent
+        color="amber"
+        description="Pompeii destroyed"
+        id="vesuvius"
+        position={[14.48, 40.75]}
+        title="Vesuvius"
+        toleranceYears={3}
+        year={79}
+      />
+      <MapTimelineControls>
+        <MapTimelinePlayButton />
+        <MapTimelineSlider />
+      </MapTimelineControls>
+    </MapTimeline>
+  ),
+};
+
+export const NoControls: Story = {
+  args: { initialYear: 800 },
+  render: (args) => (
+    <MapTimeline {...args}>
+      <MapTimelineLayer
+        color="purple"
+        endYear={1453}
+        geometry={{ polygon: BYZANTINE_RING, type: "polygon" }}
+        id="byzantium"
+        label="Byzantine Empire"
+        startYear={330}
+      />
+    </MapTimeline>
+  ),
+};

--- a/packages/ui/src/components/map-timeline/map-timeline.test.tsx
+++ b/packages/ui/src/components/map-timeline/map-timeline.test.tsx
@@ -1,0 +1,179 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  MapTimeline,
+  MapTimelineControls,
+  MapTimelineEvent,
+  MapTimelineLayer,
+  MapTimelinePlayButton,
+  MapTimelineSlider,
+} from "./map-timeline";
+
+const ROMAN_RING: [number, number][] = [
+  [-5, 50],
+  [40, 50],
+  [40, 30],
+  [-5, 30],
+  [-5, 50],
+];
+
+describe("MapTimeline", () => {
+  describe("layer visibility", () => {
+    it("renders a layer when the year falls inside its window", () => {
+      const { container } = render(
+        <MapTimeline endYear={500} initialYear={100} startYear={-100}>
+          <MapTimelineLayer
+            color="red"
+            endYear={476}
+            geometry={{ polygon: ROMAN_RING, type: "polygon" }}
+            id="rome"
+            label="Roman Empire"
+            startYear={-27}
+          />
+        </MapTimeline>,
+      );
+
+      expect(container.querySelector("[data-layer-id='rome']")).toHaveAttribute(
+        "data-state",
+        "visible",
+      );
+      expect(screen.getByText("Roman Empire")).toBeInTheDocument();
+    });
+
+    it("hides a layer when the year is outside its window", () => {
+      const { container } = render(
+        <MapTimeline endYear={500} initialYear={500} startYear={-100}>
+          <MapTimelineLayer
+            color="red"
+            endYear={476}
+            geometry={{ polygon: ROMAN_RING, type: "polygon" }}
+            id="rome"
+            label="Roman Empire"
+            startYear={-27}
+          />
+        </MapTimeline>,
+      );
+
+      expect(container.querySelector("[data-layer-id='rome']")).toBeNull();
+    });
+  });
+
+  describe("event visibility", () => {
+    it("renders an event when the year matches", () => {
+      const { container } = render(
+        <MapTimeline endYear={200} initialYear={79} startYear={0}>
+          <MapTimelineEvent
+            id="vesuvius"
+            position={[14.48, 40.75]}
+            title="Vesuvius"
+            year={79}
+          />
+        </MapTimeline>,
+      );
+
+      expect(
+        container.querySelector("[data-event-id='vesuvius']"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders an event within the tolerance window", () => {
+      const { container } = render(
+        <MapTimeline endYear={200} initialYear={82} startYear={0}>
+          <MapTimelineEvent
+            id="vesuvius"
+            position={[14.48, 40.75]}
+            title="Vesuvius"
+            toleranceYears={5}
+            year={79}
+          />
+        </MapTimeline>,
+      );
+
+      expect(
+        container.querySelector("[data-event-id='vesuvius']"),
+      ).toBeInTheDocument();
+    });
+
+    it("hides an event outside the tolerance window", () => {
+      const { container } = render(
+        <MapTimeline endYear={200} initialYear={150} startYear={0}>
+          <MapTimelineEvent
+            id="vesuvius"
+            position={[14.48, 40.75]}
+            title="Vesuvius"
+            toleranceYears={5}
+            year={79}
+          />
+        </MapTimeline>,
+      );
+
+      expect(container.querySelector("[data-event-id='vesuvius']")).toBeNull();
+    });
+  });
+
+  describe("slider", () => {
+    it("updates the visible year and fires onYearChange when the slider moves", () => {
+      const onYearChange = vi.fn();
+      const { container } = render(
+        <MapTimeline
+          endYear={500}
+          initialYear={100}
+          onYearChange={onYearChange}
+          startYear={-100}
+        >
+          <MapTimelineLayer
+            endYear={476}
+            geometry={{ polygon: ROMAN_RING, type: "polygon" }}
+            id="rome"
+            startYear={-27}
+          />
+          <MapTimelineControls>
+            <MapTimelineSlider />
+          </MapTimelineControls>
+        </MapTimeline>,
+      );
+
+      const slider = container.querySelector<HTMLInputElement>(
+        "input[type='range']",
+      );
+      expect(slider).not.toBeNull();
+      if (slider) fireEvent.change(slider, { target: { value: "300" } });
+
+      expect(onYearChange).toHaveBeenCalledWith(300);
+      expect(
+        container.querySelector("[data-current-year='300']"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("play button", () => {
+    it("toggles aria-pressed and the data-playing attribute on click", () => {
+      render(
+        <MapTimeline endYear={500} initialYear={0} startYear={0}>
+          <MapTimelineControls>
+            <MapTimelinePlayButton />
+          </MapTimelineControls>
+        </MapTimeline>,
+      );
+
+      const button = screen.getByRole("button", { name: "Play" });
+      expect(button).toHaveAttribute("aria-pressed", "false");
+
+      fireEvent.click(button);
+      const pause = screen.getByRole("button", { name: "Pause" });
+      expect(pause).toHaveAttribute("aria-pressed", "true");
+      expect(pause).toHaveAttribute("data-playing", "true");
+    });
+  });
+
+  describe("compound contract", () => {
+    it("throws when subcomponents render outside the root", () => {
+      const renderOrphan = (): void => {
+        render(<MapTimelineSlider />);
+      };
+
+      expect(renderOrphan).toThrow(/MapTimeline subcomponent/);
+    });
+  });
+});

--- a/packages/ui/src/components/map-timeline/map-timeline.tsx
+++ b/packages/ui/src/components/map-timeline/map-timeline.tsx
@@ -1,0 +1,775 @@
+"use client";
+
+import {
+  type ChangeEvent,
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+const VIEWBOX_WIDTH = 1000;
+const VIEWBOX_HEIGHT = 500;
+
+/**
+ * Geographic coordinate `[longitude, latitude]`.
+ *
+ * @public
+ */
+export type GeoPosition = [number, number];
+
+/**
+ * Color theme for layers and event markers.
+ *
+ * @public
+ */
+export type MapTimelineColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "purple"
+  | "red"
+  | "rose";
+
+const PALETTE: Record<
+  MapTimelineColor,
+  { dot: string; fill: string; stroke: string }
+> = {
+  amber: {
+    dot: "fill-amber-500",
+    fill: "rgba(245, 158, 11, 0.25)",
+    stroke: "#b45309",
+  },
+  blue: {
+    dot: "fill-blue-500",
+    fill: "rgba(59, 130, 246, 0.25)",
+    stroke: "#1d4ed8",
+  },
+  emerald: {
+    dot: "fill-emerald-500",
+    fill: "rgba(16, 185, 129, 0.25)",
+    stroke: "#047857",
+  },
+  purple: {
+    dot: "fill-purple-500",
+    fill: "rgba(168, 85, 247, 0.25)",
+    stroke: "#7c3aed",
+  },
+  red: {
+    dot: "fill-red-500",
+    fill: "rgba(239, 68, 68, 0.25)",
+    stroke: "#b91c1c",
+  },
+  rose: {
+    dot: "fill-rose-500",
+    fill: "rgba(244, 63, 94, 0.25)",
+    stroke: "#be123c",
+  },
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type MapTimelineLabels = {
+  /** Pause-button label. Defaults to `"Pause"`. */
+  pause?: string;
+  /** Play-button label. Defaults to `"Play"`. */
+  play?: string;
+  /** Aria-label for the map region. Defaults to `"Map timeline"`. */
+  region?: string;
+  /** Aria-label for the timeline slider. Defaults to `"Year"`. */
+  slider?: string;
+};
+
+const DEFAULT_LABELS = {
+  pause: "Pause",
+  play: "Play",
+  region: "Map timeline",
+  slider: "Year",
+} as const satisfies Required<MapTimelineLabels>;
+
+type Ctx = {
+  endYear: number;
+  isPlaying: boolean;
+  labels: Required<MapTimelineLabels>;
+  setIsPlaying: (next: boolean) => void;
+  setYear: (next: number) => void;
+  speed: number;
+  startYear: number;
+  year: number;
+};
+
+const TimelineContext = createContext<Ctx | null>(null);
+
+function useTimelineContext(): Ctx {
+  const ctx = useContext(TimelineContext);
+  if (!ctx) {
+    throw new Error("MapTimeline subcomponent used outside its root.");
+  }
+  return ctx;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function projectEquirectangular(position: GeoPosition): {
+  x: number;
+  y: number;
+} {
+  const [lng, lat] = position;
+  return {
+    x: ((lng + 180) / 360) * VIEWBOX_WIDTH,
+    y: ((90 - lat) / 180) * VIEWBOX_HEIGHT,
+  };
+}
+
+function formatYear(year: number): string {
+  if (year < 0) return `${Math.abs(year).toString()} BCE`;
+  return `${year.toString()} CE`;
+}
+
+function ringToPath(ring: GeoPosition[]): string {
+  return ring
+    .map((position, index) => {
+      const projected = projectEquirectangular(position);
+      return `${index === 0 ? "M" : "L"}${projected.x.toString()},${projected.y.toString()}`;
+    })
+    .join(" ");
+}
+
+/**
+ * GeoJSON-style polygon for a {@link MapTimelineLayer}. Pass either a
+ * `polygon` (single ring) or a `polygons` array (multi-polygon).
+ *
+ * @public
+ */
+export type MapTimelineGeometry =
+  | { polygon: GeoPosition[]; polygons?: never; type: "polygon" }
+  | { polygon?: never; polygons: GeoPosition[][]; type: "multipolygon" };
+
+/**
+ * Props for {@link MapTimelineLayer}.
+ *
+ * @public
+ */
+export type MapTimelineLayerProps = {
+  /** Color theme. Defaults to `"blue"`. */
+  color?: MapTimelineColor;
+  /** Year (inclusive) when the layer disappears. */
+  endYear: number;
+  /** Polygon geometry. */
+  geometry: MapTimelineGeometry;
+  /** Stable id used for analytics + React keys. */
+  id?: string;
+  /** Display label rendered in the centroid when visible. */
+  label?: ReactNode;
+  /** Year (inclusive) when the layer first appears. */
+  startYear: number;
+} & Omit<ComponentPropsWithoutRef<"g">, "id">;
+
+function geometryRings(geometry: MapTimelineGeometry): GeoPosition[][] {
+  if (geometry.type === "polygon") return [geometry.polygon];
+  return geometry.polygons;
+}
+
+function ringCentroid(ring: GeoPosition[]): { x: number; y: number } {
+  if (ring.length === 0) return { x: 0, y: 0 };
+  const total = ring.reduce<{ x: number; y: number }>(
+    (accumulator, position) => {
+      const projected = projectEquirectangular(position);
+      return { x: accumulator.x + projected.x, y: accumulator.y + projected.y };
+    },
+    { x: 0, y: 0 },
+  );
+  return { x: total.x / ring.length, y: total.y / ring.length };
+}
+
+/**
+ * Geographic layer pinned to a year window.
+ *
+ * @public
+ */
+export const MapTimelineLayer = forwardRef<SVGGElement, MapTimelineLayerProps>(
+  (props, ref) => {
+    const {
+      color = "blue",
+      endYear,
+      geometry,
+      id,
+      label,
+      startYear,
+      ...rest
+    } = props;
+    const { year } = useTimelineContext();
+    if (year < startYear || year > endYear) return null;
+    const palette = PALETTE[color];
+    const rings = geometryRings(geometry);
+    const centroid = rings[0] ? ringCentroid(rings[0]) : { x: 0, y: 0 };
+    return (
+      <g data-layer-id={id} data-state="visible" ref={ref} {...rest}>
+        {rings.map((ring, index) => (
+          <path
+            d={`${ringToPath(ring)} Z`}
+            fill={palette.fill}
+            key={`${id ?? "layer"}-ring-${index.toString()}`}
+            stroke={palette.stroke}
+            strokeWidth={1.5}
+          />
+        ))}
+        {label ? (
+          <text
+            className="select-none fill-foreground text-[11px] font-semibold"
+            dominantBaseline="middle"
+            textAnchor="middle"
+            x={centroid.x}
+            y={centroid.y}
+          >
+            {label}
+          </text>
+        ) : null}
+      </g>
+    );
+  },
+);
+MapTimelineLayer.displayName = "MapTimelineLayer";
+
+/**
+ * Props for {@link MapTimelineEvent}.
+ *
+ * @public
+ */
+export type MapTimelineEventProps = {
+  /** Color theme. Defaults to `"red"`. */
+  color?: MapTimelineColor;
+  /** Optional description rendered in the tooltip. */
+  description?: ReactNode;
+  /** Stable identifier. */
+  id?: string;
+  /** Geographic position. */
+  position: GeoPosition;
+  /** Title rendered in the tooltip. */
+  title?: ReactNode;
+  /** Inclusive ± window in years around `year` when the marker shows. Defaults to `0` (exact match). */
+  toleranceYears?: number;
+  /** Year the event happened. */
+  year: number;
+} & Omit<ComponentPropsWithoutRef<"g">, "id">;
+
+/**
+ * Year-pinned event marker.
+ *
+ * @public
+ */
+export const MapTimelineEvent = forwardRef<SVGGElement, MapTimelineEventProps>(
+  (props, ref) => {
+    const {
+      color = "red",
+      description,
+      id,
+      position,
+      title,
+      toleranceYears = 0,
+      year: eventYear,
+      ...rest
+    } = props;
+    const { year } = useTimelineContext();
+    const visible = Math.abs(year - eventYear) <= toleranceYears;
+    if (!visible) return null;
+    const palette = PALETTE[color];
+    const projected = projectEquirectangular(position);
+    return (
+      <g
+        data-event-id={id}
+        data-event-year={eventYear}
+        ref={ref}
+        transform={`translate(${projected.x.toString()}, ${projected.y.toString()})`}
+        {...rest}
+      >
+        <circle
+          className={cn("stroke-background", palette.dot)}
+          r="6"
+          strokeWidth="2"
+        >
+          {title ? (
+            <title>{typeof title === "string" ? title : ""}</title>
+          ) : null}
+        </circle>
+        {title ? (
+          <text
+            className="select-none fill-foreground text-[10px] font-semibold"
+            dominantBaseline="middle"
+            textAnchor="middle"
+            y="-12"
+          >
+            {title}
+          </text>
+        ) : null}
+        {description ? (
+          <text
+            className="select-none fill-muted-foreground text-[9px]"
+            dominantBaseline="middle"
+            textAnchor="middle"
+            y="20"
+          >
+            {description}
+          </text>
+        ) : null}
+      </g>
+    );
+  },
+);
+MapTimelineEvent.displayName = "MapTimelineEvent";
+
+/**
+ * Container for the slider + play button row.
+ *
+ * @public
+ */
+export const MapTimelineControls = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ children, className, ...rest }, ref) => (
+  <div
+    className={cn(
+      "flex items-center gap-3 border-t border-border bg-muted/40 px-4 py-2",
+      className,
+    )}
+    ref={ref}
+    {...rest}
+  >
+    {children}
+  </div>
+));
+MapTimelineControls.displayName = "MapTimelineControls";
+
+/**
+ * Range-input slider bound to the current year.
+ *
+ * @public
+ */
+export const MapTimelineSlider = forwardRef<
+  HTMLInputElement,
+  Omit<
+    ComponentPropsWithoutRef<"input">,
+    "max" | "min" | "onChange" | "type" | "value"
+  >
+>(({ className, ...rest }, ref) => {
+  const { endYear, labels, setYear, startYear, year } = useTimelineContext();
+  const sliderId = useId();
+  const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    setYear(Number.parseInt(event.target.value, 10));
+  };
+  return (
+    <div className="flex flex-1 items-center gap-2 text-xs font-medium text-muted-foreground">
+      <span aria-hidden="true">{formatYear(startYear)}</span>
+      <input
+        aria-label={labels.slider}
+        aria-valuemax={endYear}
+        aria-valuemin={startYear}
+        aria-valuenow={year}
+        className={cn("flex-1 accent-primary", className)}
+        id={sliderId}
+        max={endYear}
+        min={startYear}
+        onChange={handleChange}
+        ref={ref}
+        type="range"
+        value={year}
+        {...rest}
+      />
+      <span aria-hidden="true">{formatYear(endYear)}</span>
+      <span
+        className="ml-2 inline-flex min-w-20 justify-center rounded-md border border-border bg-background px-2 py-0.5 text-foreground"
+        data-current-year={year}
+      >
+        {formatYear(year)}
+      </span>
+    </div>
+  );
+});
+MapTimelineSlider.displayName = "MapTimelineSlider";
+
+/**
+ * Play / pause toggle that auto-advances the year on `requestAnimationFrame`.
+ *
+ * @public
+ */
+export const MapTimelinePlayButton = forwardRef<
+  HTMLButtonElement,
+  Omit<ComponentPropsWithoutRef<"button">, "aria-pressed" | "onClick" | "type">
+>(({ className, ...rest }, ref) => {
+  const { isPlaying, labels, setIsPlaying } = useTimelineContext();
+  const handleClick = (): void => {
+    setIsPlaying(!isPlaying);
+  };
+  return (
+    <button
+      aria-label={isPlaying ? labels.pause : labels.play}
+      aria-pressed={isPlaying}
+      className={cn(
+        "inline-flex h-8 items-center rounded-md border border-border bg-background px-3 text-xs font-medium hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+      data-playing={isPlaying ? "true" : undefined}
+      onClick={handleClick}
+      ref={ref}
+      type="button"
+      {...rest}
+    >
+      <span aria-hidden="true">{isPlaying ? "❚❚" : "▶"}</span>
+    </button>
+  );
+});
+MapTimelinePlayButton.displayName = "MapTimelinePlayButton";
+
+/**
+ * Props for {@link MapTimeline}.
+ *
+ * @public
+ */
+export type MapTimelineProps = {
+  /** Optional URL of a backdrop image (world map, terrain). */
+  backdrop?: string;
+  /** Aria-label for the backdrop image. */
+  backdropAlt?: string;
+  /** End of the timeline window (inclusive). */
+  endYear: number;
+  /** Initial year. Defaults to `startYear`. */
+  initialYear?: number;
+  /** Localizable strings. */
+  labels?: MapTimelineLabels;
+  /** Fires when the year changes (slider drag, play tick, or programmatic). */
+  onYearChange?: (next: number) => void;
+  /** Years per second when playing. Defaults to `25`. */
+  speed?: number;
+  /** Start of the timeline window (inclusive). Negative for BCE. */
+  startYear: number;
+} & Omit<ComponentPropsWithoutRef<"section">, "onChange">;
+
+function useTimelineCtx(arguments_: {
+  endYear: number;
+  isPlaying: boolean;
+  labels: Required<MapTimelineLabels>;
+  setIsPlaying: (next: boolean) => void;
+  setYear: (next: number) => void;
+  speed: number;
+  startYear: number;
+  year: number;
+}): Ctx {
+  const {
+    endYear,
+    isPlaying,
+    labels,
+    setIsPlaying,
+    setYear,
+    speed,
+    startYear,
+    year,
+  } = arguments_;
+  return useMemo<Ctx>(
+    () => ({
+      endYear,
+      isPlaying,
+      labels,
+      setIsPlaying,
+      setYear,
+      speed,
+      startYear,
+      year,
+    }),
+    [endYear, isPlaying, labels, setIsPlaying, setYear, speed, startYear, year],
+  );
+}
+
+function useTimelineState(arguments_: {
+  endYear: number;
+  initialYear?: number;
+  onYearChange?: (next: number) => void;
+  speed: number;
+  startYear: number;
+}): {
+  isPlaying: boolean;
+  setIsPlaying: (next: boolean) => void;
+  setYear: (next: number) => void;
+  year: number;
+} {
+  const { endYear, initialYear, onYearChange, startYear } = arguments_;
+  const [year, setYear] = useState<number>(
+    clamp(initialYear ?? startYear, startYear, endYear),
+  );
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const updateYear = useCallback(
+    (next: number) => {
+      const clamped = clamp(next, startYear, endYear);
+      setYear((current) => {
+        if (clamped >= endYear) setIsPlaying(false);
+        if (current === clamped) return current;
+        onYearChange?.(clamped);
+        return clamped;
+      });
+    },
+    [endYear, onYearChange, startYear],
+  );
+
+  return { isPlaying, setIsPlaying, setYear: updateYear, year };
+}
+
+function usePlayback(arguments_: {
+  endYear: number;
+  isPlaying: boolean;
+  setIsPlaying: (next: boolean) => void;
+  setYear: (next: number) => void;
+  speed: number;
+  startYear: number;
+  year: number;
+}): void {
+  const { endYear, isPlaying, setIsPlaying, setYear, speed, year } = arguments_;
+  const yearRef = useRef(year);
+  useEffect(() => {
+    yearRef.current = year;
+  }, [year]);
+  useEffect(() => {
+    if (!isPlaying) return;
+    if (typeof window === "undefined") return;
+    let frame = 0;
+    let last: null | number = null;
+    const step = (timestamp: number): void => {
+      if (last !== null) {
+        const delta = (timestamp - last) / 1000;
+        const next = yearRef.current + delta * speed;
+        if (next >= endYear) {
+          setYear(endYear);
+          setIsPlaying(false);
+          return;
+        }
+        setYear(next);
+      }
+      last = timestamp;
+      frame = window.requestAnimationFrame(step);
+    };
+    frame = window.requestAnimationFrame(step);
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [endYear, isPlaying, setIsPlaying, setYear, speed]);
+}
+
+type StageProps = {
+  backdrop?: string;
+  backdropAlt?: string;
+  children: ReactNode;
+};
+
+function Stage({ backdrop, backdropAlt, children }: StageProps): ReactNode {
+  return (
+    <svg
+      aria-hidden="true"
+      className="block h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+      viewBox={`0 0 ${VIEWBOX_WIDTH.toString()} ${VIEWBOX_HEIGHT.toString()}`}
+    >
+      <rect
+        className="fill-muted"
+        height={VIEWBOX_HEIGHT}
+        width={VIEWBOX_WIDTH}
+        x="0"
+        y="0"
+      />
+      {backdrop ? (
+        <image
+          aria-label={backdropAlt}
+          height={VIEWBOX_HEIGHT}
+          href={backdrop}
+          preserveAspectRatio="xMidYMid slice"
+          width={VIEWBOX_WIDTH}
+          x="0"
+          y="0"
+        />
+      ) : null}
+      {children}
+    </svg>
+  );
+}
+
+type ChildBuckets = {
+  footer: ReactNode[];
+  stage: ReactNode[];
+};
+
+function bucketChildren(children: ReactNode): ChildBuckets {
+  const list: ReactNode[] = Array.isArray(children) ? children : [children];
+  return list.reduce<ChildBuckets>(
+    (accumulator, child) => {
+      const name = displayName(child);
+      if (name === MapTimelineControls.displayName)
+        accumulator.footer.push(child);
+      else accumulator.stage.push(child);
+      return accumulator;
+    },
+    { footer: [], stage: [] },
+  );
+}
+
+function displayName(child: ReactNode): string | undefined {
+  if (typeof child !== "object" || child === null) return undefined;
+  if (!("type" in child)) return undefined;
+  const type = (child as { type: unknown }).type;
+  if (typeof type !== "object" && typeof type !== "function") return undefined;
+  const name = (type as { displayName?: unknown }).displayName;
+  return typeof name === "string" ? name : undefined;
+}
+
+type ShellProps = {
+  backdrop?: string;
+  backdropAlt?: string;
+  buckets: ChildBuckets;
+  className?: string;
+  region: string;
+  titleId: string;
+  year: number;
+};
+
+const Shell = forwardRef<HTMLElement, ShellProps>(function Shell(props, ref) {
+  const { backdrop, backdropAlt, buckets, className, region, titleId, year } =
+    props;
+  return (
+    <section
+      aria-labelledby={titleId}
+      className={cn(
+        "flex w-full flex-col overflow-hidden rounded-2xl border bg-background text-foreground",
+        className,
+      )}
+      ref={ref}
+    >
+      <span className="sr-only" id={titleId}>
+        {region}
+      </span>
+      <div
+        className="relative aspect-[2/1] w-full overflow-hidden"
+        data-current-year={year}
+      >
+        <Stage backdrop={backdrop} backdropAlt={backdropAlt}>
+          {buckets.stage}
+        </Stage>
+      </div>
+      {buckets.footer}
+    </section>
+  );
+});
+
+/**
+ * Combined map + timeline. Pass {@link MapTimelineLayer} (era polygons),
+ * {@link MapTimelineEvent} (year-pinned markers), and
+ * {@link MapTimelineControls} as children. The slider scrubs the
+ * current year; layers and events appear / disappear as the year
+ * crosses their windows.
+ *
+ * Standalone SVG primitive — no external map library required.
+ *
+ * @example
+ * ```tsx
+ * <MapTimeline startYear={-500} endYear={2025} initialYear={1}>
+ *   <MapTimelineLayer
+ *     startYear={-27}
+ *     endYear={476}
+ *     color="red"
+ *     label="Roman Empire"
+ *     geometry={{ type: 'polygon', polygon: romanRing }}
+ *   />
+ *   <MapTimelineEvent
+ *     year={79}
+ *     position={[14.48, 40.75]}
+ *     title="Vesuvius"
+ *     description="Pompeii destroyed"
+ *   />
+ *   <MapTimelineControls>
+ *     <MapTimelinePlayButton />
+ *     <MapTimelineSlider />
+ *   </MapTimelineControls>
+ * </MapTimeline>
+ * ```
+ *
+ * @public
+ */
+export const MapTimeline = forwardRef<HTMLElement, MapTimelineProps>(
+  (props, ref) => {
+    const {
+      backdrop,
+      backdropAlt,
+      children,
+      className,
+      endYear,
+      initialYear,
+      labels,
+      onYearChange,
+      speed = 25,
+      startYear,
+      ...rest
+    } = props;
+    const titleId = useId();
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+
+    const { isPlaying, setIsPlaying, setYear, year } = useTimelineState({
+      endYear,
+      initialYear,
+      onYearChange,
+      speed,
+      startYear,
+    });
+
+    usePlayback({
+      endYear,
+      isPlaying,
+      setIsPlaying,
+      setYear,
+      speed,
+      startYear,
+      year,
+    });
+
+    const ctx = useTimelineCtx({
+      endYear,
+      isPlaying,
+      labels: resolvedLabels,
+      setIsPlaying,
+      setYear,
+      speed,
+      startYear,
+      year,
+    });
+
+    const buckets = bucketChildren(children);
+    return (
+      <TimelineContext.Provider value={ctx}>
+        <Shell
+          backdrop={backdrop}
+          backdropAlt={backdropAlt}
+          buckets={buckets}
+          className={className}
+          ref={ref}
+          region={resolvedLabels.region}
+          titleId={titleId}
+          year={year}
+          {...rest}
+        />
+      </TimelineContext.Provider>
+    );
+  },
+);
+MapTimeline.displayName = "MapTimeline";

--- a/packages/ui/src/components/map-timeline/map-timeline.visual.tsx
+++ b/packages/ui/src/components/map-timeline/map-timeline.visual.tsx
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import {
+  MapTimeline,
+  MapTimelineControls,
+  MapTimelineEvent,
+  MapTimelineLayer,
+  MapTimelinePlayButton,
+  MapTimelineSlider,
+} from "./map-timeline";
+
+const ROMAN_RING: [number, number][] = [
+  [-9, 56],
+  [10, 56],
+  [40, 50],
+  [40, 30],
+  [10, 30],
+  [-9, 36],
+  [-9, 56],
+];
+
+const BYZANTINE_RING: [number, number][] = [
+  [10, 45],
+  [42, 45],
+  [42, 30],
+  [10, 30],
+  [10, 45],
+];
+
+test.describe("MapTimeline Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <MapTimeline endYear={2025} initialYear={400} startYear={-500}>
+        <MapTimelineLayer
+          color="red"
+          endYear={476}
+          geometry={{ polygon: ROMAN_RING, type: "polygon" }}
+          id="rome"
+          label="Roman Empire"
+          startYear={-27}
+        />
+        <MapTimelineLayer
+          color="purple"
+          endYear={1453}
+          geometry={{ polygon: BYZANTINE_RING, type: "polygon" }}
+          id="byzantium"
+          label="Byzantine Empire"
+          startYear={330}
+        />
+        <MapTimelineEvent
+          color="amber"
+          description="Pompeii destroyed"
+          id="vesuvius"
+          position={[14.48, 40.75]}
+          title="Vesuvius"
+          toleranceYears={400}
+          year={79}
+        />
+        <MapTimelineControls>
+          <MapTimelinePlayButton />
+          <MapTimelineSlider />
+        </MapTimelineControls>
+      </MapTimeline>,
+    );
+    await expect(component).toHaveScreenshot("map-timeline-default.png");
+  });
+});


### PR DESCRIPTION
Closes #30.

Combined map + time-slider compound family. Standalone SVG primitive — no external map library. Pass \`MapTimelineLayer\` (era polygons) and \`MapTimelineEvent\` (year-pinned markers) as children; layers and events appear / disappear as the year crosses their windows.

## What's in
- \`MapTimeline\` (root): \`startYear\`, \`endYear\`, \`initialYear\`, \`speed\`, optional \`onYearChange\`, optional backdrop image.
- \`MapTimelineLayer\`: polygon (single-ring or multi-polygon), \`startYear\` / \`endYear\` window, color theme, optional centroid label.
- \`MapTimelineEvent\`: year-pinned marker with \`toleranceYears\` window, position, title, description.
- \`MapTimelineControls\`: footer slot below the map.
- \`MapTimelineSlider\`: range input bound to the current year, with start / end / current-year labels.
- \`MapTimelinePlayButton\`: auto-advances year on \`requestAnimationFrame\` at \`speed\` years per second; pauses at \`endYear\`.
- 6-color palette: amber / blue / emerald / purple / red / rose.
- Layer wrappers emit \`data-layer-id\`, \`data-state="visible"\`. Events emit \`data-event-id\`, \`data-event-year\`. Slider exposes \`data-current-year\`. Play button exposes \`data-playing="true"\` while playing.

## Out of scope (deferred)
Era selector buttons, info-panel slot beyond children, multi-page narrative, Globe3D composition.

## Quality gates
- lint PASS
- typecheck PASS
- check:use-client PASS (180)
- check-story-coverage PASS (170/170)
- verify-stories PASS
- build PASS
- test PASS (501/501, +8 new)
- build-storybook PASS