### PR TITLE
feat(ui): add Globe3D component family

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1008,6 +1008,21 @@
       "category": "form"
     },
     {
+      "name": "globe-3d",
+      "type": "registry:component",
+      "title": "Globe 3D",
+      "description": "Standalone SVG pseudo-3D globe — orthographic projection with auto-rotation, drag interaction, lat/lng markers, and great-circle arcs.",
+      "files": [
+        {
+          "path": "registry/default/globe-3d/globe-3d.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
       "name": "group-hull",
       "type": "registry:component",
       "title": "Group Hull",

--- a/apps/registry/registry/default/globe-3d/globe-3d.tsx
+++ b/apps/registry/registry/default/globe-3d/globe-3d.tsx
@@ -1,0 +1,11 @@
+export {
+  Globe3D,
+  type Globe3DLabels,
+  type Globe3DProps,
+  GlobeArc,
+  type GlobeArcProps,
+  type GlobeColor,
+  type GlobeCoord,
+  GlobeMarker,
+  type GlobeMarkerProps,
+} from "@vllnt/ui";

--- a/packages/ui/src/components/globe-3d/globe-3d.mdx
+++ b/packages/ui/src/components/globe-3d/globe-3d.mdx
@@ -1,0 +1,67 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './globe-3d.stories'
+
+<Meta of={Stories} />
+
+# Globe3D
+
+Standalone SVG pseudo-3D globe. Renders a unit sphere with orthographic projection, a graticule (lat/lng lines), and any `GlobeMarker` / `GlobeArc` children. Auto-rotates around the Y axis; drag to rotate manually (auto-rotation pauses while dragging). No external 3D library — pure SVG + React state, so it stays small enough to drop into any project.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/globe-3d.json
+```
+
+## Import
+
+```tsx
+import { Globe3D, GlobeMarker, GlobeArc } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<Globe3D autoRotate>
+  <GlobeMarker lat={48.85} lng={2.35} label="Paris" color="blue" />
+  <GlobeMarker lat={40.71} lng={-74} label="New York" color="red" />
+  <GlobeArc
+    from={{ lat: 48.85, lng: 2.35 }}
+    to={{ lat: 40.71, lng: -74 }}
+    color="cyan"
+  />
+</Globe3D>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Auto-rotation
+
+`autoRotate` (default `true`) drives the globe around the Y axis on `requestAnimationFrame`. `rotationSpeed` is degrees per second (default `8`). Auto-rotation pauses while the user drags and resumes when the pointer is released.
+
+<Canvas of={Stories.SlowRotation} sourceState="shown" />
+
+## Static
+
+Set `autoRotate={false}` for a fixed view. The user can still drag to rotate.
+
+<Canvas of={Stories.Static} sourceState="shown" />
+
+## Visible-hemisphere culling
+
+Markers and arc segments on the far side of the globe are hidden — the projection's `z` coordinate determines visibility. Drag to bring back-side content into view.
+
+## Accessibility
+
+The component renders a hidden `<sr-only>` summary listing every marker (lat / lng / label) alongside the SVG. Screen readers can read the data without losing fidelity.
+
+## Notes
+
+- Out of scope for the MVP: WebGL / Three.js renderer, Earth texture, country / region polygons, heatmap layers, zoom controls, click-to-rotate interaction model. Composes well with a project-level Three.js wrapper if you want to upgrade later.
+- The SVG sphere emits `data-globe-sphere`. The graticule emits `data-globe-graticule`. The drag stage emits `data-globe-stage`. Markers emit `data-marker-id` + `data-marker-visible="true"`. Arcs emit `data-arc-id`. Rotation values are exposed on the SVG via `data-rotation-lat` / `data-rotation-lng`.

--- a/packages/ui/src/components/globe-3d/globe-3d.stories.tsx
+++ b/packages/ui/src/components/globe-3d/globe-3d.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Globe3D, GlobeArc, GlobeMarker } from "./globe-3d";
+
+const meta = {
+  args: {
+    autoRotate: true,
+    initialPosition: { lat: 20, lng: 0 },
+    rotationSpeed: 8,
+  },
+  component: Globe3D,
+  title: "Maps/Globe3D",
+} satisfies Meta<typeof Globe3D>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Globe3D {...args}>
+      <GlobeMarker color="blue" id="paris" label="Paris" lat={48.85} lng={2.35} />
+      <GlobeMarker color="red" id="ny" label="New York" lat={40.71} lng={-74} />
+      <GlobeMarker color="emerald" id="tokyo" label="Tokyo" lat={35.7} lng={139.7} />
+      <GlobeMarker color="rose" id="syd" label="Sydney" lat={-33.9} lng={151.2} />
+      <GlobeArc
+        color="cyan"
+        from={{ lat: 48.85, lng: 2.35 }}
+        id="paris-ny"
+        to={{ lat: 40.71, lng: -74 }}
+      />
+      <GlobeArc
+        color="amber"
+        from={{ lat: 40.71, lng: -74 }}
+        id="ny-tokyo"
+        to={{ lat: 35.7, lng: 139.7 }}
+      />
+    </Globe3D>
+  ),
+};
+
+export const Static: Story = {
+  args: {
+    autoRotate: false,
+    initialPosition: { lat: 30, lng: -30 },
+  },
+  render: (args) => (
+    <Globe3D {...args}>
+      <GlobeMarker color="blue" id="paris" label="Paris" lat={48.85} lng={2.35} />
+      <GlobeMarker color="red" id="ny" label="New York" lat={40.71} lng={-74} />
+    </Globe3D>
+  ),
+};
+
+export const SlowRotation: Story = {
+  args: {
+    autoRotate: true,
+    rotationSpeed: 2,
+  },
+  render: (args) => (
+    <Globe3D {...args}>
+      <GlobeMarker color="cyan" id="lagos" label="Lagos" lat={6.5} lng={3.4} />
+      <GlobeMarker color="purple" id="mumbai" label="Mumbai" lat={19.07} lng={72.87} />
+      <GlobeMarker color="rose" id="seoul" label="Seoul" lat={37.57} lng={126.98} />
+    </Globe3D>
+  ),
+};

