### PR TITLE
feat(ui): close canvas foundation family — InfinitePlane, ViewportBookmarks, WorldBreadcrumbs

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1012,6 +1012,21 @@
       "category": "form"
     },
     {
+      "name": "infinite-plane",
+      "type": "registry:component",
+      "title": "Infinite Plane",
+      "description": "Pannable, zoomable substrate for spatial canvases. Drag to pan; ctrl/meta+wheel to zoom.",
+      "files": [
+        {
+          "path": "registry/default/infinite-plane/infinite-plane.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
       "name": "key-concept",
       "type": "registry:component",
       "title": "Key Concept",
@@ -2330,6 +2345,21 @@
       "category": "navigation"
     },
     {
+      "name": "viewport-bookmarks",
+      "type": "registry:component",
+      "title": "Viewport Bookmarks",
+      "description": "Compact chip row of saved viewport positions for jumping between named canvas scenes.",
+      "files": [
+        {
+          "path": "registry/default/viewport-bookmarks/viewport-bookmarks.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "navigation"
+    },
+    {
       "name": "wallet-card",
       "type": "registry:component",
       "title": "Wallet Card",
@@ -2367,6 +2397,21 @@
       "files": [
         {
           "path": "registry/default/workspace-switcher/workspace-switcher.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "navigation"
+    },
+    {
+      "name": "world-breadcrumbs",
+      "type": "registry:component",
+      "title": "World Breadcrumbs",
+      "description": "Hierarchical breadcrumbs for spatial canvases (workspace → project → board → view).",
+      "files": [
+        {
+          "path": "registry/default/world-breadcrumbs/world-breadcrumbs.tsx",
           "type": "registry:component"
         }
       ],

--- a/apps/registry/registry/default/infinite-plane/infinite-plane.tsx
+++ b/apps/registry/registry/default/infinite-plane/infinite-plane.tsx
@@ -1,0 +1,5 @@
+export {
+  InfinitePlane,
+  type InfinitePlaneLabels,
+  type InfinitePlaneProps,
+} from "@vllnt/ui";

--- a/apps/registry/registry/default/viewport-bookmarks/viewport-bookmarks.tsx
+++ b/apps/registry/registry/default/viewport-bookmarks/viewport-bookmarks.tsx
@@ -1,0 +1,6 @@
+export {
+  type ViewportBookmark,
+  ViewportBookmarks,
+  type ViewportBookmarksLabels,
+  type ViewportBookmarksProps,
+} from "@vllnt/ui";

--- a/apps/registry/registry/default/world-breadcrumbs/world-breadcrumbs.tsx
+++ b/apps/registry/registry/default/world-breadcrumbs/world-breadcrumbs.tsx
@@ -1,0 +1,6 @@
+export {
+  type WorldCrumb,
+  WorldBreadcrumbs,
+  type WorldBreadcrumbsLabels,
+  type WorldBreadcrumbsProps,
+} from "@vllnt/ui";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -726,6 +726,23 @@ export {
   WorkspaceSwitcher,
   type WorkspaceSwitcherProps,
 } from "./workspace-switcher";
+export {
+  InfinitePlane,
+  type InfinitePlaneLabels,
+  type InfinitePlaneProps,
+} from "./infinite-plane";
+export {
+  type ViewportBookmark,
+  ViewportBookmarks,
+  type ViewportBookmarksLabels,
+  type ViewportBookmarksProps,
+} from "./viewport-bookmarks";
+export {
+  WorldBreadcrumbs,
+  type WorldBreadcrumbsLabels,
+  type WorldBreadcrumbsProps,
+  type WorldCrumb,
+} from "./world-breadcrumbs";
 
 // Flow/Diagram components
 export {

--- a/packages/ui/src/components/infinite-plane/index.ts
+++ b/packages/ui/src/components/infinite-plane/index.ts
@@ -1,0 +1,5 @@
+export {
+  InfinitePlane,
+  type InfinitePlaneLabels,
+  type InfinitePlaneProps,
+} from "./infinite-plane";

--- a/packages/ui/src/components/infinite-plane/infinite-plane.mdx
+++ b/packages/ui/src/components/infinite-plane/infinite-plane.mdx
@@ -1,0 +1,47 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './infinite-plane.stories'
+
+<Meta of={Stories} />
+
+# InfinitePlane
+
+Pannable, zoomable infinite-plane substrate for spatial canvases. Drag to pan; **Ctrl / Meta + wheel** to zoom. Children render inside a transformed wrapper so they keep their pixel-positioned coordinates while the plane moves.
+
+Pair with `CanvasShell`, `CanvasView`, `MiniMapPanel`, and `ZoomHUD` to assemble a full operator surface — `InfinitePlane` is the substrate underneath.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/infinite-plane.json
+```
+
+## Import
+
+```tsx
+import { InfinitePlane } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<InfinitePlane initialView={{ x: 60, y: 40, zoom: 1.2 }}>
+  <div style={{ position: 'absolute', left: 40, top: 20 }}>Object A</div>
+  <div style={{ position: 'absolute', left: 280, top: 120 }}>Object B</div>
+</InfinitePlane>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Children should be absolutely positioned in unzoomed plane coordinates. The wrapper applies the live `translate(x, y) scale(zoom)` transform.
+- The dotted-grid backdrop scales with zoom; pass `withoutGrid` to drop it for a clean surface.
+- Wheel zoom requires \`Ctrl\` or \`Meta\` to avoid hijacking page scroll. Range is `0.25×–4×`.
+- Out of scope for the MVP: pinch zoom, momentum scrolling, snap-to-grid, content virtualization. The substrate stays small.
+- The drag stage emits \`data-pan-x\` / \`data-pan-y\` / \`data-zoom\` for analytics + CSS hooks. The transformed content wrapper emits \`data-infinite-plane-content\`.

--- a/packages/ui/src/components/infinite-plane/infinite-plane.stories.tsx
+++ b/packages/ui/src/components/infinite-plane/infinite-plane.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { InfinitePlane } from "./infinite-plane";
+
+const meta = {
+  args: {
+    initialView: { x: 60, y: 40, zoom: 1 },
+  },
+  component: InfinitePlane,
+  title: "Canvas/InfinitePlane",
+} satisfies Meta<typeof InfinitePlane>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <div style={{ height: 400, width: "100%" }}>
+      <InfinitePlane {...args}>
+        <div
+          className="absolute rounded-2xl border bg-background p-3 shadow-sm"
+          style={{ left: 40, top: 20, width: 200 }}
+        >
+          <p className="text-sm font-medium">Object A</p>
+        </div>
+        <div
+          className="absolute rounded-2xl border bg-background p-3 shadow-sm"
+          style={{ left: 280, top: 120, width: 200 }}
+        >
+          <p className="text-sm font-medium">Object B</p>
+        </div>
+      </InfinitePlane>
+    </div>
+  ),
+};
+
+export const Zoomed: Story = {
+  args: { initialView: { x: 60, y: 40, zoom: 1.6 } },
+  render: (args) => (
+    <div style={{ height: 400, width: "100%" }}>
+      <InfinitePlane {...args}>
+        <div
+          className="absolute rounded-2xl border bg-background p-3 shadow-sm"
+          style={{ left: 40, top: 20, width: 200 }}
+        >
+          <p className="text-sm font-medium">Zoomed object</p>
+        </div>
+      </InfinitePlane>
+    </div>
+  ),
+};
+
+export const WithoutGrid: Story = {
+  args: { withoutGrid: true },
+  render: (args) => (
+    <div style={{ height: 400, width: "100%" }}>
+      <InfinitePlane {...args}>
+        <div
+          className="absolute rounded-2xl border bg-muted p-3"
+          style={{ left: 40, top: 20, width: 240 }}
+        >
+          <p className="text-sm font-medium">No grid</p>
+        </div>
+      </InfinitePlane>
+    </div>
+  ),
+};

--- a/packages/ui/src/components/infinite-plane/infinite-plane.test.tsx
+++ b/packages/ui/src/components/infinite-plane/infinite-plane.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { InfinitePlane } from "./infinite-plane";
+
+describe("InfinitePlane", () => {
+  describe("rendering", () => {
+    it("renders the content wrapper with the initial view", () => {
+      const { container } = render(
+        <InfinitePlane initialView={{ x: 50, y: 30, zoom: 1.5 }}>
+          <p>Object</p>
+        </InfinitePlane>,
+      );
+
+      const stage = container.querySelector("[data-zoom]");
+      expect(stage).toHaveAttribute("data-zoom", "1.5");
+      expect(stage).toHaveAttribute("data-pan-x", "50");
+      expect(stage).toHaveAttribute("data-pan-y", "30");
+    });
+
+    it("hides the grid backdrop when withoutGrid is set", () => {
+      const { container } = render(
+        <InfinitePlane withoutGrid>
+          <p>Object</p>
+        </InfinitePlane>,
+      );
+
+      expect(container.querySelector("[aria-hidden='true']")).toBeNull();
+    });
+  });
+
+  describe("interaction", () => {
+    it("renders the transformed content wrapper with pan + zoom transform", () => {
+      const { container } = render(
+        <InfinitePlane initialView={{ x: 30, y: 10, zoom: 1.25 }}>
+          <p>Object</p>
+        </InfinitePlane>,
+      );
+
+      const content = container.querySelector<HTMLDivElement>(
+        "[data-infinite-plane-content]",
+      );
+      expect(content).not.toBeNull();
+      expect(content?.style.transform).toContain("translate(30px, 10px)");
+      expect(content?.style.transform).toContain("scale(1.25)");
+    });
+  });
+});

--- a/packages/ui/src/components/infinite-plane/infinite-plane.test.tsx
+++ b/packages/ui/src/components/infinite-plane/infinite-plane.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
 
 import { InfinitePlane } from "./infinite-plane";
 

--- a/packages/ui/src/components/infinite-plane/infinite-plane.tsx
+++ b/packages/ui/src/components/infinite-plane/infinite-plane.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type WheelEvent as ReactWheelEvent,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+const MIN_ZOOM = 0.25;
+const MAX_ZOOM = 4;
+const GRID_SIZE = 40;
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type InfinitePlaneLabels = {
+  /** Aria-label for the plane region. Defaults to `"Infinite plane"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Infinite plane",
+} as const satisfies Required<InfinitePlaneLabels>;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Props for {@link InfinitePlane}.
+ *
+ * @public
+ */
+export type InfinitePlaneProps = {
+  /** Initial pan / zoom. Defaults to centered (`{ x: 0, y: 0, zoom: 1 }`). */
+  initialView?: { x: number; y: number; zoom?: number };
+  /** Localizable strings. */
+  labels?: InfinitePlaneLabels;
+  /** Fires after pan or zoom changes. */
+  onViewChange?: (view: { x: number; y: number; zoom: number }) => void;
+  /** When `true`, hides the dotted grid backdrop. */
+  withoutGrid?: boolean;
+} & ComponentPropsWithoutRef<"section">;
+
+type DragState = null | {
+  originPanX: number;
+  originPanY: number;
+  originX: number;
+  originY: number;
+};
+
+type PanHandlers = {
+  onPointerCancel: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerUp: (event: ReactPointerEvent<HTMLDivElement>) => void;
+};
+
+function usePanHandlers(arguments_: {
+  pan: { x: number; y: number };
+  setPan: (next: { x: number; y: number }) => void;
+}): PanHandlers {
+  const { pan, setPan } = arguments_;
+  const dragRef = useRef<DragState>(null);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      dragRef.current = {
+        originPanX: pan.x,
+        originPanY: pan.y,
+        originX: event.clientX,
+        originY: event.clientY,
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [pan.x, pan.y],
+  );
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      setPan({
+        x: drag.originPanX + (event.clientX - drag.originX),
+        y: drag.originPanY + (event.clientY - drag.originY),
+      });
+    },
+    [setPan],
+  );
+
+  const onPointerEnd = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      const target = event.currentTarget;
+      if (target.hasPointerCapture(event.pointerId)) {
+        target.releasePointerCapture(event.pointerId);
+      }
+      dragRef.current = null;
+    },
+    [],
+  );
+
+  return {
+    onPointerCancel: onPointerEnd,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp: onPointerEnd,
+  };
+}
+
+function usePlaneState(arguments_: {
+  initialView?: { x: number; y: number; zoom?: number };
+  onViewChange?: (view: { x: number; y: number; zoom: number }) => void;
+}): {
+  pan: { x: number; y: number };
+  setZoom: (next: number) => void;
+  updatePan: (next: { x: number; y: number }) => void;
+  zoom: number;
+  zoomFromWheel: (event: ReactWheelEvent<HTMLDivElement>) => void;
+} {
+  const { initialView, onViewChange } = arguments_;
+  const [pan, setPan] = useState<{ x: number; y: number }>({
+    x: initialView?.x ?? 0,
+    y: initialView?.y ?? 0,
+  });
+  const [zoom, setZoom] = useState<number>(
+    clamp(initialView?.zoom ?? 1, MIN_ZOOM, MAX_ZOOM),
+  );
+  const updatePan = useCallback(
+    (next: { x: number; y: number }) => {
+      setPan(next);
+      onViewChange?.({ x: next.x, y: next.y, zoom });
+    },
+    [onViewChange, zoom],
+  );
+  const zoomFromWheel = useCallback(
+    (event: ReactWheelEvent<HTMLDivElement>): void => {
+      if (!event.ctrlKey && !event.metaKey) return;
+      event.preventDefault();
+      const next = clamp(
+        zoom * (event.deltaY < 0 ? 1.1 : 1 / 1.1),
+        MIN_ZOOM,
+        MAX_ZOOM,
+      );
+      setZoom(next);
+      onViewChange?.({ x: pan.x, y: pan.y, zoom: next });
+    },
+    [onViewChange, pan.x, pan.y, zoom],
+  );
+  return { pan, setZoom, updatePan, zoom, zoomFromWheel };
+}
+
+type GridProps = {
+  pan: { x: number; y: number };
+  zoom: number;
+};
+
+function Grid({ pan, zoom }: GridProps): React.ReactElement {
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 opacity-40"
+      style={{
+        backgroundImage:
+          "radial-gradient(circle, currentColor 1px, transparent 1px)",
+        backgroundPosition: `${pan.x.toString()}px ${pan.y.toString()}px`,
+        backgroundSize: `${(GRID_SIZE * zoom).toString()}px ${(GRID_SIZE * zoom).toString()}px`,
+        color: "hsl(var(--border))",
+      }}
+    />
+  );
+}
+
+/**
+ * Pannable, zoomable infinite-plane substrate. Drag to pan; ctrl/meta +
+ * wheel to zoom. Children render inside a transformed `<div>` so they
+ * keep their pixel-positioned coordinates while the plane moves.
+ *
+ * Place children with absolute / fixed `left`+`top` (in unzoomed plane
+ * coordinates); the wrapper applies the pan + zoom transform.
+ *
+ * @example
+ * ```tsx
+ * <InfinitePlane>
+ *   <div style={{ position: "absolute", left: 100, top: 80 }}>
+ *     Object at (100, 80)
+ *   </div>
+ * </InfinitePlane>
+ * ```
+ *
+ * @public
+ */
+export const InfinitePlane = forwardRef<HTMLElement, InfinitePlaneProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      initialView,
+      labels,
+      onViewChange,
+      withoutGrid = false,
+      ...rest
+    } = props;
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const { pan, updatePan, zoom, zoomFromWheel } = usePlaneState({
+      initialView,
+      onViewChange,
+    });
+    const handlers = usePanHandlers({ pan, setPan: updatePan });
+
+    return (
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "relative h-full w-full overflow-hidden bg-background text-foreground",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <div
+          className="absolute inset-0 cursor-grab touch-none active:cursor-grabbing"
+          data-pan-x={pan.x}
+          data-pan-y={pan.y}
+          data-zoom={zoom}
+          onWheel={zoomFromWheel}
+          {...handlers}
+        >
+          {withoutGrid ? null : <Grid pan={pan} zoom={zoom} />}
+          <div
+            className="origin-top-left"
+            data-infinite-plane-content
+            style={{
+              transform: `translate(${pan.x.toString()}px, ${pan.y.toString()}px) scale(${zoom.toString()})`,
+            }}
+          >
+            {children}
+          </div>
+        </div>
+      </section>
+    );
+  },
+);
+InfinitePlane.displayName = "InfinitePlane";

