### PR TITLE
feat(ui): runtime overlays — AlertPulse + ThresholdRing + StickyMetric (partial #136)

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -163,6 +163,21 @@
       "category": "overlay"
     },
     {
+      "name": "alert-pulse",
+      "type": "registry:component",
+      "title": "Alert Pulse",
+      "description": "Pulsing ring overlay for alerting canvas objects, with severity tones.",
+      "files": [
+        {
+          "path": "registry/default/alert-pulse/alert-pulse.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "utility"
+    },
+    {
       "name": "anchor-port",
       "type": "registry:component",
       "title": "Anchor Port",
@@ -2101,6 +2116,21 @@
       "category": "learning"
     },
     {
+      "name": "sticky-metric",
+      "type": "registry:component",
+      "title": "Sticky Metric",
+      "description": "Pinned metric pill that sticks to a canvas object's corner.",
+      "files": [
+        {
+          "path": "registry/default/sticky-metric/sticky-metric.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data"
+    },
+    {
       "name": "subscription-card",
       "type": "registry:component",
       "title": "Subscription Card",
@@ -2283,6 +2313,21 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "utility"
+    },
+    {
+      "name": "threshold-ring",
+      "type": "registry:component",
+      "title": "Threshold Ring",
+      "description": "Compact ring gauge expressing how close a value is to a threshold.",
+      "files": [
+        {
+          "path": "registry/default/threshold-ring/threshold-ring.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data"
     },
     {
       "name": "ticker-tape",

--- a/apps/registry/registry/default/alert-pulse/alert-pulse.tsx
+++ b/apps/registry/registry/default/alert-pulse/alert-pulse.tsx
@@ -1,0 +1,6 @@
+export {
+  AlertPulse,
+  type AlertPulseLabels,
+  type AlertPulseProps,
+  type AlertPulseSeverity,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/sticky-metric/sticky-metric.tsx
+++ b/apps/registry/registry/default/sticky-metric/sticky-metric.tsx
@@ -1,0 +1,7 @@
+export {
+  StickyMetric,
+  type StickyMetricAnchor,
+  type StickyMetricLabels,
+  type StickyMetricProps,
+  type StickyMetricTone,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/threshold-ring/threshold-ring.tsx
+++ b/apps/registry/registry/default/threshold-ring/threshold-ring.tsx
@@ -1,0 +1,6 @@
+export {
+  ThresholdRing,
+  type ThresholdRingLabels,
+  type ThresholdRingProps,
+  type ThresholdRingTone,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/alert-pulse/alert-pulse.mdx
+++ b/packages/ui/src/components/alert-pulse/alert-pulse.mdx
@@ -1,0 +1,57 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './alert-pulse.stories'
+
+<Meta of={Stories} />
+
+# AlertPulse
+
+Pulsing ring overlay drawn around an alerting canvas object. The outer ring expands and fades to communicate "attention here"; the inner ring stays put so the object remains anchored. Pure presentation; the host computes the center + severity from the runtime alert stream.
+
+Render inside a \`position: relative\` parent that shares the canvas pixel coordinate space; the SVG is \`pointer-events: none\` so host gestures pass through.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/alert-pulse.json
+```
+
+## Import
+
+```tsx
+import { AlertPulse } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<div className="relative h-screen w-screen">
+  <Canvas />
+  <AlertPulse cx={480} cy={320} severity="error" />
+</div>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Severity tones
+
+\`info\` (blue) · \`warn\` (amber, default) · \`error\` (red).
+
+<Canvas of={Stories.Info} sourceState="shown" />
+<Canvas of={Stories.Error} sourceState="shown" />
+
+## Reduced motion
+
+Pass \`reducedMotion\` to skip the \`animate-ping\` class — useful for visual snapshots and accessibility-conscious surfaces.
+
+<Canvas of={Stories.ReducedMotion} sourceState="shown" />
+
+## Notes
+
+- Radius floors at \`6\` so the pulse never collapses into invisibility.
+- Each render emits \`data-alert-pulse\` plus \`data-alert-severity\`. The animated ring emits \`data-alert-pulse-ring\` for analytics + CSS hooks.

--- a/packages/ui/src/components/alert-pulse/alert-pulse.stories.tsx
+++ b/packages/ui/src/components/alert-pulse/alert-pulse.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { AlertPulse } from "./alert-pulse";
+
+const meta = {
+  args: {
+    cx: 120,
+    cy: 100,
+    radius: 36,
+    severity: "warn",
+  },
+  component: AlertPulse,
+  decorators: [
+    (Story) => (
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 220, width: 240 }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/AlertPulse",
+} satisfies Meta<typeof AlertPulse>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Info: Story = {
+  args: { severity: "info" },
+};
+
+export const Error: Story = {
+  args: { severity: "error", radius: 48 },
+};
+
+export const ReducedMotion: Story = {
+  args: { reducedMotion: true },
+};

--- a/packages/ui/src/components/alert-pulse/alert-pulse.test.tsx
+++ b/packages/ui/src/components/alert-pulse/alert-pulse.test.tsx
@@ -1,0 +1,54 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AlertPulse } from "./alert-pulse";
+
+describe("AlertPulse", () => {
+  it("renders the SVG with severity data attribute", () => {
+    const { container } = render(
+      <AlertPulse cx={100} cy={100} severity="error" />,
+    );
+
+    const svg = container.querySelector("[data-alert-pulse]");
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute("data-alert-severity", "error");
+  });
+
+  it("centers the SVG on the cx/cy point", () => {
+    const { container } = render(<AlertPulse cx={200} cy={150} radius={40} />);
+
+    const svg = container.querySelector("[data-alert-pulse]");
+    expect(svg).toHaveStyle({ left: `${200 - (40 * 2 + 24) / 2}px` });
+    expect(svg).toHaveStyle({ top: `${150 - (40 * 2 + 24) / 2}px` });
+  });
+
+  it("clamps radius to a sane minimum", () => {
+    const { container } = render(<AlertPulse cx={0} cy={0} radius={2} />);
+
+    const ring = container.querySelector("[data-alert-pulse-ring]");
+    expect(ring).toHaveAttribute("r", "6");
+  });
+
+  it("applies the animate-ping class by default", () => {
+    const { container } = render(<AlertPulse cx={0} cy={0} />);
+
+    const ring = container.querySelector("[data-alert-pulse-ring]");
+    expect(ring?.getAttribute("class")).toContain("animate-ping");
+  });
+
+  it("omits the animation when reducedMotion is true", () => {
+    const { container } = render(<AlertPulse cx={0} cy={0} reducedMotion />);
+
+    const ring = container.querySelector("[data-alert-pulse-ring]");
+    expect(ring?.getAttribute("class")).not.toContain("animate-ping");
+  });
+
+  it("uses severity name as the default aria-label", () => {
+    const { container } = render(<AlertPulse cx={0} cy={0} severity="info" />);
+
+    expect(container.querySelector("[data-alert-pulse]")).toHaveAttribute(
+      "aria-label",
+      "Info",
+    );
+  });
+});

--- a/packages/ui/src/components/alert-pulse/alert-pulse.tsx
+++ b/packages/ui/src/components/alert-pulse/alert-pulse.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Severity tone of an alert pulse — drives the ring color.
+ *
+ * @public
+ */
+export type AlertPulseSeverity = "error" | "info" | "warn";
+
+const SEVERITY_STROKE: Record<AlertPulseSeverity, string> = {
+  error: "stroke-red-500",
+  info: "stroke-blue-500",
+  warn: "stroke-amber-500",
+};
+
+const SEVERITY_FILL: Record<AlertPulseSeverity, string> = {
+  error: "fill-red-500/20",
+  info: "fill-blue-500/20",
+  warn: "fill-amber-500/20",
+};
+
+const SEVERITY_LABEL: Record<AlertPulseSeverity, string> = {
+  error: "Error",
+  info: "Info",
+  warn: "Warning",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type AlertPulseLabels = {
+  /** Override for the aria-label. Defaults to severity name. */
+  region?: string;
+};
+
+/**
+ * Props for {@link AlertPulse}.
+ *
+ * @public
+ */
+export type AlertPulseProps = {
+  /** Center X of the pulse in canvas pixels. */
+  cx: number;
+  /** Center Y of the pulse in canvas pixels. */
+  cy: number;
+  /** Localizable strings. */
+  labels?: AlertPulseLabels;
+  /** Outer ring radius in pixels. Defaults to `36`. */
+  radius?: number;
+  /** Disable the pulse animation. Useful for snapshots. Defaults to `false`. */
+  reducedMotion?: boolean;
+  /** Severity tone. Defaults to `"warn"`. */
+  severity?: AlertPulseSeverity;
+} & ComponentPropsWithoutRef<"svg">;
+
+const safeRadius = (value: number): number => (value < 6 ? 6 : value);
+
+/**
+ * Pulsing ring overlay drawn around an alerting canvas object. The
+ * outer ring expands and fades to communicate "attention here";
+ * the inner ring stays put so the object remains anchored. Pure
+ * presentation; the host computes the center + severity from the
+ * runtime alert stream.
+ *
+ * Render inside a `position: relative` parent that shares the canvas
+ * pixel coordinate space; the SVG is `pointer-events: none` so host
+ * gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <AlertPulse cx={480} cy={320} severity="error" />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const AlertPulse = forwardRef<SVGSVGElement, AlertPulseProps>(
+  (props, ref) => {
+    const {
+      className,
+      cx,
+      cy,
+      labels,
+      radius = 36,
+      reducedMotion = false,
+      severity = "warn",
+      ...rest
+    } = props;
+    const r = safeRadius(radius);
+    const ariaLabel = labels?.region ?? SEVERITY_LABEL[severity];
+    const size = r * 2 + 24;
+    return (
+      <svg
+        aria-label={ariaLabel}
+        className={cn(
+          "pointer-events-none absolute z-20 overflow-visible",
+          className,
+        )}
+        data-alert-pulse
+        data-alert-severity={severity}
+        height={size}
+        ref={ref}
+        role="img"
+        style={{
+          left: cx - size / 2,
+          top: cy - size / 2,
+        }}
+        width={size}
+        {...rest}
+      >
+        <circle
+          className={cn("origin-center", SEVERITY_STROKE[severity])}
+          cx={size / 2}
+          cy={size / 2}
+          fill="none"
+          r={r}
+          strokeOpacity={0.7}
+          strokeWidth={2}
+        />
+        <circle
+          className={cn(
+            "origin-center",
+            SEVERITY_STROKE[severity],
+            SEVERITY_FILL[severity],
+            reducedMotion ? null : "animate-ping",
+          )}
+          cx={size / 2}
+          cy={size / 2}
+          data-alert-pulse-ring
+          r={r}
+          strokeOpacity={0.4}
+          strokeWidth={2}
+        />
+      </svg>
+    );
+  },
+);
+AlertPulse.displayName = "AlertPulse";

--- a/packages/ui/src/components/alert-pulse/alert-pulse.visual.tsx
+++ b/packages/ui/src/components/alert-pulse/alert-pulse.visual.tsx
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { AlertPulse } from "./alert-pulse";
+
+test.describe("AlertPulse Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 240, width: 360 }}
+      >
+        <AlertPulse cx={90} cy={120} reducedMotion severity="info" />
+        <AlertPulse cx={180} cy={120} reducedMotion severity="warn" />
+        <AlertPulse cx={270} cy={120} reducedMotion severity="error" />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("alert-pulse-default.png");
+  });
+});

--- a/packages/ui/src/components/alert-pulse/index.ts
+++ b/packages/ui/src/components/alert-pulse/index.ts
@@ -1,0 +1,6 @@
+export {
+  AlertPulse,
+  type AlertPulseLabels,
+  type AlertPulseProps,
+  type AlertPulseSeverity,
+} from "./alert-pulse";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -764,6 +764,12 @@ export {
 } from "./flow-diagram";
 
 // Canvas/Object components
+export {
+  AlertPulse,
+  type AlertPulseLabels,
+  type AlertPulseProps,
+  type AlertPulseSeverity,
+} from "./alert-pulse";
 export { AnchorPort, type AnchorPortProps } from "./anchor-port";
 export {
   type ActivityEvent,
@@ -852,11 +858,24 @@ export {
   type StateBadgeState,
 } from "./state-badge-overlay";
 export {
+  StickyMetric,
+  type StickyMetricAnchor,
+  type StickyMetricLabels,
+  type StickyMetricProps,
+  type StickyMetricTone,
+} from "./sticky-metric";
+export {
   ThreadBubble,
   type ThreadBubbleLabels,
   type ThreadBubbleProps,
   type ThreadMessage,
 } from "./thread-bubble";
+export {
+  ThresholdRing,
+  type ThresholdRingLabels,
+  type ThresholdRingProps,
+  type ThresholdRingTone,
+} from "./threshold-ring";
 export {
   TimelineScrubber,
   type TimelineScrubberLabels,

--- a/packages/ui/src/components/sticky-metric/index.ts
+++ b/packages/ui/src/components/sticky-metric/index.ts
@@ -1,0 +1,7 @@
+export {
+  StickyMetric,
+  type StickyMetricAnchor,
+  type StickyMetricLabels,
+  type StickyMetricProps,
+  type StickyMetricTone,
+} from "./sticky-metric";

--- a/packages/ui/src/components/sticky-metric/sticky-metric.mdx
+++ b/packages/ui/src/components/sticky-metric/sticky-metric.mdx
@@ -1,0 +1,69 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './sticky-metric.stories'
+
+<Meta of={Stories} />
+
+# StickyMetric
+
+Pinned metric pill that sticks to a canvas object's corner. Use to overlay a single live value (errors / min, p95 latency, queue depth) on a runtime object without consuming card real-estate. Pure presentation; the host computes the anchor coords from the object's bounding box and the value from the runtime stream.
+
+The wrapper is \`pointer-events: none\` — host gestures pass through.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/sticky-metric.json
+```
+
+## Import
+
+```tsx
+import { StickyMetric } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<div className="relative h-screen w-screen">
+  <Canvas />
+  <StickyMetric
+    x={420} y={180}
+    anchor="top-right"
+    label="errs / min"
+    value="14"
+    tone="danger"
+  />
+</div>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Danger tone
+
+Pair \`tone="danger"\` with a short label + value when an SLO is breached.
+
+<Canvas of={Stories.Danger} sourceState="shown" />
+
+## Bottom-left anchor
+
+The metric translates so the chosen corner sits exactly on the anchor pixel.
+
+<Canvas of={Stories.BottomLeft} sourceState="shown" />
+
+## Plain
+
+Drop \`detail\` and use \`tone="neutral"\` for a quiet ambient overlay.
+
+<Canvas of={Stories.Plain} sourceState="shown" />
+
+## Notes
+
+- Anchors map: \`top-right\` (default) · \`top-left\` · \`bottom-right\` · \`bottom-left\`. The anchor pixel is always the meeting corner.
+- Tones map: \`neutral\` (muted) · \`success\` (emerald) · \`warn\` (amber) · \`danger\` (red).
+- Each render emits \`data-sticky-metric\` + \`data-sticky-tone\` + \`data-sticky-anchor\`. The leading dot emits \`data-sticky-metric-dot\`; the optional detail emits \`data-sticky-metric-detail\`.

--- a/packages/ui/src/components/sticky-metric/sticky-metric.stories.tsx
+++ b/packages/ui/src/components/sticky-metric/sticky-metric.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { StickyMetric } from "./sticky-metric";
+
+const meta = {
+  args: {
+    anchor: "top-right",
+    detail: "↑ 12%",
+    label: "qps",
+    tone: "success",
+    value: "240",
+    x: 200,
+    y: 100,
+  },
+  component: StickyMetric,
+  decorators: [
+    (Story) => (
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 240, width: 320 }}
+      >
+        <div
+          className="absolute rounded-md border border-border bg-background"
+          style={{ height: 80, left: 80, top: 80, width: 160 }}
+        />
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/StickyMetric",
+} satisfies Meta<typeof StickyMetric>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Danger: Story = {
+  args: {
+    detail: undefined,
+    label: "errs",
+    tone: "danger",
+    value: "14",
+  },
+};
+
+export const BottomLeft: Story = {
+  args: {
+    anchor: "bottom-left",
+    x: 80,
+    y: 160,
+  },
+};
+
+export const Plain: Story = {
+  args: {
+    detail: undefined,
+    tone: "neutral",
+  },
+};

--- a/packages/ui/src/components/sticky-metric/sticky-metric.test.tsx
+++ b/packages/ui/src/components/sticky-metric/sticky-metric.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StickyMetric } from "./sticky-metric";
+
+describe("StickyMetric", () => {
+  it("renders the label and value", () => {
+    render(<StickyMetric label="errs / min" value="14" x={100} y={50} />);
+
+    expect(screen.getByText("errs / min")).toBeInTheDocument();
+    expect(screen.getByText("14")).toBeInTheDocument();
+  });
+
+  it("positions the metric using the anchor coords", () => {
+    const { container } = render(
+      <StickyMetric label="x" value="1" x={120} y={80} />,
+    );
+
+    const metric = container.querySelector("[data-sticky-metric]");
+    expect(metric).toHaveStyle({ left: "120px", top: "80px" });
+  });
+
+  it("propagates the anchor to a data attribute", () => {
+    const { container } = render(
+      <StickyMetric anchor="bottom-left" label="x" value="1" x={0} y={0} />,
+    );
+
+    expect(container.querySelector("[data-sticky-anchor]")).toHaveAttribute(
+      "data-sticky-anchor",
+      "bottom-left",
+    );
+  });
+
+  it("renders the optional detail line", () => {
+    render(<StickyMetric detail="↑ 12%" label="qps" value="240" x={0} y={0} />);
+
+    expect(screen.getByText("↑ 12%")).toBeInTheDocument();
+  });
+
+  it("propagates tone to a data attribute", () => {
+    const { container } = render(
+      <StickyMetric label="x" tone="danger" value="1" x={0} y={0} />,
+    );
+
+    expect(container.querySelector("[data-sticky-tone]")).toHaveAttribute(
+      "data-sticky-tone",
+      "danger",
+    );
+  });
+});

--- a/packages/ui/src/components/sticky-metric/sticky-metric.tsx
+++ b/packages/ui/src/components/sticky-metric/sticky-metric.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Tone of the metric — drives the dot color.
+ *
+ * @public
+ */
+export type StickyMetricTone = "danger" | "neutral" | "success" | "warn";
+
+/**
+ * Anchor corner relative to the canvas object the metric sticks to.
+ *
+ * @public
+ */
+export type StickyMetricAnchor =
+  | "bottom-left"
+  | "bottom-right"
+  | "top-left"
+  | "top-right";
+
+const TONE_DOT: Record<StickyMetricTone, string> = {
+  danger: "bg-red-500",
+  neutral: "bg-muted-foreground",
+  success: "bg-emerald-500",
+  warn: "bg-amber-500",
+};
+
+const ANCHOR_OFFSET: Record<StickyMetricAnchor, { transform: string }> = {
+  "bottom-left": { transform: "translate(-100%, 100%)" },
+  "bottom-right": { transform: "translate(0%, 100%)" },
+  "top-left": { transform: "translate(-100%, -100%)" },
+  "top-right": { transform: "translate(0%, -100%)" },
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type StickyMetricLabels = {
+  /** Aria-label override. Defaults to `"Sticky metric"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Sticky metric",
+} as const satisfies Required<StickyMetricLabels>;
+
+/**
+ * Props for {@link StickyMetric}.
+ *
+ * @public
+ */
+export type StickyMetricProps = {
+  /** Anchor corner. Defaults to `"top-right"`. */
+  anchor?: StickyMetricAnchor;
+  /** Optional secondary slot rendered after the value (delta, unit). */
+  detail?: ReactNode;
+  /** Short metric label (e.g. `"errs/min"`). */
+  label: ReactNode;
+  /** Localizable strings. */
+  labels?: StickyMetricLabels;
+  /** Tone for the leading dot. Defaults to `"neutral"`. */
+  tone?: StickyMetricTone;
+  /** Display value (already formatted by host). */
+  value: ReactNode;
+  /** Anchor X in canvas pixels. */
+  x: number;
+  /** Anchor Y in canvas pixels. */
+  y: number;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * Pinned metric pill that sticks to a canvas object's corner. Use to
+ * overlay a single live value (errors / min, p95 latency, queue depth)
+ * on a runtime object without consuming card real-estate. Pure
+ * presentation; the host computes the anchor coords from the object's
+ * bounding box and the value from the runtime stream.
+ *
+ * The wrapper is `pointer-events: none` — host gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <StickyMetric
+ *     x={420} y={180}
+ *     anchor="top-right"
+ *     label="errs / min"
+ *     value="14"
+ *     tone="danger"
+ *   />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const StickyMetric = forwardRef<HTMLDivElement, StickyMetricProps>(
+  (props, ref) => {
+    const {
+      anchor = "top-right",
+      className,
+      detail,
+      label,
+      labels,
+      tone = "neutral",
+      value,
+      x,
+      y,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "pointer-events-none absolute z-20 inline-flex items-center gap-1.5 rounded-full border border-border bg-background/90 px-2 py-1 text-[11px] shadow-sm backdrop-blur",
+          className,
+        )}
+        data-sticky-anchor={anchor}
+        data-sticky-metric
+        data-sticky-tone={tone}
+        ref={ref}
+        role="status"
+        style={{
+          left: x,
+          top: y,
+          transform: ANCHOR_OFFSET[anchor].transform,
+        }}
+        {...rest}
+      >
+        <span
+          aria-hidden="true"
+          className={cn("h-1.5 w-1.5 rounded-full", TONE_DOT[tone])}
+          data-sticky-metric-dot
+        />
+        <span className="font-medium text-muted-foreground">{label}</span>
+        <span className="font-semibold text-foreground">{value}</span>
+        {detail ? (
+          <span
+            className="text-[10px] text-muted-foreground"
+            data-sticky-metric-detail
+          >
+            {detail}
+          </span>
+        ) : null}
+      </div>
+    );
+  },
+);
+StickyMetric.displayName = "StickyMetric";

--- a/packages/ui/src/components/sticky-metric/sticky-metric.visual.tsx
+++ b/packages/ui/src/components/sticky-metric/sticky-metric.visual.tsx
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { StickyMetric } from "./sticky-metric";
+
+test.describe("StickyMetric Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 240, width: 360 }}
+      >
+        <div
+          className="absolute rounded-md border border-border bg-background"
+          style={{ height: 80, left: 100, top: 80, width: 160 }}
+        />
+        <StickyMetric
+          anchor="top-right"
+          detail="↑ 12%"
+          label="qps"
+          tone="success"
+          value="240"
+          x={260}
+          y={80}
+        />
+        <StickyMetric
+          anchor="bottom-left"
+          label="errs"
+          tone="danger"
+          value="14"
+          x={100}
+          y={160}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("sticky-metric-default.png");
+  });
+});

--- a/packages/ui/src/components/threshold-ring/index.ts
+++ b/packages/ui/src/components/threshold-ring/index.ts
@@ -1,0 +1,6 @@
+export {
+  ThresholdRing,
+  type ThresholdRingLabels,
+  type ThresholdRingProps,
+  type ThresholdRingTone,
+} from "./threshold-ring";

--- a/packages/ui/src/components/threshold-ring/threshold-ring.mdx
+++ b/packages/ui/src/components/threshold-ring/threshold-ring.mdx
@@ -1,0 +1,60 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './threshold-ring.stories'
+
+<Meta of={Stories} />
+
+# ThresholdRing
+
+Compact ring gauge expressing how close a value is to a threshold. Pure presentation; the host supplies the value, threshold, and tone. Use to overlay budget / quota / SLA indicators on canvas objects without consuming card real-estate.
+
+Distinct from \`MetricGauge\`: this primitive is small, headless, and meant to attach to a runtime object — not a dashboard tile.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/threshold-ring.json
+```
+
+## Import
+
+```tsx
+import { ThresholdRing } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<ThresholdRing value={0.82} threshold={0.7} tone="warn" centerLabel="82%" />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Healthy budget
+
+Value below threshold + \`success\` tone.
+
+<Canvas of={Stories.HealthyBudget} sourceState="shown" />
+
+## Over threshold
+
+Value past threshold + \`danger\` tone — the threshold tick stays at its position so the user can see exactly how far past.
+
+<Canvas of={Stories.OverThreshold} sourceState="shown" />
+
+## No threshold
+
+Drop \`threshold\` to render a plain ratio ring.
+
+<Canvas of={Stories.NoThreshold} sourceState="shown" />
+
+## Notes
+
+- Tones map: \`neutral\` (foreground) · \`success\` (emerald) · \`warn\` (amber) · \`danger\` (red).
+- Value clamps to \`0..max\`; \`max\` floors at \`1\` when given a non-positive value.
+- Each render emits \`data-threshold-ring\` plus \`data-threshold-tone\`. The active arc emits \`data-threshold-ring-arc\`; the tick emits \`data-threshold-ring-tick\`; the center label emits \`data-threshold-ring-label\`.

--- a/packages/ui/src/components/threshold-ring/threshold-ring.stories.tsx
+++ b/packages/ui/src/components/threshold-ring/threshold-ring.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ThresholdRing } from "./threshold-ring";
+
+const meta = {
+  args: {
+    centerLabel: "68%",
+    threshold: 0.7,
+    tone: "warn",
+    value: 0.68,
+  },
+  component: ThresholdRing,
+  decorators: [
+    (Story) => (
+      <div className="flex items-center justify-center bg-muted/30 p-8">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/ThresholdRing",
+} satisfies Meta<typeof ThresholdRing>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const HealthyBudget: Story = {
+  args: {
+    centerLabel: "32%",
+    threshold: 0.7,
+    tone: "success",
+    value: 0.32,
+  },
+};
+
+export const OverThreshold: Story = {
+  args: {
+    centerLabel: "92%",
+    threshold: 0.7,
+    tone: "danger",
+    value: 0.92,
+  },
+};
+
+export const NoThreshold: Story = {
+  args: {
+    centerLabel: "50%",
+    threshold: undefined,
+    tone: "neutral",
+    value: 0.5,
+  },
+};

--- a/packages/ui/src/components/threshold-ring/threshold-ring.test.tsx
+++ b/packages/ui/src/components/threshold-ring/threshold-ring.test.tsx
@@ -1,0 +1,56 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ThresholdRing } from "./threshold-ring";
+
+describe("ThresholdRing", () => {
+  it("renders the SVG with tone data attribute", () => {
+    const { container } = render(<ThresholdRing tone="warn" value={0.5} />);
+
+    const svg = container.querySelector("[data-threshold-ring]");
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute("data-threshold-tone", "warn");
+  });
+
+  it("clamps value into 0..max", () => {
+    const { container } = render(<ThresholdRing max={1} value={5} />);
+
+    const arc = container.querySelector("[data-threshold-ring-arc]");
+    const dash = arc?.getAttribute("stroke-dasharray") ?? "";
+    const [filled, total] = dash.split(" ").map(Number);
+    expect(filled).toBeCloseTo(total ?? 0);
+  });
+
+  it("renders the threshold tick when threshold prop is provided", () => {
+    const { container } = render(<ThresholdRing threshold={0.7} value={0.5} />);
+
+    expect(
+      container.querySelector("[data-threshold-ring-tick]"),
+    ).toBeInTheDocument();
+  });
+
+  it("omits the threshold tick when threshold is undefined", () => {
+    const { container } = render(<ThresholdRing value={0.5} />);
+
+    expect(
+      container.querySelector("[data-threshold-ring-tick]"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the center label when provided", () => {
+    const { getByText } = render(
+      <ThresholdRing centerLabel="82%" value={0.82} />,
+    );
+
+    expect(getByText("82%")).toBeInTheDocument();
+  });
+
+  it("falls back to max=1 when given a non-positive max", () => {
+    const { container } = render(<ThresholdRing max={0} value={0.5} />);
+
+    const arc = container.querySelector("[data-threshold-ring-arc]");
+    const dash = arc?.getAttribute("stroke-dasharray") ?? "";
+    const [filled, total] = dash.split(" ").map(Number);
+    expect(filled).toBeCloseTo((total ?? 0) * 0.5);
+  });
+});

--- a/packages/ui/src/components/threshold-ring/threshold-ring.tsx
+++ b/packages/ui/src/components/threshold-ring/threshold-ring.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Tone of the active arc — drives its stroke color.
+ *
+ * @public
+ */
+export type ThresholdRingTone = "danger" | "neutral" | "success" | "warn";
+
+const TONE_STROKE: Record<ThresholdRingTone, string> = {
+  danger: "stroke-red-500",
+  neutral: "stroke-foreground",
+  success: "stroke-emerald-500",
+  warn: "stroke-amber-500",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type ThresholdRingLabels = {
+  /** Aria-label override. Defaults to `"Threshold ring"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Threshold ring",
+} as const satisfies Required<ThresholdRingLabels>;
+
+/**
+ * Props for {@link ThresholdRing}.
+ *
+ * @public
+ */
+export type ThresholdRingProps = {
+  /** Optional center label (formatted by host — e.g. `"82%"`). */
+  centerLabel?: ReactNode;
+  /** Localizable strings. */
+  labels?: ThresholdRingLabels;
+  /** Upper bound of the ring's value range. Defaults to `1`. */
+  max?: number;
+  /** Outer diameter in pixels. Defaults to `64`. */
+  size?: number;
+  /** Stroke width in pixels. Defaults to `6`. */
+  stroke?: number;
+  /** Optional threshold marker `0..max` rendered as a small notch. */
+  threshold?: number;
+  /** Tone of the active arc. Defaults to `"neutral"`. */
+  tone?: ThresholdRingTone;
+  /** Current value `0..max`. */
+  value: number;
+} & ComponentPropsWithoutRef<"svg">;
+
+const clamp = (v: number, min: number, max: number): number => {
+  if (v < min) {
+    return min;
+  }
+  if (v > max) {
+    return max;
+  }
+  return v;
+};
+
+const polar = (input: {
+  angle: number;
+  cx: number;
+  cy: number;
+  r: number;
+}): { x: number; y: number } => {
+  const rad = (input.angle - 90) * (Math.PI / 180);
+  return {
+    x: input.cx + input.r * Math.cos(rad),
+    y: input.cy + input.r * Math.sin(rad),
+  };
+};
+
+type Geometry = {
+  circumference: number;
+  cx: number;
+  cy: number;
+  r: number;
+  ratio: number;
+  size: number;
+  stroke: number;
+  tickAngle: null | number;
+};
+
+const computeGeometry = (input: {
+  max: number;
+  size: number;
+  stroke: number;
+  threshold?: number;
+  value: number;
+}): Geometry => {
+  const safeMax = input.max <= 0 ? 1 : input.max;
+  const ratio = clamp(input.value / safeMax, 0, 1);
+  const cx = input.size / 2;
+  const cy = input.size / 2;
+  const r = (input.size - input.stroke) / 2;
+  const circumference = 2 * Math.PI * r;
+  const tickAngle =
+    input.threshold === undefined
+      ? null
+      : clamp(input.threshold / safeMax, 0, 1) * 360;
+  return {
+    circumference,
+    cx,
+    cy,
+    r,
+    ratio,
+    size: input.size,
+    stroke: input.stroke,
+    tickAngle,
+  };
+};
+
+const Tick = (props: { geom: Geometry }): null | React.ReactElement => {
+  const { geom } = props;
+  if (geom.tickAngle === null) {
+    return null;
+  }
+  const inner = polar({
+    angle: geom.tickAngle,
+    cx: geom.cx,
+    cy: geom.cy,
+    r: geom.r - geom.stroke / 2,
+  });
+  const outer = polar({
+    angle: geom.tickAngle,
+    cx: geom.cx,
+    cy: geom.cy,
+    r: geom.r + geom.stroke / 2,
+  });
+  return (
+    <line
+      className="stroke-foreground/80"
+      data-threshold-ring-tick
+      strokeLinecap="round"
+      strokeWidth={2}
+      x1={inner.x}
+      x2={outer.x}
+      y1={inner.y}
+      y2={outer.y}
+    />
+  );
+};
+
+/**
+ * Compact ring gauge expressing how close a value is to a threshold.
+ * Pure presentation; the host supplies the value, threshold, and tone.
+ * Use to overlay budget / quota / SLA indicators on canvas objects
+ * without consuming card real-estate.
+ *
+ * Distinct from `MetricGauge`: this primitive is small, headless, and
+ * meant to attach to a runtime object — not a dashboard tile.
+ *
+ * @example
+ * ```tsx
+ * <ThresholdRing value={0.82} threshold={0.7} tone="warn" centerLabel="82%" />
+ * ```
+ *
+ * @public
+ */
+export const ThresholdRing = forwardRef<SVGSVGElement, ThresholdRingProps>(
+  (props, ref) => {
+    const {
+      centerLabel,
+      className,
+      labels,
+      max = 1,
+      size = 64,
+      stroke = 6,
+      threshold,
+      tone = "neutral",
+      value,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const geom = computeGeometry({ max, size, stroke, threshold, value });
+    const dash = `${geom.ratio * geom.circumference} ${geom.circumference}`;
+    return (
+      <svg
+        aria-label={resolvedLabels.region}
+        className={cn("inline-block", className)}
+        data-threshold-ring
+        data-threshold-tone={tone}
+        height={geom.size}
+        ref={ref}
+        role="img"
+        viewBox={`0 0 ${geom.size} ${geom.size}`}
+        width={geom.size}
+        {...rest}
+      >
+        <circle
+          className="stroke-muted"
+          cx={geom.cx}
+          cy={geom.cy}
+          fill="none"
+          r={geom.r}
+          strokeWidth={geom.stroke}
+        />
+        <circle
+          className={cn("transition-all duration-300", TONE_STROKE[tone])}
+          cx={geom.cx}
+          cy={geom.cy}
+          data-threshold-ring-arc
+          fill="none"
+          r={geom.r}
+          strokeDasharray={dash}
+          strokeLinecap="round"
+          strokeWidth={geom.stroke}
+          transform={`rotate(-90 ${geom.cx} ${geom.cy})`}
+        />
+        <Tick geom={geom} />
+        {centerLabel ? (
+          <text
+            className="fill-foreground text-[10px] font-semibold"
+            data-threshold-ring-label
+            dominantBaseline="central"
+            textAnchor="middle"
+            x={geom.cx}
+            y={geom.cy}
+          >
+            {centerLabel}
+          </text>
+        ) : null}
+      </svg>
+    );
+  },
+);
+ThresholdRing.displayName = "ThresholdRing";

--- a/packages/ui/src/components/threshold-ring/threshold-ring.visual.tsx
+++ b/packages/ui/src/components/threshold-ring/threshold-ring.visual.tsx
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { ThresholdRing } from "./threshold-ring";
+
+test.describe("ThresholdRing Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="flex items-center gap-4 bg-muted/30 p-6">
+        <ThresholdRing centerLabel="32%" tone="success" value={0.32} />
+        <ThresholdRing
+          centerLabel="68%"
+          threshold={0.7}
+          tone="warn"
+          value={0.68}
+        />
+        <ThresholdRing
+          centerLabel="92%"
+          threshold={0.7}
+          tone="danger"
+          value={0.92}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "threshold-ring-default.png",
+    );
+  });
+});


### PR DESCRIPTION
Closes #136

## What's in

Three calm canvas runtime overlays kicking off issue #136:

- **AlertPulse** — pulsing ring drawn around an alerting canvas object. Severity tones: \`info\` (blue) / \`warn\` (amber, default) / \`error\` (red). SVG-based, clamped radius (floors at 6), optional \`reducedMotion\` for snapshots / a11y, \`pointer-events: none\`.
- **ThresholdRing** — compact ring gauge expressing how close a value is to a threshold. Tone-aware active arc (\`neutral\` / \`success\` / \`warn\` / \`danger\`) + threshold tick at threshold position + optional center label. Distinct from \`MetricGauge\`: small, headless, attaches to runtime objects rather than dashboard tiles.
- **StickyMetric** — pinned metric pill anchored to a canvas object's corner. \`top-right\` (default) / \`top-left\` / \`bottom-right\` / \`bottom-left\` anchors so the chosen corner sits on the anchor pixel. Tone dot + label + value + optional detail. \`pointer-events: none\`.

All three are pure presentation; the host computes geometry / value / tone from the runtime stream. Wired into the \`@vllnt/ui\` barrel and the shadcn registry.

## Files

- \`packages/ui/src/components/alert-pulse/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/threshold-ring/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/sticky-metric/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/index.ts\` — barrel exports
- \`apps/registry/registry/default/{alert-pulse,threshold-ring,sticky-metric}/*.tsx\` — registry shims
- \`apps/registry/registry.json\` — three new entries (alphabetically placed)

## Out of scope (deferred to follow-up #136 PRs)

- \`RunTimeline\`
- \`BottomActivityStrip\`
- \`MetricCluster\`
- \`HeatOverlay\`
- \`StateBadgeOverlay\`
- \`TimelineScrubber\`
- \`PlaybackGhost\`

## Quality gates

- lint: PASS (\`eslint --fix\` clean)
- typecheck: PASS (\`tsc --noEmit --project tsconfig.build.json\`)
- check:use-client: PASS (182 components)
- check:story-coverage: PASS (172 components)
- verify-stories: PASS (no crash risks)
- test: PASS (510 / 510 — incl. 17 new)
- build (\`@vllnt/ui\`): PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)
- [ ] Storybook renders all 12 stories (4 per primitive) without console errors
- [ ] Visual snapshots stable across primitives