### PR TITLE
feat(ui): add StoryMap component family

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -2356,6 +2356,21 @@
       "category": "data"
     },
     {
+      "name": "story-map",
+      "type": "registry:component",
+      "title": "Story Map",
+      "description": "Standalone SVG scroll-driven narrative map — IntersectionObserver tracks the active chapter and the map shifts to its center + zoom.",
+      "files": [
+        {
+          "path": "registry/default/story-map/story-map.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
       "name": "subscription-card",
       "type": "registry:component",
       "title": "Subscription Card",

--- a/apps/registry/registry/default/story-map/story-map.tsx
+++ b/apps/registry/registry/default/story-map/story-map.tsx
@@ -1,0 +1,9 @@
+export {
+  StoryMap,
+  StoryMapChapter,
+  type StoryMapChapterProps,
+  type StoryMapColor,
+  type StoryMapLabels,
+  type StoryMapMedia,
+  type StoryMapProps,
+} from "@vllnt/ui";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -493,6 +493,15 @@ export {
   type SparklineGridProps,
 } from "./sparkline-grid";
 export {
+  StoryMap,
+  StoryMapChapter,
+  type StoryMapChapterProps,
+  type StoryMapColor,
+  type StoryMapLabels,
+  type StoryMapMedia,
+  type StoryMapProps,
+} from "./story-map";
+export {
   SubscriptionCard,
   type SubscriptionCardProps,
   type SubscriptionCardStatus,

--- a/packages/ui/src/components/story-map/index.ts
+++ b/packages/ui/src/components/story-map/index.ts
@@ -1,0 +1,10 @@
+export {
+  type GeoPosition,
+  StoryMap,
+  StoryMapChapter,
+  type StoryMapChapterProps,
+  type StoryMapColor,
+  type StoryMapLabels,
+  type StoryMapMedia,
+  type StoryMapProps,
+} from "./story-map";

--- a/packages/ui/src/components/story-map/story-map.mdx
+++ b/packages/ui/src/components/story-map/story-map.mdx
@@ -1,0 +1,78 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './story-map.stories'
+
+<Meta of={Stories} />
+
+# StoryMap
+
+Scroll-driven narrative map. Place `StoryMapChapter` children in the narrative column; an `IntersectionObserver` tracks which chapter is in view and the SVG map shifts to center on its `[lng, lat]` and `zoom`. Standalone SVG — no external map library required.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/story-map.json
+```
+
+## Import
+
+```tsx
+import { StoryMap, StoryMapChapter } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<StoryMap>
+  <StoryMapChapter
+    center={[12.49, 41.89]}
+    zoom={4}
+    title="The Fall of Rome"
+  >
+    <p>In 476 AD, the last Western Roman Emperor was deposed...</p>
+  </StoryMapChapter>
+
+  <StoryMapChapter
+    center={[28.98, 41.01]}
+    zoom={4}
+    title="Constantinople Endures"
+    color="purple"
+  >
+    <p>While Rome fell, Constantinople thrived...</p>
+  </StoryMapChapter>
+</StoryMap>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Layout
+
+- **Desktop** (≥ md): two-column. The map sticks to the top-left of the viewport while the narrative scrolls on the right.
+- **Mobile**: stacked. The narrative occupies the full width; the map renders beneath it as a fixed-height strip.
+
+## Chapter zoom
+
+`zoom` is a multiplier of the underlying viewBox: `1` shows the full world, `2` zooms in 2×, `8` zooms in tight on a city. Mid-range values (`3` – `4`) read well for country-scale narratives.
+
+## With media
+
+Pass `media={{ type: 'image', src, alt, caption? }}` to attach a thumbnail to the chapter card.
+
+<Canvas of={Stories.WithMedia} sourceState="shown" />
+
+## Single chapter
+
+The component still works with a single chapter — the map centers on its position with no scroll-driven transitions.
+
+<Canvas of={Stories.SingleChapter} sourceState="shown" />
+
+## Notes
+
+- Coordinates use a simple equirectangular projection (matches `Map2D`, `ChoroplethMap`, `RouteMap`, `HeatMapOverlay`, `MapTimeline`, `GeographyQuizMap`).
+- Out of scope for the MVP: route drawing between chapters, video media, fullscreen mode, chapter-navigation sidebar, smooth tweened transitions (the map snaps via CSS to the new viewBox). Wire those externally on top of the rendered DOM.
+- Chapter cards emit `data-chapter-id`. SVG markers emit `data-marker-id` and (when active) `data-marker-active="true"`. Each map stage emits `data-story-map-stage` (desktop) or `data-story-map-stage-mobile`. The active SVG carries `data-active-chapter-id` and `data-active-zoom`.

--- a/packages/ui/src/components/story-map/story-map.stories.tsx
+++ b/packages/ui/src/components/story-map/story-map.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { StoryMap, StoryMapChapter } from "./story-map";
+
+const meta = {
+  component: StoryMap,
+  title: "Educational/StoryMap",
+} satisfies Meta<typeof StoryMap>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <StoryMap>
+      <StoryMapChapter
+        center={[12.49, 41.89]}
+        color="red"
+        id="rome"
+        subtitle="476 AD"
+        title="The Fall of Rome"
+        zoom={3}
+      >
+        <p>
+          In 476 AD, the last Western Roman Emperor was deposed by the
+          Germanic king Odoacer, conventionally marking the end of the
+          Western Roman Empire.
+        </p>
+      </StoryMapChapter>
+      <StoryMapChapter
+        center={[28.98, 41.01]}
+        color="purple"
+        id="constantinople"
+        subtitle="476 – 1453"
+        title="Constantinople Endures"
+        zoom={3}
+      >
+        <p>
+          While Rome fell, Constantinople thrived as the capital of the
+          Byzantine Empire for nearly a thousand more years, preserving
+          much of Greek and Roman knowledge through the early Middle Ages.
+        </p>
+      </StoryMapChapter>
+      <StoryMapChapter
+        center={[36.2, 36.15]}
+        color="amber"
+        id="crusades"
+        subtitle="1096 – 1291"
+        title="The Crusades"
+        zoom={3}
+      >
+        <p>
+          Between 1096 and 1291, a series of religious wars launched by
+          Western European Christians sought to recapture Jerusalem and
+          other holy lands from Muslim rule.
+        </p>
+      </StoryMapChapter>
+    </StoryMap>
+  ),
+};
+
+export const WithMedia: Story = {
+  render: () => (
+    <StoryMap>
+      <StoryMapChapter
+        center={[2.35, 48.85]}
+        id="paris"
+        media={{
+          alt: "Paris from above",
+          caption: "Paris, France",
+          src: "https://placehold.co/640x360/0d1117/d0d0d0/png?text=Paris",
+          type: "image",
+        }}
+        title="Paris"
+        zoom={4}
+      >
+        <p>The Eiffel Tower opened to the public on May 6, 1889.</p>
+      </StoryMapChapter>
+      <StoryMapChapter
+        center={[-0.13, 51.5]}
+        id="london"
+        media={{
+          alt: "London from above",
+          caption: "London, England",
+          src: "https://placehold.co/640x360/0d1117/d0d0d0/png?text=London",
+          type: "image",
+        }}
+        title="London"
+        zoom={4}
+      >
+        <p>Big Ben rang out for the first time on May 31, 1859.</p>
+      </StoryMapChapter>
+    </StoryMap>
+  ),
+};
+
+export const SingleChapter: Story = {
+  render: () => (
+    <StoryMap>
+      <StoryMapChapter center={[2.35, 48.85]} id="paris" title="Paris" zoom={4}>
+        <p>The Eiffel Tower opened to the public on May 6, 1889.</p>
+      </StoryMapChapter>
+    </StoryMap>
+  ),
+};

--- a/packages/ui/src/components/story-map/story-map.test.tsx
+++ b/packages/ui/src/components/story-map/story-map.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StoryMap, StoryMapChapter } from "./story-map";
+
+describe("StoryMap", () => {
+  describe("rendering", () => {
+    it("renders one chapter article per child", () => {
+      const { container } = render(
+        <StoryMap>
+          <StoryMapChapter
+            center={[12.49, 41.89]}
+            id="rome"
+            title="The Fall of Rome"
+          >
+            <p>Rome fell.</p>
+          </StoryMapChapter>
+          <StoryMapChapter
+            center={[28.98, 41.01]}
+            id="constantinople"
+            title="Constantinople Endures"
+          >
+            <p>Byzantium thrived.</p>
+          </StoryMapChapter>
+        </StoryMap>,
+      );
+
+      expect(
+        container.querySelector("[data-chapter-id='rome']"),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector("[data-chapter-id='constantinople']"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("The Fall of Rome")).toBeInTheDocument();
+      expect(screen.getByText("Constantinople Endures")).toBeInTheDocument();
+    });
+
+    it("registers a marker per chapter on the SVG stages", () => {
+      const { container } = render(
+        <StoryMap>
+          <StoryMapChapter center={[12.49, 41.89]} id="rome" title="Rome" />
+          <StoryMapChapter
+            center={[28.98, 41.01]}
+            id="constantinople"
+            title="Constantinople"
+          />
+        </StoryMap>,
+      );
+
+      const markers = container.querySelectorAll("[data-marker-id='rome']");
+      expect(markers.length).toBeGreaterThan(0);
+      const otherMarkers = container.querySelectorAll(
+        "[data-marker-id='constantinople']",
+      );
+      expect(otherMarkers.length).toBeGreaterThan(0);
+    });
+
+    it("renders an image when chapter media is set", () => {
+      render(
+        <StoryMap>
+          <StoryMapChapter
+            center={[12.49, 41.89]}
+            id="rome"
+            media={{ alt: "Forum", src: "/forum.jpg", type: "image" }}
+            title="Rome"
+          />
+        </StoryMap>,
+      );
+
+      const image = screen.getByAltText("Forum");
+      expect(image).toHaveAttribute("src", "/forum.jpg");
+    });
+  });
+
+  describe("compound contract", () => {
+    it("throws when StoryMapChapter renders outside the root", () => {
+      const renderOrphan = (): void => {
+        render(
+          <StoryMapChapter center={[0, 0]} id="x" title="orphan">
+            <p>body</p>
+          </StoryMapChapter>,
+        );
+      };
+
+      expect(renderOrphan).toThrow(/StoryMap subcomponent/);
+    });
+  });
+
+  describe("progress strip", () => {
+    it("renders a progressbar landmark with the configured label", () => {
+      render(
+        <StoryMap labels={{ progress: "Story progress" }}>
+          <StoryMapChapter center={[0, 0]} id="x" title="x" />
+        </StoryMap>,
+      );
+
+      const progress = screen.getByRole("progressbar");
+      expect(progress).toHaveAttribute("aria-label", "Story progress");
+    });
+  });
+
+  describe("backdrop", () => {
+    it("renders a backdrop image when backdrop is set", () => {
+      const { container } = render(
+        <StoryMap backdrop="/world.svg" backdropAlt="World">
+          <StoryMapChapter center={[0, 0]} id="x" title="x" />
+        </StoryMap>,
+      );
+
+      const images = container.querySelectorAll("image");
+      expect(images.length).toBeGreaterThan(0);
+      expect(images[0]).toHaveAttribute("href", "/world.svg");
+    });
+  });
+});

--- a/packages/ui/src/components/story-map/story-map.tsx
+++ b/packages/ui/src/components/story-map/story-map.tsx
@@ -1,0 +1,609 @@
+"use client";
+
+import {
+  Children,
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+const VIEWBOX_WIDTH = 1000;
+const VIEWBOX_HEIGHT = 500;
+
+/**
+ * Geographic coordinate `[longitude, latitude]`.
+ *
+ * @public
+ */
+export type GeoPosition = [number, number];
+
+/**
+ * Color theme for the chapter marker.
+ *
+ * @public
+ */
+export type StoryMapColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "purple"
+  | "red"
+  | "rose";
+
+const PALETTE: Record<StoryMapColor, string> = {
+  amber: "fill-amber-500",
+  blue: "fill-blue-500",
+  emerald: "fill-emerald-500",
+  purple: "fill-purple-500",
+  red: "fill-red-500",
+  rose: "fill-rose-500",
+};
+
+/**
+ * Optional image media rendered inside the chapter card.
+ *
+ * @public
+ */
+export type StoryMapMedia = {
+  /** Required alt text. */
+  alt: string;
+  /** Optional caption rendered beneath the image. */
+  caption?: ReactNode;
+  /** Image URL. */
+  src: string;
+  /** Media kind. Image is the supported value today. */
+  type: "image";
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type StoryMapLabels = {
+  /** Aria-label for the narrative column. Defaults to `"Narrative"`. */
+  narrative?: string;
+  /** Aria-label for the progress strip. Defaults to `"Story progress"`. */
+  progress?: string;
+  /** Aria-label for the map region. Defaults to `"Story map"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  narrative: "Narrative",
+  progress: "Story progress",
+  region: "Story map",
+} as const satisfies Required<StoryMapLabels>;
+
+type RegisterArguments = {
+  center: GeoPosition;
+  color: StoryMapColor;
+  id: string;
+  zoom: number;
+};
+
+type Ctx = {
+  activeId?: string;
+  registerChapter: (id: string, node: HTMLElement | null) => void;
+  registerMarker: (entry: RegisterArguments) => void;
+  setActiveId: (id: string) => void;
+  unregisterMarker: (id: string) => void;
+};
+
+const StoryMapContext = createContext<Ctx | null>(null);
+
+function useStoryMapContext(): Ctx {
+  const ctx = useContext(StoryMapContext);
+  if (!ctx) {
+    throw new Error("StoryMap subcomponent used outside its root.");
+  }
+  return ctx;
+}
+
+function projectEquirectangular(position: GeoPosition): {
+  x: number;
+  y: number;
+} {
+  const [lng, lat] = position;
+  return {
+    x: ((lng + 180) / 360) * VIEWBOX_WIDTH,
+    y: ((90 - lat) / 180) * VIEWBOX_HEIGHT,
+  };
+}
+
+/**
+ * Props for {@link StoryMapChapter}.
+ *
+ * @public
+ */
+export type StoryMapChapterProps = {
+  /** Center the map on this position when the chapter is active. */
+  center: GeoPosition;
+  /** Color theme for the chapter marker. Defaults to `"red"`. */
+  color?: StoryMapColor;
+  /** Stable id. Defaults to a generated id. */
+  id?: string;
+  /** Optional image media. */
+  media?: StoryMapMedia;
+  /** Optional subtitle. */
+  subtitle?: ReactNode;
+  /** Chapter title. */
+  title: ReactNode;
+  /** Map zoom factor when the chapter is active. `1` shows the full world; `8` zooms in tight. Defaults to `2`. */
+  zoom?: number;
+} & Omit<ComponentPropsWithoutRef<"article">, "id" | "title">;
+
+type ChapterMediaProps = {
+  media: StoryMapMedia;
+};
+
+function ChapterMedia({ media }: ChapterMediaProps): ReactNode {
+  return (
+    <figure className="overflow-hidden rounded-xl border bg-muted">
+      <img
+        alt={media.alt}
+        className="aspect-video w-full object-cover"
+        loading="lazy"
+        src={media.src}
+      />
+      {media.caption ? (
+        <figcaption className="border-t bg-background px-3 py-2 text-xs text-muted-foreground">
+          {media.caption}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}
+
+type ChapterHeaderProps = {
+  subtitle?: ReactNode;
+  title: ReactNode;
+};
+
+function ChapterHeader({ subtitle, title }: ChapterHeaderProps): ReactNode {
+  return (
+    <header className="space-y-1">
+      <h3 className="text-xl font-semibold tracking-tight text-foreground">
+        {title}
+      </h3>
+      {subtitle ? (
+        <p className="text-sm text-muted-foreground">{subtitle}</p>
+      ) : null}
+    </header>
+  );
+}
+
+/**
+ * Single chapter section. Place narrative paragraphs as children.
+ *
+ * @public
+ */
+export const StoryMapChapter = forwardRef<HTMLElement, StoryMapChapterProps>(
+  (props, forwardedRef) => {
+    const {
+      center,
+      children,
+      className,
+      color = "red",
+      id,
+      media,
+      subtitle,
+      title,
+      zoom = 2,
+      ...rest
+    } = props;
+    const generatedId = useId();
+    const chapterId = id ?? generatedId;
+    const localRef = useRef<HTMLElement | null>(null);
+    const { registerChapter, registerMarker, unregisterMarker } =
+      useStoryMapContext();
+
+    useEffect(() => {
+      registerMarker({ center, color, id: chapterId, zoom });
+      return () => {
+        unregisterMarker(chapterId);
+      };
+    }, [center, chapterId, color, registerMarker, unregisterMarker, zoom]);
+
+    const refCallback = useCallback(
+      (node: HTMLElement | null) => {
+        localRef.current = node;
+        registerChapter(chapterId, node);
+        if (typeof forwardedRef === "function") forwardedRef(node);
+        else if (forwardedRef) forwardedRef.current = node;
+      },
+      [chapterId, forwardedRef, registerChapter],
+    );
+
+    return (
+      <article
+        className={cn(
+          "flex min-h-screen flex-col justify-center gap-3 py-12",
+          className,
+        )}
+        data-chapter-id={chapterId}
+        id={chapterId}
+        ref={refCallback}
+        {...rest}
+      >
+        <ChapterHeader subtitle={subtitle} title={title} />
+        {media ? <ChapterMedia media={media} /> : null}
+        {children ? (
+          <div className="space-y-2 text-sm leading-relaxed text-foreground [&_blockquote]:my-3 [&_blockquote]:border-l-2 [&_blockquote]:border-primary [&_blockquote]:pl-3 [&_blockquote]:italic [&_blockquote]:text-muted-foreground">
+            {children}
+          </div>
+        ) : null}
+      </article>
+    );
+  },
+);
+StoryMapChapter.displayName = "StoryMapChapter";
+
+type Marker = RegisterArguments;
+
+type StageProps = {
+  activeId?: string;
+  backdrop?: string;
+  backdropAlt?: string;
+  markers: Marker[];
+};
+
+function Stage({
+  activeId,
+  backdrop,
+  backdropAlt,
+  markers,
+}: StageProps): ReactNode {
+  const active = markers.find((marker) => marker.id === activeId);
+  const zoom = active?.zoom ?? 1;
+  const innerWidth = VIEWBOX_WIDTH / zoom;
+  const innerHeight = VIEWBOX_HEIGHT / zoom;
+  const center = active
+    ? projectEquirectangular(active.center)
+    : { x: VIEWBOX_WIDTH / 2, y: VIEWBOX_HEIGHT / 2 };
+  const viewX = center.x - innerWidth / 2;
+  const viewY = center.y - innerHeight / 2;
+  return (
+    <svg
+      aria-hidden="true"
+      className="block h-full w-full transition-[viewBox] duration-500"
+      data-active-chapter-id={activeId ?? ""}
+      data-active-zoom={zoom}
+      preserveAspectRatio="xMidYMid slice"
+      viewBox={`${viewX.toString()} ${viewY.toString()} ${innerWidth.toString()} ${innerHeight.toString()}`}
+    >
+      <rect
+        className="fill-muted"
+        height={VIEWBOX_HEIGHT}
+        width={VIEWBOX_WIDTH}
+        x="0"
+        y="0"
+      />
+      {backdrop ? (
+        <image
+          aria-label={backdropAlt}
+          height={VIEWBOX_HEIGHT}
+          href={backdrop}
+          preserveAspectRatio="xMidYMid slice"
+          width={VIEWBOX_WIDTH}
+          x="0"
+          y="0"
+        />
+      ) : null}
+      {markers.map((marker) => {
+        const point = projectEquirectangular(marker.center);
+        const isActive = marker.id === activeId;
+        return (
+          <g
+            data-marker-active={isActive ? "true" : undefined}
+            data-marker-id={marker.id}
+            key={marker.id}
+            transform={`translate(${point.x.toString()}, ${point.y.toString()})`}
+          >
+            <circle
+              className={cn("stroke-background", PALETTE[marker.color])}
+              r={isActive ? 12 : 6}
+              strokeWidth={2}
+            />
+            {isActive ? (
+              <circle
+                className={cn("opacity-30", PALETTE[marker.color])}
+                r={24}
+              />
+            ) : null}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+function chapterIdsFromChildren(children: ReactNode): string[] {
+  const ids: string[] = [];
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    const element = child as ReactElement<{ id?: string }>;
+    if (typeof element.props.id === "string") ids.push(element.props.id);
+  });
+  return ids;
+}
+
+type ProgressStripProps = {
+  activeId?: string;
+  ids: string[];
+  label: string;
+};
+
+function ProgressStrip({
+  activeId,
+  ids,
+  label,
+}: ProgressStripProps): ReactNode {
+  if (ids.length === 0) return null;
+  const activeIndex = activeId ? ids.indexOf(activeId) : -1;
+  const ratio = activeIndex < 0 ? 0 : (activeIndex + 1) / ids.length;
+  return (
+    <div
+      aria-label={label}
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={Math.round(ratio * 100)}
+      className="sticky top-0 z-20 h-1 w-full bg-border"
+      role="progressbar"
+    >
+      <span
+        className="block h-full bg-primary transition-[width] duration-200"
+        style={{ width: `${(ratio * 100).toString()}%` }}
+      />
+    </div>
+  );
+}
+
+function useChapterRegistry(): {
+  activeId?: string;
+  markerEntries: Marker[];
+  registerChapter: (id: string, node: HTMLElement | null) => void;
+  registerMarker: (entry: RegisterArguments) => void;
+  setActiveId: (id: string) => void;
+  unregisterMarker: (id: string) => void;
+} {
+  const chapterMapRef = useRef<Map<string, HTMLElement>>(new Map());
+  const markersRef = useRef<Map<string, Marker>>(new Map());
+  const [chapterIds, setChapterIds] = useState<string[]>([]);
+  const [markerEntries, setMarkerEntries] = useState<Marker[]>([]);
+  const [activeId, setActiveId] = useState<string | undefined>();
+
+  const registerChapter = useCallback(
+    (id: string, node: HTMLElement | null) => {
+      const map = chapterMapRef.current;
+      if (node) map.set(id, node);
+      else map.delete(id);
+      setChapterIds([...map.keys()]);
+    },
+    [],
+  );
+
+  const registerMarker = useCallback((entry: RegisterArguments) => {
+    markersRef.current.set(entry.id, entry);
+    setMarkerEntries([...markersRef.current.values()]);
+  }, []);
+
+  const unregisterMarker = useCallback((id: string) => {
+    markersRef.current.delete(id);
+    setMarkerEntries([...markersRef.current.values()]);
+  }, []);
+
+  useEffect(() => {
+    if (typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        const first = visible[0];
+        if (first?.target instanceof HTMLElement) {
+          const id = first.target.dataset.chapterId;
+          if (id) setActiveId(id);
+        }
+      },
+      { rootMargin: "-30% 0px -50% 0px", threshold: 0.1 },
+    );
+    [...chapterMapRef.current.values()].forEach((node) => {
+      observer.observe(node);
+    });
+    return () => {
+      observer.disconnect();
+    };
+  }, [chapterIds]);
+
+  return {
+    activeId,
+    markerEntries,
+    registerChapter,
+    registerMarker,
+    setActiveId,
+    unregisterMarker,
+  };
+}
+
+/**
+ * Props for {@link StoryMap}.
+ *
+ * @public
+ */
+export type StoryMapProps = {
+  /** Optional URL of a backdrop image (world map, terrain). */
+  backdrop?: string;
+  /** Aria-label for the backdrop image. */
+  backdropAlt?: string;
+  /** Localizable strings. */
+  labels?: StoryMapLabels;
+} & ComponentPropsWithoutRef<"section">;
+
+type ShellProps = {
+  activeId?: string;
+  backdrop?: string;
+  backdropAlt?: string;
+  children: ReactNode;
+  className?: string;
+  labels: Required<StoryMapLabels>;
+  markers: Marker[];
+  orderedIds: string[];
+  titleId: string;
+};
+
+const Shell = forwardRef<HTMLElement, ShellProps>(function Shell(props, ref) {
+  const {
+    activeId,
+    backdrop,
+    backdropAlt,
+    children,
+    className,
+    labels,
+    markers,
+    orderedIds,
+    titleId,
+  } = props;
+  return (
+    <section
+      aria-labelledby={titleId}
+      className={cn(
+        "relative flex w-full flex-col overflow-hidden rounded-2xl border bg-background text-foreground md:flex-row",
+        className,
+      )}
+      ref={ref}
+    >
+      <span className="sr-only" id={titleId}>
+        {labels.region}
+      </span>
+      <ProgressStrip
+        activeId={activeId}
+        ids={orderedIds}
+        label={labels.progress}
+      />
+      <div
+        className="sticky top-0 hidden h-[80vh] flex-1 self-start md:block"
+        data-story-map-stage
+      >
+        <Stage
+          activeId={activeId}
+          backdrop={backdrop}
+          backdropAlt={backdropAlt}
+          markers={markers}
+        />
+      </div>
+      <div
+        aria-label={labels.narrative}
+        className="flex-1 px-6 md:max-w-xl"
+        role="region"
+      >
+        {children}
+      </div>
+      <div
+        className="block aspect-[2/1] w-full border-t border-border md:hidden"
+        data-story-map-stage-mobile
+      >
+        <Stage
+          activeId={activeId}
+          backdrop={backdrop}
+          backdropAlt={backdropAlt}
+          markers={markers}
+        />
+      </div>
+    </section>
+  );
+});
+
+/**
+ * Scroll-driven narrative map. Place {@link StoryMapChapter} children
+ * in the narrative column; an `IntersectionObserver` tracks the active
+ * chapter and the SVG map shifts to center on its `[lng, lat]` and
+ * `zoom`. Standalone SVG primitive — no external map library required.
+ *
+ * @example
+ * ```tsx
+ * <StoryMap>
+ *   <StoryMapChapter
+ *     center={[12.49, 41.89]}
+ *     zoom={4}
+ *     title="The Fall of Rome"
+ *   >
+ *     <p>In 476 AD...</p>
+ *   </StoryMapChapter>
+ *   <StoryMapChapter
+ *     center={[28.98, 41.01]}
+ *     zoom={4}
+ *     title="Constantinople Endures"
+ *   >
+ *     <p>While Rome fell, Constantinople thrived...</p>
+ *   </StoryMapChapter>
+ * </StoryMap>
+ * ```
+ *
+ * @public
+ */
+export const StoryMap = forwardRef<HTMLElement, StoryMapProps>((props, ref) => {
+  const { backdrop, backdropAlt, children, className, labels, ...rest } = props;
+  const titleId = useId();
+  const resolvedLabels = useMemo(
+    () => ({ ...DEFAULT_LABELS, ...labels }),
+    [labels],
+  );
+
+  const {
+    activeId,
+    markerEntries,
+    registerChapter,
+    registerMarker,
+    setActiveId,
+    unregisterMarker,
+  } = useChapterRegistry();
+
+  const ctx = useMemo<Ctx>(
+    () => ({
+      activeId,
+      registerChapter,
+      registerMarker,
+      setActiveId,
+      unregisterMarker,
+    }),
+    [activeId, registerChapter, registerMarker, setActiveId, unregisterMarker],
+  );
+
+  const orderedIds = useMemo(
+    () => chapterIdsFromChildren(children),
+    [children],
+  );
+
+  return (
+    <StoryMapContext.Provider value={ctx}>
+      <Shell
+        activeId={activeId}
+        backdrop={backdrop}
+        backdropAlt={backdropAlt}
+        className={className}
+        labels={resolvedLabels}
+        markers={markerEntries}
+        orderedIds={orderedIds}
+        ref={ref}
+        titleId={titleId}
+        {...rest}
+      >
+        {children}
+      </Shell>
+    </StoryMapContext.Provider>
+  );
+});
+StoryMap.displayName = "StoryMap";

--- a/packages/ui/src/components/story-map/story-map.visual.tsx
+++ b/packages/ui/src/components/story-map/story-map.visual.tsx
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { StoryMap, StoryMapChapter } from "./story-map";
+
+test.describe("StoryMap Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <StoryMap>
+        <StoryMapChapter
+          center={[12.49, 41.89]}
+          color="red"
+          id="rome"
+          subtitle="476 AD"
+          title="The Fall of Rome"
+          zoom={3}
+        >
+          <p>
+            In 476 AD, the last Western Roman Emperor was deposed, ending
+            centuries of Roman political dominance.
+          </p>
+        </StoryMapChapter>
+        <StoryMapChapter
+          center={[28.98, 41.01]}
+          color="purple"
+          id="constantinople"
+          subtitle="476 – 1453"
+          title="Constantinople Endures"
+          zoom={3}
+        >
+          <p>
+            While Rome fell, Constantinople thrived as the capital of the
+            Byzantine Empire for nearly a thousand more years.
+          </p>
+        </StoryMapChapter>
+      </StoryMap>,
+    );
+    await expect(component).toHaveScreenshot("story-map-default.png");
+  });
+});


### PR DESCRIPTION
Closes #31.

Scroll-driven narrative map. Standalone SVG primitive — no external map library. Side-by-side layout: sticky map on the left, narrative chapters scroll on the right (stacked on mobile). \`IntersectionObserver\` tracks the active chapter; the SVG viewBox shifts to center on its \`[lng, lat]\` and zoom factor.

## What's in
- \`StoryMap\` (root) + \`StoryMapChapter\` children.
- Each chapter pin: \`center: [lng, lat]\`, \`zoom\` (1 = world, 8 = tight), optional color theme + media + subtitle.
- Active chapter renders a larger marker with a soft halo; others render as small dots.
- Sticky progress strip at the top tracks `current / total` chapter ratio.
- Optional backdrop image (Natural Earth SVG, terrain raster).
- Chapter cards emit \`data-chapter-id\`. SVG markers emit \`data-marker-id\`, \`data-marker-active="true"\` when active. Stages emit \`data-story-map-stage\` (desktop) and \`data-story-map-stage-mobile\`. Active SVG carries \`data-active-chapter-id\` + \`data-active-zoom\`.
- Throws when \`StoryMapChapter\` renders outside the root.

## Out of scope (deferred)
Route drawing between chapters, video media, fullscreen mode, chapter-navigation sidebar, smooth tweened viewBox transitions (the map snaps via CSS to the new viewBox).

## Quality gates
- lint PASS
- typecheck PASS
- check:use-client PASS (180)
- check-story-coverage PASS (170/170)
- verify-stories PASS
- build PASS
- test PASS (499/499, +6 new)
- build-storybook PASS