--- a/packages/ui/src/components/infinite-plane/infinite-plane.visual.tsx
+++ b/packages/ui/src/components/infinite-plane/infinite-plane.visual.tsx
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { InfinitePlane } from "./infinite-plane";
+
+test.describe("InfinitePlane Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="h-[400px] w-full">
+        <InfinitePlane initialView={{ x: 60, y: 40, zoom: 1.2 }}>
+          <div
+            className="absolute rounded-2xl border bg-background p-3 shadow-sm"
+            style={{ left: 40, top: 20, width: 200 }}
+          >
+            <p className="text-sm font-medium">Object A</p>
+            <p className="text-xs text-muted-foreground">x=40, y=20</p>
+          </div>
+          <div
+            className="absolute rounded-2xl border bg-background p-3 shadow-sm"
+            style={{ left: 280, top: 120, width: 200 }}
+          >
+            <p className="text-sm font-medium">Object B</p>
+            <p className="text-xs text-muted-foreground">x=280, y=120</p>
+          </div>
+        </InfinitePlane>
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("infinite-plane-default.png");
+  });
+});

--- a/packages/ui/src/components/viewport-bookmarks/index.ts
+++ b/packages/ui/src/components/viewport-bookmarks/index.ts
@@ -1,0 +1,6 @@
+export {
+  type ViewportBookmark,
+  ViewportBookmarks,
+  type ViewportBookmarksLabels,
+  type ViewportBookmarksProps,
+} from "./viewport-bookmarks";

