### PR TITLE
feat(ui): add RunTimeline (final #136)

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1632,6 +1632,21 @@
       "category": "content"
     },
     {
+      "name": "run-timeline",
+      "type": "registry:component",
+      "title": "Run Timeline",
+      "description": "Multi-lane execution timeline showing run phases over time, with optional cursor.",
+      "files": [
+        {
+          "path": "registry/default/run-timeline/run-timeline.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data"
+    },
+    {
       "name": "scope-selector",
       "type": "registry:component",
       "title": "Scope Selector",

--- a/apps/registry/registry/default/run-timeline/run-timeline.tsx
+++ b/apps/registry/registry/default/run-timeline/run-timeline.tsx
@@ -1,0 +1,8 @@
+export {
+  type RunPhaseState,
+  RunTimeline,
+  type RunTimelineLabels,
+  type RunTimelineLane,
+  type RunTimelinePhase,
+  type RunTimelineProps,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -804,6 +804,14 @@ export {
   type PresenceSyncState,
 } from "./presence-sync-indicator";
 export {
+  type RunPhaseState,
+  RunTimeline,
+  type RunTimelineLabels,
+  type RunTimelineLane,
+  type RunTimelinePhase,
+  type RunTimelineProps,
+} from "./run-timeline";
+export {
   SelectionPresence,
   type SelectionPresenceLabels,
   type SelectionPresenceProps,

--- a/packages/ui/src/components/run-timeline/index.ts
+++ b/packages/ui/src/components/run-timeline/index.ts
@@ -1,0 +1,8 @@
+export {
+  type RunPhaseState,
+  RunTimeline,
+  type RunTimelineLabels,
+  type RunTimelineLane,
+  type RunTimelinePhase,
+  type RunTimelineProps,
+} from "./run-timeline";

--- a/packages/ui/src/components/run-timeline/run-timeline.mdx
+++ b/packages/ui/src/components/run-timeline/run-timeline.mdx
@@ -1,0 +1,74 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './run-timeline.stories'
+
+<Meta of={Stories} />
+
+# RunTimeline
+
+Multi-lane execution timeline showing run phases over time. Each phase renders as a colored bar positioned by its start / end and routed to a lane by \`laneId\`. Optional cursor draws a thin vertical line for the current playback position.
+
+Pure presentation; the host computes the phase list from the run's execution history. Pair with \`TimelineScrubber\` to drive the cursor.
+
+Distinct from \`MapTimeline\` (geo-aware), \`Stepper\` (sequential steps), and the timeline family issues \`#32\`–\`#35\`: this primitive is specifically the run history surface inside the canvas.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/run-timeline.json
+```
+
+## Import
+
+```tsx
+import { RunTimeline } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<RunTimeline
+  start={0} end={3600}
+  cursor={1800}
+  lanes={[
+    { id: "ingest", label: "Ingest" },
+    { id: "rank",   label: "Rank" },
+  ]}
+  phases={[
+    { id: "1", laneId: "ingest", start: 0,    end: 600,  state: "complete", label: "load" },
+    { id: "2", laneId: "rank",   start: 600,  end: 2400, state: "running",  label: "score" },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Single lane
+
+Drop \`lanes\` to fall back to single-lane mode — phases route to the implicit \`"default"\` lane labelled \`"Run"\`.
+
+<Canvas of={Stories.SingleLane} sourceState="shown" />
+
+## No cursor
+
+Omit \`cursor\` for a static history view (e.g. post-run audit).
+
+<Canvas of={Stories.NoCursor} sourceState="shown" />
+
+## Empty
+
+When the phase list is empty, the timeline renders a calm placeholder.
+
+<Canvas of={Stories.Empty} sourceState="shown" />
+
+## Notes
+
+- Phase states map: \`queued\` (amber) · \`running\` (blue) · \`complete\` (emerald) · \`failed\` (red) · \`stopped\` (muted).
+- When \`end\` is not greater than \`start\`, the timeline falls back to a 1-unit span so phases still render.
+- Phases whose \`laneId\` doesn't match any provided lane are skipped silently.
+- Each render emits \`data-run-timeline\`. Lanes emit \`data-run-timeline-lane\` set to the lane id; phases emit \`data-run-phase\` + \`data-run-phase-state\`. The cursor emits \`data-run-timeline-cursor\`.

--- a/packages/ui/src/components/run-timeline/run-timeline.stories.tsx
+++ b/packages/ui/src/components/run-timeline/run-timeline.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { RunTimeline } from "./run-timeline";
+
+const noop = (): void => undefined;
+
+const meta = {
+  args: {
+    cursor: 1800,
+    end: 3600,
+    formatValue: (v: number) => `${Math.round(v / 60)}m`,
+    lanes: [
+      { id: "ingest", label: "Ingest" },
+      { id: "rank", label: "Rank" },
+      { id: "emit", label: "Emit" },
+    ],
+    phases: [
+      {
+        end: 600,
+        id: "i1",
+        label: "load",
+        laneId: "ingest",
+        onActivate: noop,
+        start: 0,
+        state: "complete",
+      },
+      {
+        end: 720,
+        id: "i2",
+        label: "tag",
+        laneId: "ingest",
+        onActivate: noop,
+        start: 600,
+        state: "complete",
+      },
+      {
+        end: 2200,
+        id: "r1",
+        label: "score",
+        laneId: "rank",
+        onActivate: noop,
+        start: 800,
+        state: "running",
+      },
+      {
+        end: 1500,
+        id: "r2",
+        label: "filter",
+        laneId: "rank",
+        onActivate: noop,
+        start: 1200,
+        state: "failed",
+      },
+      {
+        end: 3600,
+        id: "e1",
+        label: "publish",
+        laneId: "emit",
+        onActivate: noop,
+        start: 2300,
+        state: "queued",
+      },
+    ],
+    start: 0,
+  },
+  component: RunTimeline,
+  decorators: [
+    (Story) => (
+      <div className="w-[540px]">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/RunTimeline",
+} satisfies Meta<typeof RunTimeline>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const SingleLane: Story = {
+  args: {
+    lanes: undefined,
+    phases: [
+      { end: 1200, id: "1", label: "warm", start: 0, state: "complete" },
+      { end: 2400, id: "2", label: "run", start: 1200, state: "running" },
+      { end: 3600, id: "3", label: "cool", start: 2400, state: "queued" },
+    ],
+  },
+};
+
+export const NoCursor: Story = {
+  args: { cursor: undefined },
+};
+
+export const Empty: Story = {
+  args: { phases: [] },
+};

--- a/packages/ui/src/components/run-timeline/run-timeline.test.tsx
+++ b/packages/ui/src/components/run-timeline/run-timeline.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { RunTimeline, type RunTimelinePhase } from "./run-timeline";
+
+const sample: RunTimelinePhase[] = [
+  {
+    end: 600,
+    id: "1",
+    label: "load",
+    laneId: "ingest",
+    start: 0,
+    state: "complete",
+  },
+  {
+    end: 2400,
+    id: "2",
+    label: "score",
+    laneId: "rank",
+    start: 600,
+    state: "running",
+  },
+];
+
+const lanes = [
+  { id: "ingest", label: "Ingest" },
+  { id: "rank", label: "Rank" },
+];
+
+describe("RunTimeline", () => {
+  it("renders the empty state when no phases are provided", () => {
+    const { container } = render(
+      <RunTimeline end={100} phases={[]} start={0} />,
+    );
+
+    expect(
+      container.querySelector("[data-run-timeline-state='empty']"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders one phase bar per phase routed to its lane", () => {
+    const { container } = render(
+      <RunTimeline end={3600} lanes={lanes} phases={sample} start={0} />,
+    );
+
+    expect(container.querySelectorAll("[data-run-phase]")).toHaveLength(2);
+  });
+
+  it("invokes onActivate when an interactive phase is clicked", () => {
+    const handleActivate = vi.fn();
+    render(
+      <RunTimeline
+        end={100}
+        phases={[
+          {
+            end: 50,
+            id: "x",
+            label: "click",
+            onActivate: handleActivate,
+            start: 0,
+          },
+        ]}
+        start={0}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(handleActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders phases as plain elements when onActivate is omitted", () => {
+    render(<RunTimeline end={3600} lanes={lanes} phases={sample} start={0} />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("renders the cursor when a numeric value is provided", () => {
+    const { container } = render(
+      <RunTimeline
+        cursor={1800}
+        end={3600}
+        lanes={lanes}
+        phases={sample}
+        start={0}
+      />,
+    );
+
+    expect(
+      container.querySelector("[data-run-timeline-cursor]"),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to a single 'Run' lane when lanes prop is omitted", () => {
+    const { container } = render(
+      <RunTimeline
+        end={100}
+        phases={[{ end: 50, id: "p", label: "go", start: 0, state: "running" }]}
+        start={0}
+      />,
+    );
+
+    expect(
+      container.querySelector("[data-run-timeline-lane='default']"),
+    ).toBeInTheDocument();
+  });
+
+  it("applies the formatValue callback to endpoints + cursor", () => {
+    render(
+      <RunTimeline
+        cursor={1800}
+        end={3600}
+        formatValue={(v) => `${v / 60}m`}
+        phases={sample}
+        start={0}
+      />,
+    );
+
+    expect(screen.getByText("0m")).toBeInTheDocument();
+    expect(screen.getByText("60m")).toBeInTheDocument();
+    expect(screen.getByText("30m")).toBeInTheDocument();
+  });
+
+  it("falls back to a 1-unit span when end is not greater than start", () => {
+    const { container } = render(
+      <RunTimeline
+        end={5}
+        phases={[{ end: 5, id: "p", label: "go", start: 5, state: "running" }]}
+        start={5}
+      />,
+    );
+
+    expect(container.querySelector("[data-run-phase='p']")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/run-timeline/run-timeline.tsx
+++ b/packages/ui/src/components/run-timeline/run-timeline.tsx
@@ -1,0 +1,360 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Phase state — drives the bar tone.
+ *
+ * @public
+ */
+export type RunPhaseState =
+  | "complete"
+  | "failed"
+  | "queued"
+  | "running"
+  | "stopped";
+
+const STATE_FILL: Record<RunPhaseState, string> = {
+  complete: "bg-emerald-500/70",
+  failed: "bg-red-500/70",
+  queued: "bg-amber-500/70",
+  running: "bg-blue-500/70",
+  stopped: "bg-muted-foreground/40",
+};
+
+const STATE_LABEL: Record<RunPhaseState, string> = {
+  complete: "Complete",
+  failed: "Failed",
+  queued: "Queued",
+  running: "Running",
+  stopped: "Stopped",
+};
+
+/**
+ * One lane in a multi-lane run timeline.
+ *
+ * @public
+ */
+export type RunTimelineLane = {
+  /** Stable identifier — used as the React key + phase routing. */
+  id: string;
+  /** Display label rendered to the left of the lane. */
+  label: ReactNode;
+};
+
+/**
+ * One phase block in the run timeline.
+ *
+ * @public
+ */
+export type RunTimelinePhase = {
+  /** End timestamp in the same units as `start` / `end`. */
+  end: number;
+  /** Stable identifier — used as the React key + analytics hook. */
+  id: string;
+  /** Optional label rendered inside the phase bar. */
+  label?: ReactNode;
+  /** Lane id this phase belongs to. Defaults to `"default"` (single-lane mode). */
+  laneId?: string;
+  /** Optional click handler — when provided, the phase becomes a button. */
+  onActivate?: () => void;
+  /** Start timestamp `>= timeline start`. */
+  start: number;
+  /** Phase state. Defaults to `"running"`. */
+  state?: RunPhaseState;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type RunTimelineLabels = {
+  /** Empty-state copy. Defaults to `"No phases"`. */
+  empty?: string;
+  /** Aria-label override. Defaults to `"Run timeline"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No phases",
+  region: "Run timeline",
+} as const satisfies Required<RunTimelineLabels>;
+
+/**
+ * Props for {@link RunTimeline}.
+ *
+ * @public
+ */
+export type RunTimelineProps = {
+  /** Optional cursor position in the same units as the range. Renders a vertical line. */
+  cursor?: number;
+  /** End of the time range. Must be `> start`. */
+  end: number;
+  /** Optional formatter for the start / cursor / end labels. */
+  formatValue?: (value: number) => ReactNode;
+  /** Localizable strings. */
+  labels?: RunTimelineLabels;
+  /** Optional explicit lane definitions in render order. Required for multi-lane mode. */
+  lanes?: RunTimelineLane[];
+  /** Phase blocks — order is irrelevant; routed to lanes by `laneId`. */
+  phases: RunTimelinePhase[];
+  /** Start of the time range. */
+  start: number;
+} & ComponentPropsWithoutRef<"section">;
+
+const clamp = (v: number, min: number, max: number): number => {
+  if (v < min) {
+    return min;
+  }
+  if (v > max) {
+    return max;
+  }
+  return v;
+};
+
+const Endpoints = (props: {
+  cursor?: number;
+  end: number;
+  format?: (v: number) => ReactNode;
+  start: number;
+}): React.ReactElement => {
+  const fmt = props.format;
+  const showCursor = typeof props.cursor === "number";
+  return (
+    <div className="flex items-baseline justify-between gap-2 text-[11px] text-muted-foreground">
+      <span data-run-timeline-start>
+        {fmt ? fmt(props.start) : props.start}
+      </span>
+      {showCursor ? (
+        <span
+          className="font-semibold text-foreground"
+          data-run-timeline-cursor-label
+        >
+          {fmt ? fmt(props.cursor ?? 0) : props.cursor}
+        </span>
+      ) : null}
+      <span data-run-timeline-end>{fmt ? fmt(props.end) : props.end}</span>
+    </div>
+  );
+};
+
+const PhaseBar = (props: {
+  laneIndex: number;
+  laneTotal: number;
+  phase: RunTimelinePhase;
+  span: number;
+  start: number;
+}): React.ReactElement => {
+  const { laneIndex, laneTotal, phase, span, start } = props;
+  const left = clamp((phase.start - start) / span, 0, 1) * 100;
+  const right = clamp((phase.end - start) / span, 0, 1) * 100;
+  const width = Math.max(right - left, 0.5);
+  const top = (laneIndex / laneTotal) * 100;
+  const height = 100 / laneTotal;
+  const state = phase.state ?? "running";
+  const sharedStyle = {
+    height: `${height}%`,
+    left: `${left}%`,
+    top: `${top}%`,
+    width: `${width}%`,
+  };
+  const ariaLabel = `${STATE_LABEL[state]} ${phase.start} → ${phase.end}`;
+  if (phase.onActivate) {
+    const handleClick = (): void => {
+      phase.onActivate?.();
+    };
+    return (
+      <button
+        aria-label={ariaLabel}
+        className={cn(
+          "absolute flex items-center justify-start overflow-hidden truncate rounded-sm border border-border/50 px-1 text-left text-[10px] text-foreground transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          STATE_FILL[state],
+        )}
+        data-run-phase={phase.id}
+        data-run-phase-state={state}
+        onClick={handleClick}
+        style={sharedStyle}
+        type="button"
+      >
+        {phase.label}
+      </button>
+    );
+  }
+  return (
+    <span
+      aria-label={ariaLabel}
+      className={cn(
+        "absolute flex items-center justify-start overflow-hidden truncate rounded-sm border border-border/50 px-1 text-[10px] text-foreground",
+        STATE_FILL[state],
+      )}
+      data-run-phase={phase.id}
+      data-run-phase-state={state}
+      role="img"
+      style={sharedStyle}
+    >
+      {phase.label}
+    </span>
+  );
+};
+
+type LaneViewInput = {
+  cursor?: number;
+  end: number;
+  lanes: RunTimelineLane[];
+  phases: RunTimelinePhase[];
+  start: number;
+};
+
+const TrackBody = (props: LaneViewInput): React.ReactElement => {
+  const { cursor, end, lanes, phases, start } = props;
+  const span = end - start;
+  const cursorRatio =
+    typeof cursor === "number" ? clamp((cursor - start) / span, 0, 1) : null;
+  return (
+    <div className="flex items-stretch">
+      <div className="flex w-24 flex-col gap-px text-[10px] uppercase tracking-wide text-muted-foreground">
+        {lanes.map((lane) => (
+          <div
+            className="flex h-7 items-center px-2"
+            data-run-timeline-lane={lane.id}
+            key={lane.id}
+          >
+            {lane.label}
+          </div>
+        ))}
+      </div>
+      <div
+        className="relative flex-1 overflow-hidden rounded-md border border-border bg-muted/20"
+        data-run-timeline-track
+        style={{ height: `${lanes.length * 28}px` }}
+      >
+        {phases.map((phase) => {
+          const index = lanes.findIndex(
+            (lane) => lane.id === (phase.laneId ?? "default"),
+          );
+          if (index === -1) {
+            return null;
+          }
+          return (
+            <PhaseBar
+              key={phase.id}
+              laneIndex={index}
+              laneTotal={lanes.length}
+              phase={phase}
+              span={span}
+              start={start}
+            />
+          );
+        })}
+        {cursorRatio === null ? null : (
+          <span
+            aria-hidden="true"
+            className="absolute top-0 bottom-0 w-px bg-foreground"
+            data-run-timeline-cursor
+            style={{ left: `${cursorRatio * 100}%` }}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+const resolveLanes = (
+  explicit: RunTimelineLane[] | undefined,
+): RunTimelineLane[] => {
+  if (explicit && explicit.length > 0) {
+    return explicit;
+  }
+  return [{ id: "default", label: "Run" }];
+};
+
+/**
+ * Multi-lane execution timeline showing run phases over time. Each
+ * phase renders as a colored bar positioned by its start / end and
+ * routed to a lane by `laneId`. Optional cursor draws a thin vertical
+ * line for the current playback position.
+ *
+ * Pure presentation; the host computes the phase list from the run's
+ * execution history. Pair with {@link "../timeline-scrubber/timeline-scrubber".TimelineScrubber}
+ * to drive the cursor.
+ *
+ * Distinct from `MapTimeline` (geo-aware), `Stepper` (sequential
+ * steps), and the timeline family `#32`–`#35`: this primitive is
+ * specifically the run history surface inside the canvas.
+ *
+ * @example
+ * ```tsx
+ * <RunTimeline
+ *   start={0} end={3600}
+ *   cursor={1800}
+ *   lanes={[
+ *     { id: "ingest", label: "Ingest" },
+ *     { id: "rank",   label: "Rank" },
+ *   ]}
+ *   phases={[
+ *     { id: "1", laneId: "ingest", start: 0,    end: 600,  state: "complete", label: "load" },
+ *     { id: "2", laneId: "rank",   start: 600,  end: 2400, state: "running",  label: "score" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const RunTimeline = forwardRef<HTMLElement, RunTimelineProps>(
+  (props, ref) => {
+    const {
+      className,
+      cursor,
+      end,
+      formatValue,
+      labels,
+      lanes,
+      phases,
+      start,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const safeEnd = end <= start ? start + 1 : end;
+    const resolvedLanes = resolveLanes(lanes);
+    return (
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn("flex w-full flex-col gap-2", className)}
+        data-run-timeline
+        ref={ref}
+        {...rest}
+      >
+        <Endpoints
+          cursor={cursor}
+          end={safeEnd}
+          format={formatValue}
+          start={start}
+        />
+        {phases.length === 0 ? (
+          <p
+            className="rounded-md border border-border bg-muted/20 px-2 py-3 text-center text-[11px] text-muted-foreground"
+            data-run-timeline-state="empty"
+          >
+            {resolvedLabels.empty}
+          </p>
+        ) : (
+          <TrackBody
+            cursor={cursor}
+            end={safeEnd}
+            lanes={resolvedLanes}
+            phases={phases}
+            start={start}
+          />
+        )}
+      </section>
+    );
+  },
+);
+RunTimeline.displayName = "RunTimeline";

--- a/packages/ui/src/components/run-timeline/run-timeline.visual.tsx
+++ b/packages/ui/src/components/run-timeline/run-timeline.visual.tsx
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { RunTimeline } from "./run-timeline";
+
+test.describe("RunTimeline Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="bg-muted/30 p-4" style={{ width: 540 }}>
+        <RunTimeline
+          cursor={1800}
+          end={3600}
+          formatValue={(v) => `${Math.round(v / 60)}m`}
+          lanes={[
+            { id: "ingest", label: "Ingest" },
+            { id: "rank", label: "Rank" },
+            { id: "emit", label: "Emit" },
+          ]}
+          phases={[
+            { end: 600, id: "i1", label: "load", laneId: "ingest", start: 0, state: "complete" },
+            { end: 720, id: "i2", label: "tag", laneId: "ingest", start: 600, state: "complete" },
+            { end: 2200, id: "r1", label: "score", laneId: "rank", start: 800, state: "running" },
+            { end: 1500, id: "r2", label: "filter", laneId: "rank", start: 1200, state: "failed" },
+            { end: 3600, id: "e1", label: "publish", laneId: "emit", start: 2300, state: "queued" },
+          ]}
+          start={0}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("run-timeline-default.png");
+  });
+});


### PR DESCRIPTION
Closes #136

## What's in

\`RunTimeline\` — multi-lane execution timeline showing run phases over time, the final primitive for issue #136:

- Each phase renders as a colored bar positioned by its \`start\` / \`end\` and routed to a lane by \`laneId\`.
- Optional \`cursor\` draws a thin vertical line for the current playback position. Pair with \`TimelineScrubber\` to drive it.
- States: \`queued\` (amber) / \`running\` (blue) / \`complete\` (emerald) / \`failed\` (red) / \`stopped\` (muted).
- Single-lane mode (drop \`lanes\`) falls back to a default \`"Run"\` lane.
- Phases whose \`laneId\` doesn't match any provided lane are skipped without warning.
- When \`end\` is not greater than \`start\`, the timeline falls back to a 1-unit span.
- Optional \`onActivate\` per phase makes the bar a button (otherwise a plain span).

Pure presentation; the host computes the phase list from the run's execution history. Wired into the \`@vllnt/ui\` barrel and the shadcn registry.

Distinct from \`MapTimeline\` (geo-aware), \`Stepper\` (sequential steps), and the timeline family issues \`#32\`–\`#35\`: this primitive is specifically the run history surface inside the canvas.

## Files

- \`packages/ui/src/components/run-timeline/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/index.ts\` — barrel export
- \`apps/registry/registry/default/run-timeline/run-timeline.tsx\` — registry shim
- \`apps/registry/registry.json\` — new entry

## Closes the #136 component family

Together with **PR #201** (\`AlertPulse\` + \`ThresholdRing\` + \`StickyMetric\`), **PR #202** (\`HeatOverlay\` + \`StateBadgeOverlay\` + \`MetricCluster\`), and **PR #203** (\`TimelineScrubber\` + \`PlaybackGhost\` + \`BottomActivityStrip\`), this PR ships the final primitive of #136 — 10 / 10 of the canvas runtime activity + time overlay family.

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck: PASS (\`tsc --noEmit --project tsconfig.build.json\`)
- check:use-client: PASS (180 components)
- check:story-coverage: PASS (170 components)
- verify-stories: PASS (no crash risks)
- test: PASS (501 / 501 — incl. 8 new)
- build (\`@vllnt/ui\`): PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)
- [ ] Storybook renders all 4 stories without console errors
- [ ] Visual snapshot stable