### PR TITLE
feat(ui): inspector panels — PropertySection + ObjectInspector + RelationshipInspector (partial #134)

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1482,6 +1482,21 @@
       "category": "utility"
     },
     {
+      "name": "object-inspector",
+      "type": "registry:component",
+      "title": "Object Inspector",
+      "description": "Right-dock detail header — kind chip, status dot, title/subtitle, with property-section slots.",
+      "files": [
+        {
+          "path": "registry/default/object-inspector/object-inspector.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "content"
+    },
+    {
       "name": "order-book",
       "type": "registry:component",
       "title": "Order Book",
@@ -1677,6 +1692,21 @@
       "category": "data"
     },
     {
+      "name": "property-section",
+      "type": "registry:component",
+      "title": "Property Section",
+      "description": "Compact key/value grid for inspector panels — labels, sublabels, optional collapse.",
+      "files": [
+        {
+          "path": "registry/default/property-section/property-section.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "content"
+    },
+    {
       "name": "quiz",
       "type": "registry:component",
       "title": "Quiz",
@@ -1720,6 +1750,21 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "learning"
+    },
+    {
+      "name": "relationship-inspector",
+      "type": "registry:component",
+      "title": "Relationship Inspector",
+      "description": "Right-dock panel listing inbound + outbound edges of the focused canvas object.",
+      "files": [
+        {
+          "path": "registry/default/relationship-inspector/relationship-inspector.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "content"
     },
     {
       "name": "resizable",

--- a/apps/registry/registry/default/object-inspector/object-inspector.tsx
+++ b/apps/registry/registry/default/object-inspector/object-inspector.tsx
@@ -1,0 +1,7 @@
+export {
+  ObjectInspector,
+  type ObjectInspectorKind,
+  type ObjectInspectorLabels,
+  type ObjectInspectorProps,
+  type ObjectInspectorStatus,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/property-section/property-section.tsx
+++ b/apps/registry/registry/default/property-section/property-section.tsx
@@ -1,0 +1,6 @@
+export {
+  type PropertyEntry,
+  PropertySection,
+  type PropertySectionLabels,
+  type PropertySectionProps,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/relationship-inspector/relationship-inspector.tsx
+++ b/apps/registry/registry/default/relationship-inspector/relationship-inspector.tsx
@@ -1,0 +1,7 @@
+export {
+  type RelationshipDirection,
+  type RelationshipEdge,
+  RelationshipInspector,
+  type RelationshipInspectorLabels,
+  type RelationshipInspectorProps,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -838,6 +838,13 @@ export {
 } from "./object-card";
 export { ObjectHandle, type ObjectHandleProps } from "./object-handle";
 export {
+  ObjectInspector,
+  type ObjectInspectorKind,
+  type ObjectInspectorLabels,
+  type ObjectInspectorProps,
+  type ObjectInspectorStatus,
+} from "./object-inspector";
+export {
   PlaybackGhost,
   type PlaybackGhostKind,
   type PlaybackGhostLabels,
@@ -863,6 +870,19 @@ export {
   type PresenceSyncIndicatorProps,
   type PresenceSyncState,
 } from "./presence-sync-indicator";
+export {
+  type PropertyEntry,
+  PropertySection,
+  type PropertySectionLabels,
+  type PropertySectionProps,
+} from "./property-section";
+export {
+  type RelationshipDirection,
+  type RelationshipEdge,
+  RelationshipInspector,
+  type RelationshipInspectorLabels,
+  type RelationshipInspectorProps,
+} from "./relationship-inspector";
 export {
   type RoutingAssignment,
   RoutingAssignmentPanel,

--- a/packages/ui/src/components/object-inspector/index.ts
+++ b/packages/ui/src/components/object-inspector/index.ts
@@ -1,0 +1,7 @@
+export {
+  ObjectInspector,
+  type ObjectInspectorKind,
+  type ObjectInspectorLabels,
+  type ObjectInspectorProps,
+  type ObjectInspectorStatus,
+} from "./object-inspector";

--- a/packages/ui/src/components/object-inspector/object-inspector.mdx
+++ b/packages/ui/src/components/object-inspector/object-inspector.mdx
@@ -1,0 +1,61 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './object-inspector.stories'
+
+<Meta of={Stories} />
+
+# ObjectInspector
+
+Inspector header for the right dock of a spatial canvas. Renders kind chip + live status dot + title + subtitle, then any children below (typically a stack of `PropertySection` blocks). Pure presentation; the host derives props from the current selection and slots the property sections.
+
+Distinct from `ObjectCard`: \`ObjectCard\` is the **on-canvas** representation of a runtime object; \`ObjectInspector\` is the **off-canvas** detail view in the right dock. The two share kind / status semantics but live in different surfaces.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/object-inspector.json
+```
+
+## Import
+
+```tsx
+import { ObjectInspector } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<ObjectInspector
+  kind="run"
+  status="running"
+  title="research-2025-04-15"
+  subtitle="claude-3.7"
+>
+  <PropertySection title="Layout" entries={…} />
+  <PropertySection title="State" entries={…} />
+</ObjectInspector>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Empty state
+
+When no object is selected, drop \`kind\` (and / or \`title\`). The inspector renders a calm empty placeholder.
+
+<Canvas of={Stories.Empty} sourceState="shown" />
+
+## Failed status
+
+\`status="failed"\` renders the dot in red. Pair the inspector subtitle with the failure reason so the user has immediate context.
+
+<Canvas of={Stories.Failed} sourceState="shown" />
+
+## Notes
+
+- Status dot maps: \`idle\` (muted) · \`queued\` (amber) · \`running\` (blue, pulsing) · \`complete\` (emerald) · \`failed\` (red).
+- The wrapper emits \`data-object-inspector\` plus \`data-object-kind\` + \`data-object-status\` (or \`data-object-state="empty"\` in the empty state) for analytics + CSS hooks.

--- a/packages/ui/src/components/object-inspector/object-inspector.stories.tsx
+++ b/packages/ui/src/components/object-inspector/object-inspector.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ObjectInspector } from "./object-inspector";
+
+const meta = {
+  args: {
+    kind: "run",
+    status: "running",
+    subtitle: "claude-3.7 · 128k ctx",
+    title: "research-2025-04-15",
+  },
+  component: ObjectInspector,
+  decorators: [
+    (Story) => (
+      <div className="w-72">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/ObjectInspector",
+} satisfies Meta<typeof ObjectInspector>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: { kind: undefined, title: undefined },
+};
+
+export const WithBody: Story = {
+  args: {
+    children: (
+      <p className="rounded-md border border-border/60 bg-muted/30 px-2 py-1 text-xs text-muted-foreground">
+        Property sections render here.
+      </p>
+    ),
+  },
+};
+
+export const Failed: Story = {
+  args: {
+    kind: "task",
+    status: "failed",
+    subtitle: "Schema mismatch",
+    title: "ingest-rows",
+  },
+};

--- a/packages/ui/src/components/object-inspector/object-inspector.test.tsx
+++ b/packages/ui/src/components/object-inspector/object-inspector.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ObjectInspector } from "./object-inspector";
+
+describe("ObjectInspector", () => {
+  it("renders the empty state when kind is omitted", () => {
+    const { container } = render(<ObjectInspector />);
+
+    expect(
+      container.querySelector("[data-object-state='empty']"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No selection")).toBeInTheDocument();
+  });
+
+  it("renders the empty state when title is omitted", () => {
+    const { container } = render(<ObjectInspector kind="run" />);
+
+    expect(
+      container.querySelector("[data-object-state='empty']"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the kind chip + status dot when populated", () => {
+    const { container } = render(
+      <ObjectInspector
+        kind="run"
+        status="running"
+        subtitle="claude-3.7"
+        title="research-2025"
+      />,
+    );
+
+    expect(container.querySelector("[data-object-kind]")).toHaveAttribute(
+      "data-object-kind",
+      "run",
+    );
+    expect(container.querySelector("[data-object-status]")).toHaveAttribute(
+      "data-object-status",
+      "running",
+    );
+    expect(screen.getByText("Run")).toBeInTheDocument();
+    expect(screen.getByText("Running")).toBeInTheDocument();
+  });
+
+  it("renders the title and subtitle", () => {
+    render(
+      <ObjectInspector kind="agent" subtitle="claude-3.7" title="researcher" />,
+    );
+
+    expect(screen.getByText("researcher")).toBeInTheDocument();
+    expect(screen.getByText("claude-3.7")).toBeInTheDocument();
+  });
+
+  it("renders children inside the body slot", () => {
+    render(
+      <ObjectInspector kind="run" title="x">
+        <p>Body section</p>
+      </ObjectInspector>,
+    );
+
+    expect(screen.getByText("Body section")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/object-inspector/object-inspector.tsx
+++ b/packages/ui/src/components/object-inspector/object-inspector.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Object kind — drives the chip glyph + label.
+ *
+ * @public
+ */
+export type ObjectInspectorKind =
+  | "agent"
+  | "artifact"
+  | "input"
+  | "output"
+  | "run"
+  | "task";
+
+const KIND_LABEL: Record<ObjectInspectorKind, string> = {
+  agent: "Agent",
+  artifact: "Artifact",
+  input: "Input",
+  output: "Output",
+  run: "Run",
+  task: "Task",
+};
+
+const KIND_GLYPH: Record<ObjectInspectorKind, string> = {
+  agent: "◇",
+  artifact: "◌",
+  input: "↘",
+  output: "↗",
+  run: "▶",
+  task: "▢",
+};
+
+/**
+ * Live status — drives the colored dot.
+ *
+ * @public
+ */
+export type ObjectInspectorStatus =
+  | "complete"
+  | "failed"
+  | "idle"
+  | "queued"
+  | "running";
+
+const STATUS_DOT: Record<ObjectInspectorStatus, string> = {
+  complete: "bg-emerald-500",
+  failed: "bg-red-500",
+  idle: "bg-muted-foreground",
+  queued: "bg-amber-500",
+  running: "bg-blue-500 animate-pulse",
+};
+
+const STATUS_LABEL: Record<ObjectInspectorStatus, string> = {
+  complete: "Complete",
+  failed: "Failed",
+  idle: "Idle",
+  queued: "Queued",
+  running: "Running",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type ObjectInspectorLabels = {
+  /** Empty-state copy. Defaults to `"No selection"`. */
+  empty?: string;
+  /** Aria-label for the inspector. Defaults to `"Object inspector"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No selection",
+  region: "Object inspector",
+} as const satisfies Required<ObjectInspectorLabels>;
+
+/**
+ * Props for {@link ObjectInspector}.
+ *
+ * @public
+ */
+export type ObjectInspectorProps = {
+  /** Object kind. When omitted, the inspector renders the empty state. */
+  kind?: ObjectInspectorKind;
+  /** Localizable strings. */
+  labels?: ObjectInspectorLabels;
+  /** Object status. Defaults to `"idle"`. */
+  status?: ObjectInspectorStatus;
+  /** Optional subtitle (id, owner, model). */
+  subtitle?: ReactNode;
+  /** Object title. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const KindChip = (props: { kind: ObjectInspectorKind }): React.ReactElement => (
+  <span
+    aria-label={KIND_LABEL[props.kind]}
+    className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+  >
+    <span aria-hidden="true">{KIND_GLYPH[props.kind]}</span>
+    {KIND_LABEL[props.kind]}
+  </span>
+);
+
+const StatusDot = (props: {
+  status: ObjectInspectorStatus;
+}): React.ReactElement => (
+  <span
+    aria-label={`Status ${STATUS_LABEL[props.status]}`}
+    className="inline-flex items-center gap-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+  >
+    <span
+      aria-hidden="true"
+      className={cn("h-1.5 w-1.5 rounded-full", STATUS_DOT[props.status])}
+    />
+    {STATUS_LABEL[props.status]}
+  </span>
+);
+
+const Header = (props: {
+  kind: ObjectInspectorKind;
+  status: ObjectInspectorStatus;
+  subtitle?: ReactNode;
+  title: ReactNode;
+}): React.ReactElement => (
+  <header className="flex flex-col gap-2">
+    <div className="flex items-center justify-between gap-2">
+      <KindChip kind={props.kind} />
+      <StatusDot status={props.status} />
+    </div>
+    <div className="space-y-0.5">
+      <h3 className="truncate text-sm font-semibold text-foreground">
+        {props.title}
+      </h3>
+      {props.subtitle ? (
+        <p className="truncate text-xs text-muted-foreground">
+          {props.subtitle}
+        </p>
+      ) : null}
+    </div>
+  </header>
+);
+
+/**
+ * Inspector header for the right dock. Renders kind chip + status dot
+ * + title + subtitle, then any children below (typically a stack of
+ * {@link "../property-section/property-section".PropertySection} blocks). Pure presentation; the host
+ * derives props from the current selection and slots the property
+ * sections.
+ *
+ * @example
+ * ```tsx
+ * <ObjectInspector
+ *   kind="run"
+ *   status="running"
+ *   title="research-2025-04-15"
+ *   subtitle="claude-3.7"
+ * >
+ *   <PropertySection title="Layout" entries={…} />
+ *   <PropertySection title="State" entries={…} />
+ * </ObjectInspector>
+ * ```
+ *
+ * @public
+ */
+export const ObjectInspector = forwardRef<HTMLElement, ObjectInspectorProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      kind,
+      labels,
+      status = "idle",
+      subtitle,
+      title,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    if (!kind || !title) {
+      return (
+        <section
+          aria-label={resolvedLabels.region}
+          className={cn(
+            "flex w-full flex-col items-center justify-center gap-1 rounded-2xl border bg-background p-6 text-center text-xs text-muted-foreground",
+            className,
+          )}
+          data-object-inspector
+          data-object-state="empty"
+          ref={ref}
+          {...rest}
+        >
+          <span aria-hidden="true" className="text-lg">
+            ◇
+          </span>
+          <span>{resolvedLabels.empty}</span>
+        </section>
+      );
+    }
+    return (
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "flex w-full flex-col gap-3 rounded-2xl border bg-background p-3 text-foreground",
+          className,
+        )}
+        data-object-inspector
+        data-object-kind={kind}
+        data-object-status={status}
+        ref={ref}
+        {...rest}
+      >
+        <Header kind={kind} status={status} subtitle={subtitle} title={title} />
+        {children ? <div className="space-y-2">{children}</div> : null}
+      </section>
+    );
+  },
+);
+ObjectInspector.displayName = "ObjectInspector";

--- a/packages/ui/src/components/object-inspector/object-inspector.visual.tsx
+++ b/packages/ui/src/components/object-inspector/object-inspector.visual.tsx
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { ObjectInspector } from "./object-inspector";
+
+test.describe("ObjectInspector Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="w-72 p-4">
+        <ObjectInspector
+          kind="run"
+          status="running"
+          subtitle="claude-3.7 · 128k ctx"
+          title="research-2025-04-15"
+        >
+          <p className="rounded-md border border-border/60 bg-muted/30 px-2 py-1 text-xs text-muted-foreground">
+            Property sections render here.
+          </p>
+        </ObjectInspector>
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "object-inspector-default.png",
+    );
+  });
+});

--- a/packages/ui/src/components/property-section/index.ts
+++ b/packages/ui/src/components/property-section/index.ts
@@ -1,0 +1,6 @@
+export {
+  type PropertyEntry,
+  PropertySection,
+  type PropertySectionLabels,
+  type PropertySectionProps,
+} from "./property-section";

--- a/packages/ui/src/components/property-section/property-section.mdx
+++ b/packages/ui/src/components/property-section/property-section.mdx
@@ -1,0 +1,58 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './property-section.stories'
+
+<Meta of={Stories} />
+
+# PropertySection
+
+Compact key / value grid for an inspector panel. Use one `PropertySection` per logical group (Identity, Layout, State, …) so the right dock stays scannable. Pure presentation — the host computes the entries from the current selection.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/property-section.json
+```
+
+## Import
+
+```tsx
+import { PropertySection } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<PropertySection
+  title="Layout"
+  entries={[
+    { id: 'x', label: 'X', value: '120' },
+    { id: 'y', label: 'Y', value: '80' },
+    { id: 'size', label: 'Size', value: '240 × 120' },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## With sublabels
+
+Add `sublabel` to surface a unit (`px`, `ms`, `kg`) or other small qualifier under the main label.
+
+<Canvas of={Stories.WithSublabels} sourceState="shown" />
+
+## Collapsible
+
+Use a `<details>` summary header — the section starts open and folds on click. Useful when an inspector lists 5+ groups.
+
+<Canvas of={Stories.Collapsible} sourceState="shown" />
+
+## Notes
+
+- The grid uses `grid-cols-[max-content_1fr]` so labels share a left column and values right-align in the remaining space.
+- Each row emits `data-property-id`. The wrapper emits `data-property-section` and either `data-property-header` (default) or `data-property-summary` (collapsible).

--- a/packages/ui/src/components/property-section/property-section.stories.tsx
+++ b/packages/ui/src/components/property-section/property-section.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { type PropertyEntry, PropertySection } from "./property-section";
+
+const ENTRIES: PropertyEntry[] = [
+  { id: "x", label: "X", value: "120" },
+  { id: "y", label: "Y", value: "80" },
+  { id: "w", label: "Width", value: "240" },
+  { id: "h", label: "Height", value: "120" },
+];
+
+const meta = {
+  args: { entries: ENTRIES, title: "Layout" },
+  component: PropertySection,
+  decorators: [
+    (Story) => (
+      <div className="w-72">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/PropertySection",
+} satisfies Meta<typeof PropertySection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithSublabels: Story = {
+  args: {
+    entries: ENTRIES.map((entry) => ({ ...entry, sublabel: "px" })),
+  },
+};
+
+export const Collapsible: Story = { args: { collapsible: true } };
+
+export const Untitled: Story = { args: { title: undefined } };

--- a/packages/ui/src/components/property-section/property-section.test.tsx
+++ b/packages/ui/src/components/property-section/property-section.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { type PropertyEntry, PropertySection } from "./property-section";
+
+const ENTRIES: PropertyEntry[] = [
+  { id: "x", label: "X", value: "120" },
+  { id: "y", label: "Y", value: "80" },
+  {
+    id: "size",
+    label: "Size",
+    sublabel: "px",
+    value: "240 × 120",
+  },
+];
+
+describe("PropertySection", () => {
+  it("renders one row per entry", () => {
+    const { container } = render(<PropertySection entries={ENTRIES} />);
+
+    expect(
+      container.querySelector("[data-property-id='x']"),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector("[data-property-id='y']"),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector("[data-property-id='size']"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the value in the right column", () => {
+    render(<PropertySection entries={ENTRIES} />);
+
+    expect(screen.getByText("240 × 120")).toBeInTheDocument();
+  });
+
+  it("renders the title as a header by default", () => {
+    const { container } = render(
+      <PropertySection entries={ENTRIES} title="Layout" />,
+    );
+
+    expect(container.querySelector("[data-property-header]")).toHaveTextContent(
+      "Layout",
+    );
+  });
+
+  it("renders the title as a collapsible summary when collapsible is true", () => {
+    const { container } = render(
+      <PropertySection collapsible entries={ENTRIES} title="Layout" />,
+    );
+
+    expect(
+      container.querySelector("[data-property-summary]"),
+    ).toBeInTheDocument();
+    expect(container.querySelector("details")).toHaveAttribute("open");
+  });
+
+  it("renders the sublabel when set", () => {
+    render(<PropertySection entries={ENTRIES} />);
+
+    expect(screen.getByText("px")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/property-section/property-section.tsx
+++ b/packages/ui/src/components/property-section/property-section.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * One row in the property grid.
+ *
+ * @public
+ */
+export type PropertyEntry = {
+  /** Stable id (used as React key + analytics hook). */
+  id: string;
+  /** Property label (left column). */
+  label: ReactNode;
+  /** Optional sublabel rendered beneath the label. */
+  sublabel?: ReactNode;
+  /** Property value (right column). */
+  value: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type PropertySectionLabels = {
+  /** Aria-label for the section. Defaults to `"Properties"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Properties",
+} as const satisfies Required<PropertySectionLabels>;
+
+/**
+ * Props for {@link PropertySection}.
+ *
+ * @public
+ */
+export type PropertySectionProps = {
+  /** Optional collapsible affordance. Pass `false` to render the body inline (default). */
+  collapsible?: boolean;
+  /** Property entries in render order. */
+  entries: PropertyEntry[];
+  /** Localizable strings. */
+  labels?: PropertySectionLabels;
+  /** Optional title rendered as a small uppercase heading above the grid. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const Grid = (props: { entries: PropertyEntry[] }): React.ReactElement => (
+  <dl
+    className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1.5 px-3 pb-3 pt-1 text-xs"
+    data-property-grid
+  >
+    {props.entries.map((entry) => (
+      <div className="contents" key={entry.id}>
+        <dt
+          className="flex flex-col text-muted-foreground"
+          data-property-id={entry.id}
+        >
+          <span>{entry.label}</span>
+          {entry.sublabel ? (
+            <span className="text-[10px] uppercase tracking-wide text-muted-foreground/70">
+              {entry.sublabel}
+            </span>
+          ) : null}
+        </dt>
+        <dd className="text-right text-foreground">{entry.value}</dd>
+      </div>
+    ))}
+  </dl>
+);
+
+const Body = (props: {
+  collapsible: boolean;
+  entries: PropertyEntry[];
+  title?: ReactNode;
+}): React.ReactElement => {
+  const grid = <Grid entries={props.entries} />;
+  if (!props.title) {
+    return grid;
+  }
+  if (props.collapsible) {
+    return (
+      <details className="group" open>
+        <summary
+          className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+          data-property-summary
+        >
+          <span>{props.title}</span>
+          <span
+            aria-hidden="true"
+            className="text-muted-foreground/70 group-open:rotate-90"
+          >
+            ›
+          </span>
+        </summary>
+        {grid}
+      </details>
+    );
+  }
+  return (
+    <>
+      <header
+        className="flex items-center justify-between gap-2 border-b border-border px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+        data-property-header
+      >
+        {props.title}
+      </header>
+      {grid}
+    </>
+  );
+};
+
+/**
+ * Compact key / value grid for an inspector panel. Use one
+ * `PropertySection` per logical group (Identity, Layout, State, etc.)
+ * so the right dock stays scannable. Pure presentation — the host
+ * computes the entries from the current selection.
+ *
+ * @example
+ * ```tsx
+ * <PropertySection
+ *   title="Layout"
+ *   entries={[
+ *     { id: "x", label: "X", value: "120" },
+ *     { id: "y", label: "Y", value: "80" },
+ *     { id: "size", label: "Size", value: "240 × 120" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const PropertySection = forwardRef<HTMLElement, PropertySectionProps>(
+  (props, ref) => {
+    const {
+      className,
+      collapsible = false,
+      entries,
+      labels,
+      title,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "rounded-lg border bg-background text-foreground",
+          className,
+        )}
+        data-property-section
+        ref={ref}
+        {...rest}
+      >
+        <Body collapsible={collapsible} entries={entries} title={title} />
+      </section>
+    );
+  },
+);
+PropertySection.displayName = "PropertySection";

--- a/packages/ui/src/components/property-section/property-section.visual.tsx
+++ b/packages/ui/src/components/property-section/property-section.visual.tsx
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { PropertySection } from "./property-section";
+
+test.describe("PropertySection Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="w-72 p-4">
+        <PropertySection
+          entries={[
+            { id: "x", label: "X", value: "120" },
+            { id: "y", label: "Y", value: "80" },
+            { id: "w", label: "Width", value: "240" },
+            { id: "h", label: "Height", value: "120" },
+          ]}
+          title="Layout"
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "property-section-default.png",
+    );
+  });
+});

--- a/packages/ui/src/components/relationship-inspector/index.ts
+++ b/packages/ui/src/components/relationship-inspector/index.ts
@@ -1,0 +1,7 @@
+export {
+  type RelationshipDirection,
+  type RelationshipEdge,
+  RelationshipInspector,
+  type RelationshipInspectorLabels,
+  type RelationshipInspectorProps,
+} from "./relationship-inspector";

--- a/packages/ui/src/components/relationship-inspector/relationship-inspector.mdx
+++ b/packages/ui/src/components/relationship-inspector/relationship-inspector.mdx
@@ -1,0 +1,64 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './relationship-inspector.stories'
+
+<Meta of={Stories} />
+
+# RelationshipInspector
+
+Inspector panel listing inbound + outbound edges of the focused object on a spatial canvas. Each row shows direction arrow, target id, optional sublabel, and the relation kind chip. Pure presentation; the host computes edges from the runtime graph and supplies an optional click handler to jump to the related object.
+
+Pairs with \`ObjectInspector\` and \`PropertySection\` to form the right-dock detail view.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/relationship-inspector.json
+```
+
+## Import
+
+```tsx
+import { RelationshipInspector } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<RelationshipInspector
+  edges={[
+    { id: "1", direction: "inbound",  target: "research-2025", relation: "spawned-by" },
+    { id: "2", direction: "outbound", target: "summary.md",    relation: "emits", onActivate: jumpTo },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Empty state
+
+When the focused object has no relationships, the panel renders a calm empty placeholder.
+
+<Canvas of={Stories.Empty} sourceState="shown" />
+
+## Inbound only
+
+Groups with zero edges are omitted entirely — only the populated direction renders.
+
+<Canvas of={Stories.InboundOnly} sourceState="shown" />
+
+## Non-interactive
+
+Omit \`onActivate\` and rows render as plain divs (no hover, no button semantics). Useful for read-only debug views.
+
+<Canvas of={Stories.NonInteractive} sourceState="shown" />
+
+## Notes
+
+- Direction glyphs: inbound = \`←\`, outbound = \`→\`.
+- Each row emits \`data-relationship-row\` and \`data-relationship-direction\`; each group emits \`data-relationship-group\`. Use these for analytics + CSS hooks.

--- a/packages/ui/src/components/relationship-inspector/relationship-inspector.stories.tsx
+++ b/packages/ui/src/components/relationship-inspector/relationship-inspector.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { RelationshipInspector } from "./relationship-inspector";
+
+const noop = (): void => undefined;
+
+const meta = {
+  args: {
+    edges: [
+      {
+        direction: "inbound",
+        id: "1",
+        onActivate: noop,
+        relation: "spawned-by",
+        target: "run-2025-04-15",
+        targetSublabel: "claude-3.7",
+      },
+      {
+        direction: "outbound",
+        id: "2",
+        onActivate: noop,
+        relation: "emits",
+        target: "summary.md",
+        targetSublabel: "1.2 KB",
+      },
+      {
+        direction: "outbound",
+        id: "3",
+        onActivate: noop,
+        relation: "calls",
+        target: "ranker",
+      },
+    ],
+  },
+  component: RelationshipInspector,
+  decorators: [
+    (Story) => (
+      <div className="w-72">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/RelationshipInspector",
+} satisfies Meta<typeof RelationshipInspector>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: { edges: [] },
+};
+
+export const InboundOnly: Story = {
+  args: {
+    edges: [
+      {
+        direction: "inbound",
+        id: "1",
+        relation: "spawned-by",
+        target: "research-orchestrator",
+      },
+    ],
+  },
+};
+
+export const NonInteractive: Story = {
+  args: {
+    edges: [
+      {
+        direction: "inbound",
+        id: "1",
+        relation: "spawned-by",
+        target: "research-2025",
+      },
+      {
+        direction: "outbound",
+        id: "2",
+        relation: "emits",
+        target: "summary.md",
+      },
+    ],
+  },
+};

--- a/packages/ui/src/components/relationship-inspector/relationship-inspector.test.tsx
+++ b/packages/ui/src/components/relationship-inspector/relationship-inspector.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type RelationshipEdge,
+  RelationshipInspector,
+} from "./relationship-inspector";
+
+const sample: RelationshipEdge[] = [
+  { direction: "inbound", id: "1", relation: "spawned-by", target: "run-1" },
+  { direction: "outbound", id: "2", relation: "emits", target: "summary.md" },
+];
+
+describe("RelationshipInspector", () => {
+  it("renders the empty state when no edges are provided", () => {
+    const { container } = render(<RelationshipInspector edges={[]} />);
+
+    expect(
+      container.querySelector("[data-relationship-state='empty']"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No relationships")).toBeInTheDocument();
+  });
+
+  it("groups edges by direction", () => {
+    const { container } = render(<RelationshipInspector edges={sample} />);
+
+    expect(
+      container.querySelector("[data-relationship-group='inbound']"),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector("[data-relationship-group='outbound']"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the relation chip for each row", () => {
+    render(<RelationshipInspector edges={sample} />);
+
+    expect(screen.getByText("spawned-by")).toBeInTheDocument();
+    expect(screen.getByText("emits")).toBeInTheDocument();
+  });
+
+  it("invokes onActivate when a row is clicked", () => {
+    const handleActivate = vi.fn();
+    render(
+      <RelationshipInspector
+        edges={[
+          {
+            direction: "outbound",
+            id: "x",
+            onActivate: handleActivate,
+            relation: "emits",
+            target: "summary.md",
+          },
+        ]}
+      />,
+    );
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    expect(handleActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders rows as plain divs when onActivate is omitted", () => {
+    render(<RelationshipInspector edges={sample} />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/relationship-inspector/relationship-inspector.tsx
+++ b/packages/ui/src/components/relationship-inspector/relationship-inspector.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Direction of an edge relative to the focused object.
+ *
+ * @public
+ */
+export type RelationshipDirection = "inbound" | "outbound";
+
+/**
+ * One edge in the relationship list.
+ *
+ * @public
+ */
+export type RelationshipEdge = {
+  /** Direction of the edge relative to the focused object. */
+  direction: RelationshipDirection;
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Optional click handler — when provided, the row becomes a button. */
+  onActivate?: () => void;
+  /** Relation kind (e.g. `"calls"`, `"emits"`, `"depends-on"`). */
+  relation: string;
+  /** Target id (when outbound) or source id (when inbound). */
+  target: ReactNode;
+  /** Optional secondary line beneath the row. */
+  targetSublabel?: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type RelationshipInspectorLabels = {
+  /** Empty-state copy. Defaults to `"No relationships"`. */
+  empty?: string;
+  /** Header for inbound edges. Defaults to `"Inbound"`. */
+  inbound?: string;
+  /** Header for outbound edges. Defaults to `"Outbound"`. */
+  outbound?: string;
+  /** Aria-label for the inspector. Defaults to `"Relationship inspector"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No relationships",
+  inbound: "Inbound",
+  outbound: "Outbound",
+  region: "Relationship inspector",
+} as const satisfies Required<RelationshipInspectorLabels>;
+
+/**
+ * Props for {@link RelationshipInspector}.
+ *
+ * @public
+ */
+export type RelationshipInspectorProps = {
+  /** Edges to render. Empty list shows the empty state. */
+  edges: RelationshipEdge[];
+  /** Localizable strings. */
+  labels?: RelationshipInspectorLabels;
+  /** Optional inspector title. Defaults to `"Relationships"`. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const ARROW_GLYPH: Record<RelationshipDirection, string> = {
+  inbound: "←",
+  outbound: "→",
+};
+
+const RowBody = (props: { edge: RelationshipEdge }): React.ReactElement => {
+  const { edge } = props;
+  return (
+    <span className="flex flex-1 items-center gap-2">
+      <span aria-hidden="true" className="text-muted-foreground">
+        {ARROW_GLYPH[edge.direction]}
+      </span>
+      <span className="flex flex-1 flex-col text-left">
+        <span className="truncate text-xs text-foreground">{edge.target}</span>
+        {edge.targetSublabel ? (
+          <span className="truncate text-[10px] text-muted-foreground">
+            {edge.targetSublabel}
+          </span>
+        ) : null}
+      </span>
+      <span className="rounded-full border border-border bg-background px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+        {edge.relation}
+      </span>
+    </span>
+  );
+};
+
+const Row = (props: { edge: RelationshipEdge }): React.ReactElement => {
+  const { edge } = props;
+  if (edge.onActivate) {
+    const handleClick = (): void => {
+      edge.onActivate?.();
+    };
+    return (
+      <button
+        className="flex w-full items-center gap-2 rounded-md border border-transparent px-2 py-1.5 text-left transition-colors hover:border-border hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        data-relationship-direction={edge.direction}
+        data-relationship-row
+        onClick={handleClick}
+        type="button"
+      >
+        <RowBody edge={edge} />
+      </button>
+    );
+  }
+  return (
+    <div
+      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5"
+      data-relationship-direction={edge.direction}
+      data-relationship-row
+    >
+      <RowBody edge={edge} />
+    </div>
+  );
+};
+
+const Group = (props: {
+  edges: RelationshipEdge[];
+  heading: string;
+}): null | React.ReactElement => {
+  const { edges, heading } = props;
+  if (edges.length === 0) {
+    return null;
+  }
+  return (
+    <div className="space-y-1" data-relationship-group={heading.toLowerCase()}>
+      <h4 className="px-2 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        {heading}
+      </h4>
+      <ul className="space-y-0.5">
+        {edges.map((edge) => (
+          <li key={edge.id}>
+            <Row edge={edge} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+/**
+ * Inspector panel listing inbound + outbound edges of the focused
+ * object. Each row shows direction arrow, target id, optional sublabel,
+ * and the relation kind chip. Pure presentation; the host computes
+ * edges from the runtime graph and supplies an optional click handler
+ * to jump to the related object.
+ *
+ * @example
+ * ```tsx
+ * <RelationshipInspector
+ *   edges={[
+ *     { id: "1", direction: "inbound",  target: "research-2025", relation: "spawned-by" },
+ *     { id: "2", direction: "outbound", target: "summary.md",    relation: "emits" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const RelationshipInspector = forwardRef<
+  HTMLElement,
+  RelationshipInspectorProps
+>((props, ref) => {
+  const { className, edges, labels, title = "Relationships", ...rest } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const inbound = edges.filter((edge) => edge.direction === "inbound");
+  const outbound = edges.filter((edge) => edge.direction === "outbound");
+  return (
+    <section
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "flex w-full flex-col gap-2 rounded-lg border bg-background p-3 text-foreground",
+        className,
+      )}
+      data-relationship-inspector
+      ref={ref}
+      {...rest}
+    >
+      <header>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {title}
+        </h3>
+      </header>
+      {edges.length === 0 ? (
+        <p
+          className="px-2 py-3 text-center text-xs text-muted-foreground"
+          data-relationship-state="empty"
+        >
+          {resolvedLabels.empty}
+        </p>
+      ) : (
+        <div className="space-y-2">
+          <Group edges={inbound} heading={resolvedLabels.inbound} />
+          <Group edges={outbound} heading={resolvedLabels.outbound} />
+        </div>
+      )}
+    </section>
+  );
+});
+RelationshipInspector.displayName = "RelationshipInspector";

--- a/packages/ui/src/components/relationship-inspector/relationship-inspector.visual.tsx
+++ b/packages/ui/src/components/relationship-inspector/relationship-inspector.visual.tsx
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { RelationshipInspector } from "./relationship-inspector";
+
+test.describe("RelationshipInspector Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="w-72 p-4">
+        <RelationshipInspector
+          edges={[
+            {
+              direction: "inbound",
+              id: "1",
+              relation: "spawned-by",
+              target: "run-2025-04-15",
+              targetSublabel: "claude-3.7",
+            },
+            {
+              direction: "outbound",
+              id: "2",
+              relation: "emits",
+              target: "summary.md",
+              targetSublabel: "1.2 KB",
+            },
+            {
+              direction: "outbound",
+              id: "3",
+              relation: "calls",
+              target: "ranker",
+            },
+          ]}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "relationship-inspector-default.png",
+    );
+  });
+});


### PR DESCRIPTION
Closes #134

## What's in

Three calm right-dock primitives for the spatial canvas detail view (issue #134):

- **PropertySection** — compact key/value `<dl>` grid for an inspector panel. Optional collapsible affordance, sublabel support, analytics hooks (`data-property-section`, `data-property-id`).
- **ObjectInspector** — header for the active selection. Renders kind chip (Agent/Run/Task/Artifact/Input/Output) + status dot (idle/queued/running/complete/failed) + title/subtitle. Body slot for stacked `PropertySection` blocks. Calm empty state when no selection.
- **RelationshipInspector** — inbound + outbound edge list with arrow glyphs. Rows render as `<button>` only when `onActivate` is supplied (jump-to-related-object), otherwise plain `<div>`. Per-direction grouping with empty groups omitted.

All three are pure presentation; the host derives entries/edges from the runtime graph. Wired into the `@vllnt/ui` barrel and the shadcn registry.

## Files

- `packages/ui/src/components/property-section/` — tsx + index + test + visual + stories + mdx
- `packages/ui/src/components/object-inspector/` — tsx + index + test + visual + stories + mdx
- `packages/ui/src/components/relationship-inspector/` — tsx + index + test + visual + stories + mdx
- `packages/ui/src/components/index.ts` — barrel exports
- `apps/registry/registry/default/{property-section,object-inspector,relationship-inspector}/*.tsx` — registry shims
- `apps/registry/registry.json` — three new entries

## Out of scope (deferred to follow-up #134 PRs)

- JarvisDock — global command palette / agent dock
- RuntimeOverviewPanel — runtime status summary
- RoutingAssignmentPanel — agent routing config
- PolicyDeliveryPanel — policy enforcement view
- MultiSelectLasso — canvas multi-select gesture
- ContextLens — focus-context overlay

## Quality gates

- lint: PASS (`eslint --fix` clean)
- typecheck: PASS (`tsc --noEmit --project tsconfig.build.json`)
- check:use-client: PASS (182 components)
- check:story-coverage: PASS (172 components)
- verify-stories: PASS (no crash risks)
- test: PASS (508 / 508)
- build (`@vllnt/ui`): PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)
- [ ] Storybook renders all 12 stories (4 per primitive) without console errors
- [ ] Visual snapshots stable across primitives