### PR TITLE
feat(ui): close canvas collab family — FollowMode + HandoffBeacon

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -975,6 +975,21 @@
       "category": "data"
     },
     {
+      "name": "follow-mode",
+      "type": "registry:component",
+      "title": "Follow Mode",
+      "description": "Follow-mode chrome — outlines a region with a participant's color and surfaces a stop-following chip.",
+      "files": [
+        {
+          "path": "registry/default/follow-mode/follow-mode.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
       "name": "form",
       "type": "registry:component",
       "title": "Form",
@@ -1006,6 +1021,21 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "utility"
+    },
+    {
+      "name": "handoff-beacon",
+      "type": "registry:component",
+      "title": "Handoff Beacon",
+      "description": "Attention-routing beacon with pulsing ring and optional source / message card for live canvases.",
+      "files": [
+        {
+          "path": "registry/default/handoff-beacon/handoff-beacon.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
     },
     {
       "name": "heat-overlay",

--- a/apps/registry/registry/default/follow-mode/follow-mode.tsx
+++ b/apps/registry/registry/default/follow-mode/follow-mode.tsx
@@ -1,0 +1,6 @@
+export {
+  FollowMode,
+  type FollowModeColor,
+  type FollowModeLabels,
+  type FollowModeProps,
+} from "@vllnt/ui";

--- a/apps/registry/registry/default/handoff-beacon/handoff-beacon.tsx
+++ b/apps/registry/registry/default/handoff-beacon/handoff-beacon.tsx
@@ -1,0 +1,6 @@
+export {
+  HandoffBeacon,
+  type HandoffBeaconLabels,
+  type HandoffBeaconLevel,
+  type HandoffBeaconProps,
+} from "@vllnt/ui";

--- a/packages/ui/src/components/follow-mode/follow-mode.mdx
+++ b/packages/ui/src/components/follow-mode/follow-mode.mdx
@@ -1,0 +1,47 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './follow-mode.stories'
+
+<Meta of={Stories} />
+
+# FollowMode
+
+Follow-mode chrome. Wrap any region (typically the whole canvas) to outline it with the followed participant's color and surface a pinned chip + stop-following button. Pure presentation — the host drives viewport sync and toggles the wrapper on / off.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/follow-mode.json
+```
+
+## Import
+
+```tsx
+import { FollowMode } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<FollowMode color="emerald" name="Sam" onStop={stop}>
+  <CanvasView … />
+</FollowMode>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Without stop
+
+Drop \`onStop\` to render the chip alone — useful when the host surfaces the stop affordance elsewhere.
+
+<Canvas of={Stories.NoStop} sourceState="shown" />
+
+## Notes
+
+- The wrapper applies `ring-2 ring-inset` in the participant's color so the pinned chip stays inside the canvas surface.
+- The wrapper emits `data-follow-color`. The chip emits `data-follow-chip` for analytics + CSS hooks.

--- a/packages/ui/src/components/follow-mode/follow-mode.stories.tsx
+++ b/packages/ui/src/components/follow-mode/follow-mode.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { FollowMode } from "./follow-mode";
+
+const noop = (): void => undefined;
+
+const meta = {
+  args: {
+    children: (
+      <div className="flex h-full w-full items-center justify-center bg-muted/20 text-sm text-muted-foreground">
+        Followed canvas content
+      </div>
+    ),
+    color: "blue",
+    name: "Sam",
+    onStop: noop,
+  },
+  component: FollowMode,
+  decorators: [
+    (Story) => (
+      <div style={{ height: 280, width: 480 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/FollowMode",
+} satisfies Meta<typeof FollowMode>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Emerald: Story = { args: { color: "emerald", name: "Wei" } };
+
+export const NoStop: Story = { args: { onStop: undefined } };

--- a/packages/ui/src/components/follow-mode/follow-mode.test.tsx
+++ b/packages/ui/src/components/follow-mode/follow-mode.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FollowMode } from "./follow-mode";
+
+describe("FollowMode", () => {
+  it("emits the configured color via data-follow-color", () => {
+    const { container } = render(
+      <FollowMode color="emerald" name="Sam">
+        <p>Body</p>
+      </FollowMode>,
+    );
+
+    expect(container.querySelector("[data-follow-color]")).toHaveAttribute(
+      "data-follow-color",
+      "emerald",
+    );
+  });
+
+  it("renders the participant name in the chip", () => {
+    render(
+      <FollowMode name="Sam">
+        <p>Body</p>
+      </FollowMode>,
+    );
+
+    expect(screen.getByText(/Following Sam/)).toBeInTheDocument();
+  });
+
+  it("renders the stop button only when onStop is set", () => {
+    const onStop = vi.fn();
+    const { rerender } = render(
+      <FollowMode name="Sam">
+        <p>Body</p>
+      </FollowMode>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+
+    rerender(
+      <FollowMode name="Sam" onStop={onStop}>
+        <p>Body</p>
+      </FollowMode>,
+    );
+
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+  });
+
+  it("fires onStop when the stop button is clicked", () => {
+    const onStop = vi.fn();
+    render(
+      <FollowMode name="Sam" onStop={onStop}>
+        <p>Body</p>
+      </FollowMode>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders children inside the wrapper", () => {
+    render(
+      <FollowMode name="Sam">
+        <p>Inner content</p>
+      </FollowMode>,
+    );
+
+    expect(screen.getByText("Inner content")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/follow-mode/follow-mode.tsx
+++ b/packages/ui/src/components/follow-mode/follow-mode.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Color theme for the follow ring + chip.
+ *
+ * @public
+ */
+export type FollowModeColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "purple"
+  | "red"
+  | "rose";
+
+const PALETTE: Record<FollowModeColor, { chip: string; ring: string }> = {
+  amber: { chip: "bg-amber-500 text-white", ring: "ring-amber-500" },
+  blue: { chip: "bg-blue-500 text-white", ring: "ring-blue-500" },
+  emerald: { chip: "bg-emerald-500 text-white", ring: "ring-emerald-500" },
+  purple: { chip: "bg-purple-500 text-white", ring: "ring-purple-500" },
+  red: { chip: "bg-red-500 text-white", ring: "ring-red-500" },
+  rose: { chip: "bg-rose-500 text-white", ring: "ring-rose-500" },
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type FollowModeLabels = {
+  /** Aria-label for the follow chrome. Defaults to `"Follow mode"`. */
+  region?: string;
+  /** Stop-following button copy. Defaults to `"Stop"`. */
+  stop?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Follow mode",
+  stop: "Stop",
+} as const satisfies Required<FollowModeLabels>;
+
+/**
+ * Props for {@link FollowMode}.
+ *
+ * @public
+ */
+export type FollowModeProps = {
+  /** Color theme. Defaults to `"blue"`. */
+  color?: FollowModeColor;
+  /** Localizable strings. */
+  labels?: FollowModeLabels;
+  /** Display name of the followed participant. */
+  name: ReactNode;
+  /** Fires when the user picks the stop-following button. */
+  onStop?: () => void;
+} & Omit<ComponentPropsWithoutRef<"div">, "color">;
+
+/**
+ * Follow-mode chrome. Wrap any region (typically the whole canvas) to
+ * outline it with the followed participant's color and surface a
+ * pinned chip + stop-following button. Pure presentation — the host
+ * drives viewport sync and toggles the wrapper on / off.
+ *
+ * @example
+ * ```tsx
+ * <FollowMode color="emerald" name="Sam" onStop={stop}>
+ *   <CanvasView … />
+ * </FollowMode>
+ * ```
+ *
+ * @public
+ */
+export const FollowMode = forwardRef<HTMLDivElement, FollowModeProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      color = "blue",
+      labels,
+      name,
+      onStop,
+      ...rest
+    } = props;
+    const palette = PALETTE[color];
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "relative h-full w-full rounded-2xl ring-2 ring-inset",
+          palette.ring,
+          className,
+        )}
+        data-follow-color={color}
+        ref={ref}
+        {...rest}
+      >
+        <div
+          className="pointer-events-auto absolute left-1/2 top-2 z-30 flex -translate-x-1/2 items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold shadow-sm"
+          data-follow-chip
+        >
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full px-1.5 py-0.5",
+              palette.chip,
+            )}
+          >
+            <span aria-hidden="true">▸</span>
+            <span>Following {name}</span>
+          </span>
+          {onStop ? (
+            <button
+              aria-label={resolvedLabels.stop}
+              className="inline-flex h-5 items-center rounded-full border border-border bg-background px-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              onClick={onStop}
+              type="button"
+            >
+              {resolvedLabels.stop}
+            </button>
+          ) : null}
+        </div>
+        {children}
+      </div>
+    );
+  },
+);
+FollowMode.displayName = "FollowMode";

--- a/packages/ui/src/components/follow-mode/follow-mode.visual.tsx
+++ b/packages/ui/src/components/follow-mode/follow-mode.visual.tsx
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { FollowMode } from "./follow-mode";
+
+test.describe("FollowMode Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="h-[280px] w-[480px] p-2">
+        <FollowMode color="emerald" name="Sam" onStop={() => undefined}>
+          <div className="flex h-full w-full items-center justify-center bg-muted/20 text-sm text-muted-foreground">
+            <span>Followed canvas content</span>
+          </div>
+        </FollowMode>
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("follow-mode-default.png");
+  });
+});

--- a/packages/ui/src/components/follow-mode/index.ts
+++ b/packages/ui/src/components/follow-mode/index.ts
@@ -1,0 +1,6 @@
+export {
+  FollowMode,
+  type FollowModeColor,
+  type FollowModeLabels,
+  type FollowModeProps,
+} from "./follow-mode";

--- a/packages/ui/src/components/handoff-beacon/handoff-beacon.mdx
+++ b/packages/ui/src/components/handoff-beacon/handoff-beacon.mdx
@@ -1,0 +1,64 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './handoff-beacon.stories'
+
+<Meta of={Stories} />
+
+# HandoffBeacon
+
+Attention-routing beacon. Drop a beacon at the position a remote participant wants to redirect attention to — the local user sees a pulsing ring + optional message at that coordinate. Pure presentation; the host pipes the request through your realtime channel and unmounts the beacon on dismiss.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/handoff-beacon.json
+```
+
+## Import
+
+```tsx
+import { HandoffBeacon } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<HandoffBeacon
+  x={120}
+  y={80}
+  level="urgent"
+  source="Sam"
+  message="Take this — schema mismatch"
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Levels
+
+`info` (blue), `request` (amber), `urgent` (red, pulsing).
+
+<Canvas of={Stories.Pulsing} sourceState="shown" />
+
+## Cluster
+
+Render one beacon per active handoff request.
+
+<Canvas of={Stories.Cluster} sourceState="shown" />
+
+## Anonymous
+
+Drop `source` to render a message-only card.
+
+<Canvas of={Stories.Anonymous} sourceState="shown" />
+
+## Notes
+
+- The wrapper is pointer-event-transparent so it never blocks the local pointer; the inner card is `pointer-events-auto` so it can be clicked / dismissed.
+- The wrapper emits `data-handoff-level`. The card emits `data-handoff-card` for analytics + CSS hooks.
+- Absolute positioning is relative to the nearest positioned ancestor — wrap in a `relative` container.

--- a/packages/ui/src/components/handoff-beacon/handoff-beacon.stories.tsx
+++ b/packages/ui/src/components/handoff-beacon/handoff-beacon.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { HandoffBeacon } from "./handoff-beacon";
+
+const meta = {
+  args: {
+    level: "info",
+    message: "Heads up",
+    source: "Sam",
+    x: 120,
+    y: 80,
+  },
+  component: HandoffBeacon,
+  decorators: [
+    (Story) => (
+      <div className="relative h-[260px] w-[480px] rounded-2xl border bg-muted/30">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/HandoffBeacon",
+} satisfies Meta<typeof HandoffBeacon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Cluster: Story = {
+  render: () => (
+    <>
+      <HandoffBeacon
+        level="info"
+        message="Heads up"
+        source="Sam"
+        x={120}
+        y={80}
+      />
+      <HandoffBeacon
+        level="request"
+        message="Need a review"
+        source="Wei"
+        x={260}
+        y={150}
+      />
+      <HandoffBeacon
+        level="urgent"
+        message="Schema mismatch"
+        source="Riley"
+        x={380}
+        y={70}
+      />
+    </>
+  ),
+};
+
+export const Pulsing: Story = {
+  args: { level: "urgent", message: "Schema mismatch", source: "Riley" },
+};
+
+export const Anonymous: Story = {
+  args: { message: "Look here", source: undefined },
+};

--- a/packages/ui/src/components/handoff-beacon/handoff-beacon.test.tsx
+++ b/packages/ui/src/components/handoff-beacon/handoff-beacon.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { HandoffBeacon } from "./handoff-beacon";
+
+describe("HandoffBeacon", () => {
+  it("positions absolutely from x/y props", () => {
+    const { container } = render(<HandoffBeacon x={120} y={80} />);
+
+    const beacon = container.querySelector("[data-handoff-level]");
+    expect(beacon).toHaveStyle({ left: "120px", top: "80px" });
+  });
+
+  it("emits the configured level via data-handoff-level", () => {
+    const { container } = render(<HandoffBeacon level="urgent" x={0} y={0} />);
+
+    expect(container.querySelector("[data-handoff-level]")).toHaveAttribute(
+      "data-handoff-level",
+      "urgent",
+    );
+  });
+
+  it("renders the source name and message together", () => {
+    render(
+      <HandoffBeacon
+        message="Take this — schema mismatch"
+        source="Sam"
+        x={0}
+        y={0}
+      />,
+    );
+
+    expect(screen.getByText("Sam")).toBeInTheDocument();
+    expect(screen.getByText("Take this — schema mismatch")).toBeInTheDocument();
+  });
+
+  it("omits the card when neither source nor message is set", () => {
+    const { container } = render(<HandoffBeacon x={0} y={0} />);
+
+    expect(container.querySelector("[data-handoff-card]")).toBeNull();
+  });
+
+  it("renders a message-only card when source is omitted", () => {
+    const { container } = render(
+      <HandoffBeacon message="Schema mismatch" x={0} y={0} />,
+    );
+
+    expect(container.querySelector("[data-handoff-card]")).toBeInTheDocument();
+    expect(screen.getByText("Schema mismatch")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/handoff-beacon/handoff-beacon.tsx
+++ b/packages/ui/src/components/handoff-beacon/handoff-beacon.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Beacon urgency.
+ *
+ * @public
+ */
+export type HandoffBeaconLevel = "info" | "request" | "urgent";
+
+const LEVEL_RING: Record<HandoffBeaconLevel, string> = {
+  info: "ring-blue-500",
+  request: "ring-amber-500",
+  urgent: "ring-red-500 animate-pulse",
+};
+
+const LEVEL_DOT: Record<HandoffBeaconLevel, string> = {
+  info: "bg-blue-500",
+  request: "bg-amber-500",
+  urgent: "bg-red-500",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type HandoffBeaconLabels = {
+  /** Aria-label for the beacon. Defaults to `"Attention"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Attention",
+} as const satisfies Required<HandoffBeaconLabels>;
+
+/**
+ * Props for {@link HandoffBeacon}.
+ *
+ * @public
+ */
+export type HandoffBeaconProps = {
+  /** Localizable strings. */
+  labels?: HandoffBeaconLabels;
+  /** Urgency level. Defaults to `"info"`. */
+  level?: HandoffBeaconLevel;
+  /** Optional message body rendered inside the beacon. */
+  message?: ReactNode;
+  /** Origin participant name (who is requesting attention). */
+  source?: ReactNode;
+  /** X coordinate in container px. */
+  x: number;
+  /** Y coordinate in container px. */
+  y: number;
+} & Omit<ComponentPropsWithoutRef<"div">, "style">;
+
+/**
+ * Attention-routing beacon. Drop a beacon at the position a remote
+ * participant wants to redirect attention to — the local user sees a
+ * pulsing ring + optional message at that coordinate. Pure
+ * presentation; the host pipes the request through your realtime
+ * channel and unmounts the beacon on dismiss.
+ *
+ * @example
+ * ```tsx
+ * <HandoffBeacon
+ *   x={120}
+ *   y={80}
+ *   level="urgent"
+ *   source="Sam"
+ *   message="Take this — schema mismatch"
+ * />
+ * ```
+ *
+ * @public
+ */
+export const HandoffBeacon = forwardRef<HTMLDivElement, HandoffBeaconProps>(
+  (props, ref) => {
+    const {
+      className,
+      labels,
+      level = "info",
+      message,
+      source,
+      x,
+      y,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "pointer-events-none absolute z-30 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-1",
+          className,
+        )}
+        data-handoff-level={level}
+        ref={ref}
+        role="status"
+        style={{ left: `${x.toString()}px`, top: `${y.toString()}px` }}
+        {...rest}
+      >
+        <span
+          aria-hidden="true"
+          className={cn(
+            "block h-3 w-3 rounded-full ring-2 ring-offset-2 ring-offset-background",
+            LEVEL_DOT[level],
+            LEVEL_RING[level],
+          )}
+        />
+        {source || message ? (
+          <div
+            className="pointer-events-auto rounded-md border border-border bg-popover px-2 py-1 text-center text-[11px] font-medium shadow-md"
+            data-handoff-card
+          >
+            {source ? (
+              <p className="text-foreground">
+                <span className="font-semibold">{source}</span>
+                {message ? (
+                  <span className="text-muted-foreground"> · </span>
+                ) : null}
+                {message ? <span>{message}</span> : null}
+              </p>
+            ) : message ? (
+              <p className="text-foreground">{message}</p>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    );
+  },
+);
+HandoffBeacon.displayName = "HandoffBeacon";

--- a/packages/ui/src/components/handoff-beacon/handoff-beacon.visual.tsx
+++ b/packages/ui/src/components/handoff-beacon/handoff-beacon.visual.tsx
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { HandoffBeacon } from "./handoff-beacon";
+
+test.describe("HandoffBeacon Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="relative h-[260px] w-[480px] rounded-2xl border bg-muted/30">
+        <HandoffBeacon
+          level="info"
+          message="Heads up"
+          source="Sam"
+          x={120}
+          y={80}
+        />
+        <HandoffBeacon
+          level="request"
+          message="Need a review"
+          source="Wei"
+          x={260}
+          y={150}
+        />
+        <HandoffBeacon
+          level="urgent"
+          message="Schema mismatch"
+          source="Riley"
+          x={380}
+          y={70}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("handoff-beacon-default.png");
+  });
+});

--- a/packages/ui/src/components/handoff-beacon/index.ts
+++ b/packages/ui/src/components/handoff-beacon/index.ts
@@ -1,0 +1,6 @@
+export {
+  HandoffBeacon,
+  type HandoffBeaconLabels,
+  type HandoffBeaconLevel,
+  type HandoffBeaconProps,
+} from "./handoff-beacon";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -754,6 +754,18 @@ export {
   type HorizontalScrollRowProps,
 } from "./horizontal-scroll-row";
 export {
+  FollowMode,
+  type FollowModeColor,
+  type FollowModeLabels,
+  type FollowModeProps,
+} from "./follow-mode";
+export {
+  HandoffBeacon,
+  type HandoffBeaconLabels,
+  type HandoffBeaconLevel,
+  type HandoffBeaconProps,
+} from "./handoff-beacon";
+export {
   type ViewOption,
   ViewSwitcher,
   type ViewSwitcherProps,


### PR DESCRIPTION
Closes #135.

Ships the **final 2** primitives in the canvas collaboration & live presence family. Combined with #194 (\`LiveCursor\` + \`PresenceStack\` + \`PresenceSyncIndicator\`) and #195 (\`SelectionPresence\` + \`CommentPin\` + \`ThreadBubble\`), all **8/8** primitives now exist.

## What's in
- **\`FollowMode\`** — chrome wrapper that outlines a region with the followed participant's color ring + pinned chip. 6-stop palette. Optional stop button fires \`onStop\`.
- **\`HandoffBeacon\`** — attention-routing beacon with 3 levels (\`info\` / \`request\` / \`urgent\`, urgent pulses). Optional \`source\` + \`message\` render in a popover card; the wrapper itself is pointer-event-transparent.

## Notes
- Both are pure presentation. Host pipes the realtime channel + viewport sync.
- Each primitive emits stable \`data-*\` attributes (\`data-follow-color\`, \`data-follow-chip\`, \`data-handoff-level\`, \`data-handoff-card\`) for analytics + CSS hooks.

## Quality gates
- lint PASS
- typecheck PASS
- check:use-client PASS (181)
- check-story-coverage PASS (171/171)
- verify-stories PASS
- build PASS
- test PASS (503/503, +10 new)
- build-storybook PASS