--- a/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.mdx
+++ b/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.mdx
@@ -1,0 +1,61 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './viewport-bookmarks.stories'
+
+<Meta of={Stories} />
+
+# ViewportBookmarks
+
+Compact chip row of saved viewport positions. Drop into a canvas chrome surface so the operator can jump between named scenes — overview, release, incidents, audit — without losing the named context.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/viewport-bookmarks.json
+```
+
+## Import
+
+```tsx
+import { ViewportBookmarks } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+const bookmarks = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'release', label: 'Release', meta: 'Today' },
+]
+
+<ViewportBookmarks
+  bookmarks={bookmarks}
+  activeId={current}
+  onSelect={(bookmark) => restore(bookmark.id)}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Active state
+
+Pass \`activeId\` to highlight the current bookmark.
+
+<Canvas of={Stories.Active} sourceState="shown" />
+
+## Empty state
+
+Renders an inline placeholder when no bookmarks are saved.
+
+<Canvas of={Stories.Empty} sourceState="shown" />
+
+## Notes
+
+- The component is presentation-only — it does not store or restore viewport state. Wire \`onSelect\` to your own pan/zoom manager (see \`InfinitePlane\`).
+- Each chip emits \`data-bookmark-id\` and (when active) \`data-active="true"\`. The wrapper emits \`data-bookmarks-count\`.
+- Out of scope for the MVP: drag-to-reorder, in-place rename, capture-on-click. Pass an updated \`bookmarks\` array to drive any of those externally.

--- a/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.stories.tsx
+++ b/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  type ViewportBookmark,
+  ViewportBookmarks,
+} from "./viewport-bookmarks";
+
+const BOOKMARKS: ViewportBookmark[] = [
+  { id: "overview", label: "Overview" },
+  { id: "release", label: "Release", meta: "Today" },
+  { id: "incidents", label: "Incidents", meta: "Live" },
+  { id: "audit", label: "Audit" },
+];
+
+const meta = {
+  args: {
+    bookmarks: BOOKMARKS,
+  },
+  component: ViewportBookmarks,
+  title: "Canvas/ViewportBookmarks",
+} satisfies Meta<typeof ViewportBookmarks>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Active: Story = {
+  args: { activeId: "release" },
+};
+
+export const Empty: Story = {
+  args: { bookmarks: [] },
+};

--- a/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.test.tsx
+++ b/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { type ViewportBookmark, ViewportBookmarks } from "./viewport-bookmarks";
+
+const BOOKMARKS: ViewportBookmark[] = [
+  { id: "overview", label: "Overview" },
+  { id: "release", label: "Release", meta: "Today" },
+  { id: "incidents", label: "Incidents" },
+];
+
+describe("ViewportBookmarks", () => {
+  describe("rendering", () => {
+    it("renders one chip per bookmark", () => {
+      render(<ViewportBookmarks bookmarks={BOOKMARKS} />);
+
+      expect(screen.getByText("Overview")).toBeInTheDocument();
+      expect(screen.getByText("Release")).toBeInTheDocument();
+      expect(screen.getByText("Today")).toBeInTheDocument();
+      expect(screen.getByText("Incidents")).toBeInTheDocument();
+    });
+
+    it("renders the empty-state copy when bookmarks is empty", () => {
+      render(<ViewportBookmarks bookmarks={[]} />);
+
+      expect(screen.getByText("No saved viewports")).toBeInTheDocument();
+    });
+
+    it("marks the active bookmark with data-active and aria-pressed", () => {
+      const { container } = render(
+        <ViewportBookmarks activeId="release" bookmarks={BOOKMARKS} />,
+      );
+
+      const release = container.querySelector("[data-bookmark-id='release']");
+      expect(release).toHaveAttribute("data-active", "true");
+      expect(release).toHaveAttribute("aria-pressed", "true");
+
+      const overview = container.querySelector("[data-bookmark-id='overview']");
+      expect(overview).not.toHaveAttribute("data-active");
+      expect(overview).toHaveAttribute("aria-pressed", "false");
+    });
+  });
+
+  describe("interaction", () => {
+    it("fires onSelect with the picked bookmark", () => {
+      const onSelect = vi.fn();
+      render(<ViewportBookmarks bookmarks={BOOKMARKS} onSelect={onSelect} />);
+
+      fireEvent.click(screen.getByText("Release"));
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "release" }),
+      );
+    });
+  });
+});

--- a/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.tsx
+++ b/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * A saved viewport position. The shape is intentionally generic — pass
+ * any state you need to restore the viewport (pan, zoom, selection,
+ * filters) through `data` and read it back in the `onSelect` handler.
+ *
+ * @public
+ */
+export type ViewportBookmark = {
+  /** Optional payload to pass back when the user picks the bookmark. */
+  data?: unknown;
+  /** Stable identifier. */
+  id: string;
+  /** Display label. */
+  label: ReactNode;
+  /** Optional sublabel (timestamp, scale, etc.). */
+  meta?: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type ViewportBookmarksLabels = {
+  /** Empty-state body. Defaults to `"No saved viewports"`. */
+  empty?: string;
+  /** Aria-label for the chip row. Defaults to `"Saved viewports"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No saved viewports",
+  region: "Saved viewports",
+} as const satisfies Required<ViewportBookmarksLabels>;
+
+/**
+ * Props for {@link ViewportBookmarks}.
+ *
+ * @public
+ */
+export type ViewportBookmarksProps = {
+  /** Optional id of the active bookmark — adds a primary outline. */
+  activeId?: string;
+  /** Saved bookmarks. */
+  bookmarks: ViewportBookmark[];
+  /** Localizable strings. */
+  labels?: ViewportBookmarksLabels;
+  /** Fires when the user picks a bookmark. */
+  onSelect?: (bookmark: ViewportBookmark) => void;
+} & ComponentPropsWithoutRef<"nav">;
+
+/**
+ * Compact chip row of saved viewport positions. Pair with
+ * `InfinitePlane` to jump between scenes (project → board → focus
+ * mode) without losing track of named contexts.
+ *
+ * @example
+ * ```tsx
+ * <ViewportBookmarks
+ *   bookmarks={[
+ *     { id: "overview", label: "Overview" },
+ *     { id: "release", label: "Release", meta: "Today" },
+ *   ]}
+ *   activeId={current}
+ *   onSelect={(b) => restore(b.id)}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const ViewportBookmarks = forwardRef<
+  HTMLElement,
+  ViewportBookmarksProps
+>((props, ref) => {
+  const { activeId, bookmarks, className, labels, onSelect, ...rest } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  return (
+    <nav
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 rounded-md border border-border bg-background/95 px-2 py-1 text-xs text-foreground shadow-sm backdrop-blur",
+        className,
+      )}
+      data-bookmarks-count={bookmarks.length}
+      ref={ref}
+      {...rest}
+    >
+      {bookmarks.length === 0 ? (
+        <span className="text-muted-foreground">{resolvedLabels.empty}</span>
+      ) : (
+        bookmarks.map((bookmark) => {
+          const active = bookmark.id === activeId;
+          return (
+            <button
+              aria-pressed={active}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                active
+                  ? "border-primary bg-primary/10 text-foreground"
+                  : "border-border bg-background text-muted-foreground hover:bg-accent hover:text-foreground",
+              )}
+              data-active={active ? "true" : undefined}
+              data-bookmark-id={bookmark.id}
+              key={bookmark.id}
+              onClick={() => onSelect?.(bookmark)}
+              type="button"
+            >
+              <span>{bookmark.label}</span>
+              {bookmark.meta ? (
+                <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                  {bookmark.meta}
+                </span>
+              ) : null}
+            </button>
+          );
+        })
+      )}
+    </nav>
+  );
+});
+ViewportBookmarks.displayName = "ViewportBookmarks";

--- a/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.visual.tsx
+++ b/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.visual.tsx
@@ -1,0 +1,22 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { ViewportBookmarks } from "./viewport-bookmarks";
+
+test.describe("ViewportBookmarks Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="p-4">
+        <ViewportBookmarks
+          activeId="release"
+          bookmarks={[
+            { id: "overview", label: "Overview" },
+            { id: "release", label: "Release", meta: "Today" },
+            { id: "incidents", label: "Incidents", meta: "Live" },
+            { id: "audit", label: "Audit" },
+          ]}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("viewport-bookmarks-default.png");
+  });
+});

--- a/packages/ui/src/components/world-breadcrumbs/index.ts
+++ b/packages/ui/src/components/world-breadcrumbs/index.ts
@@ -1,0 +1,6 @@
+export {
+  WorldBreadcrumbs,
+  type WorldBreadcrumbsLabels,
+  type WorldBreadcrumbsProps,
+  type WorldCrumb,
+} from "./world-breadcrumbs";

--- a/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.mdx
+++ b/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.mdx
@@ -1,0 +1,65 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './world-breadcrumbs.stories'
+
+<Meta of={Stories} />
+
+# WorldBreadcrumbs
+
+Hierarchical breadcrumbs for spatial canvases. Renders the path (workspace → project → board → view) with the leaf as the current location. Distinct from the generic `Breadcrumb` primitive: every crumb in the world hierarchy stays addressable, the separator fits canvas chrome, and the trailing crumb is plain text (no link).
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/world-breadcrumbs.json
+```
+
+## Import
+
+```tsx
+import { WorldBreadcrumbs } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<WorldBreadcrumbs
+  crumbs={[
+    { id: 'ws', label: 'Acme' },
+    { id: 'proj', label: 'Q4 launch' },
+    { id: 'view', label: 'Release timeline' },
+  ]}
+  onNavigate={(crumb) => navigateTo(crumb.id)}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## With meta badges
+
+Add `meta` to a crumb for compact `v2` / `draft` markers next to the label.
+
+<Canvas of={Stories.WithMeta} sourceState="shown" />
+
+## Custom separator
+
+Pass any node as `separator` (chevron, dot, custom icon).
+
+<Canvas of={Stories.Chevron} sourceState="shown" />
+
+## Anchor crumbs
+
+Provide `href` on a crumb to render it as an anchor — keeps `cmd / ctrl / shift + click` as native open-in-new-tab. Plain clicks fire `onNavigate`.
+
+<Canvas of={Stories.Anchors} sourceState="shown" />
+
+## Notes
+
+- The trailing crumb renders as a `<span aria-current="location">` and emits `data-crumb-current="true"`. Earlier crumbs render as buttons (or anchors) and emit `data-crumb-id`.
+- The wrapper emits `data-crumbs-depth` for analytics.
+- Out of scope for the MVP: collapsing intermediate crumbs into `…` for very deep hierarchies, drag-to-rearrange, hover-preview popovers. Wire those in your hosting surface.

--- a/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.stories.tsx
+++ b/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { type WorldCrumb, WorldBreadcrumbs } from "./world-breadcrumbs";
+
+const CRUMBS: WorldCrumb[] = [
+  { id: "ws", label: "Acme" },
+  { id: "proj", label: "Q4 launch" },
+  { id: "board", label: "Operations" },
+  { id: "view", label: "Release timeline" },
+];
+
+const meta = {
+  args: { crumbs: CRUMBS },
+  component: WorldBreadcrumbs,
+  title: "Canvas/WorldBreadcrumbs",
+} satisfies Meta<typeof WorldBreadcrumbs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithMeta: Story = {
+  args: {
+    crumbs: [
+      { id: "ws", label: "Acme" },
+      { id: "proj", label: "Q4 launch", meta: "v2" },
+      { id: "view", label: "Release timeline", meta: "draft" },
+    ],
+  },
+};
+
+export const Chevron: Story = {
+  args: { separator: "›" },
+};
+
+export const Anchors: Story = {
+  args: {
+    crumbs: [
+      { href: "/acme", id: "ws", label: "Acme" },
+      { href: "/acme/q4", id: "proj", label: "Q4 launch" },
+      { id: "view", label: "Release timeline" },
+    ],
+  },
+};
+
+export const Shallow: Story = {
+  args: {
+    crumbs: [
+      { id: "ws", label: "Acme" },
+      { id: "view", label: "Overview" },
+    ],
+  },
+};

--- a/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.test.tsx
+++ b/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { WorldBreadcrumbs, type WorldCrumb } from "./world-breadcrumbs";
+
+const CRUMBS: WorldCrumb[] = [
+  { id: "ws", label: "Acme" },
+  { id: "proj", label: "Q4 launch" },
+  { id: "view", label: "Release timeline" },
+];
+
+describe("WorldBreadcrumbs", () => {
+  describe("rendering", () => {
+    it("renders one crumb per entry", () => {
+      const { container } = render(<WorldBreadcrumbs crumbs={CRUMBS} />);
+
+      expect(
+        container.querySelector("[data-crumb-id='ws']"),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector("[data-crumb-id='proj']"),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector("[data-crumb-id='view']"),
+      ).toBeInTheDocument();
+    });
+
+    it("marks the trailing crumb as current", () => {
+      const { container } = render(<WorldBreadcrumbs crumbs={CRUMBS} />);
+
+      expect(container.querySelector("[data-crumb-id='view']")).toHaveAttribute(
+        "data-crumb-current",
+        "true",
+      );
+      expect(
+        container.querySelector("[data-crumb-id='ws']"),
+      ).not.toHaveAttribute("data-crumb-current");
+    });
+
+    it("emits crumb depth on the wrapper", () => {
+      const { container } = render(<WorldBreadcrumbs crumbs={CRUMBS} />);
+
+      expect(container.querySelector("nav")).toHaveAttribute(
+        "data-crumbs-depth",
+        "3",
+      );
+    });
+
+    it("renders a separator between crumbs", () => {
+      const { container } = render(
+        <WorldBreadcrumbs crumbs={CRUMBS} separator="›" />,
+      );
+
+      const separators = container.querySelectorAll("[aria-hidden='true']");
+      expect(separators.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("interaction", () => {
+    it("fires onNavigate when an ancestor crumb is clicked", () => {
+      const onNavigate = vi.fn();
+      render(<WorldBreadcrumbs crumbs={CRUMBS} onNavigate={onNavigate} />);
+
+      fireEvent.click(screen.getByText("Q4 launch"));
+      expect(onNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "proj" }),
+      );
+    });
+
+    it("does not fire onNavigate when the current crumb is clicked", () => {
+      const onNavigate = vi.fn();
+      render(<WorldBreadcrumbs crumbs={CRUMBS} onNavigate={onNavigate} />);
+
+      fireEvent.click(screen.getByText("Release timeline"));
+      expect(onNavigate).not.toHaveBeenCalled();
+    });
+
+    it("renders an anchor when href is set", () => {
+      render(
+        <WorldBreadcrumbs
+          crumbs={[
+            { href: "/acme", id: "ws", label: "Acme" },
+            { id: "view", label: "Now" },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText("Acme").closest("a")).toHaveAttribute(
+        "href",
+        "/acme",
+      );
+    });
+  });
+});

--- a/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.tsx
+++ b/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * One node in the world hierarchy (workspace → project → board → view).
+ *
+ * @public
+ */
+export type WorldCrumb = {
+  /** Optional href for client-side navigation. When set, the crumb renders as an anchor. */
+  href?: string;
+  /** Optional icon glyph rendered before the label. */
+  icon?: ReactNode;
+  /** Stable id used for analytics + React keys. */
+  id: string;
+  /** Display label. */
+  label: ReactNode;
+  /** Optional sublabel rendered beneath the label (rare; for "@v2" / "draft" badges). */
+  meta?: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type WorldBreadcrumbsLabels = {
+  /** Aria-label for the breadcrumb nav. Defaults to `"World breadcrumbs"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "World breadcrumbs",
+} as const satisfies Required<WorldBreadcrumbsLabels>;
+
+/**
+ * Props for {@link WorldBreadcrumbs}.
+ *
+ * @public
+ */
+export type WorldBreadcrumbsProps = {
+  /** Hierarchical crumbs from root → leaf. The last crumb is the current location. */
+  crumbs: WorldCrumb[];
+  /** Localizable strings. */
+  labels?: WorldBreadcrumbsLabels;
+  /** Fires when the user picks an ancestor crumb. */
+  onNavigate?: (crumb: WorldCrumb) => void;
+  /** Custom separator. Defaults to a slash glyph. */
+  separator?: ReactNode;
+} & ComponentPropsWithoutRef<"nav">;
+
+type CrumbButtonProps = {
+  crumb: WorldCrumb;
+  current: boolean;
+  onSelect: (crumb: WorldCrumb) => void;
+};
+
+function CrumbButton({
+  crumb,
+  current,
+  onSelect,
+}: CrumbButtonProps): ReactNode {
+  const content = (
+    <span className="inline-flex items-center gap-1">
+      {crumb.icon ? (
+        <span aria-hidden="true" className="inline-flex h-3 w-3 shrink-0">
+          {crumb.icon}
+        </span>
+      ) : null}
+      <span className="font-medium">{crumb.label}</span>
+      {crumb.meta ? (
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+          {crumb.meta}
+        </span>
+      ) : null}
+    </span>
+  );
+  if (current) {
+    return (
+      <span
+        aria-current="location"
+        className="text-foreground"
+        data-crumb-current="true"
+        data-crumb-id={crumb.id}
+      >
+        {content}
+      </span>
+    );
+  }
+  if (crumb.href) {
+    return (
+      <a
+        className="text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        data-crumb-id={crumb.id}
+        href={crumb.href}
+        onClick={(event) => {
+          if (event.metaKey || event.ctrlKey || event.shiftKey) return;
+          event.preventDefault();
+          onSelect(crumb);
+        }}
+      >
+        {content}
+      </a>
+    );
+  }
+  return (
+    <button
+      className="text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      data-crumb-id={crumb.id}
+      onClick={() => {
+        onSelect(crumb);
+      }}
+      type="button"
+    >
+      {content}
+    </button>
+  );
+}
+
+/**
+ * Hierarchical breadcrumbs for spatial canvases. Renders the path
+ * (workspace → project → board → view) with the leaf as the current
+ * location. Distinct from generic `Breadcrumb`: every crumb in the
+ * world hierarchy stays addressable, the separator is a slash that fits
+ * the canvas chrome, and the trailing crumb is plain (no link).
+ *
+ * @example
+ * ```tsx
+ * <WorldBreadcrumbs
+ *   crumbs={[
+ *     { id: "ws", label: "Acme" },
+ *     { id: "proj", label: "Q4 launch" },
+ *     { id: "view", label: "Release timeline" },
+ *   ]}
+ *   onNavigate={(crumb) => navigateTo(crumb.id)}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const WorldBreadcrumbs = forwardRef<HTMLElement, WorldBreadcrumbsProps>(
+  (props, ref) => {
+    const {
+      className,
+      crumbs,
+      labels,
+      onNavigate,
+      separator = "/",
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const handleSelect = (crumb: WorldCrumb): void => {
+      onNavigate?.(crumb);
+    };
+    return (
+      <nav
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "flex items-center gap-1.5 rounded-md border border-border bg-background/95 px-2 py-1 text-xs text-foreground shadow-sm backdrop-blur",
+          className,
+        )}
+        data-crumbs-depth={crumbs.length}
+        ref={ref}
+        {...rest}
+      >
+        <ol className="flex items-center gap-1.5">
+          {crumbs.map((crumb, index) => {
+            const last = index === crumbs.length - 1;
+            return (
+              <li className="flex items-center gap-1.5" key={crumb.id}>
+                <CrumbButton
+                  crumb={crumb}
+                  current={last}
+                  onSelect={handleSelect}
+                />
+                {last ? null : (
+                  <span
+                    aria-hidden="true"
+                    className="select-none text-muted-foreground/60"
+                  >
+                    {separator}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+    );
+  },
+);
+WorldBreadcrumbs.displayName = "WorldBreadcrumbs";

--- a/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.visual.tsx
+++ b/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.visual.tsx
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { WorldBreadcrumbs } from "./world-breadcrumbs";
+
+test.describe("WorldBreadcrumbs Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="p-4">
+        <WorldBreadcrumbs
+          crumbs={[
+            { id: "ws", label: "Acme" },
+            { id: "proj", label: "Q4 launch", meta: "v2" },
+            { id: "board", label: "Operations" },
+            { id: "view", label: "Release timeline" },
+          ]}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "world-breadcrumbs-default.png",
+    );
+  });
+});


### PR DESCRIPTION
Closes #132.

Ships the three missing primitives to close the **canvas foundation & operator chrome** family. The other 8 primitives in the spec (\`TopBar\`, \`LeftRail\`, \`CanvasView\`, \`RightDock\`, \`WorkspaceSwitcher\`, \`CanvasShell\`, \`MiniMapPanel\`, \`ZoomHUD\`) already exist.

## What's in
- **\`InfinitePlane\`** — pannable, zoomable substrate. Drag to pan; ctrl/meta + wheel to zoom (\`0.25×–4×\`). Children render inside a transformed wrapper at unzoomed plane coordinates. Optional dotted-grid backdrop scales with zoom.
- **\`ViewportBookmarks\`** — compact chip row of saved viewport positions (\`Overview\`, \`Release\`, \`Incidents\`, \`Audit\`…). Active state, optional \`meta\` badge, click fires \`onSelect(bookmark)\` so the host can restore pan/zoom externally.
- **\`WorldBreadcrumbs\`** — hierarchical canvas breadcrumbs (workspace → project → board → view). Trailing crumb is plain text (no link); ancestors render as buttons or anchors when \`href\` is set; supports custom separator + per-crumb \`meta\` badge.

## Notes
- All three are presentation primitives. The host wires actual viewport state, navigation, and bookmark persistence.
- Each primitive emits stable \`data-*\` attributes (\`data-pan-x\`, \`data-zoom\`, \`data-bookmark-id\`, \`data-crumb-id\`, \`data-crumb-current\`, etc.) for analytics + CSS hooks.

## Quality gates
- lint PASS
- typecheck PASS
- check:use-client PASS (182)
- check-story-coverage PASS (172/172)
- verify-stories PASS
- build PASS
- test PASS (507/507, +13 new)
- build-storybook PASS