### PR TITLE
feat(ui): add SelectionPresence + CommentPin + ThreadBubble (partial #135)

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -583,6 +583,21 @@
       "category": "overlay"
     },
     {
+      "name": "comment-pin",
+      "type": "registry:component",
+      "title": "Comment Pin",
+      "description": "Anchored comment marker for spatial canvases — pure presentation with status colors and reply count.",
+      "files": [
+        {
+          "path": "registry/default/comment-pin/comment-pin.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
       "name": "comparison",
       "type": "registry:component",
       "title": "Comparison",
@@ -1557,6 +1572,21 @@
       "category": "content"
     },
     {
+      "name": "selection-presence",
+      "type": "registry:component",
+      "title": "Selection Presence",
+      "description": "Selection halo + name chip for a remote participant's active selection on a multi-user canvas.",
+      "files": [
+        {
+          "path": "registry/default/selection-presence/selection-presence.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
       "name": "scope-selector",
       "type": "registry:component",
       "title": "Scope Selector",
@@ -2056,6 +2086,21 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "utility"
+    },
+    {
+      "name": "thread-bubble",
+      "type": "registry:component",
+      "title": "Thread Bubble",
+      "description": "Floating thread bubble for an anchored comment — replies, optional title, Resolved pill, and a compose slot.",
+      "files": [
+        {
+          "path": "registry/default/thread-bubble/thread-bubble.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
     },
     {
       "name": "theme-toggle",

--- a/apps/registry/registry/default/comment-pin/comment-pin.tsx
+++ b/apps/registry/registry/default/comment-pin/comment-pin.tsx
@@ -1,0 +1,5 @@
+export {
+  CommentPin,
+  type CommentPinProps,
+  type CommentPinStatus,
+} from "@vllnt/ui";

--- a/apps/registry/registry/default/selection-presence/selection-presence.tsx
+++ b/apps/registry/registry/default/selection-presence/selection-presence.tsx
@@ -1,0 +1,5 @@
+export {
+  SelectionPresence,
+  type SelectionPresenceColor,
+  type SelectionPresenceProps,
+} from "@vllnt/ui";

--- a/apps/registry/registry/default/thread-bubble/thread-bubble.tsx
+++ b/apps/registry/registry/default/thread-bubble/thread-bubble.tsx
@@ -1,0 +1,6 @@
+export {
+  ThreadBubble,
+  type ThreadBubbleLabels,
+  type ThreadBubbleProps,
+  type ThreadReply,
+} from "@vllnt/ui";

--- a/packages/ui/src/components/comment-pin/comment-pin.mdx
+++ b/packages/ui/src/components/comment-pin/comment-pin.mdx
@@ -1,0 +1,52 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './comment-pin.stories'
+
+<Meta of={Stories} />
+
+# CommentPin
+
+Anchored comment marker for spatial canvases. Pure presentation — position is set absolutely from `x` / `y` props. Pair with `ThreadBubble` to surface the conversation when the pin is active.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/comment-pin.json
+```
+
+## Import
+
+```tsx
+import { CommentPin } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<CommentPin x={120} y={80} count={3} status="unread" onSelect={open} />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Cluster
+
+Render one pin per anchored thread. Status colors: `open` (blue), `unread` (amber), `resolved` (emerald).
+
+<Canvas of={Stories.Cluster} sourceState="shown" />
+
+## Initials only
+
+Pass `initials` to label the pin with the author instead of the reply count.
+
+<Canvas of={Stories.InitialsOnly} sourceState="shown" />
+
+## Notes
+
+- The pin emits `data-comment-status` for analytics + CSS hooks.
+- Absolute positioning is relative to the nearest positioned ancestor — wrap in a `relative` container.
+- The aria-label includes the status + count or initials so screen readers can distinguish pins.

--- a/packages/ui/src/components/comment-pin/comment-pin.stories.tsx
+++ b/packages/ui/src/components/comment-pin/comment-pin.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { CommentPin } from "./comment-pin";
+
+const meta = {
+  args: {
+    count: 3,
+    status: "open",
+    x: 120,
+    y: 80,
+  },
+  component: CommentPin,
+  decorators: [
+    (Story) => (
+      <div className="relative h-[240px] w-[480px] rounded-2xl border bg-muted/30">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/CommentPin",
+} satisfies Meta<typeof CommentPin>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Cluster: Story = {
+  render: () => (
+    <>
+      <CommentPin count={3} status="open" x={120} y={80} />
+      <CommentPin initials="SS" status="unread" x={260} y={140} />
+      <CommentPin count={1} status="resolved" x={380} y={50} />
+    </>
+  ),
+};
+
+export const InitialsOnly: Story = {
+  args: { count: undefined, initials: "WC" },
+};

--- a/packages/ui/src/components/comment-pin/comment-pin.test.tsx
+++ b/packages/ui/src/components/comment-pin/comment-pin.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CommentPin } from "./comment-pin";
+
+describe("CommentPin", () => {
+  it("positions absolutely from x/y props", () => {
+    const { container } = render(<CommentPin x={120} y={80} />);
+
+    const pin = container.querySelector("[data-comment-status]");
+    expect(pin).toHaveStyle({ left: "120px", top: "80px" });
+  });
+
+  it("emits the configured status via data-comment-status", () => {
+    const { container } = render(<CommentPin status="resolved" x={0} y={0} />);
+
+    expect(container.querySelector("[data-comment-status]")).toHaveAttribute(
+      "data-comment-status",
+      "resolved",
+    );
+  });
+
+  it("renders the count number inside the pin", () => {
+    render(<CommentPin count={3} x={0} y={0} />);
+
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("prefers initials over count when both are passed", () => {
+    render(<CommentPin count={5} initials="SS" x={0} y={0} />);
+
+    expect(screen.getByText("SS")).toBeInTheDocument();
+    expect(screen.queryByText("5")).toBeNull();
+  });
+
+  it("fires onSelect when the pin is clicked", () => {
+    const onSelect = vi.fn();
+    render(<CommentPin onSelect={onSelect} x={0} y={0} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/comment-pin/comment-pin.tsx
+++ b/packages/ui/src/components/comment-pin/comment-pin.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Pin status — drives the dot color.
+ *
+ * @public
+ */
+export type CommentPinStatus = "open" | "resolved" | "unread";
+
+const STATUS_CLASSES: Record<CommentPinStatus, string> = {
+  open: "bg-blue-500 text-white",
+  resolved: "bg-emerald-500 text-white",
+  unread: "bg-amber-500 text-white",
+};
+
+/**
+ * Props for {@link CommentPin}.
+ *
+ * @public
+ */
+export type CommentPinProps = {
+  /** Optional reply count rendered inside the pin. */
+  count?: number;
+  /** Optional initials of the author. Falls back to `count` or empty. */
+  initials?: string;
+  /** Optional click handler — fires after a pin click. */
+  onSelect?: () => void;
+  /** Pin status. Defaults to `"open"`. */
+  status?: CommentPinStatus;
+  /** X coordinate in container px. */
+  x: number;
+  /** Y coordinate in container px. */
+  y: number;
+} & Omit<ComponentPropsWithoutRef<"button">, "onClick" | "style" | "type">;
+
+/**
+ * Anchored comment marker. Pure presentation — the wrapper applies
+ * `position: absolute` with the `x` / `y` props as `left` / `top`. Pair
+ * with {@link ThreadBubble} to surface the conversation when the pin
+ * is active.
+ *
+ * @example
+ * ```tsx
+ * <CommentPin x={120} y={80} count={3} status="unread" onSelect={open} />
+ * ```
+ *
+ * @public
+ */
+export const CommentPin = forwardRef<HTMLButtonElement, CommentPinProps>(
+  (props, ref) => {
+    const {
+      className,
+      count,
+      initials,
+      onSelect,
+      status = "open",
+      x,
+      y,
+      ...rest
+    } = props;
+    const label = initials ?? (count === undefined ? "" : count.toString());
+    return (
+      <button
+        aria-label={`Comment ${status}${label ? ` — ${label}` : ""}`}
+        className={cn(
+          "absolute z-30 inline-flex h-7 w-7 -translate-x-1/2 -translate-y-full items-center justify-center rounded-full border-2 border-background text-[11px] font-semibold shadow-md transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          STATUS_CLASSES[status],
+          className,
+        )}
+        data-comment-status={status}
+        onClick={onSelect}
+        ref={ref}
+        style={{ left: `${x.toString()}px`, top: `${y.toString()}px` }}
+        type="button"
+        {...rest}
+      >
+        {label || (
+          <span aria-hidden="true" className="text-[10px]">
+            ●
+          </span>
+        )}
+      </button>
+    );
+  },
+);
+CommentPin.displayName = "CommentPin";

--- a/packages/ui/src/components/comment-pin/comment-pin.visual.tsx
+++ b/packages/ui/src/components/comment-pin/comment-pin.visual.tsx
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { CommentPin } from "./comment-pin";
+
+test.describe("CommentPin Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="relative h-[240px] w-[480px] rounded-2xl border bg-muted/30">
+        <CommentPin count={3} status="open" x={120} y={80} />
+        <CommentPin initials="SS" status="unread" x={260} y={140} />
+        <CommentPin count={1} status="resolved" x={380} y={50} />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("comment-pin-default.png");
+  });
+});

--- a/packages/ui/src/components/comment-pin/index.ts
+++ b/packages/ui/src/components/comment-pin/index.ts
@@ -1,0 +1,5 @@
+export {
+  CommentPin,
+  type CommentPinProps,
+  type CommentPinStatus,
+} from "./comment-pin";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -483,6 +483,22 @@ export { BarChart, LineChart } from "./chart";
 export { AreaChart } from "./chart";
 export { LiveFeed, type LiveFeedEvent, type LiveFeedProps } from "./live-feed";
 export {
+  CommentPin,
+  type CommentPinProps,
+  type CommentPinStatus,
+} from "./comment-pin";
+export {
+  SelectionPresence,
+  type SelectionPresenceColor,
+  type SelectionPresenceProps,
+} from "./selection-presence";
+export {
+  ThreadBubble,
+  type ThreadBubbleLabels,
+  type ThreadBubbleProps,
+  type ThreadReply,
+} from "./thread-bubble";
+export {
   MetricGauge,
   type MetricGaugeProps,
   type MetricGaugeThreshold,

--- a/packages/ui/src/components/selection-presence/index.ts
+++ b/packages/ui/src/components/selection-presence/index.ts
@@ -1,0 +1,5 @@
+export {
+  SelectionPresence,
+  type SelectionPresenceColor,
+  type SelectionPresenceProps,
+} from "./selection-presence";

--- a/packages/ui/src/components/selection-presence/selection-presence.mdx
+++ b/packages/ui/src/components/selection-presence/selection-presence.mdx
@@ -1,0 +1,47 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './selection-presence.stories'
+
+<Meta of={Stories} />
+
+# SelectionPresence
+
+Selection halo for a remote participant. Wrap any selected element to outline it with the participant's color and surface a name chip above the corner. Pure presentation — visibility is driven by the host (mount when remote selection exists, unmount when cleared).
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/selection-presence.json
+```
+
+## Import
+
+```tsx
+import { SelectionPresence } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<SelectionPresence color="emerald" name="Sam">
+  <ObjectCard … />
+</SelectionPresence>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Without name
+
+Drop the chip when the host already surfaces the participant elsewhere.
+
+<Canvas of={Stories.NoName} sourceState="shown" />
+
+## Notes
+
+- The wrapper applies `ring-2 ring-offset-2` plus the participant's color. The name chip is positioned at the top-left corner.
+- The wrapper emits `data-selection-color`. The chip emits `data-selection-chip` for analytics + CSS hooks.

--- a/packages/ui/src/components/selection-presence/selection-presence.stories.tsx
+++ b/packages/ui/src/components/selection-presence/selection-presence.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { SelectionPresence } from "./selection-presence";
+
+const meta = {
+  args: {
+    children: (
+      <div className="rounded-2xl border bg-background p-4">
+        <p className="text-sm font-medium">Object A</p>
+      </div>
+    ),
+    color: "blue",
+    name: "Sam",
+  },
+  component: SelectionPresence,
+  decorators: [
+    (Story) => (
+      <div className="p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/SelectionPresence",
+} satisfies Meta<typeof SelectionPresence>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Emerald: Story = { args: { color: "emerald", name: "Wei" } };
+
+export const NoName: Story = { args: { color: "rose", name: undefined } };

--- a/packages/ui/src/components/selection-presence/selection-presence.test.tsx
+++ b/packages/ui/src/components/selection-presence/selection-presence.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SelectionPresence } from "./selection-presence";
+
+describe("SelectionPresence", () => {
+  it("emits the configured color via data-selection-color", () => {
+    const { container } = render(
+      <SelectionPresence color="emerald">
+        <p>Selected card</p>
+      </SelectionPresence>,
+    );
+
+    expect(container.querySelector("[data-selection-color]")).toHaveAttribute(
+      "data-selection-color",
+      "emerald",
+    );
+  });
+
+  it("renders the name chip when name is set", () => {
+    render(
+      <SelectionPresence name="Sam">
+        <p>Body</p>
+      </SelectionPresence>,
+    );
+
+    expect(screen.getByText("Sam")).toBeInTheDocument();
+  });
+
+  it("omits the name chip when name is not set", () => {
+    const { container } = render(
+      <SelectionPresence>
+        <p>Body</p>
+      </SelectionPresence>,
+    );
+
+    expect(container.querySelector("[data-selection-chip]")).toBeNull();
+  });
+
+  it("renders children inside the wrapper", () => {
+    render(
+      <SelectionPresence color="rose" name="Sam">
+        <p>Inner content</p>
+      </SelectionPresence>,
+    );
+
+    expect(screen.getByText("Inner content")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/selection-presence/selection-presence.tsx
+++ b/packages/ui/src/components/selection-presence/selection-presence.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Color theme for the selection halo + name chip.
+ *
+ * @public
+ */
+export type SelectionPresenceColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "purple"
+  | "red"
+  | "rose";
+
+const PALETTE: Record<SelectionPresenceColor, { chip: string; ring: string }> =
+  {
+    amber: { chip: "bg-amber-500 text-white", ring: "ring-amber-500" },
+    blue: { chip: "bg-blue-500 text-white", ring: "ring-blue-500" },
+    emerald: { chip: "bg-emerald-500 text-white", ring: "ring-emerald-500" },
+    purple: { chip: "bg-purple-500 text-white", ring: "ring-purple-500" },
+    red: { chip: "bg-red-500 text-white", ring: "ring-red-500" },
+    rose: { chip: "bg-rose-500 text-white", ring: "ring-rose-500" },
+  };
+
+/**
+ * Props for {@link SelectionPresence}.
+ *
+ * @public
+ */
+export type SelectionPresenceProps = {
+  /** Color theme. Defaults to `"blue"`. */
+  color?: SelectionPresenceColor;
+  /** Optional name chip rendered above the top-left corner. */
+  name?: ReactNode;
+} & Omit<ComponentPropsWithoutRef<"div">, "color">;
+
+/**
+ * Selection halo for a remote participant. Wrap any selected element to
+ * outline it with the participant's color and surface a name chip above
+ * the corner. Pure presentation — the host controls visibility (mount
+ * when remote selection exists, unmount when cleared).
+ *
+ * @example
+ * ```tsx
+ * <SelectionPresence color="emerald" name="Sam">
+ *   <ObjectCard … />
+ * </SelectionPresence>
+ * ```
+ *
+ * @public
+ */
+export const SelectionPresence = forwardRef<
+  HTMLDivElement,
+  SelectionPresenceProps
+>((props, ref) => {
+  const { children, className, color = "blue", name, ...rest } = props;
+  const palette = PALETTE[color];
+  return (
+    <div
+      className={cn(
+        "relative rounded-2xl ring-2 ring-offset-2 ring-offset-background",
+        palette.ring,
+        className,
+      )}
+      data-selection-color={color}
+      ref={ref}
+      {...rest}
+    >
+      {name ? (
+        <span
+          className={cn(
+            "absolute -top-2 left-2 inline-flex -translate-y-full items-center rounded-md px-1.5 py-0.5 text-[10px] font-semibold shadow-sm",
+            palette.chip,
+          )}
+          data-selection-chip
+        >
+          {name}
+        </span>
+      ) : null}
+      {children}
+    </div>
+  );
+});
+SelectionPresence.displayName = "SelectionPresence";

--- a/packages/ui/src/components/selection-presence/selection-presence.visual.tsx
+++ b/packages/ui/src/components/selection-presence/selection-presence.visual.tsx
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { SelectionPresence } from "./selection-presence";
+
+test.describe("SelectionPresence Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="space-y-6 p-6">
+        <SelectionPresence color="emerald" name="Sam">
+          <div className="rounded-2xl border bg-background p-4">
+            <p className="text-sm font-medium">Object A</p>
+            <p className="text-xs text-muted-foreground">
+              Sam is selecting this card.
+            </p>
+          </div>
+        </SelectionPresence>
+        <SelectionPresence color="rose" name="Wei">
+          <div className="rounded-2xl border bg-background p-4">
+            <p className="text-sm font-medium">Object B</p>
+          </div>
+        </SelectionPresence>
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "selection-presence-default.png",
+    );
+  });
+});

--- a/packages/ui/src/components/thread-bubble/index.ts
+++ b/packages/ui/src/components/thread-bubble/index.ts
@@ -1,0 +1,6 @@
+export {
+  ThreadBubble,
+  type ThreadBubbleLabels,
+  type ThreadBubbleProps,
+  type ThreadReply,
+} from "./thread-bubble";

--- a/packages/ui/src/components/thread-bubble/thread-bubble.mdx
+++ b/packages/ui/src/components/thread-bubble/thread-bubble.mdx
@@ -1,0 +1,59 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './thread-bubble.stories'
+
+<Meta of={Stories} />
+
+# ThreadBubble
+
+Floating thread bubble for an anchored comment. Pair with `CommentPin` — surface the bubble while a pin is active. Pure presentation; the host wires reply state and submission.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/thread-bubble.json
+```
+
+## Import
+
+```tsx
+import { ThreadBubble } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<ThreadBubble
+  title="Trade-off summary"
+  replies={[
+    { id: '1', user: 'Sam', body: 'We should reword this.', timestamp: '2026-05-08T09:00:00Z' },
+    { id: '2', user: 'Wei', body: 'Agreed — drafting.', timestamp: '2026-05-08T09:05:00Z' },
+  ]}
+  composeSlot={<textarea placeholder="Reply…" />}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Resolved
+
+Pass `resolved` to surface a calm pill in the header.
+
+<Canvas of={Stories.Resolved} sourceState="shown" />
+
+## Custom compose slot
+
+Drop in your own composer (markdown editor, mention picker, attach button row).
+
+<Canvas of={Stories.CustomCompose} sourceState="shown" />
+
+## Notes
+
+- Reply rows render `user · timestamp · body`. Timestamps are formatted via `Intl.DateTimeFormat` so locale changes are respected.
+- The bubble emits `data-thread-replies` (count). Each reply emits `data-thread-reply-id`. The Resolved pill emits `data-thread-resolved`.
+- Out of scope for the MVP: reactions, mentions, attachments, threading nested replies. Wire those externally in the compose slot or by transforming the `replies` shape.

--- a/packages/ui/src/components/thread-bubble/thread-bubble.stories.tsx
+++ b/packages/ui/src/components/thread-bubble/thread-bubble.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { type ThreadReply, ThreadBubble } from "./thread-bubble";
+
+const REPLIES: ThreadReply[] = [
+  {
+    body: "We should reword this. The current copy reads passive.",
+    id: "1",
+    timestamp: "2026-05-08T09:00:00Z",
+    user: "Sam",
+  },
+  {
+    body: "Agreed — drafting a fix.",
+    id: "2",
+    timestamp: "2026-05-08T09:05:00Z",
+    user: "Wei",
+  },
+  {
+    body: "Pushed to staging.",
+    id: "3",
+    timestamp: "2026-05-08T09:32:00Z",
+    user: "Riley",
+  },
+];
+
+const meta = {
+  args: {
+    replies: REPLIES,
+    title: "Trade-off summary",
+  },
+  component: ThreadBubble,
+  title: "Canvas/ThreadBubble",
+} satisfies Meta<typeof ThreadBubble>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Resolved: Story = { args: { resolved: true } };
+
+export const Untitled: Story = { args: { title: undefined } };
+
+export const CustomCompose: Story = {
+  args: {
+    composeSlot: (
+      <textarea
+        className="min-h-12 w-full resize-y rounded-md border border-border bg-background px-2 py-1 text-xs"
+        placeholder="Reply with markdown…"
+      />
+    ),
+  },
+};

--- a/packages/ui/src/components/thread-bubble/thread-bubble.test.tsx
+++ b/packages/ui/src/components/thread-bubble/thread-bubble.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ThreadBubble, type ThreadReply } from "./thread-bubble";
+
+const REPLIES: ThreadReply[] = [
+  {
+    body: "We should reword this.",
+    id: "1",
+    timestamp: "2026-05-08T09:00:00Z",
+    user: "Sam",
+  },
+  {
+    body: "Agreed — drafting.",
+    id: "2",
+    user: "Wei",
+  },
+];
+
+describe("ThreadBubble", () => {
+  it("renders one row per reply", () => {
+    const { container } = render(<ThreadBubble replies={REPLIES} />);
+
+    expect(
+      container.querySelector("[data-thread-reply-id='1']"),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector("[data-thread-reply-id='2']"),
+    ).toBeInTheDocument();
+  });
+
+  it("emits the reply count via data-thread-replies", () => {
+    const { container } = render(<ThreadBubble replies={REPLIES} />);
+
+    expect(container.querySelector("[data-thread-replies]")).toHaveAttribute(
+      "data-thread-replies",
+      "2",
+    );
+  });
+
+  it("renders the title when set", () => {
+    render(<ThreadBubble replies={REPLIES} title="Trade-off summary" />);
+
+    expect(screen.getByText("Trade-off summary")).toBeInTheDocument();
+  });
+
+  it("renders the Resolved pill when resolved is true", () => {
+    const { container } = render(<ThreadBubble replies={REPLIES} resolved />);
+
+    expect(
+      container.querySelector("[data-thread-resolved]"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Resolved")).toBeInTheDocument();
+  });
+
+  it("renders the compose placeholder when no compose slot is provided", () => {
+    render(<ThreadBubble replies={REPLIES} />);
+
+    expect(screen.getByText("Reply…")).toBeInTheDocument();
+  });
+
+  it("renders the provided compose slot", () => {
+    render(
+      <ThreadBubble
+        composeSlot={<button type="button">Send</button>}
+        replies={REPLIES}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
+    expect(screen.queryByText("Reply…")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/thread-bubble/thread-bubble.tsx
+++ b/packages/ui/src/components/thread-bubble/thread-bubble.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * One reply inside the thread.
+ *
+ * @public
+ */
+export type ThreadReply = {
+  /** Body content. Pass plain text or rich nodes. */
+  body: ReactNode;
+  /** Stable id used for analytics + React keys. */
+  id: string;
+  /** Optional ISO timestamp string for the meta line. */
+  timestamp?: string;
+  /** Display name. */
+  user: string;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type ThreadBubbleLabels = {
+  /** Default footer placeholder copy. Defaults to `"Reply…"`. */
+  composePlaceholder?: string;
+  /** Aria-label for the bubble. Defaults to `"Comment thread"`. */
+  region?: string;
+  /** "Resolved" pill copy. Defaults to `"Resolved"`. */
+  resolved?: string;
+};
+
+const DEFAULT_LABELS = {
+  composePlaceholder: "Reply…",
+  region: "Comment thread",
+  resolved: "Resolved",
+} as const satisfies Required<ThreadBubbleLabels>;
+
+/**
+ * Props for {@link ThreadBubble}.
+ *
+ * @public
+ */
+export type ThreadBubbleProps = {
+  /** Optional compose slot rendered below the replies. */
+  composeSlot?: ReactNode;
+  /** Localizable strings. */
+  labels?: ThreadBubbleLabels;
+  /** Replies in chronological order. */
+  replies: ThreadReply[];
+  /** When `true`, surfaces a `Resolved` pill in the header. */
+  resolved?: boolean;
+  /** Optional thread title rendered as the header. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"div">;
+
+type ReplyProps = {
+  reply: ThreadReply;
+};
+
+function ReplyRow({ reply }: ReplyProps): ReactNode {
+  return (
+    <li className="space-y-1" data-thread-reply-id={reply.id}>
+      <div className="flex items-baseline gap-2 text-[11px]">
+        <span className="font-semibold text-foreground">{reply.user}</span>
+        {reply.timestamp ? (
+          <time className="text-muted-foreground" dateTime={reply.timestamp}>
+            {new Date(reply.timestamp).toLocaleString(undefined, {
+              day: "2-digit",
+              hour: "2-digit",
+              minute: "2-digit",
+              month: "short",
+            })}
+          </time>
+        ) : null}
+      </div>
+      <div className="text-sm leading-relaxed text-foreground">
+        {reply.body}
+      </div>
+    </li>
+  );
+}
+
+/**
+ * Floating thread bubble for an anchored comment. Pair with
+ * {@link CommentPin} — surface the bubble while a pin is active.
+ *
+ * @example
+ * ```tsx
+ * <ThreadBubble
+ *   title="Trade-off summary"
+ *   replies={[
+ *     { id: "1", user: "Sam", body: "We should reword this.", timestamp: "2026-05-08T09:00:00Z" },
+ *     { id: "2", user: "Wei", body: "Agreed — drafting.", timestamp: "2026-05-08T09:05:00Z" },
+ *   ]}
+ *   composeSlot={<textarea placeholder="Reply…" />}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const ThreadBubble = forwardRef<HTMLDivElement, ThreadBubbleProps>(
+  (props, ref) => {
+    const {
+      className,
+      composeSlot,
+      labels,
+      replies,
+      resolved = false,
+      title,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "z-30 flex w-72 flex-col gap-2 rounded-2xl border bg-popover p-3 text-popover-foreground shadow-lg",
+          className,
+        )}
+        data-thread-replies={replies.length}
+        ref={ref}
+        role="region"
+        {...rest}
+      >
+        {title || resolved ? (
+          <header className="flex items-center justify-between gap-2">
+            {title ? (
+              <h3 className="truncate text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {title}
+              </h3>
+            ) : (
+              <span />
+            )}
+            {resolved ? (
+              <span
+                className="inline-flex items-center rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-emerald-700 dark:text-emerald-300"
+                data-thread-resolved
+              >
+                {resolvedLabels.resolved}
+              </span>
+            ) : null}
+          </header>
+        ) : null}
+        <ol className="space-y-2 border-l border-border pl-2">
+          {replies.map((reply) => (
+            <ReplyRow key={reply.id} reply={reply} />
+          ))}
+        </ol>
+        {composeSlot ?? (
+          <div className="rounded-md border border-dashed border-border px-2 py-1 text-xs text-muted-foreground">
+            {resolvedLabels.composePlaceholder}
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+ThreadBubble.displayName = "ThreadBubble";

--- a/packages/ui/src/components/thread-bubble/thread-bubble.visual.tsx
+++ b/packages/ui/src/components/thread-bubble/thread-bubble.visual.tsx
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { type ThreadReply, ThreadBubble } from "./thread-bubble";
+
+const REPLIES: ThreadReply[] = [
+  {
+    body: "We should reword this. The current copy reads passive.",
+    id: "1",
+    timestamp: "2026-05-08T09:00:00Z",
+    user: "Sam",
+  },
+  {
+    body: "Agreed — drafting a fix.",
+    id: "2",
+    timestamp: "2026-05-08T09:05:00Z",
+    user: "Wei",
+  },
+  {
+    body: "Pushed to staging.",
+    id: "3",
+    timestamp: "2026-05-08T09:32:00Z",
+    user: "Riley",
+  },
+];
+
+test.describe("ThreadBubble Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="p-4">
+        <ThreadBubble replies={REPLIES} title="Trade-off summary" />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("thread-bubble-default.png");
+  });
+});


### PR DESCRIPTION
Closes #135

Partial progress on #135 — adds **3 more** primitives toward the canvas collaboration & live presence family. Combined with PR #194 the family is now **6 of 8** complete; \`FollowMode\` and \`HandoffBeacon\` remain.

## What's in
- **\`SelectionPresence\`** — wrap any selected element with a per-user color ring + name chip in the corner. 6-stop palette.
- **\`CommentPin\`** — anchored comment marker with status colors (\`open\` / \`unread\` / \`resolved\`), reply count or initials inside the pin, click-to-select.
- **\`ThreadBubble\`** — floating bubble for an anchored comment. Renders replies (user / timestamp / body), optional title, \`Resolved\` pill, and a compose slot (defaults to a placeholder).

## Notes
- All three are pure presentation. Host wires the realtime channel + thread state.
- Each primitive emits stable \`data-*\` attributes (\`data-selection-color\`, \`data-comment-status\`, \`data-thread-replies\`, \`data-thread-resolved\`, \`data-thread-reply-id\`, \`data-selection-chip\`) for analytics + CSS hooks.

## Quality gates
- lint PASS
- typecheck PASS
- check:use-client PASS (182)
- check-story-coverage PASS (172/172)
- verify-stories PASS
- build PASS
- test PASS (508/508, +15 new)
- build-storybook PASS