### PR TITLE
feat(ui): time navigation — TimelineScrubber + PlaybackGhost + BottomActivityStrip (partial #136)

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -328,6 +328,21 @@
       "category": "utility"
     },
     {
+      "name": "bottom-activity-strip",
+      "type": "registry:component",
+      "title": "Bottom Activity Strip",
+      "description": "Slim horizontally-scrolling row of recent canvas events for low-noise live activity.",
+      "files": [
+        {
+          "path": "registry/default/bottom-activity-strip/bottom-activity-strip.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data"
+    },
+    {
       "name": "breadcrumb",
       "type": "registry:component",
       "title": "Breadcrumb",
@@ -1437,6 +1452,21 @@
       "category": "content"
     },
     {
+      "name": "playback-ghost",
+      "type": "registry:component",
+      "title": "Playback Ghost",
+      "description": "Translucent overlay marking where a canvas object was at a previous timestamp during playback.",
+      "files": [
+        {
+          "path": "registry/default/playback-ghost/playback-ghost.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "utility"
+    },
+    {
       "name": "popover",
       "type": "registry:component",
       "title": "Popover",
@@ -2223,6 +2253,21 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "data"
+    },
+    {
+      "name": "timeline-scrubber",
+      "type": "registry:component",
+      "title": "Timeline Scrubber",
+      "description": "Range slider for scrubbing through canvas state playback, with optional milestone ticks.",
+      "files": [
+        {
+          "path": "registry/default/timeline-scrubber/timeline-scrubber.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "form"
     },
     {
       "name": "tldr-section",

--- a/apps/registry/registry/default/bottom-activity-strip/bottom-activity-strip.tsx
+++ b/apps/registry/registry/default/bottom-activity-strip/bottom-activity-strip.tsx
@@ -1,0 +1,7 @@
+export {
+  type ActivityEvent,
+  type ActivityStripTone,
+  BottomActivityStrip,
+  type BottomActivityStripLabels,
+  type BottomActivityStripProps,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/playback-ghost/playback-ghost.tsx
+++ b/apps/registry/registry/default/playback-ghost/playback-ghost.tsx
@@ -1,0 +1,6 @@
+export {
+  PlaybackGhost,
+  type PlaybackGhostKind,
+  type PlaybackGhostLabels,
+  type PlaybackGhostProps,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/timeline-scrubber/timeline-scrubber.tsx
+++ b/apps/registry/registry/default/timeline-scrubber/timeline-scrubber.tsx
@@ -1,0 +1,7 @@
+export {
+  type TimelineScrubberLabels,
+  type TimelineScrubberProps,
+  type TimelineScrubberTone,
+  TimelineScrubber,
+  type TimelineTick,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/bottom-activity-strip/bottom-activity-strip.mdx
+++ b/packages/ui/src/components/bottom-activity-strip/bottom-activity-strip.mdx
@@ -1,0 +1,67 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './bottom-activity-strip.stories'
+
+<Meta of={Stories} />
+
+# BottomActivityStrip
+
+Slim bottom strip showing a horizontally-scrolling row of recent canvas events. The lowest-noise live execution surface — keep \`ObjectCard\`, panels, and overlays for high-value surfaces; let the strip carry the steady drip of activity.
+
+Pure presentation; the host computes the event list (newest first) and supplies an optional \`onActivate\` per event to jump to the related object.
+
+Distinct from \`ActivityLog\` (vertical, persistent) and \`LiveFeed\` (full-height feed): this primitive is a single horizontal row that lives at the bottom of the canvas.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/bottom-activity-strip.json
+```
+
+## Import
+
+```tsx
+import { BottomActivityStrip } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<BottomActivityStrip
+  events={[
+    { id: "1", label: "deploy ok",   ts: "12s", tone: "success" },
+    { id: "2", label: "queue spike", ts: "1m",  tone: "warn" },
+  ]}
+  maxEvents={20}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Empty
+
+When the event list is empty, the strip renders a calm placeholder.
+
+<Canvas of={Stories.Empty} sourceState="shown" />
+
+## Capped
+
+\`maxEvents\` caps the rendered chips and drops the tail silently — the host can keep its full event log without bloating the strip.
+
+<Canvas of={Stories.Capped} sourceState="shown" />
+
+## Non-interactive
+
+Drop \`onActivate\` and chips render as plain spans (no hover, no button semantics).
+
+<Canvas of={Stories.NonInteractive} sourceState="shown" />
+
+## Notes
+
+- Tones map: \`neutral\` (muted) · \`info\` (blue) · \`success\` (emerald) · \`warn\` (amber) · \`danger\` (red).
+- Each chip emits \`data-strip-event\` (= id) + \`data-strip-event-tone\`. The wrapper emits \`data-bottom-activity-strip\`. The empty placeholder emits \`data-strip-state="empty"\`.

--- a/packages/ui/src/components/bottom-activity-strip/bottom-activity-strip.stories.tsx
+++ b/packages/ui/src/components/bottom-activity-strip/bottom-activity-strip.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { BottomActivityStrip } from "./bottom-activity-strip";
+
+const noop = (): void => undefined;
+
+const meta = {
+  args: {
+    events: [
+      { id: "1", label: "deploy ok", onActivate: noop, tone: "success", ts: "12s" },
+      { id: "2", label: "queue spike", onActivate: noop, tone: "warn", ts: "1m" },
+      { id: "3", label: "alert resolved", onActivate: noop, tone: "info", ts: "3m" },
+      { id: "4", label: "p95 trip", onActivate: noop, tone: "danger", ts: "5m" },
+      { id: "5", label: "agent idle", onActivate: noop, ts: "8m" },
+    ],
+  },
+  component: BottomActivityStrip,
+  decorators: [
+    (Story) => (
+      <div className="w-[480px]">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/BottomActivityStrip",
+} satisfies Meta<typeof BottomActivityStrip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: { events: [] },
+};
+
+export const Capped: Story = {
+  args: { maxEvents: 3 },
+};
+
+export const NonInteractive: Story = {
+  args: {
+    events: [
+      { id: "1", label: "deploy ok", tone: "success", ts: "12s" },
+      { id: "2", label: "queue spike", tone: "warn", ts: "1m" },
+    ],
+  },
+};

--- a/packages/ui/src/components/bottom-activity-strip/bottom-activity-strip.test.tsx
+++ b/packages/ui/src/components/bottom-activity-strip/bottom-activity-strip.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type ActivityEvent,
+  BottomActivityStrip,
+} from "./bottom-activity-strip";
+
+const sample: ActivityEvent[] = [
+  { id: "1", label: "deploy ok", tone: "success", ts: "12s" },
+  { id: "2", label: "queue spike", tone: "warn", ts: "1m" },
+  { id: "3", label: "alert resolved", tone: "info", ts: "3m" },
+];
+
+describe("BottomActivityStrip", () => {
+  it("renders the empty state when events list is empty", () => {
+    const { container } = render(<BottomActivityStrip events={[]} />);
+
+    expect(
+      container.querySelector("[data-strip-state='empty']"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No recent activity")).toBeInTheDocument();
+  });
+
+  it("renders one chip per event", () => {
+    const { container } = render(<BottomActivityStrip events={sample} />);
+
+    expect(container.querySelectorAll("[data-strip-event]")).toHaveLength(3);
+  });
+
+  it("propagates per-event tone to a data attribute", () => {
+    const { container } = render(<BottomActivityStrip events={sample} />);
+
+    expect(container.querySelector("[data-strip-event='1']")).toHaveAttribute(
+      "data-strip-event-tone",
+      "success",
+    );
+  });
+
+  it("invokes onActivate when an interactive chip is clicked", () => {
+    const handleActivate = vi.fn();
+    render(
+      <BottomActivityStrip
+        events={[
+          {
+            id: "1",
+            label: "click me",
+            onActivate: handleActivate,
+            ts: "now",
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(handleActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders chips as plain spans when onActivate is omitted", () => {
+    render(<BottomActivityStrip events={sample} />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("respects maxEvents and drops the tail", () => {
+    const { container } = render(
+      <BottomActivityStrip events={sample} maxEvents={2} />,
+    );
+
+    expect(container.querySelectorAll("[data-strip-event]")).toHaveLength(2);
+    expect(
+      container.querySelector("[data-strip-event='3']"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/bottom-activity-strip/bottom-activity-strip.tsx
+++ b/packages/ui/src/components/bottom-activity-strip/bottom-activity-strip.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Tone of an event — drives the leading dot color.
+ *
+ * @public
+ */
+export type ActivityStripTone =
+  | "danger"
+  | "info"
+  | "neutral"
+  | "success"
+  | "warn";
+
+const TONE_DOT: Record<ActivityStripTone, string> = {
+  danger: "bg-red-500",
+  info: "bg-blue-500",
+  neutral: "bg-muted-foreground",
+  success: "bg-emerald-500",
+  warn: "bg-amber-500",
+};
+
+/**
+ * One event in the strip.
+ *
+ * @public
+ */
+export type ActivityEvent = {
+  /** Stable identifier — used as the React key + analytics hook. */
+  id: string;
+  /** Short label (e.g. `"deploy completed"`). */
+  label: ReactNode;
+  /** Optional click handler — when provided, the chip becomes a button. */
+  onActivate?: () => void;
+  /** Optional tone for the leading dot. Defaults to `"neutral"`. */
+  tone?: ActivityStripTone;
+  /** Pre-formatted timestamp (host owns formatting). */
+  ts: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type BottomActivityStripLabels = {
+  /** Empty-state copy. Defaults to `"No recent activity"`. */
+  empty?: string;
+  /** Aria-label for the strip. Defaults to `"Recent activity"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No recent activity",
+  region: "Recent activity",
+} as const satisfies Required<BottomActivityStripLabels>;
+
+/**
+ * Props for {@link BottomActivityStrip}.
+ *
+ * @public
+ */
+export type BottomActivityStripProps = {
+  /** Event entries — newest first. */
+  events: ActivityEvent[];
+  /** Localizable strings. */
+  labels?: BottomActivityStripLabels;
+  /** Cap the rendered events. The component drops the tail without warning. */
+  maxEvents?: number;
+} & ComponentPropsWithoutRef<"section">;
+
+const ChipBody = (props: { event: ActivityEvent }): React.ReactElement => {
+  const { event } = props;
+  const tone = event.tone ?? "neutral";
+  return (
+    <span className="flex items-center gap-1.5 whitespace-nowrap">
+      <span
+        aria-hidden="true"
+        className={cn("h-1.5 w-1.5 rounded-full", TONE_DOT[tone])}
+      />
+      <span className="text-foreground">{event.label}</span>
+      <span className="text-[10px] text-muted-foreground" data-strip-event-ts>
+        {event.ts}
+      </span>
+    </span>
+  );
+};
+
+const Chip = (props: { event: ActivityEvent }): React.ReactElement => {
+  const { event } = props;
+  const tone = event.tone ?? "neutral";
+  if (event.onActivate) {
+    const handleClick = (): void => {
+      event.onActivate?.();
+    };
+    return (
+      <button
+        className="flex items-center rounded-full border border-border bg-background px-2 py-1 text-[11px] transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        data-strip-event={event.id}
+        data-strip-event-tone={tone}
+        onClick={handleClick}
+        type="button"
+      >
+        <ChipBody event={event} />
+      </button>
+    );
+  }
+  return (
+    <span
+      className="flex items-center rounded-full border border-border bg-background px-2 py-1 text-[11px]"
+      data-strip-event={event.id}
+      data-strip-event-tone={tone}
+    >
+      <ChipBody event={event} />
+    </span>
+  );
+};
+
+/**
+ * Slim bottom strip showing a horizontally-scrolling row of recent
+ * canvas events. The lowest-noise live execution surface — keep
+ * `ObjectCard`, panels, and overlays for high-value surfaces; let the
+ * strip carry the steady drip of activity.
+ *
+ * Pure presentation; the host computes the event list (newest first)
+ * and supplies an optional `onActivate` per event to jump to the
+ * related object.
+ *
+ * Distinct from `ActivityLog` (vertical, persistent) and `LiveFeed`
+ * (full-height feed): this primitive is a single horizontal row that
+ * lives at the bottom of the canvas.
+ *
+ * @example
+ * ```tsx
+ * <BottomActivityStrip
+ *   events={[
+ *     { id: "1", label: "deploy ok", ts: "12s", tone: "success" },
+ *     { id: "2", label: "queue spike", ts: "1m", tone: "warn" },
+ *   ]}
+ *   maxEvents={20}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const BottomActivityStrip = forwardRef<
+  HTMLElement,
+  BottomActivityStripProps
+>((props, ref) => {
+  const { className, events, labels, maxEvents, ...rest } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const visible =
+    maxEvents === undefined || maxEvents >= events.length
+      ? events
+      : events.slice(0, maxEvents);
+  return (
+    <section
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "flex w-full items-center gap-2 overflow-x-auto rounded-md border border-border bg-background/90 px-2 py-1 text-foreground",
+        className,
+      )}
+      data-bottom-activity-strip
+      ref={ref}
+      {...rest}
+    >
+      {visible.length === 0 ? (
+        <span
+          className="px-2 text-[11px] text-muted-foreground"
+          data-strip-state="empty"
+        >
+          {resolvedLabels.empty}
+        </span>
+      ) : (
+        visible.map((event) => <Chip event={event} key={event.id} />)
+      )}
+    </section>
+  );
+});
+BottomActivityStrip.displayName = "BottomActivityStrip";

--- a/packages/ui/src/components/bottom-activity-strip/bottom-activity-strip.visual.tsx
+++ b/packages/ui/src/components/bottom-activity-strip/bottom-activity-strip.visual.tsx
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { BottomActivityStrip } from "./bottom-activity-strip";
+
+test.describe("BottomActivityStrip Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="bg-muted/30 p-4" style={{ width: 480 }}>
+        <BottomActivityStrip
+          events={[
+            { id: "1", label: "deploy ok", tone: "success", ts: "12s" },
+            { id: "2", label: "queue spike", tone: "warn", ts: "1m" },
+            { id: "3", label: "alert resolved", tone: "info", ts: "3m" },
+            { id: "4", label: "p95 trip", tone: "danger", ts: "5m" },
+            { id: "5", label: "agent idle", ts: "8m" },
+          ]}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "bottom-activity-strip-default.png",
+    );
+  });
+});

--- a/packages/ui/src/components/bottom-activity-strip/index.ts
+++ b/packages/ui/src/components/bottom-activity-strip/index.ts
@@ -1,0 +1,7 @@
+export {
+  type ActivityEvent,
+  type ActivityStripTone,
+  BottomActivityStrip,
+  type BottomActivityStripLabels,
+  type BottomActivityStripProps,
+} from "./bottom-activity-strip";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -766,6 +766,13 @@ export {
 // Canvas/Object components
 export { AnchorPort, type AnchorPortProps } from "./anchor-port";
 export {
+  type ActivityEvent,
+  type ActivityStripTone,
+  BottomActivityStrip,
+  type BottomActivityStripLabels,
+  type BottomActivityStripProps,
+} from "./bottom-activity-strip";
+export {
   CommentPin,
   type CommentPinLabels,
   type CommentPinProps,
@@ -790,6 +797,12 @@ export {
   type ObjectCardProps,
 } from "./object-card";
 export { ObjectHandle, type ObjectHandleProps } from "./object-handle";
+export {
+  PlaybackGhost,
+  type PlaybackGhostKind,
+  type PlaybackGhostLabels,
+  type PlaybackGhostProps,
+} from "./playback-ghost";
 export {
   PresenceStack,
   type PresenceStackLabels,
@@ -822,6 +835,13 @@ export {
   type ThreadBubbleProps,
   type ThreadMessage,
 } from "./thread-bubble";
+export {
+  type TimelineScrubberLabels,
+  type TimelineScrubberProps,
+  type TimelineScrubberTone,
+  TimelineScrubber,
+  type TimelineTick,
+} from "./timeline-scrubber";
 
 // AI/Chat components
 export {

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -836,10 +836,10 @@ export {
   type ThreadMessage,
 } from "./thread-bubble";
 export {
+  TimelineScrubber,
   type TimelineScrubberLabels,
   type TimelineScrubberProps,
   type TimelineScrubberTone,
-  TimelineScrubber,
   type TimelineTick,
 } from "./timeline-scrubber";
 

--- a/packages/ui/src/components/playback-ghost/index.ts
+++ b/packages/ui/src/components/playback-ghost/index.ts
@@ -1,0 +1,6 @@
+export {
+  PlaybackGhost,
+  type PlaybackGhostKind,
+  type PlaybackGhostLabels,
+  type PlaybackGhostProps,
+} from "./playback-ghost";

--- a/packages/ui/src/components/playback-ghost/playback-ghost.mdx
+++ b/packages/ui/src/components/playback-ghost/playback-ghost.mdx
@@ -1,0 +1,65 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './playback-ghost.stories'
+
+<Meta of={Stories} />
+
+# PlaybackGhost
+
+Translucent overlay marking where a canvas object was at a previous timestamp during state playback. Renders a kind glyph (and optional label) at the historical position so the user can compare the present canvas against earlier state without losing context.
+
+Pure presentation; the host computes the historical position from the scrubbed timestamp. Pair with \`TimelineScrubber\` to drive the cursor.
+
+The wrapper is \`pointer-events: none\` so host gestures pass through.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/playback-ghost.json
+```
+
+## Import
+
+```tsx
+import { PlaybackGhost } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<div className="relative h-screen w-screen">
+  <Canvas />
+  <PlaybackGhost x={420} y={180} kind="run" label="research-2025" />
+</div>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Faint
+
+Lower \`opacity\` produces a quieter ghost — good for far-back history.
+
+<Canvas of={Stories.Faint} sourceState="shown" />
+
+## Bold
+
+Higher \`opacity\` keeps the ghost legible against busy canvases.
+
+<Canvas of={Stories.Bold} sourceState="shown" />
+
+## Glyphless
+
+Drop \`kind\` to render a label-only ghost (still emits \`data-playback-kind="unknown"\`).
+
+<Canvas of={Stories.Glyphless} sourceState="shown" />
+
+## Notes
+
+- Kinds map: \`agent\` ◇ · \`run\` ▶ · \`task\` ▢ · \`artifact\` ◌ · \`input\` ↘ · \`output\` ↗.
+- Opacity clamps to \`0..1\`; size floors at \`16\` px.
+- Each render emits \`data-playback-ghost\` + \`data-playback-kind\`. The optional label emits \`data-playback-ghost-label\`.

--- a/packages/ui/src/components/playback-ghost/playback-ghost.stories.tsx
+++ b/packages/ui/src/components/playback-ghost/playback-ghost.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PlaybackGhost } from "./playback-ghost";
+
+const meta = {
+  args: {
+    kind: "run",
+    label: "research-2025",
+    opacity: 0.4,
+    size: 40,
+    x: 160,
+    y: 100,
+  },
+  component: PlaybackGhost,
+  decorators: [
+    (Story) => (
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 220, width: 320 }}
+      >
+        <div
+          className="absolute rounded-md border border-border bg-background"
+          style={{ height: 60, left: 180, top: 80, width: 120 }}
+        />
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/PlaybackGhost",
+} satisfies Meta<typeof PlaybackGhost>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Faint: Story = {
+  args: { opacity: 0.2 },
+};
+
+export const Bold: Story = {
+  args: { opacity: 0.7 },
+};
+
+export const Glyphless: Story = {
+  args: { kind: undefined, label: "anon" },
+};

--- a/packages/ui/src/components/playback-ghost/playback-ghost.test.tsx
+++ b/packages/ui/src/components/playback-ghost/playback-ghost.test.tsx
@@ -7,10 +7,13 @@ describe("PlaybackGhost", () => {
   it("centers the ghost on the cx/cy point", () => {
     const { container } = render(<PlaybackGhost size={50} x={120} y={80} />);
 
-    expect(container.querySelector("[data-playback-ghost]")).toHaveStyle({
-      left: `${120 - 50 / 2}px`,
-      top: `${80 - 50 / 2}px`,
+    const ghost = container.querySelector("[data-playback-ghost]");
+    expect(ghost).toHaveStyle({
+      left: "120px",
+      top: "80px",
     });
+    expect(ghost?.className).toMatch(/-translate-x-1\/2/);
+    expect(ghost?.className).toMatch(/-translate-y-1\/2/);
   });
 
   it("renders the kind glyph + label", () => {

--- a/packages/ui/src/components/playback-ghost/playback-ghost.test.tsx
+++ b/packages/ui/src/components/playback-ghost/playback-ghost.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PlaybackGhost } from "./playback-ghost";
+
+describe("PlaybackGhost", () => {
+  it("centers the ghost on the cx/cy point", () => {
+    const { container } = render(<PlaybackGhost size={50} x={120} y={80} />);
+
+    expect(container.querySelector("[data-playback-ghost]")).toHaveStyle({
+      left: `${120 - 50 / 2}px`,
+      top: `${80 - 50 / 2}px`,
+    });
+  });
+
+  it("renders the kind glyph + label", () => {
+    render(<PlaybackGhost kind="run" label="research-2025" x={0} y={0} />);
+
+    expect(screen.getByText("research-2025")).toBeInTheDocument();
+    expect(screen.getByLabelText("Playback ghost: Run")).toBeInTheDocument();
+  });
+
+  it("propagates kind to a data attribute", () => {
+    const { container } = render(<PlaybackGhost kind="task" x={0} y={0} />);
+
+    expect(container.querySelector("[data-playback-ghost]")).toHaveAttribute(
+      "data-playback-kind",
+      "task",
+    );
+  });
+
+  it("falls back to 'unknown' when kind is omitted", () => {
+    const { container } = render(<PlaybackGhost x={0} y={0} />);
+
+    expect(container.querySelector("[data-playback-ghost]")).toHaveAttribute(
+      "data-playback-kind",
+      "unknown",
+    );
+  });
+
+  it("clamps opacity into 0..1", () => {
+    const { container } = render(<PlaybackGhost opacity={5} x={0} y={0} />);
+
+    expect(container.querySelector("[data-playback-ghost]")).toHaveStyle({
+      opacity: "1",
+    });
+  });
+
+  it("clamps size to a sane minimum", () => {
+    const { container } = render(<PlaybackGhost size={4} x={0} y={0} />);
+
+    expect(container.querySelector("[data-playback-ghost]")).toHaveStyle({
+      "min-width": "16px",
+    });
+  });
+});

--- a/packages/ui/src/components/playback-ghost/playback-ghost.tsx
+++ b/packages/ui/src/components/playback-ghost/playback-ghost.tsx
@@ -128,7 +128,7 @@ export const PlaybackGhost = forwardRef<HTMLDivElement, PlaybackGhostProps>(
       <div
         aria-label={ariaLabel}
         className={cn(
-          "pointer-events-none absolute z-10 inline-flex items-center gap-1.5 rounded-md border border-dashed border-border/70 bg-background/40 px-2 py-1 text-xs text-foreground backdrop-blur-sm",
+          "pointer-events-none absolute z-10 inline-flex -translate-x-1/2 -translate-y-1/2 items-center justify-center gap-1.5 rounded-md border border-dashed border-border/70 bg-background/40 px-2 py-1 text-xs text-foreground backdrop-blur-sm",
           className,
         )}
         data-playback-ghost
@@ -136,11 +136,11 @@ export const PlaybackGhost = forwardRef<HTMLDivElement, PlaybackGhostProps>(
         ref={ref}
         role="img"
         style={{
-          left: x - safeSize / 2,
+          left: x,
           minHeight: safeSize,
           minWidth: safeSize,
           opacity: safeOpacity,
-          top: y - safeSize / 2,
+          top: y,
         }}
         {...rest}
       >

--- a/packages/ui/src/components/playback-ghost/playback-ghost.tsx
+++ b/packages/ui/src/components/playback-ghost/playback-ghost.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Object kind — drives the ghost glyph.
+ *
+ * @public
+ */
+export type PlaybackGhostKind =
+  | "agent"
+  | "artifact"
+  | "input"
+  | "output"
+  | "run"
+  | "task";
+
+const KIND_GLYPH: Record<PlaybackGhostKind, string> = {
+  agent: "◇",
+  artifact: "◌",
+  input: "↘",
+  output: "↗",
+  run: "▶",
+  task: "▢",
+};
+
+const KIND_LABEL: Record<PlaybackGhostKind, string> = {
+  agent: "Agent",
+  artifact: "Artifact",
+  input: "Input",
+  output: "Output",
+  run: "Run",
+  task: "Task",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type PlaybackGhostLabels = {
+  /** Aria-label override. Defaults to `"Playback ghost"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Playback ghost",
+} as const satisfies Required<PlaybackGhostLabels>;
+
+/**
+ * Props for {@link PlaybackGhost}.
+ *
+ * @public
+ */
+export type PlaybackGhostProps = {
+  /** Optional kind glyph + tooltip. */
+  kind?: PlaybackGhostKind;
+  /** Optional label rendered next to the glyph (e.g. id, run name). */
+  label?: ReactNode;
+  /** Localizable strings. */
+  labels?: PlaybackGhostLabels;
+  /** Ghost opacity `0..1`. Defaults to `0.4`. */
+  opacity?: number;
+  /** Ghost size in pixels. Defaults to `40`. */
+  size?: number;
+  /** Center X in canvas pixels. */
+  x: number;
+  /** Center Y in canvas pixels. */
+  y: number;
+} & ComponentPropsWithoutRef<"div">;
+
+const clamp01 = (v: number): number => {
+  if (v < 0) {
+    return 0;
+  }
+  if (v > 1) {
+    return 1;
+  }
+  return v;
+};
+
+/**
+ * Translucent overlay marking where a canvas object was at a previous
+ * timestamp during state playback. Renders a kind glyph (and optional
+ * label) at the historical position so the user can compare the
+ * present canvas against earlier state without losing context.
+ *
+ * Pure presentation; the host computes the historical position from the
+ * scrubbed timestamp. The wrapper is `pointer-events: none` so host
+ * gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <PlaybackGhost x={420} y={180} kind="run" label="research-2025" />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const PlaybackGhost = forwardRef<HTMLDivElement, PlaybackGhostProps>(
+  (props, ref) => {
+    const {
+      className,
+      kind,
+      label,
+      labels,
+      opacity = 0.4,
+      size = 40,
+      x,
+      y,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const safeOpacity = clamp01(opacity);
+    const safeSize = size < 16 ? 16 : size;
+    const ariaLabel = kind
+      ? `${resolvedLabels.region}: ${KIND_LABEL[kind]}`
+      : resolvedLabels.region;
+    return (
+      <div
+        aria-label={ariaLabel}
+        className={cn(
+          "pointer-events-none absolute z-10 inline-flex items-center gap-1.5 rounded-md border border-dashed border-border/70 bg-background/40 px-2 py-1 text-xs text-foreground backdrop-blur-sm",
+          className,
+        )}
+        data-playback-ghost
+        data-playback-kind={kind ?? "unknown"}
+        ref={ref}
+        role="img"
+        style={{
+          left: x - safeSize / 2,
+          minHeight: safeSize,
+          minWidth: safeSize,
+          opacity: safeOpacity,
+          top: y - safeSize / 2,
+        }}
+        {...rest}
+      >
+        {kind ? (
+          <span aria-hidden="true" className="text-muted-foreground">
+            {KIND_GLYPH[kind]}
+          </span>
+        ) : null}
+        {label ? (
+          <span className="truncate" data-playback-ghost-label>
+            {label}
+          </span>
+        ) : null}
+      </div>
+    );
+  },
+);
+PlaybackGhost.displayName = "PlaybackGhost";

--- a/packages/ui/src/components/playback-ghost/playback-ghost.visual.tsx
+++ b/packages/ui/src/components/playback-ghost/playback-ghost.visual.tsx
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { PlaybackGhost } from "./playback-ghost";
+
+test.describe("PlaybackGhost Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 240, width: 360 }}
+      >
+        <div
+          className="absolute rounded-md border border-border bg-background"
+          style={{ height: 60, left: 200, top: 90, width: 120 }}
+        />
+        <PlaybackGhost
+          kind="run"
+          label="research-2025"
+          opacity={0.4}
+          x={120}
+          y={120}
+        />
+        <PlaybackGhost
+          kind="task"
+          label="ingest"
+          opacity={0.55}
+          x={70}
+          y={180}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("playback-ghost-default.png");
+  });
+});

--- a/packages/ui/src/components/timeline-scrubber/index.ts
+++ b/packages/ui/src/components/timeline-scrubber/index.ts
@@ -1,0 +1,7 @@
+export {
+  TimelineScrubber,
+  type TimelineScrubberLabels,
+  type TimelineScrubberProps,
+  type TimelineScrubberTone,
+  type TimelineTick,
+} from "./timeline-scrubber";

--- a/packages/ui/src/components/timeline-scrubber/timeline-scrubber.mdx
+++ b/packages/ui/src/components/timeline-scrubber/timeline-scrubber.mdx
@@ -1,0 +1,66 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './timeline-scrubber.stories'
+
+<Meta of={Stories} />
+
+# TimelineScrubber
+
+Range slider for scrubbing through canvas state playback. Renders a thin track with optional milestone ticks plus the current value cursor; the underlying native range input keeps keyboard + pointer + screen-reader semantics for free.
+
+Pure presentation; the host owns the value + drives playback in its own loop. Pair with \`PlaybackGhost\` to fade the canvas back to historical state as the user scrubs.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/timeline-scrubber.json
+```
+
+## Import
+
+```tsx
+import { TimelineScrubber } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<TimelineScrubber
+  start={0} end={3600}
+  value={cursor}
+  onValueChange={setCursor}
+  ticks={milestones}
+  formatValue={(v) => formatDuration(v)}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## No ticks
+
+Drop \`ticks\` to render a clean track with just start / cursor / end labels.
+
+<Canvas of={Stories.NoTicks} sourceState="shown" />
+
+## Warning tone
+
+\`tone="warn"\` shifts the filled track + cursor toward amber — useful when scrubbing into a degraded window.
+
+<Canvas of={Stories.Warning} sourceState="shown" />
+
+## Raw values
+
+Drop \`formatValue\` to fall back to plain numeric labels.
+
+<Canvas of={Stories.RawValues} sourceState="shown" />
+
+## Notes
+
+- Tones map: \`neutral\` (foreground) · \`primary\` (blue, default) · \`success\` (emerald) · \`warn\` (amber) · \`danger\` (red).
+- Value clamps to the \`start..end\` range; when \`end\` is not greater than \`start\`, the component falls back to a 1-unit span so the slider remains operable.
+- Each render emits \`data-timeline-scrubber\` + \`data-timeline-tone\`. The cursor / endpoints emit \`data-timeline-scrubber-cursor\`, \`data-timeline-scrubber-start\`, \`data-timeline-scrubber-end\`. Ticks emit \`data-scrubber-tick\` set to the tick id + \`data-scrubber-tick-tone\`.

--- a/packages/ui/src/components/timeline-scrubber/timeline-scrubber.stories.tsx
+++ b/packages/ui/src/components/timeline-scrubber/timeline-scrubber.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { TimelineScrubber } from "./timeline-scrubber";
+
+const meta = {
+  args: {
+    end: 3600,
+    formatValue: (v: number) => `${Math.round(v / 60)}m`,
+    onValueChange: () => undefined,
+    start: 0,
+    ticks: [
+      { id: "deploy", tone: "primary", value: 600 },
+      { id: "alert", tone: "danger", value: 2400 },
+    ],
+    tone: "primary",
+    value: 1800,
+  },
+  component: TimelineScrubber,
+  decorators: [
+    (Story) => (
+      <div className="w-72 bg-muted/30 p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/TimelineScrubber",
+} satisfies Meta<typeof TimelineScrubber>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const NoTicks: Story = {
+  args: { ticks: undefined },
+};
+
+export const Warning: Story = {
+  args: { tone: "warn", value: 3000 },
+};
+
+export const RawValues: Story = {
+  args: { formatValue: undefined, ticks: undefined },
+};

--- a/packages/ui/src/components/timeline-scrubber/timeline-scrubber.test.tsx
+++ b/packages/ui/src/components/timeline-scrubber/timeline-scrubber.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TimelineScrubber } from "./timeline-scrubber";
+
+describe("TimelineScrubber", () => {
+  it("renders the start, end, and cursor values", () => {
+    render(
+      <TimelineScrubber
+        end={100}
+        onValueChange={vi.fn()}
+        start={0}
+        value={25}
+      />,
+    );
+
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.getByText("100")).toBeInTheDocument();
+    expect(screen.getByText("25")).toBeInTheDocument();
+  });
+
+  it("invokes onValueChange when the underlying range input changes", () => {
+    const handleChange = vi.fn();
+    render(
+      <TimelineScrubber
+        end={100}
+        onValueChange={handleChange}
+        start={0}
+        value={25}
+      />,
+    );
+
+    const input = screen.getByRole("slider");
+    fireEvent.change(input, { target: { value: "60" } });
+    expect(handleChange).toHaveBeenCalledWith(60);
+  });
+
+  it("clamps incoming value into the start..end range", () => {
+    const { container } = render(
+      <TimelineScrubber
+        end={100}
+        onValueChange={vi.fn()}
+        start={0}
+        value={500}
+      />,
+    );
+
+    const fill = container.querySelector("[data-timeline-scrubber-fill]");
+    expect(fill).toHaveStyle({ width: "100%" });
+  });
+
+  it("applies the formatValue callback when provided", () => {
+    render(
+      <TimelineScrubber
+        end={3600}
+        formatValue={(v) => `${v}s`}
+        onValueChange={vi.fn()}
+        start={0}
+        value={1800}
+      />,
+    );
+
+    expect(screen.getByText("1800s")).toBeInTheDocument();
+    expect(screen.getByText("3600s")).toBeInTheDocument();
+  });
+
+  it("renders one tick per entry", () => {
+    const { container } = render(
+      <TimelineScrubber
+        end={100}
+        onValueChange={vi.fn()}
+        start={0}
+        ticks={[
+          { id: "a", value: 25 },
+          { id: "b", tone: "danger", value: 75 },
+        ]}
+        value={25}
+      />,
+    );
+
+    expect(container.querySelectorAll("[data-scrubber-tick]")).toHaveLength(2);
+    expect(container.querySelector("[data-scrubber-tick='b']")).toHaveAttribute(
+      "data-scrubber-tick-tone",
+      "danger",
+    );
+  });
+
+  it("falls back to a 1-unit span when end is not greater than start", () => {
+    render(
+      <TimelineScrubber end={5} onValueChange={vi.fn()} start={5} value={5} />,
+    );
+
+    const input = screen.getByRole("slider");
+    expect(input).toHaveAttribute("min", "5");
+    expect(input).toHaveAttribute("max", "6");
+  });
+});

--- a/packages/ui/src/components/timeline-scrubber/timeline-scrubber.tsx
+++ b/packages/ui/src/components/timeline-scrubber/timeline-scrubber.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import {
+  type ChangeEvent,
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useId,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * One milestone tick rendered along the scrubber track.
+ *
+ * @public
+ */
+export type TimelineTick = {
+  /** Stable identifier — used as the React key + analytics hook. */
+  id: string;
+  /** Optional accessible label (e.g. `"deploy"`, `"alert"`). */
+  label?: ReactNode;
+  /** Optional tone for the tick. Defaults to `"neutral"`. */
+  tone?: TimelineScrubberTone;
+  /** Time value of the tick. */
+  value: number;
+};
+
+/**
+ * Tone of the scrubber's filled track + handle.
+ *
+ * @public
+ */
+export type TimelineScrubberTone =
+  | "danger"
+  | "neutral"
+  | "primary"
+  | "success"
+  | "warn";
+
+const TONE_FILL: Record<TimelineScrubberTone, string> = {
+  danger: "bg-red-500",
+  neutral: "bg-foreground",
+  primary: "bg-blue-500",
+  success: "bg-emerald-500",
+  warn: "bg-amber-500",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type TimelineScrubberLabels = {
+  /** Aria-label for the slider. Defaults to `"Timeline scrubber"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Timeline scrubber",
+} as const satisfies Required<TimelineScrubberLabels>;
+
+/**
+ * Props for {@link TimelineScrubber}.
+ *
+ * @public
+ */
+export type TimelineScrubberProps = {
+  /** End of the time range. Must be `> start`. */
+  end: number;
+  /** Optional formatter for the cursor + endpoint labels. Receives the raw value. */
+  formatValue?: (value: number) => ReactNode;
+  /** Localizable strings. */
+  labels?: TimelineScrubberLabels;
+  /** Change handler — receives the new clamped value. */
+  onValueChange: (value: number) => void;
+  /** Start of the time range. */
+  start: number;
+  /** Step granularity for the underlying range input. Defaults to `1`. */
+  step?: number;
+  /** Optional milestone ticks rendered along the track. */
+  ticks?: TimelineTick[];
+  /** Tone of the filled track + handle. Defaults to `"primary"`. */
+  tone?: TimelineScrubberTone;
+  /** Current scrub value `start..end`. */
+  value: number;
+} & Omit<ComponentPropsWithoutRef<"div">, "onChange">;
+
+const clamp = (v: number, min: number, max: number): number => {
+  if (v < min) {
+    return min;
+  }
+  if (v > max) {
+    return max;
+  }
+  return v;
+};
+
+type LabelsRow = {
+  clamped: number;
+  end: number;
+  formatValue?: (value: number) => ReactNode;
+  start: number;
+};
+
+const Labels = (props: LabelsRow): React.ReactElement => {
+  const fmt = props.formatValue;
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <span data-timeline-scrubber-start>
+        {fmt ? fmt(props.start) : props.start}
+      </span>
+      <span
+        className="font-semibold text-foreground"
+        data-timeline-scrubber-cursor
+      >
+        {fmt ? fmt(props.clamped) : props.clamped}
+      </span>
+      <span data-timeline-scrubber-end>{fmt ? fmt(props.end) : props.end}</span>
+    </div>
+  );
+};
+
+type TrackInput = {
+  ariaLabel: string;
+  inputId: string;
+  max: number;
+  min: number;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  ratio: number;
+  scrubberId: string;
+  span: number;
+  start: number;
+  step: number;
+  ticks?: TimelineTick[];
+  tone: TimelineScrubberTone;
+  value: number;
+};
+
+const Track = (props: TrackInput): React.ReactElement => (
+  <div className="relative h-6">
+    <span
+      aria-hidden="true"
+      className="absolute left-0 right-0 top-1/2 h-1 -translate-y-1/2 rounded-full bg-muted"
+    />
+    <span
+      aria-hidden="true"
+      className={cn(
+        "absolute left-0 top-1/2 h-1 -translate-y-1/2 rounded-full",
+        TONE_FILL[props.tone],
+      )}
+      data-timeline-scrubber-fill
+      style={{ width: `${props.ratio * 100}%` }}
+    />
+    {props.ticks?.map((tick) => (
+      <TickMark
+        key={tick.id}
+        scrubberId={props.scrubberId}
+        span={props.span}
+        start={props.start}
+        tick={tick}
+      />
+    ))}
+    <input
+      aria-label={props.ariaLabel}
+      className="absolute inset-0 h-full w-full cursor-pointer appearance-none bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      data-timeline-scrubber-input
+      id={props.inputId}
+      max={props.max}
+      min={props.min}
+      onChange={props.onChange}
+      step={props.step}
+      type="range"
+      value={props.value}
+    />
+  </div>
+);
+
+const TickMark = (props: {
+  scrubberId: string;
+  span: number;
+  start: number;
+  tick: TimelineTick;
+}): React.ReactElement => {
+  const { scrubberId, span, start, tick } = props;
+  const ratio = clamp((tick.value - start) / span, 0, 1);
+  const tone = tick.tone ?? "neutral";
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "absolute top-1/2 h-2.5 w-px -translate-y-1/2 rounded-full",
+        TONE_FILL[tone],
+      )}
+      data-scrubber-tick={tick.id}
+      data-scrubber-tick-of={scrubberId}
+      data-scrubber-tick-tone={tone}
+      style={{ left: `${ratio * 100}%` }}
+      title={typeof tick.label === "string" ? tick.label : undefined}
+    />
+  );
+};
+
+/**
+ * Range slider for scrubbing through canvas state playback. Renders a
+ * thin track with optional milestone ticks plus the current value
+ * cursor; the underlying `<input type="range">` keeps keyboard +
+ * pointer + screen-reader semantics for free.
+ *
+ * Pure presentation; the host owns the value + drives playback in its
+ * own loop. Pair with {@link "../playback-ghost/playback-ghost".PlaybackGhost} to fade the canvas
+ * back to historical state as the user scrubs.
+ *
+ * @example
+ * ```tsx
+ * <TimelineScrubber
+ *   start={0} end={3600}
+ *   value={cursor}
+ *   onValueChange={setCursor}
+ *   ticks={milestones}
+ *   formatValue={(v) => formatDuration(v)}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const TimelineScrubber = forwardRef<
+  HTMLDivElement,
+  TimelineScrubberProps
+>((props, ref) => {
+  const {
+    className,
+    end,
+    formatValue,
+    labels,
+    onValueChange,
+    start,
+    step = 1,
+    ticks,
+    tone = "primary",
+    value,
+    ...rest
+  } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const inputId = useId();
+  const safeEnd = end <= start ? start + 1 : end;
+  const span = safeEnd - start;
+  const clamped = clamp(value, start, safeEnd);
+  const ratio = clamp((clamped - start) / span, 0, 1);
+  const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    onValueChange(clamp(Number(event.target.value), start, safeEnd));
+  };
+  return (
+    <div
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "flex w-full flex-col gap-1 text-[11px] text-muted-foreground",
+        className,
+      )}
+      data-timeline-scrubber
+      data-timeline-tone={tone}
+      ref={ref}
+      role="group"
+      {...rest}
+    >
+      <Labels
+        clamped={clamped}
+        end={safeEnd}
+        formatValue={formatValue}
+        start={start}
+      />
+      <Track
+        ariaLabel={resolvedLabels.region}
+        inputId={inputId}
+        max={safeEnd}
+        min={start}
+        onChange={handleChange}
+        ratio={ratio}
+        scrubberId={inputId}
+        span={span}
+        start={start}
+        step={step}
+        ticks={ticks}
+        tone={tone}
+        value={clamped}
+      />
+    </div>
+  );
+});
+TimelineScrubber.displayName = "TimelineScrubber";

--- a/packages/ui/src/components/timeline-scrubber/timeline-scrubber.visual.tsx
+++ b/packages/ui/src/components/timeline-scrubber/timeline-scrubber.visual.tsx
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { TimelineScrubber } from "./timeline-scrubber";
+
+test.describe("TimelineScrubber Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="w-72 bg-muted/30 p-4">
+        <TimelineScrubber
+          end={3600}
+          formatValue={(v) => `${Math.round(v / 60)}m`}
+          onValueChange={() => undefined}
+          start={0}
+          ticks={[
+            { id: "deploy", tone: "primary", value: 600 },
+            { id: "alert", tone: "danger", value: 2400 },
+          ]}
+          value={1800}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "timeline-scrubber-default.png",
+    );
+  });
+});


### PR DESCRIPTION
Closes #136

## What's in

Three more #136 primitives — the time-navigation surface for canvas state playback:

- **TimelineScrubber** — range slider with optional milestone ticks + cursor + endpoint labels. Native range input under the hood, so keyboard / pointer / screen-reader semantics come for free. Tones: \`neutral\` / \`primary\` (default) / \`success\` / \`warn\` / \`danger\`. Optional \`formatValue\` callback for human time labels.
- **PlaybackGhost** — translucent overlay marking where a canvas object was at a previous timestamp. Kind glyph (agent / run / task / artifact / input / output) + optional label. Clamped opacity + size, \`pointer-events: none\`.
- **BottomActivityStrip** — slim horizontally-scrolling row of recent canvas events. Tones: \`neutral\` / \`info\` / \`success\` / \`warn\` / \`danger\`. Optional click-to-jump per chip; optional \`maxEvents\` cap. Distinct from \`ActivityLog\` (vertical, persistent) and \`LiveFeed\` (full-height feed).

All three are pure presentation; the host owns the playback loop and event stream. Wired into the \`@vllnt/ui\` barrel and the shadcn registry.

## Files

- \`packages/ui/src/components/timeline-scrubber/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/playback-ghost/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/bottom-activity-strip/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/index.ts\` — barrel exports
- \`apps/registry/registry/default/{timeline-scrubber,playback-ghost,bottom-activity-strip}/*.tsx\` — registry shims
- \`apps/registry/registry.json\` — three new entries (alphabetically placed)

## Stacks with prior #136 PRs

- PR #201 — \`AlertPulse\` + \`ThresholdRing\` + \`StickyMetric\`
- PR #202 — \`HeatOverlay\` + \`StateBadgeOverlay\` + \`MetricCluster\`
- This PR — 9 / 10 of #136

Remaining: \`RunTimeline\`.

## Quality gates

- lint: PASS (\`eslint --fix\` clean)
- typecheck: PASS (\`tsc --noEmit --project tsconfig.build.json\`)
- check:use-client: PASS (182 components)
- check:story-coverage: PASS (172 components)
- verify-stories: PASS (no crash risks)
- test: PASS (511 / 511 — incl. 18 new)
- build (\`@vllnt/ui\`): PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)
- [ ] Storybook renders all 12 stories (4 per primitive) without console errors
- [ ] Visual snapshots stable across primitives