### PR TITLE
feat(ui): runtime overlays — HeatOverlay + StateBadgeOverlay + MetricCluster (partial #136)

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -963,6 +963,21 @@
       "category": "utility"
     },
     {
+      "name": "heat-overlay",
+      "type": "registry:component",
+      "title": "Heat Overlay",
+      "description": "Heatmap-style overlay drawing soft radial blobs for canvas activity samples.",
+      "files": [
+        {
+          "path": "registry/default/heat-overlay/heat-overlay.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data"
+    },
+    {
       "name": "horizontal-scroll-row",
       "type": "registry:component",
       "title": "Horizontal Scroll Row",
@@ -1235,6 +1250,21 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "navigation"
+    },
+    {
+      "name": "metric-cluster",
+      "type": "registry:component",
+      "title": "Metric Cluster",
+      "description": "Compact stack of related metrics pinned to a canvas object's corner.",
+      "files": [
+        {
+          "path": "registry/default/metric-cluster/metric-cluster.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data"
     },
     {
       "name": "metric-gauge",
@@ -1979,6 +2009,21 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "data"
+    },
+    {
+      "name": "state-badge-overlay",
+      "type": "registry:component",
+      "title": "State Badge Overlay",
+      "description": "State chip pinned to a canvas object's corner — idle, queued, running, complete, failed, stopped.",
+      "files": [
+        {
+          "path": "registry/default/state-badge-overlay/state-badge-overlay.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "utility"
     },
     {
       "name": "status-board",

--- a/apps/registry/registry/default/heat-overlay/heat-overlay.tsx
+++ b/apps/registry/registry/default/heat-overlay/heat-overlay.tsx
@@ -1,0 +1,7 @@
+export {
+  HeatOverlay,
+  type HeatOverlayLabels,
+  type HeatOverlayProps,
+  type HeatOverlayTone,
+  type HeatPoint,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/metric-cluster/metric-cluster.tsx
+++ b/apps/registry/registry/default/metric-cluster/metric-cluster.tsx
@@ -1,0 +1,8 @@
+export {
+  MetricCluster,
+  type MetricClusterAnchor,
+  type MetricClusterEntry,
+  type MetricClusterLabels,
+  type MetricClusterProps,
+  type MetricClusterTone,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/state-badge-overlay/state-badge-overlay.tsx
+++ b/apps/registry/registry/default/state-badge-overlay/state-badge-overlay.tsx
@@ -1,0 +1,7 @@
+export {
+  type StateBadgeAnchor,
+  StateBadgeOverlay,
+  type StateBadgeOverlayLabels,
+  type StateBadgeOverlayProps,
+  type StateBadgeState,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/heat-overlay/heat-overlay.mdx
+++ b/packages/ui/src/components/heat-overlay/heat-overlay.mdx
@@ -1,0 +1,70 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './heat-overlay.stories'
+
+<Meta of={Stories} />
+
+# HeatOverlay
+
+Heatmap-style overlay drawn on top of a canvas. Each sample renders as a soft radial blob whose radius + opacity scale with its weight. Pure presentation; the host computes the point list from the activity stream.
+
+Render inside a \`position: relative\` parent that shares the canvas pixel coordinate space; the SVG is \`pointer-events: none\` so host gestures pass through.
+
+Distinct from \`ActivityHeatmap\`: that primitive is a calendar-style fixed grid; this one floats over a free-form canvas.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/heat-overlay.json
+```
+
+## Import
+
+```tsx
+import { HeatOverlay } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<div className="relative h-screen w-screen">
+  <Canvas />
+  <HeatOverlay
+    points={[
+      { id: "a", x: 120, y: 80,  weight: 1.0, tone: "danger" },
+      { id: "b", x: 320, y: 220, weight: 0.4 },
+    ]}
+  />
+</div>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Empty
+
+Empty point list returns nothing — pass live state directly without conditional wrapping.
+
+<Canvas of={Stories.Empty} sourceState="shown" />
+
+## Cool tone
+
+\`defaultTone="cool"\` shifts the gradient toward blue — useful for ambient activity rather than incidents.
+
+<Canvas of={Stories.Cool} sourceState="shown" />
+
+## High intensity
+
+Larger \`intensity\` widens the blobs; weight still scales them within that envelope.
+
+<Canvas of={Stories.HighIntensity} sourceState="shown" />
+
+## Notes
+
+- Tones map: \`neutral\` (foreground) · \`warn\` (amber, default) · \`danger\` (red) · \`cool\` (blue).
+- Weight clamps to \`0..1\`; radius floors at \`8\` so points never collapse to invisibility.
+- Each blob emits \`data-heat-point\` (= id) + \`data-heat-tone\`. The wrapper emits \`data-heat-overlay\`.

--- a/packages/ui/src/components/heat-overlay/heat-overlay.stories.tsx
+++ b/packages/ui/src/components/heat-overlay/heat-overlay.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { HeatOverlay } from "./heat-overlay";
+
+const meta = {
+  args: {
+    intensity: 56,
+    points: [
+      { id: "a", tone: "danger", weight: 1, x: 90, y: 80 },
+      { id: "b", tone: "warn", weight: 0.6, x: 200, y: 110 },
+      { id: "c", tone: "cool", weight: 0.4, x: 280, y: 180 },
+      { id: "d", weight: 0.5, x: 140, y: 180 },
+    ],
+  },
+  component: HeatOverlay,
+  decorators: [
+    (Story) => (
+      <div
+        className="relative bg-muted/20"
+        style={{ height: 240, width: 360 }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/HeatOverlay",
+} satisfies Meta<typeof HeatOverlay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: { points: [] },
+};
+
+export const Cool: Story = {
+  args: {
+    defaultTone: "cool",
+    points: [
+      { id: "a", weight: 0.8, x: 100, y: 90 },
+      { id: "b", weight: 0.5, x: 220, y: 140 },
+    ],
+  },
+};
+
+export const HighIntensity: Story = {
+  args: { intensity: 96 },
+};

--- a/packages/ui/src/components/heat-overlay/heat-overlay.test.tsx
+++ b/packages/ui/src/components/heat-overlay/heat-overlay.test.tsx
@@ -1,0 +1,71 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { HeatOverlay, type HeatPoint } from "./heat-overlay";
+
+const sample: HeatPoint[] = [
+  { id: "a", tone: "danger", weight: 1, x: 120, y: 80 },
+  { id: "b", weight: 0.4, x: 320, y: 220 },
+];
+
+describe("HeatOverlay", () => {
+  it("renders nothing when points is empty", () => {
+    const { container } = render(<HeatOverlay points={[]} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders one circle per point", () => {
+    const { container } = render(<HeatOverlay points={sample} />);
+
+    expect(container.querySelectorAll("[data-heat-point]")).toHaveLength(2);
+  });
+
+  it("propagates per-point tone to a data attribute", () => {
+    const { container } = render(<HeatOverlay points={sample} />);
+
+    expect(container.querySelector("[data-heat-point='a']")).toHaveAttribute(
+      "data-heat-tone",
+      "danger",
+    );
+  });
+
+  it("falls back to defaultTone when a point omits its tone", () => {
+    const { container } = render(
+      <HeatOverlay defaultTone="cool" points={sample} />,
+    );
+
+    expect(container.querySelector("[data-heat-point='b']")).toHaveAttribute(
+      "data-heat-tone",
+      "cool",
+    );
+  });
+
+  it("clamps weight when computing radius", () => {
+    const { container } = render(
+      <HeatOverlay
+        intensity={100}
+        points={[{ id: "x", weight: 5, x: 0, y: 0 }]}
+      />,
+    );
+
+    expect(container.querySelector("[data-heat-point='x']")).toHaveAttribute(
+      "r",
+      "100",
+    );
+  });
+
+  it("floors radius at the minimum sample size", () => {
+    const { container } = render(
+      <HeatOverlay
+        intensity={1}
+        points={[{ id: "x", weight: 0, x: 0, y: 0 }]}
+      />,
+    );
+
+    expect(container.querySelector("[data-heat-point='x']")).toHaveAttribute(
+      "r",
+      "8",
+    );
+  });
+});

--- a/packages/ui/src/components/heat-overlay/heat-overlay.tsx
+++ b/packages/ui/src/components/heat-overlay/heat-overlay.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { type ComponentPropsWithoutRef, forwardRef, useId } from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Tone of the heat gradient — drives the inner circle color.
+ *
+ * @public
+ */
+export type HeatOverlayTone = "cool" | "danger" | "neutral" | "warn";
+
+const TONE_FILL: Record<HeatOverlayTone, string> = {
+  cool: "fill-blue-500",
+  danger: "fill-red-500",
+  neutral: "fill-foreground",
+  warn: "fill-amber-500",
+};
+
+/**
+ * One heat sample.
+ *
+ * @public
+ */
+export type HeatPoint = {
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Optional per-point tone override. */
+  tone?: HeatOverlayTone;
+  /** Sample weight `0..1` — drives the circle opacity + radius. */
+  weight: number;
+  /** X coordinate in canvas pixels. */
+  x: number;
+  /** Y coordinate in canvas pixels. */
+  y: number;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type HeatOverlayLabels = {
+  /** Aria-label override. Defaults to `"Heat overlay"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Heat overlay",
+} as const satisfies Required<HeatOverlayLabels>;
+
+/**
+ * Props for {@link HeatOverlay}.
+ *
+ * @public
+ */
+export type HeatOverlayProps = {
+  /** Optional global tone applied to every point that omits its own. Defaults to `"warn"`. */
+  defaultTone?: HeatOverlayTone;
+  /** Sample radius in pixels at full weight. Defaults to `48`. */
+  intensity?: number;
+  /** Localizable strings. */
+  labels?: HeatOverlayLabels;
+  /** Sample points in render order. */
+  points: HeatPoint[];
+} & ComponentPropsWithoutRef<"svg">;
+
+const clamp01 = (v: number): number => {
+  if (v < 0) {
+    return 0;
+  }
+  if (v > 1) {
+    return 1;
+  }
+  return v;
+};
+
+const HeatBlob = (props: {
+  defaultTone: HeatOverlayTone;
+  gradientId: string;
+  intensity: number;
+  point: HeatPoint;
+}): React.ReactElement => {
+  const { defaultTone, gradientId, intensity, point } = props;
+  const weight = clamp01(point.weight);
+  const tone = point.tone ?? defaultTone;
+  return (
+    <circle
+      className={cn("mix-blend-multiply", TONE_FILL[tone])}
+      cx={point.x}
+      cy={point.y}
+      data-heat-point={point.id}
+      data-heat-tone={tone}
+      fill={`url(#${gradientId})`}
+      fillOpacity={weight * 0.6}
+      r={Math.max(8, intensity * weight)}
+    />
+  );
+};
+
+/**
+ * Heatmap-style overlay drawn on top of a canvas. Each sample renders
+ * as a soft radial blob whose radius + opacity scale with its weight.
+ * Pure presentation; the host computes the point list from the
+ * activity stream.
+ *
+ * Render inside a `position: relative` parent that shares the canvas
+ * pixel coordinate space; the SVG is `pointer-events: none` so host
+ * gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <HeatOverlay
+ *     points={[
+ *       { id: "a", x: 120, y: 80,  weight: 1.0, tone: "danger" },
+ *       { id: "b", x: 320, y: 220, weight: 0.4 },
+ *     ]}
+ *   />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const HeatOverlay = forwardRef<SVGSVGElement, HeatOverlayProps>(
+  (props, ref) => {
+    const {
+      className,
+      defaultTone = "warn",
+      intensity = 48,
+      labels,
+      points,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const gradientId = useId();
+    if (points.length === 0) {
+      return null;
+    }
+    return (
+      <svg
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "pointer-events-none absolute inset-0 z-10 h-full w-full",
+          className,
+        )}
+        data-heat-overlay
+        ref={ref}
+        role="img"
+        {...rest}
+      >
+        <defs>
+          <radialGradient cx="50%" cy="50%" id={gradientId} r="50%">
+            <stop offset="0%" stopColor="currentColor" stopOpacity="1" />
+            <stop offset="70%" stopColor="currentColor" stopOpacity="0.4" />
+            <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+          </radialGradient>
+        </defs>
+        {points.map((point) => (
+          <HeatBlob
+            defaultTone={defaultTone}
+            gradientId={gradientId}
+            intensity={intensity}
+            key={point.id}
+            point={point}
+          />
+        ))}
+      </svg>
+    );
+  },
+);
+HeatOverlay.displayName = "HeatOverlay";

--- a/packages/ui/src/components/heat-overlay/heat-overlay.visual.tsx
+++ b/packages/ui/src/components/heat-overlay/heat-overlay.visual.tsx
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { HeatOverlay } from "./heat-overlay";
+
+test.describe("HeatOverlay Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div
+        className="relative bg-muted/20"
+        style={{ height: 240, width: 360 }}
+      >
+        <HeatOverlay
+          points={[
+            { id: "a", tone: "danger", weight: 1, x: 90, y: 80 },
+            { id: "b", tone: "warn", weight: 0.6, x: 200, y: 110 },
+            { id: "c", tone: "cool", weight: 0.4, x: 280, y: 180 },
+            { id: "d", weight: 0.5, x: 140, y: 180 },
+          ]}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("heat-overlay-default.png");
+  });
+});

--- a/packages/ui/src/components/heat-overlay/index.ts
+++ b/packages/ui/src/components/heat-overlay/index.ts
@@ -1,0 +1,7 @@
+export {
+  HeatOverlay,
+  type HeatOverlayLabels,
+  type HeatOverlayProps,
+  type HeatOverlayTone,
+  type HeatPoint,
+} from "./heat-overlay";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -786,10 +786,25 @@ export {
 export { EdgeLabel, type EdgeLabelProps } from "./edge-label";
 export { GroupHull, type GroupHullProps } from "./group-hull";
 export {
+  HeatOverlay,
+  type HeatOverlayLabels,
+  type HeatOverlayProps,
+  type HeatOverlayTone,
+  type HeatPoint,
+} from "./heat-overlay";
+export {
   LiveCursor,
   type LiveCursorLabels,
   type LiveCursorProps,
 } from "./live-cursor";
+export {
+  MetricCluster,
+  type MetricClusterAnchor,
+  type MetricClusterEntry,
+  type MetricClusterLabels,
+  type MetricClusterProps,
+  type MetricClusterTone,
+} from "./metric-cluster";
 export {
   ObjectCard,
   type ObjectCardAction,
@@ -829,6 +844,13 @@ export {
   type SelectionPresenceLabels,
   type SelectionPresenceProps,
 } from "./selection-presence";
+export {
+  type StateBadgeAnchor,
+  StateBadgeOverlay,
+  type StateBadgeOverlayLabels,
+  type StateBadgeOverlayProps,
+  type StateBadgeState,
+} from "./state-badge-overlay";
 export {
   ThreadBubble,
   type ThreadBubbleLabels,

--- a/packages/ui/src/components/metric-cluster/index.ts
+++ b/packages/ui/src/components/metric-cluster/index.ts
@@ -1,0 +1,8 @@
+export {
+  MetricCluster,
+  type MetricClusterAnchor,
+  type MetricClusterEntry,
+  type MetricClusterLabels,
+  type MetricClusterProps,
+  type MetricClusterTone,
+} from "./metric-cluster";

--- a/packages/ui/src/components/metric-cluster/metric-cluster.mdx
+++ b/packages/ui/src/components/metric-cluster/metric-cluster.mdx
@@ -1,0 +1,69 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './metric-cluster.stories'
+
+<Meta of={Stories} />
+
+# MetricCluster
+
+Compact stack of related metrics pinned to a canvas object's corner. Use when a single \`StickyMetric\` doesn't carry enough signal — for runs whose throughput, latency, and error rate must all be visible at once. Pure presentation; the host supplies the anchor coords + the metric list.
+
+The wrapper is \`pointer-events: none\` — host gestures pass through.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/metric-cluster.json
+```
+
+## Import
+
+```tsx
+import { MetricCluster } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<MetricCluster
+  x={420} y={180}
+  anchor="top-right"
+  title="research-2025"
+  metrics={[
+    { id: "qps",  label: "qps",   value: "240", tone: "success" },
+    { id: "errs", label: "errs",  value: "14",  tone: "danger" },
+    { id: "p95",  label: "p95",   value: "180ms" },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Untitled
+
+Drop \`title\` for an even tighter ambient overlay.
+
+<Canvas of={Stories.Untitled} sourceState="shown" />
+
+## Bottom-left anchor
+
+The cluster translates so the chosen corner sits exactly on the anchor pixel.
+
+<Canvas of={Stories.BottomLeft} sourceState="shown" />
+
+## Healthy stack
+
+A row of \`success\` tones reads as a calm green column.
+
+<Canvas of={Stories.Healthy} sourceState="shown" />
+
+## Notes
+
+- Anchors map: \`top-right\` (default) · \`top-left\` · \`bottom-right\` · \`bottom-left\`. The anchor pixel is always the meeting corner.
+- Tones map: \`neutral\` (muted) · \`success\` (emerald) · \`warn\` (amber) · \`danger\` (red).
+- Each row emits \`data-metric-cluster-row\` (= id) + \`data-metric-cluster-tone\`. The wrapper emits \`data-metric-cluster\` + \`data-metric-cluster-anchor\`. The optional title emits \`data-metric-cluster-title\`.

--- a/packages/ui/src/components/metric-cluster/metric-cluster.stories.tsx
+++ b/packages/ui/src/components/metric-cluster/metric-cluster.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { MetricCluster } from "./metric-cluster";
+
+const meta = {
+  args: {
+    anchor: "top-right",
+    metrics: [
+      { id: "qps", label: "qps", tone: "success", value: "240" },
+      { id: "errs", label: "errs", tone: "danger", value: "14" },
+      { id: "p95", label: "p95", value: "180ms" },
+    ],
+    title: "research-2025",
+    x: 200,
+    y: 100,
+  },
+  component: MetricCluster,
+  decorators: [
+    (Story) => (
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 280, width: 360 }}
+      >
+        <div
+          className="absolute rounded-md border border-border bg-background"
+          style={{ height: 80, left: 80, top: 80, width: 160 }}
+        />
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/MetricCluster",
+} satisfies Meta<typeof MetricCluster>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Untitled: Story = {
+  args: { title: undefined },
+};
+
+export const BottomLeft: Story = {
+  args: {
+    anchor: "bottom-left",
+    x: 80,
+    y: 160,
+  },
+};
+
+export const Healthy: Story = {
+  args: {
+    metrics: [
+      { id: "qps", label: "qps", tone: "success", value: "240" },
+      { id: "errs", label: "errs", tone: "success", value: "0" },
+      { id: "p95", label: "p95", tone: "success", value: "85ms" },
+    ],
+  },
+};

--- a/packages/ui/src/components/metric-cluster/metric-cluster.test.tsx
+++ b/packages/ui/src/components/metric-cluster/metric-cluster.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MetricCluster, type MetricClusterEntry } from "./metric-cluster";
+
+const sample: MetricClusterEntry[] = [
+  { id: "qps", label: "qps", tone: "success", value: "240" },
+  { id: "errs", label: "errs", tone: "danger", value: "14" },
+  { id: "p95", label: "p95", value: "180ms" },
+];
+
+describe("MetricCluster", () => {
+  it("renders one row per metric", () => {
+    const { container } = render(
+      <MetricCluster metrics={sample} x={0} y={0} />,
+    );
+
+    expect(
+      container.querySelectorAll("[data-metric-cluster-row]"),
+    ).toHaveLength(3);
+  });
+
+  it("renders the title when provided", () => {
+    render(
+      <MetricCluster metrics={sample} title="research-2025" x={0} y={0} />,
+    );
+
+    expect(screen.getByText("research-2025")).toBeInTheDocument();
+  });
+
+  it("omits the title when not provided", () => {
+    const { container } = render(
+      <MetricCluster metrics={sample} x={0} y={0} />,
+    );
+
+    expect(
+      container.querySelector("[data-metric-cluster-title]"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("positions the cluster using the anchor coords", () => {
+    const { container } = render(
+      <MetricCluster metrics={sample} x={120} y={80} />,
+    );
+
+    expect(container.querySelector("[data-metric-cluster]")).toHaveStyle({
+      left: "120px",
+      top: "80px",
+    });
+  });
+
+  it("propagates per-row tone to a data attribute", () => {
+    const { container } = render(
+      <MetricCluster metrics={sample} x={0} y={0} />,
+    );
+
+    expect(
+      container.querySelector("[data-metric-cluster-row='errs']"),
+    ).toHaveAttribute("data-metric-cluster-tone", "danger");
+  });
+
+  it("falls back to neutral tone when omitted", () => {
+    const { container } = render(
+      <MetricCluster metrics={sample} x={0} y={0} />,
+    );
+
+    expect(
+      container.querySelector("[data-metric-cluster-row='p95']"),
+    ).toHaveAttribute("data-metric-cluster-tone", "neutral");
+  });
+});

--- a/packages/ui/src/components/metric-cluster/metric-cluster.tsx
+++ b/packages/ui/src/components/metric-cluster/metric-cluster.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Tone of a single metric line — drives the dot color.
+ *
+ * @public
+ */
+export type MetricClusterTone = "danger" | "neutral" | "success" | "warn";
+
+const TONE_DOT: Record<MetricClusterTone, string> = {
+  danger: "bg-red-500",
+  neutral: "bg-muted-foreground",
+  success: "bg-emerald-500",
+  warn: "bg-amber-500",
+};
+
+/**
+ * Anchor corner relative to the canvas object the cluster attaches to.
+ *
+ * @public
+ */
+export type MetricClusterAnchor =
+  | "bottom-left"
+  | "bottom-right"
+  | "top-left"
+  | "top-right";
+
+const ANCHOR_TRANSFORM: Record<MetricClusterAnchor, string> = {
+  "bottom-left": "translate(-100%, 100%)",
+  "bottom-right": "translate(0%, 100%)",
+  "top-left": "translate(-100%, -100%)",
+  "top-right": "translate(0%, -100%)",
+};
+
+/**
+ * One metric in the cluster.
+ *
+ * @public
+ */
+export type MetricClusterEntry = {
+  /** Stable identifier — used as the React key + analytics hook. */
+  id: string;
+  /** Short label (e.g. `"errs/min"`). */
+  label: ReactNode;
+  /** Optional tone for the leading dot. Defaults to `"neutral"`. */
+  tone?: MetricClusterTone;
+  /** Display value (already formatted by host). */
+  value: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type MetricClusterLabels = {
+  /** Aria-label override. Defaults to `"Metric cluster"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Metric cluster",
+} as const satisfies Required<MetricClusterLabels>;
+
+/**
+ * Props for {@link MetricCluster}.
+ *
+ * @public
+ */
+export type MetricClusterProps = {
+  /** Anchor corner. Defaults to `"top-right"`. */
+  anchor?: MetricClusterAnchor;
+  /** Localizable strings. */
+  labels?: MetricClusterLabels;
+  /** Metric entries in render order. */
+  metrics: MetricClusterEntry[];
+  /** Optional cluster title rendered above the rows. */
+  title?: ReactNode;
+  /** Anchor X in canvas pixels. */
+  x: number;
+  /** Anchor Y in canvas pixels. */
+  y: number;
+} & ComponentPropsWithoutRef<"div">;
+
+const Row = (props: { entry: MetricClusterEntry }): React.ReactElement => {
+  const { entry } = props;
+  const tone = entry.tone ?? "neutral";
+  return (
+    <li
+      className="flex items-center justify-between gap-2 text-[11px]"
+      data-metric-cluster-row={entry.id}
+      data-metric-cluster-tone={tone}
+    >
+      <span className="flex items-center gap-1.5 text-muted-foreground">
+        <span
+          aria-hidden="true"
+          className={cn("h-1.5 w-1.5 rounded-full", TONE_DOT[tone])}
+        />
+        {entry.label}
+      </span>
+      <span className="font-semibold text-foreground">{entry.value}</span>
+    </li>
+  );
+};
+
+/**
+ * Compact stack of related metrics pinned to a canvas object's corner.
+ * Use when a single `StickyMetric` doesn't carry enough signal — for
+ * runs whose throughput, latency, and error rate must all be visible
+ * at once. Pure presentation; the host supplies the anchor coords + the
+ * metric list.
+ *
+ * The wrapper is `pointer-events: none` — host gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <MetricCluster
+ *   x={420} y={180}
+ *   anchor="top-right"
+ *   title="research-2025"
+ *   metrics={[
+ *     { id: "qps",  label: "qps",   value: "240", tone: "success" },
+ *     { id: "errs", label: "errs",  value: "14",  tone: "danger" },
+ *     { id: "p95",  label: "p95",   value: "180ms" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const MetricCluster = forwardRef<HTMLDivElement, MetricClusterProps>(
+  (props, ref) => {
+    const {
+      anchor = "top-right",
+      className,
+      labels,
+      metrics,
+      title,
+      x,
+      y,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "pointer-events-none absolute z-20 flex flex-col gap-1 rounded-md border border-border bg-background/90 p-2 shadow-sm backdrop-blur",
+          className,
+        )}
+        data-metric-cluster
+        data-metric-cluster-anchor={anchor}
+        ref={ref}
+        role="status"
+        style={{
+          left: x,
+          top: y,
+          transform: ANCHOR_TRANSFORM[anchor],
+        }}
+        {...rest}
+      >
+        {title ? (
+          <header
+            className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+            data-metric-cluster-title
+          >
+            {title}
+          </header>
+        ) : null}
+        <ul className="space-y-0.5">
+          {metrics.map((entry) => (
+            <Row entry={entry} key={entry.id} />
+          ))}
+        </ul>
+      </div>
+    );
+  },
+);
+MetricCluster.displayName = "MetricCluster";

--- a/packages/ui/src/components/metric-cluster/metric-cluster.visual.tsx
+++ b/packages/ui/src/components/metric-cluster/metric-cluster.visual.tsx
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { MetricCluster } from "./metric-cluster";
+
+test.describe("MetricCluster Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 240, width: 360 }}
+      >
+        <div
+          className="absolute rounded-md border border-border bg-background"
+          style={{ height: 80, left: 100, top: 80, width: 160 }}
+        />
+        <MetricCluster
+          metrics={[
+            { id: "qps", label: "qps", tone: "success", value: "240" },
+            { id: "errs", label: "errs", tone: "danger", value: "14" },
+            { id: "p95", label: "p95", value: "180ms" },
+          ]}
+          title="research-2025"
+          x={260}
+          y={80}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("metric-cluster-default.png");
+  });
+});

--- a/packages/ui/src/components/state-badge-overlay/index.ts
+++ b/packages/ui/src/components/state-badge-overlay/index.ts
@@ -1,0 +1,7 @@
+export {
+  type StateBadgeAnchor,
+  StateBadgeOverlay,
+  type StateBadgeOverlayLabels,
+  type StateBadgeOverlayProps,
+  type StateBadgeState,
+} from "./state-badge-overlay";

--- a/packages/ui/src/components/state-badge-overlay/state-badge-overlay.mdx
+++ b/packages/ui/src/components/state-badge-overlay/state-badge-overlay.mdx
@@ -1,0 +1,63 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './state-badge-overlay.stories'
+
+<Meta of={Stories} />
+
+# StateBadgeOverlay
+
+State chip pinned to a canvas object's corner. Use when a single-letter glyph in \`ObjectCard\` doesn't carry enough signal — for runs that just transitioned, jobs that failed, agents idling. Pure presentation; the host computes the anchor from the object's bounding box.
+
+The wrapper is \`pointer-events: none\` — host gestures pass through.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/state-badge-overlay.json
+```
+
+## Import
+
+```tsx
+import { StateBadgeOverlay } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<div className="relative h-screen w-screen">
+  <Canvas />
+  <StateBadgeOverlay state="running" x={420} y={180} anchor="top-right" />
+</div>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Failed state
+
+\`failed\` renders the chip in red so the user can spot the problem object across a busy canvas.
+
+<Canvas of={Stories.Failed} sourceState="shown" />
+
+## Complete state
+
+\`complete\` is a calm emerald chip — visible but not loud, since complete is the default eventual state.
+
+<Canvas of={Stories.Complete} sourceState="shown" />
+
+## Custom label
+
+Pass \`label\` to override the humanized state name (e.g. domain-specific verbs).
+
+<Canvas of={Stories.CustomLabel} sourceState="shown" />
+
+## Notes
+
+- States map: \`idle\` (muted) · \`queued\` (amber) · \`running\` (blue, pulsing dot) · \`complete\` (emerald) · \`failed\` (red) · \`stopped\` (foreground).
+- Anchors map: \`top-right\` (default) · \`top-left\` · \`bottom-right\` · \`bottom-left\`. The anchor pixel is always the meeting corner.
+- Each render emits \`data-state-badge-overlay\` + \`data-state-name\` + \`data-state-anchor\`. The leading dot emits \`data-state-badge-dot\`.

--- a/packages/ui/src/components/state-badge-overlay/state-badge-overlay.stories.tsx
+++ b/packages/ui/src/components/state-badge-overlay/state-badge-overlay.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { StateBadgeOverlay } from "./state-badge-overlay";
+
+const meta = {
+  args: {
+    anchor: "top-right",
+    state: "running",
+    x: 200,
+    y: 100,
+  },
+  component: StateBadgeOverlay,
+  decorators: [
+    (Story) => (
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 240, width: 320 }}
+      >
+        <div
+          className="absolute rounded-md border border-border bg-background"
+          style={{ height: 80, left: 80, top: 80, width: 160 }}
+        />
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/StateBadgeOverlay",
+} satisfies Meta<typeof StateBadgeOverlay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Failed: Story = {
+  args: {
+    anchor: "bottom-left",
+    state: "failed",
+    x: 80,
+    y: 160,
+  },
+};
+
+export const Complete: Story = {
+  args: {
+    state: "complete",
+  },
+};
+
+export const CustomLabel: Story = {
+  args: {
+    label: "Spawning",
+    state: "queued",
+  },
+};

--- a/packages/ui/src/components/state-badge-overlay/state-badge-overlay.test.tsx
+++ b/packages/ui/src/components/state-badge-overlay/state-badge-overlay.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StateBadgeOverlay } from "./state-badge-overlay";
+
+describe("StateBadgeOverlay", () => {
+  it("renders the humanized state label by default", () => {
+    render(<StateBadgeOverlay state="running" x={0} y={0} />);
+
+    expect(screen.getByText("Running")).toBeInTheDocument();
+  });
+
+  it("uses the override label when provided", () => {
+    render(<StateBadgeOverlay label="In flight" state="running" x={0} y={0} />);
+
+    expect(screen.getByText("In flight")).toBeInTheDocument();
+  });
+
+  it("positions the badge using the anchor coords", () => {
+    const { container } = render(
+      <StateBadgeOverlay state="idle" x={120} y={80} />,
+    );
+
+    expect(container.querySelector("[data-state-badge-overlay]")).toHaveStyle({
+      left: "120px",
+      top: "80px",
+    });
+  });
+
+  it("propagates state + anchor to data attributes", () => {
+    const { container } = render(
+      <StateBadgeOverlay anchor="bottom-left" state="failed" x={0} y={0} />,
+    );
+
+    const badge = container.querySelector("[data-state-badge-overlay]");
+    expect(badge).toHaveAttribute("data-state-name", "failed");
+    expect(badge).toHaveAttribute("data-state-anchor", "bottom-left");
+  });
+
+  it("includes the human state in the aria-label", () => {
+    render(<StateBadgeOverlay state="complete" x={0} y={0} />);
+
+    expect(screen.getByLabelText("State: Complete")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/state-badge-overlay/state-badge-overlay.tsx
+++ b/packages/ui/src/components/state-badge-overlay/state-badge-overlay.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * State name — drives the badge tone.
+ *
+ * @public
+ */
+export type StateBadgeState =
+  | "complete"
+  | "failed"
+  | "idle"
+  | "queued"
+  | "running"
+  | "stopped";
+
+const STATE_LABEL: Record<StateBadgeState, string> = {
+  complete: "Complete",
+  failed: "Failed",
+  idle: "Idle",
+  queued: "Queued",
+  running: "Running",
+  stopped: "Stopped",
+};
+
+const STATE_TONE: Record<StateBadgeState, string> = {
+  complete:
+    "border-emerald-500/40 bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+  failed: "border-red-500/40 bg-red-500/15 text-red-700 dark:text-red-300",
+  idle: "border-border bg-muted/40 text-muted-foreground",
+  queued:
+    "border-amber-500/40 bg-amber-500/15 text-amber-700 dark:text-amber-300",
+  running: "border-blue-500/40 bg-blue-500/15 text-blue-700 dark:text-blue-300",
+  stopped: "border-border bg-background text-foreground",
+};
+
+const STATE_DOT: Record<StateBadgeState, string> = {
+  complete: "bg-emerald-500",
+  failed: "bg-red-500",
+  idle: "bg-muted-foreground",
+  queued: "bg-amber-500",
+  running: "bg-blue-500 animate-pulse",
+  stopped: "bg-muted-foreground",
+};
+
+/**
+ * Anchor corner relative to the canvas object the badge attaches to.
+ *
+ * @public
+ */
+export type StateBadgeAnchor =
+  | "bottom-left"
+  | "bottom-right"
+  | "top-left"
+  | "top-right";
+
+const ANCHOR_TRANSFORM: Record<StateBadgeAnchor, string> = {
+  "bottom-left": "translate(-100%, 100%)",
+  "bottom-right": "translate(0%, 100%)",
+  "top-left": "translate(-100%, -100%)",
+  "top-right": "translate(0%, -100%)",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type StateBadgeOverlayLabels = {
+  /** Aria-label override. Defaults to `"State"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "State",
+} as const satisfies Required<StateBadgeOverlayLabels>;
+
+/**
+ * Props for {@link StateBadgeOverlay}.
+ *
+ * @public
+ */
+export type StateBadgeOverlayProps = {
+  /** Anchor corner. Defaults to `"top-right"`. */
+  anchor?: StateBadgeAnchor;
+  /** Optional override label (defaults to humanized state name). */
+  label?: ReactNode;
+  /** Localizable strings. */
+  labels?: StateBadgeOverlayLabels;
+  /** State to display. */
+  state: StateBadgeState;
+  /** Anchor X in canvas pixels. */
+  x: number;
+  /** Anchor Y in canvas pixels. */
+  y: number;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * State chip pinned to a canvas object's corner. Use when a single-
+ * letter glyph in `ObjectCard` doesn't carry enough signal — for
+ * runs that have transitioned, jobs that failed, agents idling. Pure
+ * presentation; the host computes the anchor from the object's
+ * bounding box.
+ *
+ * The wrapper is `pointer-events: none` — host gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <StateBadgeOverlay state="running" x={420} y={180} anchor="top-right" />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const StateBadgeOverlay = forwardRef<
+  HTMLDivElement,
+  StateBadgeOverlayProps
+>((props, ref) => {
+  const {
+    anchor = "top-right",
+    className,
+    label,
+    labels,
+    state,
+    x,
+    y,
+    ...rest
+  } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const text = label ?? STATE_LABEL[state];
+  return (
+    <div
+      aria-label={`${resolvedLabels.region}: ${STATE_LABEL[state]}`}
+      className={cn(
+        "pointer-events-none absolute z-20 inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide shadow-sm backdrop-blur",
+        STATE_TONE[state],
+        className,
+      )}
+      data-state-anchor={anchor}
+      data-state-badge-overlay
+      data-state-name={state}
+      ref={ref}
+      role="status"
+      style={{
+        left: x,
+        top: y,
+        transform: ANCHOR_TRANSFORM[anchor],
+      }}
+      {...rest}
+    >
+      <span
+        aria-hidden="true"
+        className={cn("h-1.5 w-1.5 rounded-full", STATE_DOT[state])}
+        data-state-badge-dot
+      />
+      {text}
+    </div>
+  );
+});
+StateBadgeOverlay.displayName = "StateBadgeOverlay";

--- a/packages/ui/src/components/state-badge-overlay/state-badge-overlay.visual.tsx
+++ b/packages/ui/src/components/state-badge-overlay/state-badge-overlay.visual.tsx
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { StateBadgeOverlay } from "./state-badge-overlay";
+
+test.describe("StateBadgeOverlay Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 240, width: 360 }}
+      >
+        <div
+          className="absolute rounded-md border border-border bg-background"
+          style={{ height: 80, left: 100, top: 80, width: 160 }}
+        />
+        <StateBadgeOverlay state="running" x={260} y={80} />
+        <StateBadgeOverlay
+          anchor="bottom-left"
+          state="failed"
+          x={100}
+          y={160}
+        />
+        <StateBadgeOverlay
+          anchor="bottom-right"
+          state="complete"
+          x={260}
+          y={160}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "state-badge-overlay-default.png",
+    );
+  });
+});


### PR DESCRIPTION
Closes #136

## What's in

Three more calm canvas runtime overlays for issue #136:

- **HeatOverlay** — heatmap-style overlay with soft radial blobs whose radius + opacity scale with each sample's weight. Tones: \`neutral\` / \`warn\` (default) / \`danger\` / \`cool\`. SVG \`mix-blend-multiply\`, \`pointer-events: none\`. Distinct from \`ActivityHeatmap\` (calendar-style grid): \`HeatOverlay\` floats over a free-form canvas.
- **StateBadgeOverlay** — state chip pinned to a canvas object's corner. States: \`idle\` / \`queued\` / \`running\` (pulsing dot) / \`complete\` / \`failed\` / \`stopped\`. Four anchor corners, optional \`label\` override for domain-specific verbs.
- **MetricCluster** — compact stack of related metrics pinned to a corner. Optional \`title\` row; per-row tone dot; four anchors. Use when a single \`StickyMetric\` doesn't carry enough signal (qps + errs + p95 in one calm tile).

All three are pure presentation; the host computes geometry / value / tone from the runtime stream. Wired into the \`@vllnt/ui\` barrel and the shadcn registry.

## Files

- \`packages/ui/src/components/heat-overlay/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/state-badge-overlay/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/metric-cluster/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/index.ts\` — barrel exports
- \`apps/registry/registry/default/{heat-overlay,state-badge-overlay,metric-cluster}/*.tsx\` — registry shims
- \`apps/registry/registry.json\` — three new entries (alphabetically placed)

## Stacks with PR #201

PR #201 shipped \`AlertPulse\` + \`ThresholdRing\` + \`StickyMetric\`. Together with this PR that's 6 / 10 of \`#136\`. Remaining: \`RunTimeline\`, \`BottomActivityStrip\`, \`TimelineScrubber\`, \`PlaybackGhost\`.

## Quality gates

- lint: PASS (\`eslint --fix\` clean)
- typecheck: PASS (\`tsc --noEmit --project tsconfig.build.json\`)
- check:use-client: PASS (182 components)
- check:story-coverage: PASS (172 components)
- verify-stories: PASS (no crash risks)
- test: PASS (510 / 510 — incl. 17 new)
- build (\`@vllnt/ui\`): PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)
- [ ] Storybook renders all 12 stories (4 per primitive) without console errors
- [ ] Visual snapshots stable across primitives