--- a/packages/ui/src/components/globe-3d/globe-3d.test.tsx
+++ b/packages/ui/src/components/globe-3d/globe-3d.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Globe3D, GlobeArc, GlobeMarker } from "./globe-3d";
+
+describe("Globe3D", () => {
+  describe("rendering", () => {
+    it("renders the sphere and graticule", () => {
+      const { container } = render(<Globe3D autoRotate={false} />);
+
+      expect(
+        container.querySelector("[data-globe-sphere]"),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector("[data-globe-graticule]"),
+      ).toBeInTheDocument();
+    });
+
+    it("emits the rotation attributes on the SVG", () => {
+      const { container } = render(
+        <Globe3D autoRotate={false} initialPosition={{ lat: 30, lng: -45 }} />,
+      );
+
+      const svg = container.querySelector("svg[data-rotation-lng]");
+      expect(svg).toHaveAttribute("data-rotation-lat", "30");
+      expect(svg).toHaveAttribute("data-rotation-lng", "45");
+    });
+  });
+
+  describe("markers", () => {
+    it("renders a marker for points on the visible hemisphere", () => {
+      const { container } = render(
+        <Globe3D autoRotate={false} initialPosition={{ lat: 0, lng: 0 }}>
+          <GlobeMarker color="blue" id="paris" lat={48.85} lng={2.35} />
+        </Globe3D>,
+      );
+
+      expect(
+        container.querySelector("[data-marker-id='paris']"),
+      ).toBeInTheDocument();
+    });
+
+    it("hides markers on the far side of the globe", () => {
+      const { container } = render(
+        <Globe3D autoRotate={false} initialPosition={{ lat: 0, lng: 0 }}>
+          <GlobeMarker id="antipodal" lat={-30} lng={170} />
+        </Globe3D>,
+      );
+
+      expect(
+        container.querySelector("[data-marker-id='antipodal']"),
+      ).toBeNull();
+    });
+
+    it("renders the data-summary fallback list with one entry per marker", () => {
+      render(
+        <Globe3D autoRotate={false} initialPosition={{ lat: 0, lng: 0 }}>
+          <GlobeMarker id="paris" label="Paris" lat={48.85} lng={2.35} />
+          <GlobeMarker id="ny" label="New York" lat={40.71} lng={-74} />
+        </Globe3D>,
+      );
+
+      expect(screen.getByText(/2 marker/)).toBeInTheDocument();
+    });
+  });
+
+  describe("arcs", () => {
+    it("renders an arc path between two coordinates", () => {
+      const { container } = render(
+        <Globe3D autoRotate={false} initialPosition={{ lat: 0, lng: 0 }}>
+          <GlobeArc
+            color="cyan"
+            from={{ lat: 48.85, lng: 2.35 }}
+            id="paris-ny"
+            to={{ lat: 40.71, lng: -74 }}
+          />
+        </Globe3D>,
+      );
+
+      const arc = container.querySelector("[data-arc-id='paris-ny']");
+      expect(arc).toBeInTheDocument();
+      expect(arc?.getAttribute("d")).toMatch(/^M/);
+    });
+  });
+
+  describe("compound contract", () => {
+    it("throws when subcomponents render outside the root", () => {
+      const renderOrphan = (): void => {
+        render(<GlobeMarker lat={0} lng={0} />);
+      };
+
+      expect(renderOrphan).toThrow(/Globe3D subcomponent/);
+    });
+  });
+});

