### PR TITLE
feat(ui): canvas overlays — JarvisDock + MultiSelectLasso + ContextLens (final #134)

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -688,6 +688,21 @@
       "category": "content"
     },
     {
+      "name": "context-lens",
+      "type": "registry:component",
+      "title": "Context Lens",
+      "description": "Vignette overlay that dims the canvas outside a circular focus region.",
+      "files": [
+        {
+          "path": "registry/default/context-lens/context-lens.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "utility"
+    },
+    {
       "name": "context-menu",
       "type": "registry:component",
       "title": "Context Menu",
@@ -1087,6 +1102,21 @@
       "category": "form"
     },
     {
+      "name": "jarvis-dock",
+      "type": "registry:component",
+      "title": "Jarvis Dock",
+      "description": "Floating bottom dock with quick-action buttons + a command-palette trigger.",
+      "files": [
+        {
+          "path": "registry/default/jarvis-dock/jarvis-dock.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "navigation"
+    },
+    {
       "name": "key-concept",
       "type": "registry:component",
       "title": "Key Concept",
@@ -1345,6 +1375,21 @@
       ],
       "dependencies": [],
       "category": "form"
+    },
+    {
+      "name": "multi-select-lasso",
+      "type": "registry:component",
+      "title": "Multi Select Lasso",
+      "description": "Selection rectangle overlay for canvas multi-select gestures.",
+      "files": [
+        {
+          "path": "registry/default/multi-select-lasso/multi-select-lasso.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "utility"
     },
     {
       "name": "navbar-saas",

--- a/apps/registry/registry/default/context-lens/context-lens.tsx
+++ b/apps/registry/registry/default/context-lens/context-lens.tsx
@@ -1,0 +1,6 @@
+export {
+  ContextLens,
+  type ContextLensFocus,
+  type ContextLensLabels,
+  type ContextLensProps,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/jarvis-dock/jarvis-dock.tsx
+++ b/apps/registry/registry/default/jarvis-dock/jarvis-dock.tsx
@@ -1,0 +1,7 @@
+export {
+  JarvisDock,
+  type JarvisDockAction,
+  type JarvisDockLabels,
+  type JarvisDockProps,
+  type JarvisDockTone,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/multi-select-lasso/multi-select-lasso.tsx
+++ b/apps/registry/registry/default/multi-select-lasso/multi-select-lasso.tsx
@@ -1,0 +1,6 @@
+export {
+  type LassoRect,
+  MultiSelectLasso,
+  type MultiSelectLassoLabels,
+  type MultiSelectLassoProps,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/context-lens/context-lens.mdx
+++ b/packages/ui/src/components/context-lens/context-lens.mdx
@@ -1,0 +1,63 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './context-lens.stories'
+
+<Meta of={Stories} />
+
+# ContextLens
+
+Vignette overlay that dims the canvas outside a circular focus region. Use to draw the eye to a selection, run, or recently-changed object. Pure presentation; the host computes the focus center + radii from the active selection's bounding box.
+
+The lens is \`pointer-events: none\` — host gestures pass through.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/context-lens.json
+```
+
+## Import
+
+```tsx
+import { ContextLens } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<div className="relative h-screen w-screen">
+  <Canvas />
+  <ContextLens focus={{ cx: 480, cy: 320, inner: 90, outer: 180 }} />
+</div>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Tight focus
+
+Smaller \`inner\` + \`outer\` and higher \`opacity\` produce a sharp spotlight.
+
+<Canvas of={Stories.Tight} sourceState="shown" />
+
+## Soft focus
+
+Larger radii + lower \`opacity\` produce a gentle vignette that hints rather than commands attention.
+
+<Canvas of={Stories.Soft} sourceState="shown" />
+
+## Hidden
+
+\`focus={null}\` returns nothing — pass selection state directly without conditional wrapping.
+
+<Canvas of={Stories.Hidden} sourceState="shown" />
+
+## Notes
+
+- Negative or inverted radii are clamped: \`inner\` floors at \`0\`, \`outer\` floors at \`inner\`.
+- \`opacity\` is clamped into \`0..1\`.
+- Each render emits \`data-context-lens\` plus \`data-context-lens-dim\` and \`data-context-lens-gradient\` for analytics + CSS hooks.

--- a/packages/ui/src/components/context-lens/context-lens.stories.tsx
+++ b/packages/ui/src/components/context-lens/context-lens.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ContextLens } from "./context-lens";
+
+const meta = {
+  args: {
+    focus: { cx: 240, cy: 160, inner: 60, outer: 160 },
+    opacity: 0.55,
+  },
+  component: ContextLens,
+  decorators: [
+    (Story) => (
+      <div
+        className="relative overflow-hidden rounded-lg border bg-gradient-to-br from-blue-500/40 to-emerald-500/40"
+        style={{ height: 320, width: 480 }}
+      >
+        <div className="absolute inset-0 grid grid-cols-6 grid-rows-4 gap-2 p-3">
+          {Array.from({ length: 24 }).map((_, idx) => (
+            <div
+              className="rounded-md bg-white/40"
+              key={`tile-${idx}`}
+            />
+          ))}
+        </div>
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/ContextLens",
+} satisfies Meta<typeof ContextLens>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Tight: Story = {
+  args: {
+    focus: { cx: 240, cy: 160, inner: 30, outer: 80 },
+    opacity: 0.7,
+  },
+};
+
+export const Soft: Story = {
+  args: {
+    focus: { cx: 240, cy: 160, inner: 100, outer: 220 },
+    opacity: 0.35,
+  },
+};
+
+export const Hidden: Story = {
+  args: { focus: null },
+};

--- a/packages/ui/src/components/context-lens/context-lens.test.tsx
+++ b/packages/ui/src/components/context-lens/context-lens.test.tsx
@@ -1,0 +1,50 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ContextLens } from "./context-lens";
+
+describe("ContextLens", () => {
+  it("renders nothing when focus is null", () => {
+    const { container } = render(<ContextLens focus={null} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the SVG layer when focus is provided", () => {
+    const { container } = render(
+      <ContextLens focus={{ cx: 100, cy: 100, inner: 30, outer: 80 }} />,
+    );
+
+    expect(container.querySelector("[data-context-lens]")).toBeInTheDocument();
+  });
+
+  it("clamps inner radius to non-negative", () => {
+    const { container } = render(
+      <ContextLens focus={{ cx: 0, cy: 0, inner: -5, outer: 50 }} />,
+    );
+
+    const gradient = container.querySelector("[data-context-lens-gradient]");
+    expect(gradient).toHaveAttribute("r", "50");
+  });
+
+  it("clamps outer radius to be at least inner", () => {
+    const { container } = render(
+      <ContextLens focus={{ cx: 0, cy: 0, inner: 60, outer: 30 }} />,
+    );
+
+    const gradient = container.querySelector("[data-context-lens-gradient]");
+    expect(gradient).toHaveAttribute("r", "60");
+  });
+
+  it("clamps opacity into 0..1", () => {
+    const { container } = render(
+      <ContextLens
+        focus={{ cx: 0, cy: 0, inner: 10, outer: 50 }}
+        opacity={5}
+      />,
+    );
+
+    const dim = container.querySelector("[data-context-lens-dim]");
+    expect(dim).toHaveAttribute("fill-opacity", "1");
+  });
+});

--- a/packages/ui/src/components/context-lens/context-lens.tsx
+++ b/packages/ui/src/components/context-lens/context-lens.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { type ComponentPropsWithoutRef, forwardRef, useId } from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Focus point — pixel coordinates relative to the canvas viewport.
+ *
+ * @public
+ */
+export type ContextLensFocus = {
+  /** Center X of the lens. */
+  cx: number;
+  /** Center Y of the lens. */
+  cy: number;
+  /** Inner radius — fully transparent inside this circle. */
+  inner: number;
+  /** Outer radius — full dim beyond this circle. */
+  outer: number;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type ContextLensLabels = {
+  /** Aria-label for the lens layer. Defaults to `"Context lens"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Context lens",
+} as const satisfies Required<ContextLensLabels>;
+
+/**
+ * Props for {@link ContextLens}.
+ *
+ * @public
+ */
+export type ContextLensProps = {
+  /** Lens geometry. When `null`, no lens renders (full surface unobscured). */
+  focus: ContextLensFocus | null;
+  /** Localizable strings. */
+  labels?: ContextLensLabels;
+  /** Dim opacity outside the outer ring (0..1). Defaults to `0.55`. */
+  opacity?: number;
+} & ComponentPropsWithoutRef<"svg">;
+
+const clamp01 = (value: number): number => {
+  if (value < 0) {
+    return 0;
+  }
+  if (value > 1) {
+    return 1;
+  }
+  return value;
+};
+
+const safeRadius = (value: number): number => (value < 0 ? 0 : value);
+
+/**
+ * Vignette overlay that dims the canvas outside a circular focus
+ * region. Use to draw the eye to a selection, an active run, or any
+ * single object the user must attend to. Pure presentation; the host
+ * computes the focus center + radii from the active selection's
+ * bounding box.
+ *
+ * The lens is `pointer-events: none` — host gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <ContextLens focus={{ cx: 480, cy: 320, inner: 90, outer: 180 }} />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const ContextLens = forwardRef<SVGSVGElement, ContextLensProps>(
+  (props, ref) => {
+    const { className, focus, labels, opacity = 0.55, ...rest } = props;
+    const maskId = useId();
+    if (!focus) {
+      return null;
+    }
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const inner = safeRadius(focus.inner);
+    const outer = safeRadius(Math.max(focus.outer, inner));
+    const fillOpacity = clamp01(opacity);
+    return (
+      <svg
+        aria-hidden="true"
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "pointer-events-none absolute inset-0 z-20 h-full w-full",
+          className,
+        )}
+        data-context-lens
+        ref={ref}
+        {...rest}
+      >
+        <defs>
+          <radialGradient
+            cx={focus.cx}
+            cy={focus.cy}
+            data-context-lens-gradient
+            gradientUnits="userSpaceOnUse"
+            id={maskId}
+            r={outer === 0 ? 1 : outer}
+          >
+            <stop offset="0%" stopColor="black" stopOpacity={0} />
+            <stop
+              offset={outer === 0 ? "100%" : `${(inner / outer) * 100}%`}
+              stopColor="black"
+              stopOpacity={0}
+            />
+            <stop offset="100%" stopColor="black" stopOpacity={1} />
+          </radialGradient>
+        </defs>
+        <rect
+          data-context-lens-dim
+          fill="black"
+          fillOpacity={fillOpacity}
+          height="100%"
+          mask={`url(#${maskId}-mask)`}
+          width="100%"
+          x={0}
+          y={0}
+        />
+        <mask id={`${maskId}-mask`}>
+          <rect fill="white" height="100%" width="100%" x={0} y={0} />
+          <circle
+            cx={focus.cx}
+            cy={focus.cy}
+            fill={`url(#${maskId})`}
+            r={outer}
+          />
+        </mask>
+      </svg>
+    );
+  },
+);
+ContextLens.displayName = "ContextLens";

--- a/packages/ui/src/components/context-lens/context-lens.visual.tsx
+++ b/packages/ui/src/components/context-lens/context-lens.visual.tsx
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { ContextLens } from "./context-lens";
+
+test.describe("ContextLens Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div
+        className="relative overflow-hidden rounded-lg border bg-gradient-to-br from-blue-500/40 to-emerald-500/40"
+        style={{ height: 320, width: 480 }}
+      >
+        <div className="absolute inset-0 grid grid-cols-6 grid-rows-4 gap-2 p-3">
+          {Array.from({ length: 24 }).map((_, idx) => (
+            <div
+              className="rounded-md bg-white/40"
+              key={`tile-${idx}`}
+            />
+          ))}
+        </div>
+        <ContextLens focus={{ cx: 240, cy: 160, inner: 60, outer: 160 }} />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("context-lens-default.png");
+  });
+});

--- a/packages/ui/src/components/context-lens/index.ts
+++ b/packages/ui/src/components/context-lens/index.ts
@@ -1,0 +1,6 @@
+export {
+  ContextLens,
+  type ContextLensFocus,
+  type ContextLensLabels,
+  type ContextLensProps,
+} from "./context-lens";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -789,6 +789,12 @@ export {
   type ConnectorEdgePoint,
   type ConnectorEdgeProps,
 } from "./connector-edge";
+export {
+  ContextLens,
+  type ContextLensFocus,
+  type ContextLensLabels,
+  type ContextLensProps,
+} from "./context-lens";
 export { EdgeLabel, type EdgeLabelProps } from "./edge-label";
 export { GroupHull, type GroupHullProps } from "./group-hull";
 export {
@@ -798,6 +804,13 @@ export {
   type HeatOverlayTone,
   type HeatPoint,
 } from "./heat-overlay";
+export {
+  JarvisDock,
+  type JarvisDockAction,
+  type JarvisDockLabels,
+  type JarvisDockProps,
+  type JarvisDockTone,
+} from "./jarvis-dock";
 export {
   LiveCursor,
   type LiveCursorLabels,
@@ -811,6 +824,12 @@ export {
   type MetricClusterProps,
   type MetricClusterTone,
 } from "./metric-cluster";
+export {
+  type LassoRect,
+  MultiSelectLasso,
+  type MultiSelectLassoLabels,
+  type MultiSelectLassoProps,
+} from "./multi-select-lasso";
 export {
   ObjectCard,
   type ObjectCardAction,

--- a/packages/ui/src/components/jarvis-dock/index.ts
+++ b/packages/ui/src/components/jarvis-dock/index.ts
@@ -1,0 +1,7 @@
+export {
+  JarvisDock,
+  type JarvisDockAction,
+  type JarvisDockLabels,
+  type JarvisDockProps,
+  type JarvisDockTone,
+} from "./jarvis-dock";

--- a/packages/ui/src/components/jarvis-dock/jarvis-dock.mdx
+++ b/packages/ui/src/components/jarvis-dock/jarvis-dock.mdx
@@ -1,0 +1,61 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './jarvis-dock.stories'
+
+<Meta of={Stories} />
+
+# JarvisDock
+
+Floating bottom dock for the spatial canvas. Renders a compact row of agent / quick-action buttons plus a trailing command-palette trigger (⌘). Pure presentation; the host wires \`onActivate\` per action and \`onOpenPalette\` for the palette button.
+
+Pairs with the right-dock inspector primitives (\`ObjectInspector\`, \`PropertySection\`, \`RelationshipInspector\`, \`RuntimeOverviewPanel\`, \`RoutingAssignmentPanel\`, \`PolicyDeliveryPanel\`) to form the full canvas chrome.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/jarvis-dock.json
+```
+
+## Import
+
+```tsx
+import { JarvisDock } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<JarvisDock
+  actions={[
+    { id: "summon", glyph: "+", label: "Summon", tone: "primary",
+      onActivate: () => spawnAgent() },
+    { id: "review", glyph: "✓", label: "Review", tone: "success",
+      onActivate: () => openReview() },
+  ]}
+  onOpenPalette={() => openCommandPalette()}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## No palette
+
+Drop \`onOpenPalette\` to render the dock without the trailing ⌘ trigger.
+
+<Canvas of={Stories.NoPalette} sourceState="shown" />
+
+## With badges
+
+Each action accepts an optional \`badge\` slot — a count, dot, or short label rendered top-right.
+
+<Canvas of={Stories.WithBadges} sourceState="shown" />
+
+## Notes
+
+- Tone classes map: \`neutral\` (foreground) · \`primary\` (blue) · \`success\` (emerald) · \`danger\` (red).
+- Each action button emits \`data-jarvis-action\` (= id) + \`data-jarvis-tone\`. The wrapper emits \`data-jarvis-dock\`. Badges emit \`data-jarvis-badge\`. The palette trigger emits \`data-jarvis-palette-trigger\`.

--- a/packages/ui/src/components/jarvis-dock/jarvis-dock.stories.tsx
+++ b/packages/ui/src/components/jarvis-dock/jarvis-dock.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { JarvisDock } from "./jarvis-dock";
+
+const noop = (): void => undefined;
+
+const meta = {
+  args: {
+    actions: [
+      {
+        glyph: "+",
+        id: "summon",
+        label: "Summon",
+        onActivate: noop,
+        tone: "primary",
+      },
+      {
+        badge: "3",
+        glyph: "✓",
+        id: "review",
+        label: "Review",
+        onActivate: noop,
+        tone: "success",
+      },
+      { glyph: "↻", id: "retry", label: "Retry", onActivate: noop },
+      { glyph: "⏵", id: "play", label: "Play", onActivate: noop },
+      {
+        glyph: "⏸",
+        id: "pause",
+        label: "Pause",
+        onActivate: noop,
+        tone: "danger",
+      },
+    ],
+    onOpenPalette: noop,
+  },
+  component: JarvisDock,
+  decorators: [
+    (Story) => (
+      <div className="flex items-center justify-center bg-muted/40 p-8">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/JarvisDock",
+} satisfies Meta<typeof JarvisDock>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const NoPalette: Story = {
+  args: { onOpenPalette: undefined },
+};
+
+export const ActionsOnly: Story = {
+  args: {
+    actions: [
+      { glyph: "+", id: "summon", label: "Summon", onActivate: noop },
+    ],
+    onOpenPalette: undefined,
+  },
+};
+
+export const WithBadges: Story = {
+  args: {
+    actions: [
+      {
+        badge: "•",
+        glyph: "✉",
+        id: "inbox",
+        label: "Inbox",
+        onActivate: noop,
+        tone: "primary",
+      },
+      {
+        badge: "12",
+        glyph: "!",
+        id: "alerts",
+        label: "Alerts",
+        onActivate: noop,
+        tone: "danger",
+      },
+      {
+        badge: "2",
+        glyph: "✓",
+        id: "review",
+        label: "Review",
+        onActivate: noop,
+        tone: "success",
+      },
+    ],
+  },
+};

--- a/packages/ui/src/components/jarvis-dock/jarvis-dock.test.tsx
+++ b/packages/ui/src/components/jarvis-dock/jarvis-dock.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { JarvisDock, type JarvisDockAction } from "./jarvis-dock";
+
+const buildActions = (
+  overrides: Partial<JarvisDockAction> = {},
+): JarvisDockAction[] => [
+  {
+    glyph: "+",
+    id: "summon",
+    label: "Summon",
+    onActivate: vi.fn(),
+    tone: "primary",
+    ...overrides,
+  },
+  {
+    glyph: "✓",
+    id: "review",
+    label: "Review",
+    onActivate: vi.fn(),
+    tone: "success",
+  },
+];
+
+describe("JarvisDock", () => {
+  it("renders one button per action with the label", () => {
+    const actions = buildActions();
+    render(<JarvisDock actions={actions} />);
+
+    expect(screen.getByText("Summon")).toBeInTheDocument();
+    expect(screen.getByText("Review")).toBeInTheDocument();
+  });
+
+  it("invokes onActivate when an action is clicked", () => {
+    const handleActivate = vi.fn();
+    render(
+      <JarvisDock
+        actions={[
+          {
+            glyph: "+",
+            id: "summon",
+            label: "Summon",
+            onActivate: handleActivate,
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Summon"));
+    expect(handleActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the palette trigger only when onOpenPalette is provided", () => {
+    const { container, rerender } = render(
+      <JarvisDock actions={buildActions()} />,
+    );
+
+    expect(
+      container.querySelector("[data-jarvis-palette-trigger]"),
+    ).not.toBeInTheDocument();
+
+    rerender(<JarvisDock actions={buildActions()} onOpenPalette={vi.fn()} />);
+    expect(
+      container.querySelector("[data-jarvis-palette-trigger]"),
+    ).toBeInTheDocument();
+  });
+
+  it("invokes onOpenPalette when the palette trigger is clicked", () => {
+    const handleOpen = vi.fn();
+    render(<JarvisDock actions={buildActions()} onOpenPalette={handleOpen} />);
+
+    fireEvent.click(screen.getByLabelText("Open command palette"));
+    expect(handleOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the badge when provided", () => {
+    render(
+      <JarvisDock
+        actions={[
+          {
+            badge: "3",
+            glyph: "+",
+            id: "summon",
+            label: "Summon",
+            onActivate: vi.fn(),
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/jarvis-dock/jarvis-dock.tsx
+++ b/packages/ui/src/components/jarvis-dock/jarvis-dock.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Tone of a dock action — drives its accent color.
+ *
+ * @public
+ */
+export type JarvisDockTone = "danger" | "neutral" | "primary" | "success";
+
+const TONE_CLASS: Record<JarvisDockTone, string> = {
+  danger: "text-red-600 dark:text-red-400",
+  neutral: "text-foreground",
+  primary: "text-blue-600 dark:text-blue-400",
+  success: "text-emerald-600 dark:text-emerald-400",
+};
+
+/**
+ * One action button slotted in the dock.
+ *
+ * @public
+ */
+export type JarvisDockAction = {
+  /** Optional badge value rendered as a small dot or count. */
+  badge?: ReactNode;
+  /** Glyph rendered above the label (single character or icon). */
+  glyph: ReactNode;
+  /** Stable identifier — used as the React key + analytics hook. */
+  id: string;
+  /** Short label shown beneath the glyph. */
+  label: ReactNode;
+  /** Click handler. */
+  onActivate: () => void;
+  /** Optional tone. Defaults to `"neutral"`. */
+  tone?: JarvisDockTone;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type JarvisDockLabels = {
+  /** Aria-label for the command-palette trigger. Defaults to `"Open command palette"`. */
+  paletteTrigger?: string;
+  /** Aria-label for the dock. Defaults to `"Jarvis dock"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  paletteTrigger: "Open command palette",
+  region: "Jarvis dock",
+} as const satisfies Required<JarvisDockLabels>;
+
+/**
+ * Props for {@link JarvisDock}.
+ *
+ * @public
+ */
+export type JarvisDockProps = {
+  /** Action buttons in render order. */
+  actions: JarvisDockAction[];
+  /** Localizable strings. */
+  labels?: JarvisDockLabels;
+  /** Optional handler for the "..." command-palette trigger. */
+  onOpenPalette?: () => void;
+} & ComponentPropsWithoutRef<"nav">;
+
+const ActionButton = (props: {
+  action: JarvisDockAction;
+}): React.ReactElement => {
+  const { action } = props;
+  const tone = action.tone ?? "neutral";
+  const handleClick = (): void => {
+    action.onActivate();
+  };
+  return (
+    <button
+      className="group relative flex h-12 w-12 flex-col items-center justify-center gap-0.5 rounded-md border border-transparent text-[10px] uppercase tracking-wide text-muted-foreground transition-colors hover:border-border hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      data-jarvis-action={action.id}
+      data-jarvis-tone={tone}
+      onClick={handleClick}
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "text-base leading-none transition-transform group-hover:scale-110",
+          TONE_CLASS[tone],
+        )}
+      >
+        {action.glyph}
+      </span>
+      <span className="truncate">{action.label}</span>
+      {action.badge ? (
+        <span
+          className="absolute right-1 top-1 inline-flex min-h-[14px] min-w-[14px] items-center justify-center rounded-full bg-foreground px-1 text-[9px] font-medium text-background"
+          data-jarvis-badge
+        >
+          {action.badge}
+        </span>
+      ) : null}
+    </button>
+  );
+};
+
+/**
+ * Floating bottom dock for the spatial canvas. Renders a compact row
+ * of agent / quick-action buttons plus a trailing command-palette
+ * trigger. Pure presentation; the host wires `onActivate` per action
+ * and `onOpenPalette` for the palette button.
+ *
+ * @example
+ * ```tsx
+ * <JarvisDock
+ *   actions={[
+ *     { id: "summon", glyph: "+", label: "Summon", tone: "primary",
+ *       onActivate: () => spawnAgent() },
+ *     { id: "review", glyph: "✓", label: "Review", tone: "success",
+ *       onActivate: () => openReview() },
+ *   ]}
+ *   onOpenPalette={() => openCommandPalette()}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const JarvisDock = forwardRef<HTMLElement, JarvisDockProps>(
+  (props, ref) => {
+    const { actions, className, labels, onOpenPalette, ...rest } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const handlePalette = (): void => {
+      onOpenPalette?.();
+    };
+    return (
+      <nav
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "inline-flex items-center gap-1 rounded-2xl border bg-background/90 p-1.5 shadow-md backdrop-blur",
+          className,
+        )}
+        data-jarvis-dock
+        ref={ref}
+        {...rest}
+      >
+        {actions.map((action) => (
+          <ActionButton action={action} key={action.id} />
+        ))}
+        {onOpenPalette ? (
+          <>
+            <span aria-hidden="true" className="mx-1 h-8 w-px bg-border" />
+            <button
+              aria-label={resolvedLabels.paletteTrigger}
+              className="flex h-12 w-12 items-center justify-center rounded-md border border-transparent text-base text-muted-foreground transition-colors hover:border-border hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              data-jarvis-palette-trigger
+              onClick={handlePalette}
+              type="button"
+            >
+              <span aria-hidden="true">⌘</span>
+            </button>
+          </>
+        ) : null}
+      </nav>
+    );
+  },
+);
+JarvisDock.displayName = "JarvisDock";

--- a/packages/ui/src/components/jarvis-dock/jarvis-dock.visual.tsx
+++ b/packages/ui/src/components/jarvis-dock/jarvis-dock.visual.tsx
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { JarvisDock } from "./jarvis-dock";
+
+const noop = (): void => undefined;
+
+test.describe("JarvisDock Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="flex items-center justify-center bg-muted/40 p-8">
+        <JarvisDock
+          actions={[
+            {
+              glyph: "+",
+              id: "summon",
+              label: "Summon",
+              onActivate: noop,
+              tone: "primary",
+            },
+            {
+              badge: "3",
+              glyph: "✓",
+              id: "review",
+              label: "Review",
+              onActivate: noop,
+              tone: "success",
+            },
+            {
+              glyph: "↻",
+              id: "retry",
+              label: "Retry",
+              onActivate: noop,
+            },
+            {
+              glyph: "⏵",
+              id: "play",
+              label: "Play",
+              onActivate: noop,
+            },
+            {
+              glyph: "⏸",
+              id: "pause",
+              label: "Pause",
+              onActivate: noop,
+              tone: "danger",
+            },
+          ]}
+          onOpenPalette={noop}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("jarvis-dock-default.png");
+  });
+});

--- a/packages/ui/src/components/multi-select-lasso/index.ts
+++ b/packages/ui/src/components/multi-select-lasso/index.ts
@@ -1,0 +1,6 @@
+export {
+  type LassoRect,
+  MultiSelectLasso,
+  type MultiSelectLassoLabels,
+  type MultiSelectLassoProps,
+} from "./multi-select-lasso";

--- a/packages/ui/src/components/multi-select-lasso/multi-select-lasso.mdx
+++ b/packages/ui/src/components/multi-select-lasso/multi-select-lasso.mdx
@@ -1,0 +1,62 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './multi-select-lasso.stories'
+
+<Meta of={Stories} />
+
+# MultiSelectLasso
+
+Selection rectangle for canvas multi-select. Render as a sibling of the canvas with a \`position: relative\` parent so the \`rect\` coordinates land in the same pixel space. Pure presentation; the host owns the pointer-down / move / up lifecycle and produces the rect (or \`null\` to hide the lasso).
+
+Negative-direction drags are normalized automatically — pass the raw delta and the lasso flips into the right quadrant.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/multi-select-lasso.json
+```
+
+## Import
+
+```tsx
+import { MultiSelectLasso } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<div className="relative h-screen w-screen" onPointerDown={…}>
+  <Canvas />
+  <MultiSelectLasso rect={lassoRect} count={hoveredIds.length} />
+</div>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## No count
+
+Omit \`count\` and \`hint\` to render a quiet rectangle without badges.
+
+<Canvas of={Stories.NoCount} sourceState="shown" />
+
+## Single item
+
+Count \`1\` uses the singular noun automatically (defaults to \`"item"\`).
+
+<Canvas of={Stories.SingleItem} sourceState="shown" />
+
+## Hidden
+
+\`rect={null}\` (or zero-area rect) returns nothing, so the host can pass the live drag state directly without conditional wrapping.
+
+<Canvas of={Stories.Hidden} sourceState="shown" />
+
+## Notes
+
+- The wrapper is \`pointer-events-none\` — the lasso never intercepts host events.
+- Each render emits \`data-multi-select-lasso\`. Badges emit \`data-multi-select-hint\` and \`data-multi-select-count\`.

--- a/packages/ui/src/components/multi-select-lasso/multi-select-lasso.stories.tsx
+++ b/packages/ui/src/components/multi-select-lasso/multi-select-lasso.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { MultiSelectLasso } from "./multi-select-lasso";
+
+const meta = {
+  args: {
+    count: 4,
+    hint: "Drag",
+    rect: { height: 120, width: 180, x: 60, y: 50 },
+  },
+  component: MultiSelectLasso,
+  decorators: [
+    (Story) => (
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 240, width: 360 }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/MultiSelectLasso",
+} satisfies Meta<typeof MultiSelectLasso>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const NoCount: Story = {
+  args: { count: undefined, hint: undefined },
+};
+
+export const SingleItem: Story = {
+  args: { count: 1, hint: undefined },
+};
+
+export const Hidden: Story = {
+  args: { rect: null },
+};

--- a/packages/ui/src/components/multi-select-lasso/multi-select-lasso.test.tsx
+++ b/packages/ui/src/components/multi-select-lasso/multi-select-lasso.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MultiSelectLasso } from "./multi-select-lasso";
+
+describe("MultiSelectLasso", () => {
+  it("renders nothing when rect is null", () => {
+    const { container } = render(<MultiSelectLasso rect={null} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when the rect has zero area", () => {
+    const { container } = render(
+      <MultiSelectLasso rect={{ height: 0, width: 100, x: 0, y: 0 }} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("positions the lasso from the rect coordinates", () => {
+    const { container } = render(
+      <MultiSelectLasso rect={{ height: 80, width: 120, x: 50, y: 30 }} />,
+    );
+
+    const lasso = container.querySelector("[data-multi-select-lasso]");
+    expect(lasso).toHaveStyle({
+      height: "80px",
+      left: "50px",
+      top: "30px",
+      width: "120px",
+    });
+  });
+
+  it("normalizes a negative-direction drag", () => {
+    const { container } = render(
+      <MultiSelectLasso rect={{ height: -40, width: -60, x: 100, y: 80 }} />,
+    );
+
+    const lasso = container.querySelector("[data-multi-select-lasso]");
+    expect(lasso).toHaveStyle({
+      height: "40px",
+      left: "40px",
+      top: "40px",
+      width: "60px",
+    });
+  });
+
+  it("renders the count badge with pluralization", () => {
+    render(
+      <MultiSelectLasso
+        count={3}
+        rect={{ height: 60, width: 80, x: 0, y: 0 }}
+      />,
+    );
+
+    expect(screen.getByText("3 items")).toBeInTheDocument();
+  });
+
+  it("uses the singular noun when count is 1", () => {
+    render(
+      <MultiSelectLasso
+        count={1}
+        rect={{ height: 60, width: 80, x: 0, y: 0 }}
+      />,
+    );
+
+    expect(screen.getByText("1 item")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/multi-select-lasso/multi-select-lasso.tsx
+++ b/packages/ui/src/components/multi-select-lasso/multi-select-lasso.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Lasso geometry — pixel coordinates on the underlying canvas.
+ *
+ * @public
+ */
+export type LassoRect = {
+  /** Height in pixels (always positive after normalization). */
+  height: number;
+  /** Width in pixels (always positive after normalization). */
+  width: number;
+  /** Left edge in pixels. */
+  x: number;
+  /** Top edge in pixels. */
+  y: number;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type MultiSelectLassoLabels = {
+  /** Plural noun for the count badge. Defaults to `"items"`. */
+  plural?: string;
+  /** Aria-label for the lasso layer. Defaults to `"Multi-select lasso"`. */
+  region?: string;
+  /** Singular noun for the count badge. Defaults to `"item"`. */
+  singular?: string;
+};
+
+const DEFAULT_LABELS = {
+  plural: "items",
+  region: "Multi-select lasso",
+  singular: "item",
+} as const satisfies Required<MultiSelectLassoLabels>;
+
+/**
+ * Props for {@link MultiSelectLasso}.
+ *
+ * @public
+ */
+export type MultiSelectLassoProps = {
+  /** Optional count badge — rendered near the bottom-right corner. */
+  count?: number;
+  /** Optional override slot rendered inside the lasso (e.g. a label). */
+  hint?: ReactNode;
+  /** Localizable strings. */
+  labels?: MultiSelectLassoLabels;
+  /** Drag rectangle in pixels. When `null`, nothing renders. */
+  rect: LassoRect | null;
+} & ComponentPropsWithoutRef<"div">;
+
+const normalizeRect = (rect: LassoRect): LassoRect => {
+  const x = rect.width < 0 ? rect.x + rect.width : rect.x;
+  const y = rect.height < 0 ? rect.y + rect.height : rect.y;
+  const width = Math.abs(rect.width);
+  const height = Math.abs(rect.height);
+  return { height, width, x, y };
+};
+
+/**
+ * Selection rectangle for canvas multi-select. Render as a sibling of
+ * the canvas with `position: absolute` parent so the `rect` coordinates
+ * land in the same pixel space. Pure presentation; the host owns the
+ * pointer-down/move/up lifecycle and produces the rect (or `null` to
+ * hide the lasso).
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen" onPointerDown={…}>
+ *   <Canvas />
+ *   <MultiSelectLasso rect={lassoRect} count={hoveredIds.length} />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const MultiSelectLasso = forwardRef<
+  HTMLDivElement,
+  MultiSelectLassoProps
+>((props, ref) => {
+  const { className, count, hint, labels, rect, ...rest } = props;
+  if (!rect) {
+    return null;
+  }
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const normalized = normalizeRect(rect);
+  if (normalized.width === 0 || normalized.height === 0) {
+    return null;
+  }
+  const noun = count === 1 ? resolvedLabels.singular : resolvedLabels.plural;
+  return (
+    <div
+      aria-hidden="true"
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "pointer-events-none absolute z-30 rounded-md border-2 border-blue-500/70 bg-blue-500/10",
+        className,
+      )}
+      data-multi-select-lasso
+      ref={ref}
+      style={{
+        height: normalized.height,
+        left: normalized.x,
+        top: normalized.y,
+        width: normalized.width,
+      }}
+      {...rest}
+    >
+      {hint ? (
+        <span
+          className="absolute -top-7 left-0 rounded-md bg-foreground/90 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-background"
+          data-multi-select-hint
+        >
+          {hint}
+        </span>
+      ) : null}
+      {typeof count === "number" ? (
+        <span
+          className="absolute -bottom-7 right-0 rounded-full bg-foreground px-2 py-0.5 text-[10px] font-semibold text-background"
+          data-multi-select-count
+        >
+          {count} {noun}
+        </span>
+      ) : null}
+    </div>
+  );
+});
+MultiSelectLasso.displayName = "MultiSelectLasso";

--- a/packages/ui/src/components/multi-select-lasso/multi-select-lasso.visual.tsx
+++ b/packages/ui/src/components/multi-select-lasso/multi-select-lasso.visual.tsx
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { MultiSelectLasso } from "./multi-select-lasso";
+
+test.describe("MultiSelectLasso Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 240, width: 360 }}
+      >
+        <MultiSelectLasso
+          count={4}
+          hint="Drag"
+          rect={{ height: 120, width: 180, x: 60, y: 50 }}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "multi-select-lasso-default.png",
+    );
+  });
+});


### PR DESCRIPTION
Closes #134

## What's in

Three calm canvas overlays that finish the spatial-canvas component family for issue #134:

- **JarvisDock** — floating bottom dock with quick-action buttons + a command-palette trigger (⌘). Tone classes: \`neutral\` / \`primary\` / \`success\` / \`danger\`. Optional badge slot per action. Pure presentation; host wires \`onActivate\` per action and \`onOpenPalette\` for the trailing trigger.
- **MultiSelectLasso** — selection rectangle for canvas multi-select gestures. Normalizes negative-direction drags, hides on \`null\` / zero-area. \`pointer-events: none\` so host gestures pass through. Optional count badge with built-in pluralization.
- **ContextLens** — vignette overlay that dims the canvas outside a circular focus region. SVG radial-gradient mask, clamped opacity + radii, \`pointer-events: none\`.

All three are pure presentation; the host computes geometry / state from the live runtime. Wired into the \`@vllnt/ui\` barrel and the shadcn registry.

## Files

- \`packages/ui/src/components/jarvis-dock/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/multi-select-lasso/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/context-lens/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/index.ts\` — barrel exports
- \`apps/registry/registry/default/{jarvis-dock,multi-select-lasso,context-lens}/*.tsx\` — registry shims
- \`apps/registry/registry.json\` — three new entries

## Closes the #134 component family

Together with **PR #198** (PropertySection + ObjectInspector + RelationshipInspector) and **PR #199** (RuntimeOverviewPanel + RoutingAssignmentPanel + PolicyDeliveryPanel), this PR ships the final 3 of 9 primitives requested for #134. Merging all three lands the full canvas + dock + overlay surface.

## Quality gates

- lint: PASS (\`eslint --fix\` clean)
- typecheck: PASS (\`tsc --noEmit --project tsconfig.build.json\`)
- check:use-client: PASS (182 components)
- check:story-coverage: PASS (172 components)
- verify-stories: PASS (no crash risks)
- test: PASS (509 / 509 — incl. 16 new)
- build (\`@vllnt/ui\`): PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)
- [ ] Storybook renders all 12 stories (4 per primitive) without console errors
- [ ] Visual snapshots stable across primitives