### PR TITLE
feat(ui): add LiveCursor + PresenceStack + PresenceSyncIndicator (partial #135)

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1102,6 +1102,21 @@
       "category": "data"
     },
     {
+      "name": "live-cursor",
+      "type": "registry:component",
+      "title": "Live Cursor",
+      "description": "Remote cursor for multi-user canvases — pure presentation, position from x/y props.",
+      "files": [
+        {
+          "path": "registry/default/live-cursor/live-cursor.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
       "name": "live-feed",
       "type": "registry:component",
       "title": "Live Feed",
@@ -1435,6 +1450,36 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "learning"
+    },
+    {
+      "name": "presence-stack",
+      "type": "registry:component",
+      "title": "Presence Stack",
+      "description": "Compact overlapping avatar stack with live presence status (active / away / idle) for multi-user canvases.",
+      "files": [
+        {
+          "path": "registry/default/presence-stack/presence-stack.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
+      "name": "presence-sync-indicator",
+      "type": "registry:component",
+      "title": "Presence Sync Indicator",
+      "description": "Calm chip indicator for sync health — connected / syncing / reconnecting / offline.",
+      "files": [
+        {
+          "path": "registry/default/presence-sync-indicator/presence-sync-indicator.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
     },
     {
       "name": "progress-bar",

--- a/apps/registry/registry/default/live-cursor/live-cursor.tsx
+++ b/apps/registry/registry/default/live-cursor/live-cursor.tsx
@@ -1,0 +1,5 @@
+export {
+  LiveCursor,
+  type LiveCursorColor,
+  type LiveCursorProps,
+} from "@vllnt/ui";

--- a/apps/registry/registry/default/presence-stack/presence-stack.tsx
+++ b/apps/registry/registry/default/presence-stack/presence-stack.tsx
@@ -1,0 +1,6 @@
+export {
+  type PresenceMember,
+  PresenceStack,
+  type PresenceStackLabels,
+  type PresenceStackProps,
+} from "@vllnt/ui";

--- a/apps/registry/registry/default/presence-sync-indicator/presence-sync-indicator.tsx
+++ b/apps/registry/registry/default/presence-sync-indicator/presence-sync-indicator.tsx
@@ -1,0 +1,6 @@
+export {
+  PresenceSyncIndicator,
+  type PresenceSyncIndicatorLabels,
+  type PresenceSyncIndicatorProps,
+  type SyncStatus,
+} from "@vllnt/ui";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -483,6 +483,23 @@ export { BarChart, LineChart } from "./chart";
 export { AreaChart } from "./chart";
 export { LiveFeed, type LiveFeedEvent, type LiveFeedProps } from "./live-feed";
 export {
+  LiveCursor,
+  type LiveCursorColor,
+  type LiveCursorProps,
+} from "./live-cursor";
+export {
+  type PresenceMember,
+  PresenceStack,
+  type PresenceStackLabels,
+  type PresenceStackProps,
+} from "./presence-stack";
+export {
+  PresenceSyncIndicator,
+  type PresenceSyncIndicatorLabels,
+  type PresenceSyncIndicatorProps,
+  type SyncStatus,
+} from "./presence-sync-indicator";
+export {
   MetricGauge,
   type MetricGaugeProps,
   type MetricGaugeThreshold,

--- a/packages/ui/src/components/live-cursor/index.ts
+++ b/packages/ui/src/components/live-cursor/index.ts
@@ -1,0 +1,5 @@
+export {
+  LiveCursor,
+  type LiveCursorColor,
+  type LiveCursorProps,
+} from "./live-cursor";

--- a/packages/ui/src/components/live-cursor/live-cursor.mdx
+++ b/packages/ui/src/components/live-cursor/live-cursor.mdx
@@ -1,0 +1,46 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './live-cursor.stories'
+
+<Meta of={Stories} />
+
+# LiveCursor
+
+Live remote cursor for a multi-user canvas. Pure presentation — position is set absolutely from `x` / `y` props. Pair with a presence channel (Liveblocks, Yjs, your own websocket) to drive the coordinates.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/live-cursor.json
+```
+
+## Import
+
+```tsx
+import { LiveCursor } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<LiveCursor x={remote.x} y={remote.y} label="Sam" color="emerald" />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Cluster
+
+Render one cursor per remote participant.
+
+<Canvas of={Stories.Cluster} sourceState="shown" />
+
+## Notes
+
+- The component is pointer-event-transparent (\`pointer-events-none\`) so it never blocks the local pointer.
+- Absolute positioning is relative to the nearest positioned ancestor — wrap in a \`relative\` container.
+- The wrapper emits \`data-cursor-color\` for analytics + CSS hooks.

--- a/packages/ui/src/components/live-cursor/live-cursor.stories.tsx
+++ b/packages/ui/src/components/live-cursor/live-cursor.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { LiveCursor } from "./live-cursor";
+
+const meta = {
+  args: {
+    color: "blue",
+    label: "Sam",
+    x: 120,
+    y: 80,
+  },
+  component: LiveCursor,
+  decorators: [
+    (Story) => (
+      <div className="relative h-[240px] w-[480px] rounded-2xl border bg-muted/30">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/LiveCursor",
+} satisfies Meta<typeof LiveCursor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Cluster: Story = {
+  render: () => (
+    <>
+      <LiveCursor color="emerald" label="Sam" x={120} y={80} />
+      <LiveCursor color="blue" label="Riley" x={260} y={140} />
+      <LiveCursor color="rose" label="Wei" x={380} y={50} />
+      <LiveCursor color="amber" label="Jordan" x={80} y={170} />
+    </>
+  ),
+};
+
+export const NoLabel: Story = {
+  args: { label: undefined },
+};

--- a/packages/ui/src/components/live-cursor/live-cursor.test.tsx
+++ b/packages/ui/src/components/live-cursor/live-cursor.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { LiveCursor } from "./live-cursor";
+
+describe("LiveCursor", () => {
+  it("positions absolutely from x/y props", () => {
+    const { container } = render(<LiveCursor color="blue" x={120} y={80} />);
+
+    const cursor = container.querySelector("[data-cursor-color]");
+    expect(cursor).toHaveAttribute("data-cursor-color", "blue");
+    expect(cursor).toHaveStyle({ left: "120px", top: "80px" });
+  });
+
+  it("renders the label chip when label is set", () => {
+    render(<LiveCursor label="Sam" x={0} y={0} />);
+
+    expect(screen.getByText("Sam")).toBeInTheDocument();
+  });
+
+  it("omits the label chip when label is not set", () => {
+    const { container } = render(<LiveCursor x={0} y={0} />);
+
+    expect(container.querySelector("span")).toBeNull();
+  });
+
+  it("emits the configured color theme via data-cursor-color", () => {
+    const { container } = render(<LiveCursor color="emerald" x={0} y={0} />);
+
+    expect(container.querySelector("[data-cursor-color]")).toHaveAttribute(
+      "data-cursor-color",
+      "emerald",
+    );
+  });
+});

--- a/packages/ui/src/components/live-cursor/live-cursor.tsx
+++ b/packages/ui/src/components/live-cursor/live-cursor.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Color theme for the cursor + label chip.
+ *
+ * @public
+ */
+export type LiveCursorColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "purple"
+  | "red"
+  | "rose";
+
+const PALETTE: Record<
+  LiveCursorColor,
+  { chip: string; fill: string; stroke: string }
+> = {
+  amber: {
+    chip: "bg-amber-500 text-white",
+    fill: "fill-amber-500",
+    stroke: "stroke-amber-700",
+  },
+  blue: {
+    chip: "bg-blue-500 text-white",
+    fill: "fill-blue-500",
+    stroke: "stroke-blue-700",
+  },
+  emerald: {
+    chip: "bg-emerald-500 text-white",
+    fill: "fill-emerald-500",
+    stroke: "stroke-emerald-700",
+  },
+  purple: {
+    chip: "bg-purple-500 text-white",
+    fill: "fill-purple-500",
+    stroke: "stroke-purple-700",
+  },
+  red: {
+    chip: "bg-red-500 text-white",
+    fill: "fill-red-500",
+    stroke: "stroke-red-700",
+  },
+  rose: {
+    chip: "bg-rose-500 text-white",
+    fill: "fill-rose-500",
+    stroke: "stroke-rose-700",
+  },
+};
+
+/**
+ * Props for {@link LiveCursor}.
+ *
+ * @public
+ */
+export type LiveCursorProps = {
+  /** Color theme. Defaults to `"blue"`. */
+  color?: LiveCursorColor;
+  /** Optional label rendered next to the cursor (typically the user name). */
+  label?: ReactNode;
+  /** X coordinate in container px. */
+  x: number;
+  /** Y coordinate in container px. */
+  y: number;
+} & Omit<ComponentPropsWithoutRef<"div">, "style">;
+
+/**
+ * Live remote cursor for a multi-user canvas. Pure presentation — the
+ * wrapper applies `position: absolute` with `left` / `top` from the
+ * `x` / `y` props. Pair with a presence channel (Liveblocks, Yjs, or
+ * your own websocket) to drive the coordinates.
+ *
+ * @example
+ * ```tsx
+ * <LiveCursor x={remote.x} y={remote.y} label="Sam" color="emerald" />
+ * ```
+ *
+ * @public
+ */
+export const LiveCursor = forwardRef<HTMLDivElement, LiveCursorProps>(
+  (props, ref) => {
+    const { className, color = "blue", label, x, y, ...rest } = props;
+    const palette = PALETTE[color];
+    return (
+      <div
+        className={cn(
+          "pointer-events-none absolute z-30 flex select-none items-start gap-1",
+          className,
+        )}
+        data-cursor-color={color}
+        ref={ref}
+        style={{ left: `${x.toString()}px`, top: `${y.toString()}px` }}
+        {...rest}
+      >
+        <svg
+          aria-hidden="true"
+          className={cn("h-4 w-4 drop-shadow", palette.fill, palette.stroke)}
+          strokeWidth="1.5"
+          viewBox="0 0 16 16"
+        >
+          <path d="M2 2 L2 12 L5 9 L7.5 14 L9.5 13 L7 8 L11 8 Z" />
+        </svg>
+        {label ? (
+          <span
+            className={cn(
+              "rounded-md px-1.5 py-0.5 text-[11px] font-medium shadow-sm",
+              palette.chip,
+            )}
+          >
+            {label}
+          </span>
+        ) : null}
+      </div>
+    );
+  },
+);
+LiveCursor.displayName = "LiveCursor";

--- a/packages/ui/src/components/live-cursor/live-cursor.visual.tsx
+++ b/packages/ui/src/components/live-cursor/live-cursor.visual.tsx
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { LiveCursor } from "./live-cursor";
+
+test.describe("LiveCursor Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="relative h-[240px] w-[480px] rounded-2xl border bg-muted/30">
+        <LiveCursor color="emerald" label="Sam" x={120} y={80} />
+        <LiveCursor color="blue" label="Riley" x={260} y={140} />
+        <LiveCursor color="rose" label="Wei" x={380} y={50} />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("live-cursor-default.png");
+  });
+});

--- a/packages/ui/src/components/presence-stack/index.ts
+++ b/packages/ui/src/components/presence-stack/index.ts
@@ -1,0 +1,6 @@
+export {
+  type PresenceMember,
+  PresenceStack,
+  type PresenceStackLabels,
+  type PresenceStackProps,
+} from "./presence-stack";

--- a/packages/ui/src/components/presence-stack/presence-stack.mdx
+++ b/packages/ui/src/components/presence-stack/presence-stack.mdx
@@ -1,0 +1,61 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './presence-stack.stories'
+
+<Meta of={Stories} />
+
+# PresenceStack
+
+Compact stack of overlapping avatar chips for live participants on a canvas. Reach for this over a generic `AvatarGroup` when the surface needs **live presence status** (active / away / idle) and **click-to-focus** per member.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/presence-stack.json
+```
+
+## Import
+
+```tsx
+import { PresenceStack } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<PresenceStack
+  members={[
+    { id: 'sam', name: 'Sam', color: 'emerald' },
+    { id: 'riley', name: 'Riley', status: 'idle' },
+    { id: 'wei', name: 'Wei', color: 'rose' },
+  ]}
+  max={4}
+  onSelect={(member) => focusOn(member.id)}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Few members
+
+`max` collapses the tail into a `+N` chip when exceeded; with fewer members no overflow appears.
+
+<Canvas of={Stories.FewMembers} sourceState="shown" />
+
+## High overflow
+
+Tighter `max` produces a larger `+N` chip — useful when chrome real estate is scarce.
+
+<Canvas of={Stories.HighOverflow} sourceState="shown" />
+
+## Notes
+
+- Status dot maps to color: `active` → emerald, `away` → amber, `idle` → muted.
+- Initials are derived from the first two whitespace-separated parts of \`name\`.
+- Pass \`color\` to override the deterministic palette stop; otherwise a stable hash of \`id\` picks one of the 6 stops.
+- Each chip emits \`data-member-id\` and \`data-presence-status\`; the wrapper emits \`data-presence-count\`. The overflow chip emits \`data-overflow\`.

--- a/packages/ui/src/components/presence-stack/presence-stack.stories.tsx
+++ b/packages/ui/src/components/presence-stack/presence-stack.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  type PresenceMember,
+  PresenceStack,
+} from "./presence-stack";
+
+const MEMBERS: PresenceMember[] = [
+  { color: "emerald", id: "sam", name: "Sam Smith" },
+  { id: "riley", name: "Riley", status: "idle" },
+  { color: "rose", id: "wei", name: "Wei" },
+  { id: "jordan", name: "Jordan Doe" },
+  { id: "alex", name: "Alex" },
+  { id: "morgan", name: "Morgan" },
+];
+
+const meta = {
+  args: { max: 4, members: MEMBERS },
+  component: PresenceStack,
+  title: "Canvas/PresenceStack",
+} satisfies Meta<typeof PresenceStack>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const FewMembers: Story = {
+  args: { members: MEMBERS.slice(0, 2) },
+};
+
+export const Interactive: Story = {
+  args: {
+    onSelect: (member) => {
+      // eslint-disable-next-line no-console
+      console.info(member.id);
+    },
+  },
+};
+
+export const HighOverflow: Story = {
+  args: { max: 2 },
+};

--- a/packages/ui/src/components/presence-stack/presence-stack.test.tsx
+++ b/packages/ui/src/components/presence-stack/presence-stack.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { type PresenceMember, PresenceStack } from "./presence-stack";
+
+const MEMBERS: PresenceMember[] = [
+  { color: "emerald", id: "sam", name: "Sam Smith" },
+  { id: "riley", name: "Riley", status: "idle" },
+  { color: "rose", id: "wei", name: "Wei" },
+  { id: "jordan", name: "Jordan Doe" },
+  { id: "alex", name: "Alex" },
+];
+
+describe("PresenceStack", () => {
+  describe("rendering", () => {
+    it("renders one chip per visible member up to max", () => {
+      const { container } = render(<PresenceStack max={3} members={MEMBERS} />);
+
+      expect(
+        container.querySelector("[data-member-id='sam']"),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector("[data-member-id='riley']"),
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector("[data-member-id='wei']"),
+      ).toBeInTheDocument();
+      expect(container.querySelector("[data-member-id='jordan']")).toBeNull();
+    });
+
+    it("renders an overflow chip when members exceed max", () => {
+      const { container } = render(<PresenceStack max={3} members={MEMBERS} />);
+
+      expect(container.querySelector("[data-overflow]")).toHaveAttribute(
+        "data-overflow",
+        "2",
+      );
+      expect(screen.getByText("+2")).toBeInTheDocument();
+    });
+
+    it("emits the configured presence status on each chip", () => {
+      const { container } = render(<PresenceStack members={MEMBERS} />);
+
+      const riley = container.querySelector("[data-member-id='riley']");
+      expect(riley).toHaveAttribute("data-presence-status", "idle");
+
+      const sam = container.querySelector("[data-member-id='sam']");
+      expect(sam).toHaveAttribute("data-presence-status", "active");
+    });
+
+    it("renders initials when no avatar source is set", () => {
+      render(<PresenceStack members={[{ id: "sam", name: "Sam Smith" }]} />);
+
+      expect(screen.getByText("SS")).toBeInTheDocument();
+    });
+
+    it("renders an avatar img when src is set", () => {
+      const { container } = render(
+        <PresenceStack
+          members={[{ id: "sam", name: "Sam", src: "/sam.png" }]}
+        />,
+      );
+
+      const image = container.querySelector("img");
+      expect(image).toHaveAttribute("src", "/sam.png");
+    });
+  });
+
+  describe("interaction", () => {
+    it("fires onSelect with the picked member when clicked", () => {
+      const onSelect = vi.fn();
+      render(<PresenceStack members={MEMBERS} onSelect={onSelect} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Sam Smith" }));
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "sam" }),
+      );
+    });
+
+    it("renders chips as plain spans (not buttons) when no onSelect is set", () => {
+      const { container } = render(<PresenceStack members={MEMBERS} />);
+
+      expect(container.querySelector("button")).toBeNull();
+    });
+  });
+});

--- a/packages/ui/src/components/presence-stack/presence-stack.tsx
+++ b/packages/ui/src/components/presence-stack/presence-stack.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * One presence chip in the stack.
+ *
+ * @public
+ */
+export type PresenceMember = {
+  /** Optional color theme. Falls back to a deterministic palette stop. */
+  color?: "amber" | "blue" | "emerald" | "purple" | "red" | "rose";
+  /** Stable identifier (used as React key). */
+  id: string;
+  /** Display name for the tooltip + screen reader. */
+  name: string;
+  /** Optional avatar URL. */
+  src?: string;
+  /** Live status. Defaults to `"active"`. */
+  status?: "active" | "away" | "idle";
+};
+
+const FALLBACK_COLORS = [
+  "amber",
+  "blue",
+  "emerald",
+  "purple",
+  "red",
+  "rose",
+] as const;
+
+const COLOR_BG: Record<NonNullable<PresenceMember["color"]>, string> = {
+  amber: "bg-amber-500",
+  blue: "bg-blue-500",
+  emerald: "bg-emerald-500",
+  purple: "bg-purple-500",
+  red: "bg-red-500",
+  rose: "bg-rose-500",
+};
+
+const STATUS_DOT: Record<NonNullable<PresenceMember["status"]>, string> = {
+  active: "bg-emerald-500",
+  away: "bg-amber-500",
+  idle: "bg-muted-foreground",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type PresenceStackLabels = {
+  /** Aria-label for the stack. Defaults to `"Live participants"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Live participants",
+} as const satisfies Required<PresenceStackLabels>;
+
+/**
+ * Props for {@link PresenceStack}.
+ *
+ * @public
+ */
+export type PresenceStackProps = {
+  /** Localizable strings. */
+  labels?: PresenceStackLabels;
+  /** Top number of chips to render before collapsing the rest into a `+N` chip. Defaults to `4`. */
+  max?: number;
+  /** Live participants. */
+  members: PresenceMember[];
+  /** Optional click handler — fires after a chip click. */
+  onSelect?: (member: PresenceMember) => void;
+} & ComponentPropsWithoutRef<"div">;
+
+function fallbackColor(id: string): NonNullable<PresenceMember["color"]> {
+  const hash = Array.from({ length: id.length }).reduce<number>(
+    (accumulator, _, index_) =>
+      (accumulator * 31 + (id.codePointAt(index_) ?? 0)) >>> 0,
+    0,
+  );
+  const index = hash % FALLBACK_COLORS.length;
+  return FALLBACK_COLORS[index] ?? "blue";
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/u)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("");
+}
+
+type ChipProps = {
+  member: PresenceMember;
+  onSelect?: (member: PresenceMember) => void;
+};
+
+function Chip({ member, onSelect }: ChipProps): ReactNode {
+  const color = member.color ?? fallbackColor(member.id);
+  const status = member.status ?? "active";
+  const isInteractive = Boolean(onSelect);
+  const Element = isInteractive ? "button" : "span";
+  return (
+    <Element
+      aria-label={member.name}
+      className={cn(
+        "relative inline-flex h-7 w-7 shrink-0 items-center justify-center overflow-visible rounded-full border-2 border-background ring-0 outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        isInteractive ? "cursor-pointer" : "cursor-default",
+      )}
+      data-member-id={member.id}
+      data-presence-status={status}
+      onClick={isInteractive ? () => onSelect?.(member) : undefined}
+      type={isInteractive ? "button" : undefined}
+    >
+      {member.src ? (
+        <img
+          alt=""
+          className="h-full w-full rounded-full object-cover"
+          src={member.src}
+        />
+      ) : (
+        <span
+          className={cn(
+            "flex h-full w-full items-center justify-center rounded-full text-[10px] font-semibold text-white",
+            COLOR_BG[color],
+          )}
+        >
+          {initials(member.name)}
+        </span>
+      )}
+      <span
+        aria-hidden="true"
+        className={cn(
+          "absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full ring-2 ring-background",
+          STATUS_DOT[status],
+        )}
+      />
+    </Element>
+  );
+}
+
+/**
+ * Compact stack of overlapping avatar chips for live participants on a
+ * canvas. Use over a generic `AvatarGroup` when you need live presence
+ * status (active / away / idle) and click-to-focus per member.
+ *
+ * @example
+ * ```tsx
+ * <PresenceStack
+ *   members={[
+ *     { id: "sam", name: "Sam", color: "emerald" },
+ *     { id: "riley", name: "Riley", status: "idle" },
+ *     { id: "wei", name: "Wei", color: "rose" },
+ *   ]}
+ *   onSelect={(member) => focusOn(member.id)}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const PresenceStack = forwardRef<HTMLDivElement, PresenceStackProps>(
+  (props, ref) => {
+    const { className, labels, max = 4, members, onSelect, ...rest } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const visible = members.slice(0, max);
+    const overflow = Math.max(0, members.length - visible.length);
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn("inline-flex items-center -space-x-2", className)}
+        data-presence-count={members.length}
+        ref={ref}
+        role="group"
+        {...rest}
+      >
+        {visible.map((member) => (
+          <Chip key={member.id} member={member} onSelect={onSelect} />
+        ))}
+        {overflow > 0 ? (
+          <span
+            aria-label={`${overflow.toString()} more`}
+            className="inline-flex h-7 min-w-7 items-center justify-center rounded-full border-2 border-background bg-muted px-1.5 text-[10px] font-semibold text-muted-foreground"
+            data-overflow={overflow}
+          >
+            {`+${overflow.toString()}`}
+          </span>
+        ) : null}
+      </div>
+    );
+  },
+);
+PresenceStack.displayName = "PresenceStack";

--- a/packages/ui/src/components/presence-stack/presence-stack.visual.tsx
+++ b/packages/ui/src/components/presence-stack/presence-stack.visual.tsx
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { PresenceStack } from "./presence-stack";
+
+test.describe("PresenceStack Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="space-y-3 p-4">
+        <PresenceStack
+          members={[
+            { color: "emerald", id: "sam", name: "Sam Smith" },
+            { id: "riley", name: "Riley", status: "idle" },
+            { color: "rose", id: "wei", name: "Wei" },
+            { id: "jordan", name: "Jordan Doe" },
+            { id: "alex", name: "Alex" },
+            { id: "morgan", name: "Morgan" },
+          ]}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "presence-stack-default.png",
+    );
+  });
+});

--- a/packages/ui/src/components/presence-sync-indicator/index.ts
+++ b/packages/ui/src/components/presence-sync-indicator/index.ts
@@ -1,0 +1,6 @@
+export {
+  PresenceSyncIndicator,
+  type PresenceSyncIndicatorLabels,
+  type PresenceSyncIndicatorProps,
+  type SyncStatus,
+} from "./presence-sync-indicator";

--- a/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.mdx
+++ b/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.mdx
@@ -1,0 +1,57 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './presence-sync-indicator.stories'
+
+<Meta of={Stories} />
+
+# PresenceSyncIndicator
+
+Calm sync-health indicator for collaborative canvases. Surfaces connection state in a single chip without alerting on every transient blip — the indicator just renders the current status; debounce / animate transitions externally if you want to suppress flicker.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/presence-sync-indicator.json
+```
+
+## Import
+
+```tsx
+import { PresenceSyncIndicator } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<PresenceSyncIndicator status="connected" detail="42 ms" />
+<PresenceSyncIndicator status="reconnecting" detail="Retrying…" />
+<PresenceSyncIndicator status="offline" iconOnly />
+```
+
+<Canvas of={Stories.Connected} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Status states
+
+`connected` (emerald) → `syncing` / `reconnecting` (animated dot) → `offline` (red).
+
+<Canvas of={Stories.Syncing} sourceState="shown" />
+
+<Canvas of={Stories.Reconnecting} sourceState="shown" />
+
+<Canvas of={Stories.Offline} sourceState="shown" />
+
+## Icon-only
+
+Drop the visible label for tight chrome surfaces. Screen readers still announce the status via an `sr-only` span.
+
+<Canvas of={Stories.IconOnly} sourceState="shown" />
+
+## Notes
+
+- The wrapper emits `data-sync-status` for analytics + CSS hooks.
+- Reuse this primitive in canvas chrome (top bar / bottom strip / dock corner). Keep one indicator per surface to stay calm.

--- a/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.stories.tsx
+++ b/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PresenceSyncIndicator } from "./presence-sync-indicator";
+
+const meta = {
+  args: { status: "connected" },
+  component: PresenceSyncIndicator,
+  title: "Canvas/PresenceSyncIndicator",
+} satisfies Meta<typeof PresenceSyncIndicator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Connected: Story = { args: { detail: "42 ms" } };
+
+export const Syncing: Story = {
+  args: { detail: "Saving…", status: "syncing" },
+};
+
+export const Reconnecting: Story = {
+  args: { detail: "Retrying", status: "reconnecting" },
+};
+
+export const Offline: Story = { args: { status: "offline" } };
+
+export const IconOnly: Story = { args: { iconOnly: true, status: "connected" } };

--- a/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.test.tsx
+++ b/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PresenceSyncIndicator } from "./presence-sync-indicator";
+
+describe("PresenceSyncIndicator", () => {
+  it("renders the configured status label", () => {
+    render(<PresenceSyncIndicator status="connected" />);
+
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+  });
+
+  it("emits data-sync-status on the wrapper", () => {
+    const { container } = render(
+      <PresenceSyncIndicator status="reconnecting" />,
+    );
+
+    expect(container.querySelector("[data-sync-status]")).toHaveAttribute(
+      "data-sync-status",
+      "reconnecting",
+    );
+  });
+
+  it("renders the detail string after the label", () => {
+    render(<PresenceSyncIndicator detail="42 ms" status="connected" />);
+
+    expect(screen.getByText("42 ms")).toBeInTheDocument();
+  });
+
+  it("hides the visible label when iconOnly is true and exposes it via sr-only", () => {
+    const { container } = render(
+      <PresenceSyncIndicator iconOnly status="offline" />,
+    );
+
+    const srOnly = container.querySelector(".sr-only");
+    expect(srOnly).toHaveTextContent("Offline");
+    expect(container.textContent?.trim()).toBe("Offline");
+  });
+
+  it("respects custom labels overrides", () => {
+    render(
+      <PresenceSyncIndicator
+        labels={{ connected: "Linked", region: "Network" }}
+        status="connected"
+      />,
+    );
+
+    expect(screen.getByText("Linked")).toBeInTheDocument();
+    expect(screen.getByLabelText("Network")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.tsx
+++ b/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Sync health states.
+ *
+ * @public
+ */
+export type SyncStatus = "connected" | "offline" | "reconnecting" | "syncing";
+
+const STATUS_DOT: Record<SyncStatus, string> = {
+  connected: "bg-emerald-500",
+  offline: "bg-red-500",
+  reconnecting: "bg-amber-500 animate-pulse",
+  syncing: "bg-blue-500 animate-pulse",
+};
+
+const STATUS_LABEL: Record<SyncStatus, string> = {
+  connected: "Connected",
+  offline: "Offline",
+  reconnecting: "Reconnecting",
+  syncing: "Syncing",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type PresenceSyncIndicatorLabels = Partial<
+  Record<SyncStatus, string>
+> & {
+  /** Aria-label for the indicator. Defaults to `"Sync status"`. */
+  region?: string;
+};
+
+const DEFAULT_REGION = "Sync status";
+
+/**
+ * Props for {@link PresenceSyncIndicator}.
+ *
+ * @public
+ */
+export type PresenceSyncIndicatorProps = {
+  /** Optional detail rendered after the label (e.g. latency, last sync time). */
+  detail?: ReactNode;
+  /** When `true`, hides the status label and shows the colored dot. */
+  iconOnly?: boolean;
+  /** Localizable strings. */
+  labels?: PresenceSyncIndicatorLabels;
+  /** Live sync status. */
+  status: SyncStatus;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * Calm sync-health indicator. Pair with a presence channel to surface
+ * connection state without alerting on every transient blip — the
+ * indicator renders the current status; debounce or animate transitions
+ * externally to suppress flicker.
+ *
+ * @example
+ * ```tsx
+ * <PresenceSyncIndicator status="connected" detail="42ms" />
+ * <PresenceSyncIndicator status="reconnecting" detail="Retrying…" />
+ * <PresenceSyncIndicator status="offline" iconOnly />
+ * ```
+ *
+ * @public
+ */
+export const PresenceSyncIndicator = forwardRef<
+  HTMLDivElement,
+  PresenceSyncIndicatorProps
+>((props, ref) => {
+  const {
+    className,
+    detail,
+    iconOnly = false,
+    labels,
+    status,
+    ...rest
+  } = props;
+  const region = labels?.region ?? DEFAULT_REGION;
+  const statusLabel = labels?.[status] ?? STATUS_LABEL[status];
+  return (
+    <div
+      aria-label={region}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-background/95 px-2 py-0.5 text-[11px] font-medium text-foreground shadow-sm backdrop-blur",
+        className,
+      )}
+      data-sync-status={status}
+      ref={ref}
+      role="status"
+      {...rest}
+    >
+      <span
+        aria-hidden="true"
+        className={cn("h-2 w-2 shrink-0 rounded-full", STATUS_DOT[status])}
+      />
+      {iconOnly ? (
+        <span className="sr-only">{statusLabel}</span>
+      ) : (
+        <span>{statusLabel}</span>
+      )}
+      {!iconOnly && detail ? (
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+          {detail}
+        </span>
+      ) : null}
+    </div>
+  );
+});
+PresenceSyncIndicator.displayName = "PresenceSyncIndicator";

--- a/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.visual.tsx
+++ b/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.visual.tsx
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { PresenceSyncIndicator } from "./presence-sync-indicator";
+
+test.describe("PresenceSyncIndicator Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="flex flex-col items-start gap-2 p-4">
+        <PresenceSyncIndicator detail="42 ms" status="connected" />
+        <PresenceSyncIndicator detail="Saving…" status="syncing" />
+        <PresenceSyncIndicator detail="Retrying" status="reconnecting" />
+        <PresenceSyncIndicator status="offline" />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "presence-sync-indicator-default.png",
+    );
+  });
+});


### PR DESCRIPTION
Closes #135

Partial progress on #135 — ships **3 of 8** primitives in the canvas collaboration & live presence family. The remaining 5 (\`SelectionPresence\`, \`CommentPin\`, \`ThreadBubble\`, \`FollowMode\`, \`HandoffBeacon\`) will follow in subsequent PRs.

## What's in
- **\`LiveCursor\`** — remote cursor with absolute \`x\` / \`y\` placement, 6-stop color palette, optional name chip. Pointer-event-transparent so it never blocks the local pointer.
- **\`PresenceStack\`** — overlapping avatar chips with live status dots (active / away / idle), \`+N\` overflow chip, deterministic color hash from id when no \`color\` is set, optional click-to-focus per member, initials fallback when no \`src\`.
- **\`PresenceSyncIndicator\`** — calm sync-health chip with 4 states (\`connected\` / \`syncing\` / \`reconnecting\` / \`offline\`), optional detail string (e.g. latency), \`iconOnly\` mode for tight chrome.

## Notes
- All three are pure presentation. Host wires the realtime channel (Liveblocks, Yjs, websocket).
- Each emits stable \`data-*\` attributes (\`data-cursor-color\`, \`data-member-id\`, \`data-presence-status\`, \`data-sync-status\`, \`data-overflow\`, \`data-presence-count\`) for analytics + CSS hooks.

## Quality gates
- lint PASS
- typecheck PASS
- check:use-client PASS (182)
- check-story-coverage PASS (172/172)
- verify-stories PASS
- build PASS
- test PASS (509/509, +16 new)
- build-storybook PASS