--- a/packages/ui/src/components/globe-3d/globe-3d.tsx
+++ b/packages/ui/src/components/globe-3d/globe-3d.tsx
@@ -1,0 +1,642 @@
+"use client";
+
+import {
+  Children,
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  isValidElement,
+  type PointerEvent as ReactPointerEvent,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+const VIEWBOX = 400;
+const SPHERE_RADIUS = 180;
+const CENTER = VIEWBOX / 2;
+
+/**
+ * Geographic coordinate as `{ lat, lng }`.
+ *
+ * @public
+ */
+export type GlobeCoord = { lat: number; lng: number };
+
+/**
+ * Color theme for markers and arcs.
+ *
+ * @public
+ */
+export type GlobeColor =
+  | "amber"
+  | "blue"
+  | "cyan"
+  | "emerald"
+  | "purple"
+  | "red"
+  | "rose";
+
+const PALETTE: Record<GlobeColor, { fill: string; stroke: string }> = {
+  amber: { fill: "fill-amber-500", stroke: "stroke-amber-500" },
+  blue: { fill: "fill-blue-500", stroke: "stroke-blue-500" },
+  cyan: { fill: "fill-cyan-500", stroke: "stroke-cyan-500" },
+  emerald: { fill: "fill-emerald-500", stroke: "stroke-emerald-500" },
+  purple: { fill: "fill-purple-500", stroke: "stroke-purple-500" },
+  red: { fill: "fill-red-500", stroke: "stroke-red-500" },
+  rose: { fill: "fill-rose-500", stroke: "stroke-rose-500" },
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type Globe3DLabels = {
+  /** Aria-label for the globe region. Defaults to `"Globe"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Globe",
+} as const satisfies Required<Globe3DLabels>;
+
+type Vec3 = { x: number; y: number; z: number };
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function rotate(vector: Vec3, lngOffset: number, latOffset: number): Vec3 {
+  const yawRad = toRadians(lngOffset);
+  const pitchRad = toRadians(latOffset);
+  const cosY = Math.cos(yawRad);
+  const sinY = Math.sin(yawRad);
+  const xy = vector.x * cosY + vector.z * sinY;
+  const zy = -vector.x * sinY + vector.z * cosY;
+  const cosP = Math.cos(pitchRad);
+  const sinP = Math.sin(pitchRad);
+  const yp = vector.y * cosP - zy * sinP;
+  const zp = vector.y * sinP + zy * cosP;
+  return { x: xy, y: yp, z: zp };
+}
+
+function latLngToVector({ lat, lng }: GlobeCoord): Vec3 {
+  const phi = toRadians(90 - lat);
+  const theta = toRadians(lng);
+  return {
+    x: Math.sin(phi) * Math.sin(theta),
+    y: Math.cos(phi),
+    z: Math.sin(phi) * Math.cos(theta),
+  };
+}
+
+function project(
+  coord: GlobeCoord,
+  rotationLng: number,
+  rotationLat: number,
+): { visible: boolean; x: number; y: number; z: number } {
+  const baseVector = latLngToVector(coord);
+  const rotated = rotate(baseVector, rotationLng, rotationLat);
+  return {
+    visible: rotated.z >= 0,
+    x: CENTER + rotated.x * SPHERE_RADIUS,
+    y: CENTER - rotated.y * SPHERE_RADIUS,
+    z: rotated.z,
+  };
+}
+
+type Ctx = {
+  rotationLat: number;
+  rotationLng: number;
+};
+
+const GlobeContext = createContext<Ctx | null>(null);
+
+function useGlobeContext(): Ctx {
+  const ctx = useContext(GlobeContext);
+  if (!ctx) {
+    throw new Error("Globe3D subcomponent used outside its root.");
+  }
+  return ctx;
+}
+
+/**
+ * Props for {@link GlobeMarker}.
+ *
+ * @public
+ */
+export type GlobeMarkerProps = {
+  /** Color theme. Defaults to `"red"`. */
+  color?: GlobeColor;
+  /** Stable id used for analytics + React keys. */
+  id?: string;
+  /** Optional label rendered next to the marker. */
+  label?: ReactNode;
+  /** Latitude. Positive = north. */
+  lat: number;
+  /** Longitude. Positive = east. */
+  lng: number;
+} & Omit<ComponentPropsWithoutRef<"g">, "id">;
+
+/**
+ * Point marker pinned to a `[lat, lng]`. Hidden when the point falls on
+ * the far side of the globe.
+ *
+ * @public
+ */
+export const GlobeMarker = forwardRef<SVGGElement, GlobeMarkerProps>(
+  (props, ref) => {
+    const { color = "red", id, label, lat, lng, ...rest } = props;
+    const { rotationLat, rotationLng } = useGlobeContext();
+    const projected = project({ lat, lng }, rotationLng, rotationLat);
+    if (!projected.visible) return null;
+    const palette = PALETTE[color];
+    return (
+      <g
+        data-marker-id={id}
+        data-marker-visible="true"
+        ref={ref}
+        transform={`translate(${projected.x.toString()}, ${projected.y.toString()})`}
+        {...rest}
+      >
+        <circle
+          className={cn("stroke-background", palette.fill)}
+          r="5"
+          strokeWidth="1.5"
+        />
+        {label ? (
+          <text
+            className="select-none fill-foreground text-[10px] font-semibold"
+            dominantBaseline="middle"
+            textAnchor="middle"
+            y="-10"
+          >
+            {label}
+          </text>
+        ) : null}
+      </g>
+    );
+  },
+);
+GlobeMarker.displayName = "GlobeMarker";
+
+/**
+ * Props for {@link GlobeArc}.
+ *
+ * @public
+ */
+export type GlobeArcProps = {
+  /** Color theme. Defaults to `"cyan"`. */
+  color?: GlobeColor;
+  /** Origin coordinate. */
+  from: GlobeCoord;
+  /** Stable id used for analytics + React keys. */
+  id?: string;
+  /** Stroke width in viewBox units. Defaults to `2`. */
+  strokeWidth?: number;
+  /** Destination coordinate. */
+  to: GlobeCoord;
+} & Omit<ComponentPropsWithoutRef<"path">, "d" | "id" | "stroke">;
+
+function buildArc(arguments_: {
+  from: GlobeCoord;
+  rotationLat: number;
+  rotationLng: number;
+  to: GlobeCoord;
+}): string {
+  const { from, rotationLat, rotationLng, to } = arguments_;
+  const samples = 36;
+  return Array.from({ length: samples + 1 })
+    .map((_, index) => {
+      const t = index / samples;
+      const lat = from.lat + (to.lat - from.lat) * t;
+      const lng = from.lng + (to.lng - from.lng) * t;
+      return project({ lat, lng }, rotationLng, rotationLat);
+    })
+    .reduce<{ path: string; pen: "down" | "up" }>(
+      (state, projected) => {
+        if (!projected.visible) return { path: state.path, pen: "up" };
+        const head = state.pen === "up" ? "M" : "L";
+        const separator = state.path.length > 0 ? " " : "";
+        return {
+          path: `${state.path}${separator}${head}${projected.x.toString()},${projected.y.toString()}`,
+          pen: "down",
+        };
+      },
+      { path: "", pen: "up" },
+    ).path;
+}
+
+/**
+ * Great-circle-style arc between two coordinates. The component clips
+ * any segment on the far side of the globe.
+ *
+ * @public
+ */
+export const GlobeArc = forwardRef<SVGPathElement, GlobeArcProps>(
+  (props, ref) => {
+    const { color = "cyan", from, id, strokeWidth = 2, to, ...rest } = props;
+    const { rotationLat, rotationLng } = useGlobeContext();
+    const path = buildArc({ from, rotationLat, rotationLng, to });
+    if (!path) return null;
+    const palette = PALETTE[color];
+    return (
+      <path
+        className={cn("fill-none", palette.stroke)}
+        d={path}
+        data-arc-id={id}
+        ref={ref}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+        {...rest}
+      />
+    );
+  },
+);
+GlobeArc.displayName = "GlobeArc";
+
+type GraticuleProps = {
+  rotationLat: number;
+  rotationLng: number;
+};
+
+function buildLine(arguments_: {
+  points: GlobeCoord[];
+  rotationLat: number;
+  rotationLng: number;
+}): string {
+  const { points, rotationLat, rotationLng } = arguments_;
+  return points
+    .map((coord) => project(coord, rotationLng, rotationLat))
+    .reduce<{ path: string; pen: "down" | "up" }>(
+      (state, projected) => {
+        if (!projected.visible) return { path: state.path, pen: "up" };
+        const head = state.pen === "up" ? "M" : "L";
+        const separator = state.path.length > 0 ? " " : "";
+        return {
+          path: `${state.path}${separator}${head}${projected.x.toString()},${projected.y.toString()}`,
+          pen: "down",
+        };
+      },
+      { path: "", pen: "up" },
+    ).path;
+}
+
+function range(start: number, end: number, step: number): number[] {
+  const length = Math.floor((end - start) / step) + 1;
+  return Array.from({ length }).map((_, index) => start + index * step);
+}
+
+function Graticule({ rotationLat, rotationLng }: GraticuleProps): ReactNode {
+  const parallels = range(-60, 60, 30).map<GlobeCoord[]>((lat) =>
+    range(-180, 180, 5).map((lng) => ({ lat, lng })),
+  );
+  const meridians = range(-150, 180, 30).map<GlobeCoord[]>((lng) =>
+    range(-85, 85, 5).map((lat) => ({ lat, lng })),
+  );
+  const lines = [...parallels, ...meridians]
+    .map((points) => buildLine({ points, rotationLat, rotationLng }))
+    .filter((path) => path.length > 0);
+  return (
+    <g
+      className="fill-none stroke-foreground/20"
+      data-globe-graticule
+      strokeWidth={0.5}
+    >
+      {lines.map((path) => (
+        <path d={path} key={path} />
+      ))}
+    </g>
+  );
+}
+
+type SphereProps = {
+  children: ReactNode;
+  rotationLat: number;
+  rotationLng: number;
+};
+
+function Sphere({
+  children,
+  rotationLat,
+  rotationLng,
+}: SphereProps): ReactNode {
+  return (
+    <svg
+      aria-hidden="true"
+      className="block h-full w-full touch-none"
+      data-rotation-lat={rotationLat}
+      data-rotation-lng={rotationLng}
+      preserveAspectRatio="xMidYMid meet"
+      viewBox={`0 0 ${VIEWBOX.toString()} ${VIEWBOX.toString()}`}
+    >
+      <defs>
+        <radialGradient cx="50%" cy="40%" id="globe-shade" r="60%">
+          <stop offset="0%" stopColor="rgba(99, 102, 241, 0.4)" />
+          <stop offset="100%" stopColor="rgba(15, 23, 42, 0.85)" />
+        </radialGradient>
+      </defs>
+      <circle
+        className="fill-[url(#globe-shade)] stroke-foreground/30"
+        cx={CENTER}
+        cy={CENTER}
+        data-globe-sphere
+        r={SPHERE_RADIUS}
+        strokeWidth={1}
+      />
+      <Graticule rotationLat={rotationLat} rotationLng={rotationLng} />
+      {children}
+    </svg>
+  );
+}
+
+/**
+ * Props for {@link Globe3D}.
+ *
+ * @public
+ */
+export type Globe3DProps = {
+  /** When `true`, the globe rotates on its own. Defaults to `true`. */
+  autoRotate?: boolean;
+  /** Initial view position. */
+  initialPosition?: GlobeCoord;
+  /** Localizable strings. */
+  labels?: Globe3DLabels;
+  /** Auto-rotation rate in degrees per second. Defaults to `8`. */
+  rotationSpeed?: number;
+} & ComponentPropsWithoutRef<"section">;
+
+function useAutoRotation(arguments_: {
+  autoRotate: boolean;
+  isDragging: boolean;
+  rotationSpeed: number;
+  setRotationLng: (next: (current: number) => number) => void;
+}): void {
+  const { autoRotate, isDragging, rotationSpeed, setRotationLng } = arguments_;
+  useEffect(() => {
+    if (!autoRotate || isDragging) return;
+    if (typeof window === "undefined") return;
+    let frame = 0;
+    let last: null | number = null;
+    const step = (timestamp: number): void => {
+      if (last !== null) {
+        const delta = (timestamp - last) / 1000;
+        setRotationLng((current) => current + delta * rotationSpeed);
+      }
+      last = timestamp;
+      frame = window.requestAnimationFrame(step);
+    };
+    frame = window.requestAnimationFrame(step);
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [autoRotate, isDragging, rotationSpeed, setRotationLng]);
+}
+
+type DragState = null | {
+  originLat: number;
+  originLng: number;
+  originX: number;
+  originY: number;
+};
+
+type DragHandlers = {
+  onPointerCancel: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerUp: (event: ReactPointerEvent<HTMLDivElement>) => void;
+};
+
+function useDragRotation(arguments_: {
+  rotationLat: number;
+  rotationLng: number;
+  setIsDragging: (next: boolean) => void;
+  setRotationLat: (next: number) => void;
+  setRotationLng: (next: number) => void;
+}): DragHandlers {
+  const {
+    rotationLat,
+    rotationLng,
+    setIsDragging,
+    setRotationLat,
+    setRotationLng,
+  } = arguments_;
+  const dragRef = useRef<DragState>(null);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      dragRef.current = {
+        originLat: rotationLat,
+        originLng: rotationLng,
+        originX: event.clientX,
+        originY: event.clientY,
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+      setIsDragging(true);
+    },
+    [rotationLat, rotationLng, setIsDragging],
+  );
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      const dx = event.clientX - drag.originX;
+      const dy = event.clientY - drag.originY;
+      setRotationLng(drag.originLng + dx * 0.4);
+      setRotationLat(clamp(drag.originLat - dy * 0.4, -85, 85));
+    },
+    [setRotationLat, setRotationLng],
+  );
+
+  const onPointerEnd = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      const target = event.currentTarget;
+      if (target.hasPointerCapture(event.pointerId)) {
+        target.releasePointerCapture(event.pointerId);
+      }
+      dragRef.current = null;
+      setIsDragging(false);
+    },
+    [setIsDragging],
+  );
+
+  return {
+    onPointerCancel: onPointerEnd,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp: onPointerEnd,
+  };
+}
+
+function useGlobeRotation(initialPosition: GlobeCoord): {
+  isDragging: boolean;
+  rotationLat: number;
+  rotationLng: number;
+  setIsDragging: (next: boolean) => void;
+  setRotationLat: (next: number) => void;
+  setRotationLng: (next: ((current: number) => number) | number) => void;
+} {
+  const [rotationLng, setRotationLng] = useState<number>(-initialPosition.lng);
+  const [rotationLat, setRotationLat] = useState<number>(initialPosition.lat);
+  const [isDragging, setIsDragging] = useState(false);
+  return {
+    isDragging,
+    rotationLat,
+    rotationLng,
+    setIsDragging,
+    setRotationLat,
+    setRotationLng,
+  };
+}
+
+type DataSummaryProps = {
+  children: ReactNode;
+  titleId: string;
+};
+
+function DataSummary({ children, titleId }: DataSummaryProps): ReactNode {
+  const markers: {
+    color: string;
+    label: ReactNode;
+    lat: number;
+    lng: number;
+  }[] = [];
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    const element = child as ReactElement<GlobeMarkerProps>;
+    if (
+      typeof element.props.lat === "number" &&
+      typeof element.props.lng === "number"
+    ) {
+      markers.push({
+        color: element.props.color ?? "red",
+        label: element.props.label ?? null,
+        lat: element.props.lat,
+        lng: element.props.lng,
+      });
+    }
+  });
+  return (
+    <div aria-labelledby={titleId} className="sr-only" role="region">
+      <h3 id={titleId}>Globe data summary</h3>
+      <p>{markers.length.toString()} marker(s) plotted on the globe.</p>
+      <ul>
+        {markers.map((marker, index) => (
+          <li
+            key={`${index.toString()}-${marker.lat.toString()}-${marker.lng.toString()}`}
+          >
+            {`${marker.lat.toString()}, ${marker.lng.toString()}: ${marker.label ? String(marker.label) : marker.color}`}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * Standalone SVG pseudo-3D globe. Renders a unit sphere with
+ * orthographic projection, a graticule (lat/lng lines), and any
+ * {@link GlobeMarker} / {@link GlobeArc} children. Auto-rotates around
+ * the Y axis; drag to rotate manually (auto-rotation pauses while
+ * dragging). No external 3D library — pure SVG + React state.
+ *
+ * @example
+ * ```tsx
+ * <Globe3D autoRotate>
+ *   <GlobeMarker lat={48.85} lng={2.35} label="Paris" color="blue" />
+ *   <GlobeMarker lat={40.71} lng={-74} label="New York" color="red" />
+ *   <GlobeArc
+ *     from={{ lat: 48.85, lng: 2.35 }}
+ *     to={{ lat: 40.71, lng: -74 }}
+ *     color="cyan"
+ *   />
+ * </Globe3D>
+ * ```
+ *
+ * @public
+ */
+export const Globe3D = forwardRef<HTMLElement, Globe3DProps>((props, ref) => {
+  const {
+    autoRotate = true,
+    children,
+    className,
+    initialPosition = { lat: 20, lng: 0 },
+    labels,
+    rotationSpeed = 8,
+    ...rest
+  } = props;
+  const titleId = useId();
+  const resolvedLabels = useMemo(
+    () => ({ ...DEFAULT_LABELS, ...labels }),
+    [labels],
+  );
+  const {
+    isDragging,
+    rotationLat,
+    rotationLng,
+    setIsDragging,
+    setRotationLat,
+    setRotationLng,
+  } = useGlobeRotation(initialPosition);
+
+  useAutoRotation({ autoRotate, isDragging, rotationSpeed, setRotationLng });
+
+  const handlers = useDragRotation({
+    rotationLat,
+    rotationLng,
+    setIsDragging,
+    setRotationLat,
+    setRotationLng: (next) => {
+      setRotationLng(next);
+    },
+  });
+
+  const ctx = useMemo<Ctx>(
+    () => ({ rotationLat, rotationLng }),
+    [rotationLat, rotationLng],
+  );
+
+  return (
+    <GlobeContext.Provider value={ctx}>
+      <section
+        aria-labelledby={titleId}
+        className={cn(
+          "relative aspect-square w-full max-w-md overflow-hidden rounded-2xl border bg-background text-foreground",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <span className="sr-only" id={titleId}>
+          {resolvedLabels.region}
+        </span>
+        <div
+          className="block h-full w-full cursor-grab active:cursor-grabbing"
+          data-globe-stage
+          {...handlers}
+        >
+          <Sphere rotationLat={rotationLat} rotationLng={rotationLng}>
+            {children}
+          </Sphere>
+        </div>
+        <DataSummary titleId={titleId}>{children}</DataSummary>
+      </section>
+    </GlobeContext.Provider>
+  );
+});
+Globe3D.displayName = "Globe3D";

--- a/packages/ui/src/components/globe-3d/globe-3d.visual.tsx
+++ b/packages/ui/src/components/globe-3d/globe-3d.visual.tsx
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { Globe3D, GlobeArc, GlobeMarker } from "./globe-3d";
+
+test.describe("Globe3D Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <Globe3D autoRotate={false} initialPosition={{ lat: 30, lng: -30 }}>
+        <GlobeMarker color="blue" id="paris" label="Paris" lat={48.85} lng={2.35} />
+        <GlobeMarker color="red" id="ny" label="New York" lat={40.71} lng={-74} />
+        <GlobeMarker
+          color="emerald"
+          id="rio"
+          label="Rio"
+          lat={-22.9}
+          lng={-43.2}
+        />
+        <GlobeArc
+          color="cyan"
+          from={{ lat: 48.85, lng: 2.35 }}
+          id="paris-ny"
+          to={{ lat: 40.71, lng: -74 }}
+        />
+      </Globe3D>,
+    );
+    await expect(component).toHaveScreenshot("globe-3d-default.png");
+  });
+});

--- a/packages/ui/src/components/globe-3d/index.ts
+++ b/packages/ui/src/components/globe-3d/index.ts
@@ -1,0 +1,11 @@
+export {
+  Globe3D,
+  type Globe3DLabels,
+  type Globe3DProps,
+  GlobeArc,
+  type GlobeArcProps,
+  type GlobeColor,
+  type GlobeCoord,
+  GlobeMarker,
+  type GlobeMarkerProps,
+} from "./globe-3d";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -358,6 +358,17 @@ export {
   ChatDockSection,
   type ChatDockSectionProps,
 } from "./chat-dock-section";
+export {
+  Globe3D,
+  type Globe3DLabels,
+  type Globe3DProps,
+  GlobeArc,
+  type GlobeArcProps,
+  type GlobeColor,
+  type GlobeCoord,
+  GlobeMarker,
+  type GlobeMarkerProps,
+} from "./globe-3d";
 export { GlassPanel, type GlassPanelProps } from "./glass-panel";
 export {
   InfinitePlane,


### PR DESCRIPTION
Closes #29.

Standalone SVG pseudo-3D globe. Renders a unit sphere with orthographic projection, a graticule (lat/lng lines), and any \`GlobeMarker\` / \`GlobeArc\` children. Auto-rotates around the Y axis; drag to rotate manually (auto-rotation pauses while dragging). Visible-hemisphere culling hides far-side markers + arc segments.

## What's in
- \`Globe3D\` (root): \`autoRotate\` (default \`true\`), \`rotationSpeed\` (default \`8\` deg/s), \`initialPosition\`, optional \`labels\`.
- \`GlobeMarker\`: lat / lng / label / color (7-stop palette).
- \`GlobeArc\`: from / to / color / strokeWidth — great-circle-style sample path with 36 segments, clipped to the visible hemisphere.
- Graticule overlay (lat 30° + lng 30°) for visual reference.
- Pointer-driven drag: yaw + clamped pitch (±85°). Auto-rotation pauses while dragging and resumes on release.
- Hidden \`<sr-only>\` summary lists every marker for screen readers.
- Sphere emits \`data-globe-sphere\`, graticule emits \`data-globe-graticule\`, drag stage emits \`data-globe-stage\`. SVG carries \`data-rotation-lat\` / \`data-rotation-lng\`. Markers emit \`data-marker-id\` + \`data-marker-visible="true"\`. Arcs emit \`data-arc-id\`.
- Throws when subcomponents render outside the root.

## Out of scope (deferred)
WebGL / Three.js renderer, Earth texture, country / region polygons, heatmap layers, zoom controls, click-to-rotate UX. The standalone SVG MVP keeps the bundle small; project-level Three.js wrappers can layer on top later.

## Quality gates
- lint PASS
- typecheck PASS
- check:use-client PASS (180)
- check-story-coverage PASS (170/170)
- verify-stories PASS
- build PASS
- test PASS (500/500, +7 new)
- build-storybook PASS