### PR TITLE
feat(ui): dock panels — RuntimeOverview + RoutingAssignment + PolicyDelivery (partial #134)

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1557,6 +1557,21 @@
       "category": "utility"
     },
     {
+      "name": "policy-delivery-panel",
+      "type": "registry:component",
+      "title": "Policy Delivery Panel",
+      "description": "Right-dock panel listing policies / guardrails active for the route or run.",
+      "files": [
+        {
+          "path": "registry/default/policy-delivery-panel/policy-delivery-panel.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "content"
+    },
+    {
       "name": "popover",
       "type": "registry:component",
       "title": "Popover",
@@ -1752,6 +1767,21 @@
       "category": "content"
     },
     {
+      "name": "routing-assignment-panel",
+      "type": "registry:component",
+      "title": "Routing Assignment Panel",
+      "description": "Right-dock panel listing the agent slots an active route dispatches to.",
+      "files": [
+        {
+          "path": "registry/default/routing-assignment-panel/routing-assignment-panel.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "content"
+    },
+    {
       "name": "run-timeline",
       "type": "registry:component",
       "title": "Run Timeline",
@@ -1765,6 +1795,21 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "data"
+    },
+    {
+      "name": "runtime-overview-panel",
+      "type": "registry:component",
+      "title": "Runtime Overview Panel",
+      "description": "Top-of-dock summary tile grid for runtime health when no canvas object is selected.",
+      "files": [
+        {
+          "path": "registry/default/runtime-overview-panel/runtime-overview-panel.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "content"
     },
     {
       "name": "scope-selector",

--- a/apps/registry/registry/default/policy-delivery-panel/policy-delivery-panel.tsx
+++ b/apps/registry/registry/default/policy-delivery-panel/policy-delivery-panel.tsx
@@ -1,0 +1,7 @@
+export {
+  PolicyDeliveryPanel,
+  type PolicyDeliveryPanelLabels,
+  type PolicyDeliveryPanelProps,
+  type PolicyEntry,
+  type PolicyStatus,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/routing-assignment-panel/routing-assignment-panel.tsx
+++ b/apps/registry/registry/default/routing-assignment-panel/routing-assignment-panel.tsx
@@ -1,0 +1,7 @@
+export {
+  type RoutingAssignment,
+  RoutingAssignmentPanel,
+  type RoutingAssignmentPanelLabels,
+  type RoutingAssignmentPanelProps,
+  type RoutingRole,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/runtime-overview-panel/runtime-overview-panel.tsx
+++ b/apps/registry/registry/default/runtime-overview-panel/runtime-overview-panel.tsx
@@ -1,0 +1,8 @@
+export {
+  type RuntimeMetric,
+  type RuntimeMetricTone,
+  type RuntimeMetricTrend,
+  RuntimeOverviewPanel,
+  type RuntimeOverviewPanelLabels,
+  type RuntimeOverviewPanelProps,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -844,6 +844,13 @@ export {
   type PlaybackGhostProps,
 } from "./playback-ghost";
 export {
+  PolicyDeliveryPanel,
+  type PolicyDeliveryPanelLabels,
+  type PolicyDeliveryPanelProps,
+  type PolicyEntry,
+  type PolicyStatus,
+} from "./policy-delivery-panel";
+export {
   PresenceStack,
   type PresenceStackLabels,
   type PresenceStackProps,
@@ -857,6 +864,13 @@ export {
   type PresenceSyncState,
 } from "./presence-sync-indicator";
 export {
+  type RoutingAssignment,
+  RoutingAssignmentPanel,
+  type RoutingAssignmentPanelLabels,
+  type RoutingAssignmentPanelProps,
+  type RoutingRole,
+} from "./routing-assignment-panel";
+export {
   type RunPhaseState,
   RunTimeline,
   type RunTimelineLabels,
@@ -864,6 +878,14 @@ export {
   type RunTimelinePhase,
   type RunTimelineProps,
 } from "./run-timeline";
+export {
+  type RuntimeMetric,
+  type RuntimeMetricTone,
+  type RuntimeMetricTrend,
+  RuntimeOverviewPanel,
+  type RuntimeOverviewPanelLabels,
+  type RuntimeOverviewPanelProps,
+} from "./runtime-overview-panel";
 export {
   SelectionPresence,
   type SelectionPresenceLabels,

--- a/packages/ui/src/components/policy-delivery-panel/index.ts
+++ b/packages/ui/src/components/policy-delivery-panel/index.ts
@@ -1,0 +1,7 @@
+export {
+  PolicyDeliveryPanel,
+  type PolicyDeliveryPanelLabels,
+  type PolicyDeliveryPanelProps,
+  type PolicyEntry,
+  type PolicyStatus,
+} from "./policy-delivery-panel";

--- a/packages/ui/src/components/policy-delivery-panel/policy-delivery-panel.mdx
+++ b/packages/ui/src/components/policy-delivery-panel/policy-delivery-panel.mdx
@@ -1,0 +1,63 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './policy-delivery-panel.stories'
+
+<Meta of={Stories} />
+
+# PolicyDeliveryPanel
+
+Right-dock panel listing the policies / guardrails that apply to the active route or run. Each row shows the policy name, enforcement status chip, and optional rationale. Pure presentation; the host computes the list from the live config and supplies an optional toggle handler for admin views.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/policy-delivery-panel.json
+```
+
+## Import
+
+```tsx
+import { PolicyDeliveryPanel } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<PolicyDeliveryPanel
+  policies={[
+    { id: "pii",  name: "PII redaction", status: "enforced" },
+    { id: "rate", name: "Rate limiting", status: "advisory", description: "60 / s soft cap" },
+    { id: "exp",  name: "Experiment B",  status: "disabled" },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Empty state
+
+When no policies are provided, the panel renders a calm placeholder.
+
+<Canvas of={Stories.Empty} sourceState="shown" />
+
+## All enforced
+
+A fully-locked-down route renders as a uniformly green chip column.
+
+<Canvas of={Stories.AllEnforced} sourceState="shown" />
+
+## Non-interactive
+
+Omit \`onToggle\` and rows render as plain divs (no hover, no button semantics). Useful for read-only audit views.
+
+<Canvas of={Stories.NonInteractive} sourceState="shown" />
+
+## Notes
+
+- Status chips map: \`enforced\` (emerald) · \`advisory\` (amber) · \`disabled\` (muted).
+- Each row emits \`data-policy-row\` (= id) + \`data-policy-status\`. The wrapper emits \`data-policy-delivery-panel\`.

--- a/packages/ui/src/components/policy-delivery-panel/policy-delivery-panel.stories.tsx
+++ b/packages/ui/src/components/policy-delivery-panel/policy-delivery-panel.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PolicyDeliveryPanel } from "./policy-delivery-panel";
+
+const noop = (): void => undefined;
+
+const meta = {
+  args: {
+    policies: [
+      {
+        id: "pii",
+        name: "PII redaction",
+        onToggle: noop,
+        status: "enforced",
+      },
+      {
+        description: "60 / s soft cap",
+        id: "rate",
+        name: "Rate limiting",
+        onToggle: noop,
+        status: "advisory",
+      },
+      {
+        description: "rolled out 12 % of traffic",
+        id: "exp",
+        name: "Experiment B",
+        onToggle: noop,
+        status: "disabled",
+      },
+    ],
+  },
+  component: PolicyDeliveryPanel,
+  decorators: [
+    (Story) => (
+      <div className="w-72">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/PolicyDeliveryPanel",
+} satisfies Meta<typeof PolicyDeliveryPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: { policies: [] },
+};
+
+export const AllEnforced: Story = {
+  args: {
+    policies: [
+      { id: "pii", name: "PII redaction", status: "enforced" },
+      { id: "tox", name: "Toxicity filter", status: "enforced" },
+      { id: "rate", name: "Rate limiting", status: "enforced" },
+    ],
+  },
+};
+
+export const NonInteractive: Story = {
+  args: {
+    policies: [
+      { id: "pii", name: "PII redaction", status: "enforced" },
+      { id: "rate", name: "Rate limiting", status: "advisory" },
+    ],
+  },
+};

--- a/packages/ui/src/components/policy-delivery-panel/policy-delivery-panel.test.tsx
+++ b/packages/ui/src/components/policy-delivery-panel/policy-delivery-panel.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PolicyDeliveryPanel, type PolicyEntry } from "./policy-delivery-panel";
+
+const sample: PolicyEntry[] = [
+  { id: "pii", name: "PII redaction", status: "enforced" },
+  {
+    description: "60 / s soft cap",
+    id: "rate",
+    name: "Rate limiting",
+    status: "advisory",
+  },
+  { id: "exp", name: "Experiment B", status: "disabled" },
+];
+
+describe("PolicyDeliveryPanel", () => {
+  it("renders the empty state when no policies are provided", () => {
+    const { container } = render(<PolicyDeliveryPanel policies={[]} />);
+
+    expect(
+      container.querySelector("[data-policy-state='empty']"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No policies")).toBeInTheDocument();
+  });
+
+  it("renders one row per policy with the status chip", () => {
+    const { container } = render(<PolicyDeliveryPanel policies={sample} />);
+
+    expect(container.querySelectorAll("[data-policy-row]")).toHaveLength(3);
+    expect(screen.getByText("Enforced")).toBeInTheDocument();
+    expect(screen.getByText("Advisory")).toBeInTheDocument();
+    expect(screen.getByText("Disabled")).toBeInTheDocument();
+  });
+
+  it("renders the optional description line", () => {
+    render(<PolicyDeliveryPanel policies={sample} />);
+
+    expect(screen.getByText("60 / s soft cap")).toBeInTheDocument();
+  });
+
+  it("invokes onToggle when a row is clicked", () => {
+    const handleToggle = vi.fn();
+    render(
+      <PolicyDeliveryPanel
+        policies={[
+          {
+            id: "pii",
+            name: "PII redaction",
+            onToggle: handleToggle,
+            status: "enforced",
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(handleToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders rows as plain divs when onToggle is omitted", () => {
+    render(<PolicyDeliveryPanel policies={sample} />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/policy-delivery-panel/policy-delivery-panel.tsx
+++ b/packages/ui/src/components/policy-delivery-panel/policy-delivery-panel.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Enforcement status for a policy.
+ *
+ * @public
+ */
+export type PolicyStatus = "advisory" | "disabled" | "enforced";
+
+const STATUS_LABEL: Record<PolicyStatus, string> = {
+  advisory: "Advisory",
+  disabled: "Disabled",
+  enforced: "Enforced",
+};
+
+const STATUS_TONE: Record<PolicyStatus, string> = {
+  advisory:
+    "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  disabled: "border-border bg-muted/40 text-muted-foreground",
+  enforced:
+    "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+};
+
+/**
+ * One policy row.
+ *
+ * @public
+ */
+export type PolicyEntry = {
+  /** Optional secondary line (rationale, owner, last-updated). */
+  description?: ReactNode;
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Display name (e.g. `"PII redaction"`). */
+  name: ReactNode;
+  /** Optional toggle handler — when provided, the row becomes a button. */
+  onToggle?: () => void;
+  /** Enforcement status. */
+  status: PolicyStatus;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type PolicyDeliveryPanelLabels = {
+  /** Empty-state copy. Defaults to `"No policies"`. */
+  empty?: string;
+  /** Aria-label for the panel. Defaults to `"Policy delivery"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No policies",
+  region: "Policy delivery",
+} as const satisfies Required<PolicyDeliveryPanelLabels>;
+
+/**
+ * Props for {@link PolicyDeliveryPanel}.
+ *
+ * @public
+ */
+export type PolicyDeliveryPanelProps = {
+  /** Localizable strings. */
+  labels?: PolicyDeliveryPanelLabels;
+  /** Policy entries in render order. */
+  policies: PolicyEntry[];
+  /** Panel title. Defaults to `"Policies"`. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const RowBody = (props: { policy: PolicyEntry }): React.ReactElement => {
+  const { policy } = props;
+  return (
+    <span className="flex flex-1 flex-col gap-0.5 text-left">
+      <span className="flex items-center justify-between gap-2">
+        <span className="truncate text-xs font-medium text-foreground">
+          {policy.name}
+        </span>
+        <span
+          className={cn(
+            "rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
+            STATUS_TONE[policy.status],
+          )}
+        >
+          {STATUS_LABEL[policy.status]}
+        </span>
+      </span>
+      {policy.description ? (
+        <span className="truncate text-[10px] text-muted-foreground">
+          {policy.description}
+        </span>
+      ) : null}
+    </span>
+  );
+};
+
+const Row = (props: { policy: PolicyEntry }): React.ReactElement => {
+  const { policy } = props;
+  if (policy.onToggle) {
+    const handleClick = (): void => {
+      policy.onToggle?.();
+    };
+    return (
+      <button
+        className="flex w-full items-center gap-2 rounded-md border border-transparent px-2 py-1.5 text-left transition-colors hover:border-border hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        data-policy-row={policy.id}
+        data-policy-status={policy.status}
+        onClick={handleClick}
+        type="button"
+      >
+        <RowBody policy={policy} />
+      </button>
+    );
+  }
+  return (
+    <div
+      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5"
+      data-policy-row={policy.id}
+      data-policy-status={policy.status}
+    >
+      <RowBody policy={policy} />
+    </div>
+  );
+};
+
+/**
+ * Right-dock panel listing the policies / guardrails that apply to the
+ * active route or run. Each row shows the policy name, enforcement
+ * status chip, and optional rationale. Pure presentation; the host
+ * computes the policy list from the live config and supplies an
+ * optional toggle handler for admin views.
+ *
+ * @example
+ * ```tsx
+ * <PolicyDeliveryPanel
+ *   policies={[
+ *     { id: "pii",  name: "PII redaction", status: "enforced" },
+ *     { id: "rate", name: "Rate limiting", status: "advisory", description: "60 / s soft cap" },
+ *     { id: "exp",  name: "Experiment B",  status: "disabled" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const PolicyDeliveryPanel = forwardRef<
+  HTMLElement,
+  PolicyDeliveryPanelProps
+>((props, ref) => {
+  const { className, labels, policies, title = "Policies", ...rest } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  return (
+    <section
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "flex w-full flex-col gap-2 rounded-lg border bg-background p-3 text-foreground",
+        className,
+      )}
+      data-policy-delivery-panel
+      ref={ref}
+      {...rest}
+    >
+      <header>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {title}
+        </h3>
+      </header>
+      {policies.length === 0 ? (
+        <p
+          className="px-2 py-3 text-center text-xs text-muted-foreground"
+          data-policy-state="empty"
+        >
+          {resolvedLabels.empty}
+        </p>
+      ) : (
+        <ul className="space-y-0.5">
+          {policies.map((policy) => (
+            <li key={policy.id}>
+              <Row policy={policy} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+});
+PolicyDeliveryPanel.displayName = "PolicyDeliveryPanel";

--- a/packages/ui/src/components/policy-delivery-panel/policy-delivery-panel.visual.tsx
+++ b/packages/ui/src/components/policy-delivery-panel/policy-delivery-panel.visual.tsx
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { PolicyDeliveryPanel } from "./policy-delivery-panel";
+
+test.describe("PolicyDeliveryPanel Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="w-72 p-4">
+        <PolicyDeliveryPanel
+          policies={[
+            { id: "pii", name: "PII redaction", status: "enforced" },
+            {
+              description: "60 / s soft cap",
+              id: "rate",
+              name: "Rate limiting",
+              status: "advisory",
+            },
+            {
+              description: "rolled out 12 % of traffic",
+              id: "exp",
+              name: "Experiment B",
+              status: "disabled",
+            },
+          ]}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "policy-delivery-panel-default.png",
+    );
+  });
+});

--- a/packages/ui/src/components/routing-assignment-panel/index.ts
+++ b/packages/ui/src/components/routing-assignment-panel/index.ts
@@ -1,0 +1,7 @@
+export {
+  type RoutingAssignment,
+  RoutingAssignmentPanel,
+  type RoutingAssignmentPanelLabels,
+  type RoutingAssignmentPanelProps,
+  type RoutingRole,
+} from "./routing-assignment-panel";

--- a/packages/ui/src/components/routing-assignment-panel/routing-assignment-panel.mdx
+++ b/packages/ui/src/components/routing-assignment-panel/routing-assignment-panel.mdx
@@ -1,0 +1,64 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './routing-assignment-panel.stories'
+
+<Meta of={Stories} />
+
+# RoutingAssignmentPanel
+
+Right-dock panel listing the agent slots the active route dispatches to: primary handler + fallbacks + shadow probes. Each row shows the agent name, role chip, and optional load bar. Pure presentation; the host computes the assignments from the routing config + observed traffic.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/routing-assignment-panel.json
+```
+
+## Import
+
+```tsx
+import { RoutingAssignmentPanel } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<RoutingAssignmentPanel
+  assignments={[
+    { id: "1", agent: "researcher",      role: "primary",  load: 0.82 },
+    { id: "2", agent: "researcher-mini", role: "fallback", load: 0.04 },
+    { id: "3", agent: "shadow-eval",     role: "shadow" },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Empty state
+
+When no assignments are provided, the panel renders a calm placeholder.
+
+<Canvas of={Stories.Empty} sourceState="shown" />
+
+## Primary only
+
+Routes with no fallbacks render as a single row.
+
+<Canvas of={Stories.PrimaryOnly} sourceState="shown" />
+
+## Non-interactive
+
+Omit \`onActivate\` and rows render as plain divs (no hover, no button semantics). Useful for read-only debug views.
+
+<Canvas of={Stories.NonInteractive} sourceState="shown" />
+
+## Notes
+
+- Role chips map: \`primary\` (emerald) · \`fallback\` (amber) · \`shadow\` (muted).
+- Load bar accepts \`0..1\` and clamps out-of-range values.
+- Each row emits \`data-routing-assignment\` (= id) + \`data-routing-role\`. The wrapper emits \`data-routing-assignment-panel\`.

--- a/packages/ui/src/components/routing-assignment-panel/routing-assignment-panel.stories.tsx
+++ b/packages/ui/src/components/routing-assignment-panel/routing-assignment-panel.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { RoutingAssignmentPanel } from "./routing-assignment-panel";
+
+const noop = (): void => undefined;
+
+const meta = {
+  args: {
+    assignments: [
+      {
+        agent: "researcher",
+        id: "1",
+        load: 0.82,
+        onActivate: noop,
+        role: "primary",
+      },
+      {
+        agent: "researcher-mini",
+        id: "2",
+        load: 0.04,
+        onActivate: noop,
+        role: "fallback",
+      },
+      { agent: "shadow-eval", id: "3", onActivate: noop, role: "shadow" },
+    ],
+  },
+  component: RoutingAssignmentPanel,
+  decorators: [
+    (Story) => (
+      <div className="w-72">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/RoutingAssignmentPanel",
+} satisfies Meta<typeof RoutingAssignmentPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: { assignments: [] },
+};
+
+export const PrimaryOnly: Story = {
+  args: {
+    assignments: [
+      { agent: "researcher", id: "1", load: 0.42, role: "primary" },
+    ],
+  },
+};
+
+export const NonInteractive: Story = {
+  args: {
+    assignments: [
+      { agent: "researcher", id: "1", load: 0.82, role: "primary" },
+      { agent: "researcher-mini", id: "2", load: 0.04, role: "fallback" },
+    ],
+  },
+};

--- a/packages/ui/src/components/routing-assignment-panel/routing-assignment-panel.test.tsx
+++ b/packages/ui/src/components/routing-assignment-panel/routing-assignment-panel.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type RoutingAssignment,
+  RoutingAssignmentPanel,
+} from "./routing-assignment-panel";
+
+const sample: RoutingAssignment[] = [
+  { agent: "researcher", id: "1", load: 0.82, role: "primary" },
+  { agent: "researcher-mini", id: "2", load: 0.04, role: "fallback" },
+  { agent: "shadow-eval", id: "3", role: "shadow" },
+];
+
+describe("RoutingAssignmentPanel", () => {
+  it("renders the empty state when no assignments are provided", () => {
+    const { container } = render(<RoutingAssignmentPanel assignments={[]} />);
+
+    expect(
+      container.querySelector("[data-routing-state='empty']"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No assignments")).toBeInTheDocument();
+  });
+
+  it("renders one row per assignment with the role chip", () => {
+    const { container } = render(
+      <RoutingAssignmentPanel assignments={sample} />,
+    );
+
+    expect(
+      container.querySelectorAll("[data-routing-assignment]"),
+    ).toHaveLength(3);
+    expect(screen.getByText("Primary")).toBeInTheDocument();
+    expect(screen.getByText("Fallback")).toBeInTheDocument();
+    expect(screen.getByText("Shadow")).toBeInTheDocument();
+  });
+
+  it("invokes onActivate when an interactive row is clicked", () => {
+    const handleActivate = vi.fn();
+    render(
+      <RoutingAssignmentPanel
+        assignments={[
+          {
+            agent: "researcher",
+            id: "x",
+            onActivate: handleActivate,
+            role: "primary",
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(handleActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders rows as plain divs when onActivate is omitted", () => {
+    render(<RoutingAssignmentPanel assignments={sample} />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("clamps load values into the 0..1 range", () => {
+    const { container } = render(
+      <RoutingAssignmentPanel
+        assignments={[{ agent: "x", id: "x", load: 5, role: "primary" }]}
+      />,
+    );
+
+    const bar = container.querySelector("[style*='width']");
+    expect(bar).toHaveAttribute("style", expect.stringContaining("100%"));
+  });
+});

--- a/packages/ui/src/components/routing-assignment-panel/routing-assignment-panel.tsx
+++ b/packages/ui/src/components/routing-assignment-panel/routing-assignment-panel.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Role of an agent in the routing graph.
+ *
+ * @public
+ */
+export type RoutingRole = "fallback" | "primary" | "shadow";
+
+const ROLE_LABEL: Record<RoutingRole, string> = {
+  fallback: "Fallback",
+  primary: "Primary",
+  shadow: "Shadow",
+};
+
+const ROLE_TONE: Record<RoutingRole, string> = {
+  fallback:
+    "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  primary:
+    "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  shadow: "border-border bg-muted/40 text-muted-foreground",
+};
+
+/**
+ * One row in the routing assignment list.
+ *
+ * @public
+ */
+export type RoutingAssignment = {
+  /** Display name (e.g. `"researcher"`, `"ranker"`). */
+  agent: ReactNode;
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Optional load fraction `0..1` rendered as a thin progress bar. */
+  load?: number;
+  /** Optional click handler — when provided, the row becomes a button. */
+  onActivate?: () => void;
+  /** Role of the agent for this slot. */
+  role: RoutingRole;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type RoutingAssignmentPanelLabels = {
+  /** Empty-state copy. Defaults to `"No assignments"`. */
+  empty?: string;
+  /** Aria-label for the panel. Defaults to `"Routing assignments"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No assignments",
+  region: "Routing assignments",
+} as const satisfies Required<RoutingAssignmentPanelLabels>;
+
+/**
+ * Props for {@link RoutingAssignmentPanel}.
+ *
+ * @public
+ */
+export type RoutingAssignmentPanelProps = {
+  /** Assignments in render order. */
+  assignments: RoutingAssignment[];
+  /** Localizable strings. */
+  labels?: RoutingAssignmentPanelLabels;
+  /** Panel title. Defaults to `"Routing"`. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const clampLoad = (value: number): number => {
+  if (value < 0) {
+    return 0;
+  }
+  if (value > 1) {
+    return 1;
+  }
+  return value;
+};
+
+const RowBody = (props: {
+  assignment: RoutingAssignment;
+}): React.ReactElement => {
+  const { assignment } = props;
+  const load =
+    assignment.load === undefined ? null : clampLoad(assignment.load);
+  return (
+    <span className="flex flex-1 flex-col gap-1">
+      <span className="flex items-center justify-between gap-2">
+        <span className="truncate text-xs text-foreground">
+          {assignment.agent}
+        </span>
+        <span
+          className={cn(
+            "rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
+            ROLE_TONE[assignment.role],
+          )}
+        >
+          {ROLE_LABEL[assignment.role]}
+        </span>
+      </span>
+      {load === null ? null : (
+        <span
+          aria-hidden="true"
+          className="h-1 w-full overflow-hidden rounded-full bg-muted/40"
+        >
+          <span
+            className="block h-full rounded-full bg-foreground/50"
+            style={{ width: `${load * 100}%` }}
+          />
+        </span>
+      )}
+    </span>
+  );
+};
+
+const Row = (props: { assignment: RoutingAssignment }): React.ReactElement => {
+  const { assignment } = props;
+  if (assignment.onActivate) {
+    const handleClick = (): void => {
+      assignment.onActivate?.();
+    };
+    return (
+      <button
+        className="flex w-full items-center gap-2 rounded-md border border-transparent px-2 py-1.5 text-left transition-colors hover:border-border hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        data-routing-assignment={assignment.id}
+        data-routing-role={assignment.role}
+        onClick={handleClick}
+        type="button"
+      >
+        <RowBody assignment={assignment} />
+      </button>
+    );
+  }
+  return (
+    <div
+      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5"
+      data-routing-assignment={assignment.id}
+      data-routing-role={assignment.role}
+    >
+      <RowBody assignment={assignment} />
+    </div>
+  );
+};
+
+/**
+ * Right-dock panel listing the agent slots that the active route
+ * dispatches to: primary handler + fallbacks + shadow probes. Each row
+ * shows the agent name, role chip, and optional load bar. Pure
+ * presentation; the host computes the assignments from the routing
+ * config + observed traffic.
+ *
+ * @example
+ * ```tsx
+ * <RoutingAssignmentPanel
+ *   assignments={[
+ *     { id: "1", agent: "researcher",     role: "primary",  load: 0.82 },
+ *     { id: "2", agent: "researcher-mini", role: "fallback", load: 0.04 },
+ *     { id: "3", agent: "shadow-eval",    role: "shadow" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const RoutingAssignmentPanel = forwardRef<
+  HTMLElement,
+  RoutingAssignmentPanelProps
+>((props, ref) => {
+  const { assignments, className, labels, title = "Routing", ...rest } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  return (
+    <section
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "flex w-full flex-col gap-2 rounded-lg border bg-background p-3 text-foreground",
+        className,
+      )}
+      data-routing-assignment-panel
+      ref={ref}
+      {...rest}
+    >
+      <header>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {title}
+        </h3>
+      </header>
+      {assignments.length === 0 ? (
+        <p
+          className="px-2 py-3 text-center text-xs text-muted-foreground"
+          data-routing-state="empty"
+        >
+          {resolvedLabels.empty}
+        </p>
+      ) : (
+        <ul className="space-y-0.5">
+          {assignments.map((assignment) => (
+            <li key={assignment.id}>
+              <Row assignment={assignment} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+});
+RoutingAssignmentPanel.displayName = "RoutingAssignmentPanel";

--- a/packages/ui/src/components/routing-assignment-panel/routing-assignment-panel.visual.tsx
+++ b/packages/ui/src/components/routing-assignment-panel/routing-assignment-panel.visual.tsx
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { RoutingAssignmentPanel } from "./routing-assignment-panel";
+
+test.describe("RoutingAssignmentPanel Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="w-72 p-4">
+        <RoutingAssignmentPanel
+          assignments={[
+            { agent: "researcher", id: "1", load: 0.82, role: "primary" },
+            {
+              agent: "researcher-mini",
+              id: "2",
+              load: 0.04,
+              role: "fallback",
+            },
+            { agent: "shadow-eval", id: "3", role: "shadow" },
+          ]}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "routing-assignment-panel-default.png",
+    );
+  });
+});

--- a/packages/ui/src/components/runtime-overview-panel/index.ts
+++ b/packages/ui/src/components/runtime-overview-panel/index.ts
@@ -1,0 +1,8 @@
+export {
+  type RuntimeMetric,
+  type RuntimeMetricTone,
+  type RuntimeMetricTrend,
+  RuntimeOverviewPanel,
+  type RuntimeOverviewPanelLabels,
+  type RuntimeOverviewPanelProps,
+} from "./runtime-overview-panel";

--- a/packages/ui/src/components/runtime-overview-panel/runtime-overview-panel.mdx
+++ b/packages/ui/src/components/runtime-overview-panel/runtime-overview-panel.mdx
@@ -1,0 +1,66 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './runtime-overview-panel.stories'
+
+<Meta of={Stories} />
+
+# RuntimeOverviewPanel
+
+Top-of-dock summary for the runtime when nothing on the canvas is selected. Renders a compact 2-column grid of metric tiles — active runs, throughput, error rate, latency. Pure presentation; the host computes the metric list from the runtime stream.
+
+Pairs with \`ObjectInspector\`: when a canvas object becomes the focus, swap to \`ObjectInspector\`; when selection clears, fall back to \`RuntimeOverviewPanel\`.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/runtime-overview-panel.json
+```
+
+## Import
+
+```tsx
+import { RuntimeOverviewPanel } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<RuntimeOverviewPanel
+  metrics={[
+    { id: "runs", label: "Active runs", value: 3, tone: "success" },
+    { id: "errs", label: "Errors / hr", value: 0, tone: "neutral", trend: "flat" },
+    { id: "tps",  label: "Throughput",  value: "120 / s", tone: "success", trend: "up" },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Empty state
+
+When the metric list is empty, the panel renders a calm placeholder.
+
+<Canvas of={Stories.Empty} sourceState="shown" />
+
+## All healthy
+
+\`tone: "success"\` across the grid renders a uniformly green dot row.
+
+<Canvas of={Stories.AllHealthy} sourceState="shown" />
+
+## Degraded
+
+Mixed tones (\`warn\`, \`danger\`) communicate degradation without shouting.
+
+<Canvas of={Stories.Degraded} sourceState="shown" />
+
+## Notes
+
+- Tone dots map: \`neutral\` (muted) · \`success\` (emerald) · \`warn\` (amber) · \`danger\` (red).
+- Trend glyphs map: \`up\` ↑ · \`flat\` · · \`down\` ↓.
+- Each tile emits \`data-runtime-metric\` (= id) + \`data-runtime-tone\` for analytics + CSS hooks. The grid emits \`data-runtime-grid\`.

--- a/packages/ui/src/components/runtime-overview-panel/runtime-overview-panel.stories.tsx
+++ b/packages/ui/src/components/runtime-overview-panel/runtime-overview-panel.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { RuntimeOverviewPanel } from "./runtime-overview-panel";
+
+const meta = {
+  args: {
+    metrics: [
+      { id: "runs", label: "Active runs", tone: "success", trend: "up", value: 3 },
+      {
+        detail: "0 last hour",
+        id: "errs",
+        label: "Errors",
+        tone: "neutral",
+        trend: "flat",
+        value: 0,
+      },
+      {
+        id: "tps",
+        label: "Throughput",
+        tone: "success",
+        trend: "up",
+        value: "120 / s",
+      },
+      {
+        detail: "p95 240ms",
+        id: "lat",
+        label: "Latency",
+        tone: "warn",
+        trend: "down",
+        value: "180ms",
+      },
+    ],
+  },
+  component: RuntimeOverviewPanel,
+  decorators: [
+    (Story) => (
+      <div className="w-72">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/RuntimeOverviewPanel",
+} satisfies Meta<typeof RuntimeOverviewPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: { metrics: [] },
+};
+
+export const AllHealthy: Story = {
+  args: {
+    metrics: [
+      { id: "runs", label: "Active runs", tone: "success", value: 5 },
+      { id: "errs", label: "Errors", tone: "success", value: 0 },
+      { id: "tps", label: "Throughput", tone: "success", value: "240 / s" },
+      { id: "lat", label: "Latency", tone: "success", value: "85ms" },
+    ],
+  },
+};
+
+export const Degraded: Story = {
+  args: {
+    metrics: [
+      {
+        detail: "queue backed up",
+        id: "runs",
+        label: "Active runs",
+        tone: "warn",
+        value: 12,
+      },
+      {
+        detail: "rate-limit hit",
+        id: "errs",
+        label: "Errors",
+        tone: "danger",
+        trend: "up",
+        value: 14,
+      },
+      {
+        id: "tps",
+        label: "Throughput",
+        tone: "warn",
+        trend: "down",
+        value: "60 / s",
+      },
+      {
+        detail: "p95 1.2s",
+        id: "lat",
+        label: "Latency",
+        tone: "danger",
+        trend: "up",
+        value: "880ms",
+      },
+    ],
+  },
+};

--- a/packages/ui/src/components/runtime-overview-panel/runtime-overview-panel.test.tsx
+++ b/packages/ui/src/components/runtime-overview-panel/runtime-overview-panel.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  type RuntimeMetric,
+  RuntimeOverviewPanel,
+} from "./runtime-overview-panel";
+
+const sample: RuntimeMetric[] = [
+  { id: "runs", label: "Active runs", tone: "success", value: 3 },
+  {
+    detail: "stable",
+    id: "tps",
+    label: "Throughput",
+    tone: "success",
+    trend: "up",
+    value: "120 / s",
+  },
+];
+
+describe("RuntimeOverviewPanel", () => {
+  it("renders the empty state when metrics list is empty", () => {
+    const { container } = render(<RuntimeOverviewPanel metrics={[]} />);
+
+    expect(
+      container.querySelector("[data-runtime-state='empty']"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No runtime metrics")).toBeInTheDocument();
+  });
+
+  it("renders one tile per metric", () => {
+    const { container } = render(<RuntimeOverviewPanel metrics={sample} />);
+
+    expect(container.querySelectorAll("[data-runtime-metric]")).toHaveLength(2);
+  });
+
+  it("propagates tone to the tile data attribute", () => {
+    const { container } = render(<RuntimeOverviewPanel metrics={sample} />);
+
+    expect(
+      container.querySelector("[data-runtime-metric='runs']"),
+    ).toHaveAttribute("data-runtime-tone", "success");
+  });
+
+  it("renders the optional detail line", () => {
+    render(<RuntimeOverviewPanel metrics={sample} />);
+
+    expect(screen.getByText("stable")).toBeInTheDocument();
+  });
+
+  it("renders the title", () => {
+    render(<RuntimeOverviewPanel metrics={sample} title="Live" />);
+
+    expect(screen.getByText("Live")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/runtime-overview-panel/runtime-overview-panel.tsx
+++ b/packages/ui/src/components/runtime-overview-panel/runtime-overview-panel.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Trend direction for a runtime metric.
+ *
+ * @public
+ */
+export type RuntimeMetricTrend = "down" | "flat" | "up";
+
+/**
+ * Tone of the metric value — drives the dot color.
+ *
+ * @public
+ */
+export type RuntimeMetricTone = "danger" | "neutral" | "success" | "warn";
+
+/**
+ * One metric tile in the runtime overview.
+ *
+ * @public
+ */
+export type RuntimeMetric = {
+  /** Optional secondary line (delta, target, owner). */
+  detail?: ReactNode;
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Short label (e.g. `"Active runs"`). */
+  label: ReactNode;
+  /** Optional tone for the dot. Defaults to `"neutral"`. */
+  tone?: RuntimeMetricTone;
+  /** Optional trend arrow next to the value. */
+  trend?: RuntimeMetricTrend;
+  /** Display value (already formatted by the host). */
+  value: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type RuntimeOverviewPanelLabels = {
+  /** Empty-state copy. Defaults to `"No runtime metrics"`. */
+  empty?: string;
+  /** Aria-label for the panel. Defaults to `"Runtime overview"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No runtime metrics",
+  region: "Runtime overview",
+} as const satisfies Required<RuntimeOverviewPanelLabels>;
+
+const TONE_DOT: Record<RuntimeMetricTone, string> = {
+  danger: "bg-red-500",
+  neutral: "bg-muted-foreground",
+  success: "bg-emerald-500",
+  warn: "bg-amber-500",
+};
+
+const TREND_GLYPH: Record<RuntimeMetricTrend, string> = {
+  down: "↓",
+  flat: "·",
+  up: "↑",
+};
+
+/**
+ * Props for {@link RuntimeOverviewPanel}.
+ *
+ * @public
+ */
+export type RuntimeOverviewPanelProps = {
+  /** Localizable strings. */
+  labels?: RuntimeOverviewPanelLabels;
+  /** Metric tiles in render order. */
+  metrics: RuntimeMetric[];
+  /** Panel title. Defaults to `"Runtime"`. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const Tile = (props: { metric: RuntimeMetric }): React.ReactElement => {
+  const { metric } = props;
+  const tone = metric.tone ?? "neutral";
+  return (
+    <li
+      className="flex flex-col gap-1 rounded-md border border-border/60 bg-muted/20 px-2.5 py-2"
+      data-runtime-metric={metric.id}
+      data-runtime-tone={tone}
+    >
+      <span className="flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+        <span
+          aria-hidden="true"
+          className={cn("h-1.5 w-1.5 rounded-full", TONE_DOT[tone])}
+        />
+        {metric.label}
+      </span>
+      <span className="flex items-baseline gap-1.5 text-sm font-semibold text-foreground">
+        <span>{metric.value}</span>
+        {metric.trend ? (
+          <span
+            aria-hidden="true"
+            className="text-[10px] text-muted-foreground"
+          >
+            {TREND_GLYPH[metric.trend]}
+          </span>
+        ) : null}
+      </span>
+      {metric.detail ? (
+        <span className="text-[10px] text-muted-foreground">
+          {metric.detail}
+        </span>
+      ) : null}
+    </li>
+  );
+};
+
+/**
+ * Top-of-dock summary for the runtime when nothing on the canvas is
+ * selected. Renders a compact grid of metric tiles (active runs,
+ * throughput, error rate, etc.). Pure presentation; the host computes
+ * the metric list from the runtime stream.
+ *
+ * @example
+ * ```tsx
+ * <RuntimeOverviewPanel
+ *   metrics={[
+ *     { id: "runs",  label: "Active runs", value: 3, tone: "success" },
+ *     { id: "errs",  label: "Errors / hr", value: 0, tone: "neutral", trend: "flat" },
+ *     { id: "tps",   label: "Throughput", value: "120 / s", tone: "success", trend: "up" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const RuntimeOverviewPanel = forwardRef<
+  HTMLElement,
+  RuntimeOverviewPanelProps
+>((props, ref) => {
+  const { className, labels, metrics, title = "Runtime", ...rest } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  return (
+    <section
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "flex w-full flex-col gap-2 rounded-2xl border bg-background p-3 text-foreground",
+        className,
+      )}
+      data-runtime-overview-panel
+      ref={ref}
+      {...rest}
+    >
+      <header>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {title}
+        </h3>
+      </header>
+      {metrics.length === 0 ? (
+        <p
+          className="px-2 py-3 text-center text-xs text-muted-foreground"
+          data-runtime-state="empty"
+        >
+          {resolvedLabels.empty}
+        </p>
+      ) : (
+        <ul className="grid grid-cols-2 gap-1.5" data-runtime-grid>
+          {metrics.map((metric) => (
+            <Tile key={metric.id} metric={metric} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+});
+RuntimeOverviewPanel.displayName = "RuntimeOverviewPanel";

--- a/packages/ui/src/components/runtime-overview-panel/runtime-overview-panel.visual.tsx
+++ b/packages/ui/src/components/runtime-overview-panel/runtime-overview-panel.visual.tsx
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { RuntimeOverviewPanel } from "./runtime-overview-panel";
+
+test.describe("RuntimeOverviewPanel Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="w-72 p-4">
+        <RuntimeOverviewPanel
+          metrics={[
+            {
+              id: "runs",
+              label: "Active runs",
+              tone: "success",
+              trend: "up",
+              value: 3,
+            },
+            {
+              detail: "0 last hour",
+              id: "errs",
+              label: "Errors",
+              tone: "neutral",
+              trend: "flat",
+              value: 0,
+            },
+            {
+              id: "tps",
+              label: "Throughput",
+              tone: "success",
+              trend: "up",
+              value: "120 / s",
+            },
+            {
+              detail: "p95 240ms",
+              id: "lat",
+              label: "Latency",
+              tone: "warn",
+              trend: "down",
+              value: "180ms",
+            },
+          ]}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "runtime-overview-panel-default.png",
+    );
+  });
+});


### PR DESCRIPTION
Closes #134

## What's in

Three calm right-dock panels for the spatial canvas (issue #134):

- **RuntimeOverviewPanel** — top-of-dock metric tile grid for the runtime when no canvas object is selected. Active runs / throughput / errors / latency, each with tone dot (neutral / success / warn / danger) and optional trend arrow (up / flat / down).
- **RoutingAssignmentPanel** — agent slots the active route dispatches to: primary handler + fallbacks + shadow probes. Role chips (emerald / amber / muted), optional clamped \`0..1\` load bar, optional click-to-jump.
- **PolicyDeliveryPanel** — guardrails / policies applied to the active route or run. Status chips: \`enforced\` / \`advisory\` / \`disabled\`. Optional toggle handler for admin views.

All three are pure presentation; the host computes the metric / slot / policy lists from the live runtime + config. Pairs with PR #198 (PropertySection + ObjectInspector + RelationshipInspector) to fill out the right dock.

## Files

- \`packages/ui/src/components/runtime-overview-panel/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/routing-assignment-panel/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/policy-delivery-panel/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/index.ts\` — barrel exports
- \`apps/registry/registry/default/{runtime-overview-panel,routing-assignment-panel,policy-delivery-panel}/*.tsx\` — registry shims
- \`apps/registry/registry.json\` — three new entries

## Out of scope (deferred to follow-up #134 PRs)

- JarvisDock — global command palette / agent dock
- MultiSelectLasso — canvas multi-select gesture
- ContextLens — focus-context overlay

## Quality gates

- lint: PASS (\`eslint --fix\` clean)
- typecheck: PASS (\`tsc --noEmit --project tsconfig.build.json\`)
- check:use-client: PASS (182 components)
- check:story-coverage: PASS (172 components)
- verify-stories: PASS (no crash risks)
- test: PASS (508 / 508 — incl. 15 new)
- build (\`@vllnt/ui\`): PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)
- [ ] Storybook renders all 12 stories (4 per primitive) without console errors
- [ ] Visual snapshots stable across primitives