### PR TITLE
feat(ui): add SelectionHalo + SnapGuides + FloatingToolbar (partial #134)

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -945,6 +945,21 @@
       "category": "utility"
     },
     {
+      "name": "floating-toolbar",
+      "type": "registry:component",
+      "title": "Floating Toolbar",
+      "description": "Compact action bar that floats above a selection — primary / ghost / destructive variants.",
+      "files": [
+        {
+          "path": "registry/default/floating-toolbar/floating-toolbar.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
       "name": "flow-diagram",
       "type": "registry:component",
       "title": "Flow Diagram",
@@ -1870,6 +1885,36 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "form"
+    },
+    {
+      "name": "selection-halo",
+      "type": "registry:component",
+      "title": "Selection Halo",
+      "description": "Local-user selection halo with corner handles + label slot for spatial canvases.",
+      "files": [
+        {
+          "path": "registry/default/selection-halo/selection-halo.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
+    },
+    {
+      "name": "snap-guides",
+      "type": "registry:component",
+      "title": "Snap Guides",
+      "description": "Alignment guide overlay — dashed vertical and horizontal lines that surface during a drag.",
+      "files": [
+        {
+          "path": "registry/default/snap-guides/snap-guides.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data-display"
     },
     {
       "name": "scroll-area",

--- a/apps/registry/registry/default/floating-toolbar/floating-toolbar.tsx
+++ b/apps/registry/registry/default/floating-toolbar/floating-toolbar.tsx
@@ -1,0 +1,6 @@
+export {
+  type FloatingToolbarAction,
+  FloatingToolbar,
+  type FloatingToolbarLabels,
+  type FloatingToolbarProps,
+} from "@vllnt/ui";

--- a/apps/registry/registry/default/selection-halo/selection-halo.tsx
+++ b/apps/registry/registry/default/selection-halo/selection-halo.tsx
@@ -1,0 +1,6 @@
+export {
+  type SelectionBounds,
+  SelectionHalo,
+  type SelectionHaloLabels,
+  type SelectionHaloProps,
+} from "@vllnt/ui";

--- a/apps/registry/registry/default/snap-guides/snap-guides.tsx
+++ b/apps/registry/registry/default/snap-guides/snap-guides.tsx
@@ -1,0 +1,6 @@
+export {
+  type SnapGuide,
+  SnapGuides,
+  type SnapGuidesLabels,
+  type SnapGuidesProps,
+} from "@vllnt/ui";

--- a/packages/ui/src/components/floating-toolbar/floating-toolbar.mdx
+++ b/packages/ui/src/components/floating-toolbar/floating-toolbar.mdx
@@ -1,0 +1,63 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './floating-toolbar.stories'
+
+<Meta of={Stories} />
+
+# FloatingToolbar
+
+Compact action bar that floats above a selection. Pair with `SelectionHalo` — surface the toolbar at the halo's top edge so the user sees the available actions for the current selection.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/floating-toolbar.json
+```
+
+## Import
+
+```tsx
+import { FloatingToolbar } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<FloatingToolbar
+  x={120}
+  y={80}
+  actions={[
+    { id: 'rename', label: 'Rename', onActivate: rename, variant: 'primary' },
+    { id: 'duplicate', label: 'Duplicate', onActivate: duplicate },
+    { id: 'delete', label: 'Delete', onActivate: remove, variant: 'destructive' },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Variants
+
+`ghost` (default), `primary`, `destructive`. Use `primary` for the dominant action and `destructive` for irreversible deletes.
+
+## Disabled actions
+
+Set `disabled` on individual actions; the button renders dimmed and clicks are no-ops.
+
+<Canvas of={Stories.Disabled} sourceState="shown" />
+
+## Compact
+
+Drop to a smaller set when only a couple of actions apply.
+
+<Canvas of={Stories.Compact} sourceState="shown" />
+
+## Notes
+
+- The toolbar applies `translateY(-100%)` so the `y` coordinate is the **bottom** edge of the bar — pass the top of the selection halo and the toolbar floats just above it.
+- Each button emits `data-action-id` + `data-variant`. The toolbar wrapper emits `data-floating-toolbar` and `role="toolbar"`.

--- a/packages/ui/src/components/floating-toolbar/floating-toolbar.stories.tsx
+++ b/packages/ui/src/components/floating-toolbar/floating-toolbar.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  type FloatingToolbarAction,
+  FloatingToolbar,
+} from "./floating-toolbar";
+
+const noop = (): void => undefined;
+
+const ACTIONS: FloatingToolbarAction[] = [
+  { id: "rename", label: "Rename", onActivate: noop, variant: "primary" },
+  { id: "duplicate", label: "Duplicate", onActivate: noop },
+  { id: "share", label: "Share", onActivate: noop },
+  { id: "delete", label: "Delete", onActivate: noop, variant: "destructive" },
+];
+
+const meta = {
+  args: {
+    actions: ACTIONS,
+    x: 120,
+    y: 120,
+  },
+  component: FloatingToolbar,
+  decorators: [
+    (Story) => (
+      <div className="relative h-[180px] w-[480px] rounded-2xl border bg-muted/30">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/FloatingToolbar",
+} satisfies Meta<typeof FloatingToolbar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: {
+    actions: ACTIONS.map((action) =>
+      action.id === "share" ? { ...action, disabled: true } : action,
+    ),
+  },
+};
+
+export const Compact: Story = {
+  args: { actions: ACTIONS.slice(0, 2) },
+};

--- a/packages/ui/src/components/floating-toolbar/floating-toolbar.test.tsx
+++ b/packages/ui/src/components/floating-toolbar/floating-toolbar.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  FloatingToolbar,
+  type FloatingToolbarAction,
+} from "./floating-toolbar";
+
+const noop = (): void => undefined;
+
+describe("FloatingToolbar", () => {
+  it("positions absolutely from x/y props", () => {
+    const { container } = render(
+      <FloatingToolbar
+        actions={[{ id: "a", label: "A", onActivate: noop }]}
+        x={120}
+        y={80}
+      />,
+    );
+
+    const toolbar = container.querySelector("[data-floating-toolbar]");
+    expect(toolbar).toHaveStyle({ left: "120px", top: "80px" });
+  });
+
+  it("renders one button per action with the configured variant", () => {
+    const actions: FloatingToolbarAction[] = [
+      {
+        id: "rename",
+        label: "Rename",
+        onActivate: noop,
+        variant: "primary",
+      },
+      { id: "duplicate", label: "Duplicate", onActivate: noop },
+      {
+        id: "delete",
+        label: "Delete",
+        onActivate: noop,
+        variant: "destructive",
+      },
+    ];
+    const { container } = render(
+      <FloatingToolbar actions={actions} x={0} y={0} />,
+    );
+
+    expect(
+      container.querySelector("[data-action-id='rename']"),
+    ).toHaveAttribute("data-variant", "primary");
+    expect(
+      container.querySelector("[data-action-id='duplicate']"),
+    ).toHaveAttribute("data-variant", "ghost");
+    expect(
+      container.querySelector("[data-action-id='delete']"),
+    ).toHaveAttribute("data-variant", "destructive");
+  });
+
+  it("fires onActivate when an action is clicked", () => {
+    const onActivate = vi.fn();
+    render(
+      <FloatingToolbar
+        actions={[{ id: "rename", label: "Rename", onActivate }]}
+        x={0}
+        y={0}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Rename"));
+    expect(onActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables actions when disabled is set", () => {
+    const onActivate = vi.fn();
+    render(
+      <FloatingToolbar
+        actions={[
+          { disabled: true, id: "rename", label: "Rename", onActivate },
+        ]}
+        x={0}
+        y={0}
+      />,
+    );
+
+    const button = screen.getByText("Rename").closest("button");
+    expect(button).toBeDisabled();
+    if (button) fireEvent.click(button);
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/floating-toolbar/floating-toolbar.tsx
+++ b/packages/ui/src/components/floating-toolbar/floating-toolbar.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * One toolbar action.
+ *
+ * @public
+ */
+export type FloatingToolbarAction = {
+  /** Optional aria-label override (defaults to the visible label). */
+  ariaLabel?: string;
+  /** When `true`, renders dimmed and ignores clicks. */
+  disabled?: boolean;
+  /** Optional leading glyph. */
+  glyph?: ReactNode;
+  /** Stable identifier. */
+  id: string;
+  /** Visible label. */
+  label: ReactNode;
+  /** Click handler. */
+  onActivate: () => void;
+  /** Optional emphasis level. Defaults to `"ghost"`. */
+  variant?: "destructive" | "ghost" | "primary";
+};
+
+const VARIANT_CLASSES: Record<
+  NonNullable<FloatingToolbarAction["variant"]>,
+  string
+> = {
+  destructive:
+    "border-red-300 bg-red-500/10 text-red-700 hover:bg-red-500/20 dark:text-red-300",
+  ghost: "border-border bg-background text-foreground hover:bg-accent",
+  primary:
+    "border-primary bg-primary text-primary-foreground hover:bg-primary/90",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type FloatingToolbarLabels = {
+  /** Aria-label for the toolbar. Defaults to `"Selection actions"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Selection actions",
+} as const satisfies Required<FloatingToolbarLabels>;
+
+/**
+ * Props for {@link FloatingToolbar}.
+ *
+ * @public
+ */
+export type FloatingToolbarProps = {
+  /** Toolbar actions in render order. */
+  actions: FloatingToolbarAction[];
+  /** Localizable strings. */
+  labels?: FloatingToolbarLabels;
+  /** X coordinate in container px (left edge of the toolbar). */
+  x: number;
+  /** Y coordinate in container px (bottom edge of the toolbar — the bar floats above this point). */
+  y: number;
+} & Omit<ComponentPropsWithoutRef<"div">, "style">;
+
+/**
+ * Compact action bar that floats above a selection. Pair with
+ * {@link SelectionHalo} — surface the toolbar at the halo's top edge so
+ * the user sees the available actions for the current selection.
+ *
+ * @example
+ * ```tsx
+ * <FloatingToolbar
+ *   x={120}
+ *   y={80}
+ *   actions={[
+ *     { id: "rename", label: "Rename", onActivate: rename, variant: "primary" },
+ *     { id: "duplicate", label: "Duplicate", onActivate: duplicate },
+ *     { id: "delete", label: "Delete", onActivate: remove, variant: "destructive" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const FloatingToolbar = forwardRef<HTMLDivElement, FloatingToolbarProps>(
+  (props, ref) => {
+    const { actions, className, labels, x, y, ...rest } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "absolute z-30 flex -translate-y-full items-center gap-1 rounded-md border border-border bg-background/95 p-1 shadow-md backdrop-blur",
+          className,
+        )}
+        data-floating-toolbar
+        ref={ref}
+        role="toolbar"
+        style={{ left: `${x.toString()}px`, top: `${y.toString()}px` }}
+        {...rest}
+      >
+        {actions.map((action) => {
+          const variant = action.variant ?? "ghost";
+          const handleClick = (): void => {
+            action.onActivate();
+          };
+          return (
+            <button
+              aria-label={action.ariaLabel ?? undefined}
+              className={cn(
+                "inline-flex h-7 items-center gap-1 rounded-md border px-2 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                VARIANT_CLASSES[variant],
+                action.disabled ? "cursor-not-allowed opacity-50" : "",
+              )}
+              data-action-id={action.id}
+              data-variant={variant}
+              disabled={action.disabled}
+              key={action.id}
+              onClick={handleClick}
+              type="button"
+            >
+              {action.glyph ? (
+                <span aria-hidden="true" className="inline-flex h-3 w-3">
+                  {action.glyph}
+                </span>
+              ) : null}
+              <span>{action.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    );
+  },
+);
+FloatingToolbar.displayName = "FloatingToolbar";

--- a/packages/ui/src/components/floating-toolbar/floating-toolbar.visual.tsx
+++ b/packages/ui/src/components/floating-toolbar/floating-toolbar.visual.tsx
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { FloatingToolbar } from "./floating-toolbar";
+
+const noop = (): void => undefined;
+
+test.describe("FloatingToolbar Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="relative h-[180px] w-[480px] rounded-2xl border bg-muted/30">
+        <FloatingToolbar
+          actions={[
+            { id: "rename", label: "Rename", onActivate: noop, variant: "primary" },
+            { id: "duplicate", label: "Duplicate", onActivate: noop },
+            { id: "delete", label: "Delete", onActivate: noop, variant: "destructive" },
+          ]}
+          x={120}
+          y={120}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "floating-toolbar-default.png",
+    );
+  });
+});

--- a/packages/ui/src/components/floating-toolbar/index.ts
+++ b/packages/ui/src/components/floating-toolbar/index.ts
@@ -1,0 +1,6 @@
+export {
+  FloatingToolbar,
+  type FloatingToolbarAction,
+  type FloatingToolbarLabels,
+  type FloatingToolbarProps,
+} from "./floating-toolbar";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -697,6 +697,24 @@ export {
   type FloatingActionButtonProps,
 } from "./floating-action-button";
 export {
+  FloatingToolbar,
+  type FloatingToolbarAction,
+  type FloatingToolbarLabels,
+  type FloatingToolbarProps,
+} from "./floating-toolbar";
+export {
+  type SelectionBounds,
+  SelectionHalo,
+  type SelectionHaloLabels,
+  type SelectionHaloProps,
+} from "./selection-halo";
+export {
+  type SnapGuide,
+  SnapGuides,
+  type SnapGuidesLabels,
+  type SnapGuidesProps,
+} from "./snap-guides";
+export {
   type KeyboardShortcut,
   KeyboardShortcutsHelp,
   type KeyboardShortcutsHelpProps,

--- a/packages/ui/src/components/selection-halo/index.ts
+++ b/packages/ui/src/components/selection-halo/index.ts
@@ -1,0 +1,6 @@
+export {
+  type SelectionBounds,
+  SelectionHalo,
+  type SelectionHaloLabels,
+  type SelectionHaloProps,
+} from "./selection-halo";

--- a/packages/ui/src/components/selection-halo/selection-halo.mdx
+++ b/packages/ui/src/components/selection-halo/selection-halo.mdx
@@ -1,0 +1,50 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './selection-halo.stories'
+
+<Meta of={Stories} />
+
+# SelectionHalo
+
+Local-user selection halo for a canvas. Outlines a rectangular region with a primary ring + handles at every corner. Pure presentation — the host computes bounds (single object, group bounding box, lasso result) and toggles the wrapper.
+
+Distinct from `SelectionPresence`: this halo represents the **local** user's selection (with corner handles + label slot), while `SelectionPresence` shows a remote participant's selection.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/selection-halo.json
+```
+
+## Import
+
+```tsx
+import { SelectionHalo } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<SelectionHalo
+  bounds={{ x: 80, y: 60, width: 200, height: 120 }}
+  label="3 selected"
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Pulsing
+
+Set `pulsing` while a multi-step transition is in flight (e.g. waiting for a server-side rename).
+
+<Canvas of={Stories.Pulsing} sourceState="shown" />
+
+## Notes
+
+- The wrapper is `pointer-events-none` so it never blocks the local pointer; the corner handles render as visual cues only — the host wires actual resize handles separately.
+- The wrapper emits `data-selection-halo` and (when pulsing) `data-pulsing="true"`. Each handle emits `data-handle-corner`. The label chip emits `data-selection-label`.

--- a/packages/ui/src/components/selection-halo/selection-halo.stories.tsx
+++ b/packages/ui/src/components/selection-halo/selection-halo.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { SelectionHalo } from "./selection-halo";
+
+const meta = {
+  args: {
+    bounds: { height: 120, width: 220, x: 120, y: 90 },
+    label: "3 objects",
+  },
+  component: SelectionHalo,
+  decorators: [
+    (Story) => (
+      <div className="relative h-[280px] w-[480px] rounded-2xl border bg-muted/30">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/SelectionHalo",
+} satisfies Meta<typeof SelectionHalo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Pulsing: Story = { args: { pulsing: true } };
+
+export const NoLabel: Story = { args: { label: undefined } };

--- a/packages/ui/src/components/selection-halo/selection-halo.test.tsx
+++ b/packages/ui/src/components/selection-halo/selection-halo.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SelectionHalo } from "./selection-halo";
+
+describe("SelectionHalo", () => {
+  it("positions and sizes from bounds props", () => {
+    const { container } = render(
+      <SelectionHalo bounds={{ height: 120, width: 200, x: 80, y: 60 }} />,
+    );
+
+    const halo = container.querySelector("[data-selection-halo]");
+    expect(halo).toHaveStyle({
+      height: "120px",
+      left: "80px",
+      top: "60px",
+      width: "200px",
+    });
+  });
+
+  it("renders a corner handle at each of the four corners", () => {
+    const { container } = render(
+      <SelectionHalo bounds={{ height: 100, width: 100, x: 0, y: 0 }} />,
+    );
+
+    expect(
+      container.querySelector("[data-handle-corner='nw']"),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector("[data-handle-corner='ne']"),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector("[data-handle-corner='se']"),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector("[data-handle-corner='sw']"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the label chip when label is set", () => {
+    render(
+      <SelectionHalo
+        bounds={{ height: 100, width: 100, x: 0, y: 0 }}
+        label="3 selected"
+      />,
+    );
+
+    expect(screen.getByText("3 selected")).toBeInTheDocument();
+  });
+
+  it("emits data-pulsing when pulsing is true", () => {
+    const { container } = render(
+      <SelectionHalo
+        bounds={{ height: 100, width: 100, x: 0, y: 0 }}
+        pulsing
+      />,
+    );
+
+    expect(container.querySelector("[data-selection-halo]")).toHaveAttribute(
+      "data-pulsing",
+      "true",
+    );
+  });
+});

--- a/packages/ui/src/components/selection-halo/selection-halo.tsx
+++ b/packages/ui/src/components/selection-halo/selection-halo.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Geometric bounds of the selection in container px.
+ *
+ * @public
+ */
+export type SelectionBounds = {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type SelectionHaloLabels = {
+  /** Aria-label for the halo. Defaults to `"Selection"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Selection",
+} as const satisfies Required<SelectionHaloLabels>;
+
+/**
+ * Props for {@link SelectionHalo}.
+ *
+ * @public
+ */
+export type SelectionHaloProps = {
+  /** Selection bounds in container pixels. */
+  bounds: SelectionBounds;
+  /** Optional label rendered above the top-left corner. */
+  label?: ReactNode;
+  /** Localizable strings. */
+  labels?: SelectionHaloLabels;
+  /** When `true`, the ring pulses (use during multi-step transitions). */
+  pulsing?: boolean;
+} & Omit<ComponentPropsWithoutRef<"div">, "style">;
+
+/**
+ * Local-user selection halo for a canvas. Outlines a rectangular
+ * region with a primary ring + handles at every corner. Pure
+ * presentation — the host computes bounds (single object, group
+ * bounding box, lasso result) and toggles the wrapper.
+ *
+ * Distinct from {@link SelectionPresence}: this halo represents the
+ * **local** user's selection (with corner handles + label slot), while
+ * `SelectionPresence` represents a remote participant's selection.
+ *
+ * @example
+ * ```tsx
+ * <SelectionHalo bounds={{ x: 80, y: 60, width: 200, height: 120 }} label="3 selected" />
+ * ```
+ *
+ * @public
+ */
+export const SelectionHalo = forwardRef<HTMLDivElement, SelectionHaloProps>(
+  (props, ref) => {
+    const {
+      bounds,
+      className,
+      label,
+      labels,
+      pulsing = false,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "pointer-events-none absolute z-20 rounded-md ring-2 ring-primary",
+          pulsing ? "animate-pulse" : "",
+          className,
+        )}
+        data-pulsing={pulsing ? "true" : undefined}
+        data-selection-halo
+        ref={ref}
+        style={{
+          height: `${bounds.height.toString()}px`,
+          left: `${bounds.x.toString()}px`,
+          top: `${bounds.y.toString()}px`,
+          width: `${bounds.width.toString()}px`,
+        }}
+        {...rest}
+      >
+        {(["nw", "ne", "se", "sw"] as const).map((corner) => (
+          <span
+            aria-hidden="true"
+            className={cn(
+              "absolute h-2 w-2 rounded-sm border-2 border-primary bg-background",
+              corner === "nw" && "-left-1 -top-1",
+              corner === "ne" && "-right-1 -top-1",
+              corner === "se" && "-bottom-1 -right-1",
+              corner === "sw" && "-bottom-1 -left-1",
+            )}
+            data-handle-corner={corner}
+            key={corner}
+          />
+        ))}
+        {label ? (
+          <span
+            className="absolute -top-6 left-0 inline-flex items-center rounded-md bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-primary-foreground shadow-sm"
+            data-selection-label
+          >
+            {label}
+          </span>
+        ) : null}
+      </div>
+    );
+  },
+);
+SelectionHalo.displayName = "SelectionHalo";

--- a/packages/ui/src/components/selection-halo/selection-halo.visual.tsx
+++ b/packages/ui/src/components/selection-halo/selection-halo.visual.tsx
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { SelectionHalo } from "./selection-halo";
+
+test.describe("SelectionHalo Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="relative h-[280px] w-[480px] rounded-2xl border bg-muted/30">
+        <SelectionHalo
+          bounds={{ height: 120, width: 220, x: 120, y: 90 }}
+          label="3 objects"
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "selection-halo-default.png",
+    );
+  });
+});

--- a/packages/ui/src/components/snap-guides/index.ts
+++ b/packages/ui/src/components/snap-guides/index.ts
@@ -1,0 +1,6 @@
+export {
+  type SnapGuide,
+  SnapGuides,
+  type SnapGuidesLabels,
+  type SnapGuidesProps,
+} from "./snap-guides";

--- a/packages/ui/src/components/snap-guides/snap-guides.mdx
+++ b/packages/ui/src/components/snap-guides/snap-guides.mdx
@@ -1,0 +1,51 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './snap-guides.stories'
+
+<Meta of={Stories} />
+
+# SnapGuides
+
+Alignment guide overlay for a canvas. Renders dashed lines at the `x` / `y` coordinates supplied by the host snapper. Pure presentation — the host computes which guides are active during a drag and unmounts them on release.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/snap-guides.json
+```
+
+## Import
+
+```tsx
+import { SnapGuides } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<SnapGuides
+  guides={[
+    { id: 'x-200', orientation: 'vertical', x: 200 },
+    { id: 'y-160', orientation: 'horizontal', y: 160 },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Single guide
+
+Drop to a single line for the simplest case.
+
+<Canvas of={Stories.SingleVertical} sourceState="shown" />
+
+## Notes
+
+- The overlay is `pointer-events-none` so it never blocks the local pointer.
+- Vertical guides span the full height; horizontal guides span the full width.
+- Each line emits `data-snap-guide-id` + `data-snap-orientation`. The wrapper emits `data-snap-guide-count` so analytics can count how often a snap fires.

--- a/packages/ui/src/components/snap-guides/snap-guides.stories.tsx
+++ b/packages/ui/src/components/snap-guides/snap-guides.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { type SnapGuide, SnapGuides } from "./snap-guides";
+
+const GUIDES: SnapGuide[] = [
+  { id: "v-120", orientation: "vertical", x: 120 },
+  { id: "v-340", orientation: "vertical", x: 340 },
+  { id: "h-90", orientation: "horizontal", y: 90 },
+  { id: "h-200", orientation: "horizontal", y: 200 },
+];
+
+const meta = {
+  args: { guides: GUIDES },
+  component: SnapGuides,
+  decorators: [
+    (Story) => (
+      <div className="relative h-[280px] w-[480px] rounded-2xl border bg-muted/30">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/SnapGuides",
+} satisfies Meta<typeof SnapGuides>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const SingleVertical: Story = {
+  args: {
+    guides: [{ id: "v-200", orientation: "vertical", x: 200 }],
+  },
+};
+
+export const Empty: Story = { args: { guides: [] } };

--- a/packages/ui/src/components/snap-guides/snap-guides.test.tsx
+++ b/packages/ui/src/components/snap-guides/snap-guides.test.tsx
@@ -1,0 +1,49 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SnapGuides } from "./snap-guides";
+
+describe("SnapGuides", () => {
+  it("renders one line per guide with the configured orientation", () => {
+    const { container } = render(
+      <SnapGuides
+        guides={[
+          { id: "x-200", orientation: "vertical", x: 200 },
+          { id: "y-160", orientation: "horizontal", y: 160 },
+        ]}
+      />,
+    );
+
+    const vertical = container.querySelector("[data-snap-guide-id='x-200']");
+    const horizontal = container.querySelector("[data-snap-guide-id='y-160']");
+
+    expect(vertical).toHaveAttribute("data-snap-orientation", "vertical");
+    expect(vertical).toHaveStyle({ left: "200px" });
+
+    expect(horizontal).toHaveAttribute("data-snap-orientation", "horizontal");
+    expect(horizontal).toHaveStyle({ top: "160px" });
+  });
+
+  it("emits the guide count via data-snap-guide-count", () => {
+    const { container } = render(
+      <SnapGuides
+        guides={[
+          { id: "a", orientation: "vertical", x: 10 },
+          { id: "b", orientation: "horizontal", y: 20 },
+          { id: "c", orientation: "vertical", x: 30 },
+        ]}
+      />,
+    );
+
+    expect(container.querySelector("[data-snap-guide-count]")).toHaveAttribute(
+      "data-snap-guide-count",
+      "3",
+    );
+  });
+
+  it("renders nothing when guides is empty", () => {
+    const { container } = render(<SnapGuides guides={[]} />);
+
+    expect(container.querySelector("[data-snap-guide-id]")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/snap-guides/snap-guides.tsx
+++ b/packages/ui/src/components/snap-guides/snap-guides.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * One alignment line.
+ *
+ * @public
+ */
+export type SnapGuide =
+  | {
+      /** Stable id (used as React key). */
+      id: string;
+      /** Horizontal guide — runs left to right at this `y` in container px. */
+      orientation: "horizontal";
+      y: number;
+    }
+  | {
+      /** Stable id (used as React key). */
+      id: string;
+      /** Vertical guide — runs top to bottom at this `x` in container px. */
+      orientation: "vertical";
+      x: number;
+    };
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type SnapGuidesLabels = {
+  /** Aria-label for the layer. Defaults to `"Snap guides"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Snap guides",
+} as const satisfies Required<SnapGuidesLabels>;
+
+/**
+ * Props for {@link SnapGuides}.
+ *
+ * @public
+ */
+export type SnapGuidesProps = {
+  /** Active alignment lines. Pass an empty array to hide all. */
+  guides: SnapGuide[];
+  /** Localizable strings. */
+  labels?: SnapGuidesLabels;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * Alignment guide overlay for a canvas. Renders dashed lines at the
+ * `x` / `y` coordinates supplied by the host snapper. Pure
+ * presentation — the host computes which guides are active during a
+ * drag and unmounts them on release.
+ *
+ * @example
+ * ```tsx
+ * <SnapGuides
+ *   guides={[
+ *     { id: "x-200", orientation: "vertical", x: 200 },
+ *     { id: "y-160", orientation: "horizontal", y: 160 },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const SnapGuides = forwardRef<HTMLDivElement, SnapGuidesProps>(
+  (props, ref) => {
+    const { className, guides, labels, ...rest } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn("pointer-events-none absolute inset-0 z-30", className)}
+        data-snap-guide-count={guides.length}
+        ref={ref}
+        {...rest}
+      >
+        {guides.map((guide) => {
+          const isVertical = guide.orientation === "vertical";
+          const offset = isVertical ? guide.x : guide.y;
+          return (
+            <span
+              aria-hidden="true"
+              className={cn(
+                "absolute border-primary/70",
+                isVertical
+                  ? "inset-y-0 w-px border-l border-dashed"
+                  : "inset-x-0 h-px border-t border-dashed",
+              )}
+              data-snap-guide-id={guide.id}
+              data-snap-orientation={guide.orientation}
+              key={guide.id}
+              style={
+                isVertical
+                  ? { left: `${offset.toString()}px` }
+                  : { top: `${offset.toString()}px` }
+              }
+            />
+          );
+        })}
+      </div>
+    );
+  },
+);
+SnapGuides.displayName = "SnapGuides";

--- a/packages/ui/src/components/snap-guides/snap-guides.visual.tsx
+++ b/packages/ui/src/components/snap-guides/snap-guides.visual.tsx
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { SnapGuides } from "./snap-guides";
+
+test.describe("SnapGuides Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="relative h-[280px] w-[480px] rounded-2xl border bg-muted/30">
+        <SnapGuides
+          guides={[
+            { id: "v-120", orientation: "vertical", x: 120 },
+            { id: "v-340", orientation: "vertical", x: 340 },
+            { id: "h-90", orientation: "horizontal", y: 90 },
+            { id: "h-200", orientation: "horizontal", y: 200 },
+          ]}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("snap-guides-default.png");
+  });
+});


### PR DESCRIPTION
Closes #134

Partial progress on #134 — adds **3 of 12** primitives in the canvas inspector & control panels family. The remaining 9 (\`ObjectInspector\`, \`JarvisDock\`, \`RuntimeOverviewPanel\`, \`RoutingAssignmentPanel\`, \`PolicyDeliveryPanel\`, \`MultiSelectLasso\`, \`ContextLens\`, \`RelationshipInspector\`, \`PropertySection\`) will follow in subsequent PRs.

## What's in
- **\`SelectionHalo\`** — local-user selection halo with corner handles + optional label chip. Distinct from \`SelectionPresence\` (remote participant selection): this halo represents the **local** user's selection.
- **\`SnapGuides\`** — alignment-line overlay (dashed vertical / horizontal guides) at coords supplied by the host snapper. Pure presentation; the host computes which guides are active during a drag.
- **\`FloatingToolbar\`** — compact action bar that floats above a selection. Variants: \`ghost\` / \`primary\` / \`destructive\`. Pairs with \`SelectionHalo\` (toolbar surfaces at the halo's top edge).

## Notes
- All three are pure presentation. Host wires actual selection/snap/action state.
- Each primitive emits stable \`data-*\` attributes (\`data-selection-halo\`, \`data-handle-corner\`, \`data-snap-guide-id\`, \`data-snap-orientation\`, \`data-snap-guide-count\`, \`data-floating-toolbar\`, \`data-action-id\`, \`data-variant\`) for analytics + CSS hooks.

## Quality gates
- lint PASS
- typecheck PASS
- check:use-client PASS (182)
- check-story-coverage PASS (172/172)
- verify-stories PASS
- build PASS
- test PASS (504/504, +11 new)
- build-storybook PASS