### PR TITLE
feat(ui): collab primitives — LiveCursor + CommentPin + PresenceSyncIndicator (partial #135)

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -583,6 +583,21 @@
       "category": "overlay"
     },
     {
+      "name": "comment-pin",
+      "type": "registry:component",
+      "title": "Comment Pin",
+      "description": "Anchored discussion pin rendered at canvas coordinates with author + unread badge.",
+      "files": [
+        {
+          "path": "registry/default/comment-pin/comment-pin.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "utility"
+    },
+    {
       "name": "comparison",
       "type": "registry:component",
       "title": "Comparison",
@@ -1117,6 +1132,21 @@
       "category": "data"
     },
     {
+      "name": "live-cursor",
+      "type": "registry:component",
+      "title": "Live Cursor",
+      "description": "Remote user's cursor rendered at canvas coordinates with name + status chip.",
+      "files": [
+        {
+          "path": "registry/default/live-cursor/live-cursor.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "utility"
+    },
+    {
       "name": "live-feed",
       "type": "registry:component",
       "title": "Live Feed",
@@ -1429,6 +1459,21 @@
       "files": [
         {
           "path": "registry/default/presence-stack/presence-stack.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data"
+    },
+    {
+      "name": "presence-sync-indicator",
+      "type": "registry:component",
+      "title": "Presence Sync Indicator",
+      "description": "Compact pill that surfaces live connection + sync health for a collaborative canvas.",
+      "files": [
+        {
+          "path": "registry/default/presence-sync-indicator/presence-sync-indicator.tsx",
           "type": "registry:component"
         }
       ],

--- a/apps/registry/registry/default/comment-pin/comment-pin.tsx
+++ b/apps/registry/registry/default/comment-pin/comment-pin.tsx
@@ -1,0 +1,6 @@
+export {
+  CommentPin,
+  type CommentPinLabels,
+  type CommentPinProps,
+  type CommentPinState,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/live-cursor/live-cursor.tsx
+++ b/apps/registry/registry/default/live-cursor/live-cursor.tsx
@@ -1,0 +1,5 @@
+export {
+  LiveCursor,
+  type LiveCursorLabels,
+  type LiveCursorProps,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/presence-sync-indicator/presence-sync-indicator.tsx
+++ b/apps/registry/registry/default/presence-sync-indicator/presence-sync-indicator.tsx
@@ -1,0 +1,6 @@
+export {
+  PresenceSyncIndicator,
+  type PresenceSyncIndicatorLabels,
+  type PresenceSyncIndicatorProps,
+  type PresenceSyncState,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/comment-pin/comment-pin.mdx
+++ b/packages/ui/src/components/comment-pin/comment-pin.mdx
@@ -1,0 +1,69 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './comment-pin.stories'
+
+<Meta of={Stories} />
+
+# CommentPin
+
+Anchored discussion pin rendered at canvas coordinates. Use to mark an object-anchored comment thread; click to expand into a \`ThreadBubble\` (or whatever the host wires up).
+
+Pure presentation; the host owns the thread store + supplies the unread count and resolution state.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/comment-pin.json
+```
+
+## Import
+
+```tsx
+import { CommentPin } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<div className="relative h-screen w-screen">
+  <Canvas />
+  <CommentPin
+    x={420} y={180}
+    authorInitial="B"
+    unread={3}
+    onActivate={() => openThread("c-1")}
+  />
+</div>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Resolved
+
+A resolved thread renders in muted tones — present on the canvas for context, but quiet.
+
+<Canvas of={Stories.Resolved} sourceState="shown" />
+
+## No unread
+
+When the unread count is zero or omitted, no badge renders.
+
+<Canvas of={Stories.NoUnread} sourceState="shown" />
+
+## Non-interactive
+
+Drop \`onActivate\` and the pin renders as a plain span (no button semantics, no focus ring).
+
+<Canvas of={Stories.NonInteractive} sourceState="shown" />
+
+## Notes
+
+- States map: \`open\` (foreground / accent fill) · \`resolved\` (muted).
+- \`color\` overrides the open-state fill for author / theme color coding.
+- Pin centers on \`(x, y)\` via translate \`-50% / -50%\`.
+- Each render emits \`data-comment-pin\` + \`data-comment-pin-state\`. The body emits \`data-comment-pin-body\`; the unread badge emits \`data-comment-pin-unread\`; the click trigger emits \`data-comment-pin-trigger\`.

--- a/packages/ui/src/components/comment-pin/comment-pin.stories.tsx
+++ b/packages/ui/src/components/comment-pin/comment-pin.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { CommentPin } from "./comment-pin";
+
+const noop = (): void => undefined;
+
+const meta = {
+  args: {
+    authorInitial: "B",
+    color: "#5b8def",
+    onActivate: noop,
+    unread: 3,
+    x: 120,
+    y: 100,
+  },
+  component: CommentPin,
+  decorators: [
+    (Story) => (
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 220, width: 240 }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/CommentPin",
+} satisfies Meta<typeof CommentPin>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Resolved: Story = {
+  args: {
+    state: "resolved",
+    unread: undefined,
+  },
+};
+
+export const NoUnread: Story = {
+  args: { unread: undefined },
+};
+
+export const NonInteractive: Story = {
+  args: { onActivate: undefined },
+};

--- a/packages/ui/src/components/comment-pin/comment-pin.test.tsx
+++ b/packages/ui/src/components/comment-pin/comment-pin.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CommentPin } from "./comment-pin";
+
+describe("CommentPin", () => {
+  it("positions the pin at the given coordinates", () => {
+    const { container } = render(<CommentPin x={120} y={80} />);
+
+    expect(container.querySelector("[data-comment-pin]")).toHaveStyle({
+      left: "120px",
+      top: "80px",
+    });
+  });
+
+  it("renders the author initial", () => {
+    render(<CommentPin authorInitial="B" x={0} y={0} />);
+
+    expect(screen.getByText("B")).toBeInTheDocument();
+  });
+
+  it("renders the unread badge when count is positive", () => {
+    const { container } = render(<CommentPin unread={3} x={0} y={0} />);
+
+    expect(
+      container.querySelector("[data-comment-pin-unread]"),
+    ).toHaveTextContent("3");
+  });
+
+  it("hides the unread badge when count is zero", () => {
+    const { container } = render(<CommentPin unread={0} x={0} y={0} />);
+
+    expect(
+      container.querySelector("[data-comment-pin-unread]"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("invokes onActivate when the pin is clicked", () => {
+    const handleActivate = vi.fn();
+    render(<CommentPin onActivate={handleActivate} x={0} y={0} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(handleActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders as a plain span when onActivate is omitted", () => {
+    render(<CommentPin x={0} y={0} />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("propagates state to a data attribute", () => {
+    const { container } = render(<CommentPin state="resolved" x={0} y={0} />);
+
+    expect(container.querySelector("[data-comment-pin]")).toHaveAttribute(
+      "data-comment-pin-state",
+      "resolved",
+    );
+  });
+});

--- a/packages/ui/src/components/comment-pin/comment-pin.tsx
+++ b/packages/ui/src/components/comment-pin/comment-pin.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Resolution state of a pinned comment.
+ *
+ * @public
+ */
+export type CommentPinState = "open" | "resolved";
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type CommentPinLabels = {
+  /** Aria-label override. Defaults to `"Comment"`. */
+  region?: string;
+  /** Suffix appended after the unread count for screen readers. */
+  unreadSuffix?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Comment",
+  unreadSuffix: "unread",
+} as const satisfies Required<CommentPinLabels>;
+
+/**
+ * Props for {@link CommentPin}.
+ *
+ * @public
+ */
+export type CommentPinProps = {
+  /** Optional author initial / glyph rendered inside the pin. */
+  authorInitial?: ReactNode;
+  /** Optional accent color for the pin. Defaults to the foreground. */
+  color?: string;
+  /** Localizable strings. */
+  labels?: CommentPinLabels;
+  /** Click handler — when provided, the pin becomes a button. */
+  onActivate?: () => void;
+  /** State of the underlying thread. Defaults to `"open"`. */
+  state?: CommentPinState;
+  /** Optional unread reply count. Renders as a small numeric badge. */
+  unread?: number;
+  /** Anchor X in canvas pixels. */
+  x: number;
+  /** Anchor Y in canvas pixels. */
+  y: number;
+} & ComponentPropsWithoutRef<"div">;
+
+const STATE_FILL: Record<CommentPinState, string> = {
+  open: "bg-foreground text-background",
+  resolved: "bg-muted text-muted-foreground",
+};
+
+type PinBodyInput = {
+  accent?: string;
+  authorInitial?: ReactNode;
+  state: CommentPinState;
+  unread?: number;
+};
+
+const PinBody = (props: PinBodyInput): React.ReactElement => {
+  const showBadge = typeof props.unread === "number" && props.unread > 0;
+  const useAccent = props.accent && props.state === "open";
+  return (
+    <>
+      <span
+        aria-hidden="true"
+        className={cn(
+          "flex h-7 w-7 items-center justify-center rounded-full border border-background text-[11px] font-semibold shadow-sm",
+          STATE_FILL[props.state],
+        )}
+        data-comment-pin-body
+        style={
+          useAccent
+            ? { backgroundColor: props.accent, color: "white" }
+            : undefined
+        }
+      >
+        {props.authorInitial ?? "•"}
+      </span>
+      {showBadge ? (
+        <span
+          aria-hidden="true"
+          className="absolute -right-1 -top-1 inline-flex min-h-[14px] min-w-[14px] items-center justify-center rounded-full bg-red-500 px-1 text-[9px] font-medium text-white"
+          data-comment-pin-unread
+        >
+          {props.unread}
+        </span>
+      ) : null}
+    </>
+  );
+};
+
+/**
+ * Anchored discussion pin rendered at canvas coordinates. Use to mark
+ * an object-anchored comment thread; click to expand into a
+ * {@link "../thread-bubble/thread-bubble".ThreadBubble} (or whatever the host wires up).
+ *
+ * Pure presentation; the host owns the thread store + supplies the
+ * unread count and resolution state.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <CommentPin
+ *     x={420} y={180}
+ *     authorInitial="B"
+ *     unread={3}
+ *     onActivate={() => openThread("c-1")}
+ *   />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const CommentPin = forwardRef<HTMLDivElement, CommentPinProps>(
+  (props, ref) => {
+    const {
+      authorInitial,
+      className,
+      color,
+      labels,
+      onActivate,
+      state = "open",
+      unread,
+      x,
+      y,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const showBadge = typeof unread === "number" && unread > 0;
+    const ariaLabel = showBadge
+      ? `${resolvedLabels.region}, ${unread} ${resolvedLabels.unreadSuffix}`
+      : resolvedLabels.region;
+    const handleClick = (): void => {
+      onActivate?.();
+    };
+    const body = (
+      <PinBody
+        accent={color}
+        authorInitial={authorInitial}
+        state={state}
+        unread={unread}
+      />
+    );
+    return (
+      <div
+        aria-label={ariaLabel}
+        className={cn(
+          "absolute z-30 inline-flex -translate-x-1/2 -translate-y-1/2",
+          className,
+        )}
+        data-comment-pin
+        data-comment-pin-state={state}
+        ref={ref}
+        role="img"
+        style={{ left: x, top: y }}
+        {...rest}
+      >
+        {onActivate ? (
+          <button
+            aria-label={ariaLabel}
+            className="relative inline-flex rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            data-comment-pin-trigger
+            onClick={handleClick}
+            type="button"
+          >
+            {body}
+          </button>
+        ) : (
+          <span className="relative inline-flex">{body}</span>
+        )}
+      </div>
+    );
+  },
+);
+CommentPin.displayName = "CommentPin";

--- a/packages/ui/src/components/comment-pin/comment-pin.visual.tsx
+++ b/packages/ui/src/components/comment-pin/comment-pin.visual.tsx
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { CommentPin } from "./comment-pin";
+
+test.describe("CommentPin Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 240, width: 360 }}
+      >
+        <CommentPin authorInitial="B" color="#5b8def" unread={3} x={90} y={80} />
+        <CommentPin authorInitial="L" color="#10b981" x={200} y={140} />
+        <CommentPin authorInitial="S" state="resolved" x={300} y={200} />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("comment-pin-default.png");
+  });
+});

--- a/packages/ui/src/components/comment-pin/index.ts
+++ b/packages/ui/src/components/comment-pin/index.ts
@@ -1,0 +1,6 @@
+export {
+  CommentPin,
+  type CommentPinLabels,
+  type CommentPinProps,
+  type CommentPinState,
+} from "./comment-pin";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -766,12 +766,23 @@ export {
 // Canvas/Object components
 export { AnchorPort, type AnchorPortProps } from "./anchor-port";
 export {
+  CommentPin,
+  type CommentPinLabels,
+  type CommentPinProps,
+  type CommentPinState,
+} from "./comment-pin";
+export {
   ConnectorEdge,
   type ConnectorEdgePoint,
   type ConnectorEdgeProps,
 } from "./connector-edge";
 export { EdgeLabel, type EdgeLabelProps } from "./edge-label";
 export { GroupHull, type GroupHullProps } from "./group-hull";
+export {
+  LiveCursor,
+  type LiveCursorLabels,
+  type LiveCursorProps,
+} from "./live-cursor";
 export {
   ObjectCard,
   type ObjectCardAction,
@@ -786,6 +797,12 @@ export {
   type PresenceStatus,
   type PresenceUser,
 } from "./presence-stack";
+export {
+  PresenceSyncIndicator,
+  type PresenceSyncIndicatorLabels,
+  type PresenceSyncIndicatorProps,
+  type PresenceSyncState,
+} from "./presence-sync-indicator";
 export {
   SelectionPresence,
   type SelectionPresenceLabels,

--- a/packages/ui/src/components/live-cursor/index.ts
+++ b/packages/ui/src/components/live-cursor/index.ts
@@ -1,0 +1,5 @@
+export {
+  LiveCursor,
+  type LiveCursorLabels,
+  type LiveCursorProps,
+} from "./live-cursor";

--- a/packages/ui/src/components/live-cursor/live-cursor.mdx
+++ b/packages/ui/src/components/live-cursor/live-cursor.mdx
@@ -1,0 +1,56 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './live-cursor.stories'
+
+<Meta of={Stories} />
+
+# LiveCursor
+
+Remote user's cursor rendered at canvas coordinates with an optional name + status chip. Pure presentation; the host owns the websocket stream + maps user ids to colors.
+
+The wrapper is \`pointer-events: none\` so host gestures pass through.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/live-cursor.json
+```
+
+## Import
+
+```tsx
+import { LiveCursor } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<div className="relative h-screen w-screen">
+  <Canvas />
+  <LiveCursor x={420} y={180} name="Bea" color="#5b8def" />
+</div>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## With status
+
+Pass \`status\` to render a secondary line in the chip — e.g. \`"editing"\`, \`"idle"\`, role / object id.
+
+<Canvas of={Stories.WithStatus} sourceState="shown" />
+
+## Chip hidden
+
+Pass \`name={null}\` for a pure pointer (useful when the chip would clutter dense canvases or duplicate \`PresenceStack\`).
+
+<Canvas of={Stories.ChipHidden} sourceState="shown" />
+
+## Notes
+
+- \`color\` accepts any CSS color value (hex, \`oklch(...)\`, \`var(--my-color)\`). Defaults to \`var(--foreground)\`.
+- Each render emits \`data-live-cursor\`. The pointer emits \`data-live-cursor-pointer\`; the chip emits \`data-live-cursor-chip\`; the optional status line emits \`data-live-cursor-status\`.

--- a/packages/ui/src/components/live-cursor/live-cursor.stories.tsx
+++ b/packages/ui/src/components/live-cursor/live-cursor.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { LiveCursor } from "./live-cursor";
+
+const meta = {
+  args: {
+    color: "#5b8def",
+    name: "Bea",
+    x: 120,
+    y: 80,
+  },
+  component: LiveCursor,
+  decorators: [
+    (Story) => (
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 240, width: 320 }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/LiveCursor",
+} satisfies Meta<typeof LiveCursor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithStatus: Story = {
+  args: {
+    color: "#10b981",
+    name: "Lior",
+    status: "editing",
+  },
+};
+
+export const ChipHidden: Story = {
+  args: { name: null },
+};
+
+export const Warm: Story = {
+  args: { color: "#f59e0b", name: "Sam" },
+};

--- a/packages/ui/src/components/live-cursor/live-cursor.test.tsx
+++ b/packages/ui/src/components/live-cursor/live-cursor.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { LiveCursor } from "./live-cursor";
+
+describe("LiveCursor", () => {
+  it("positions the cursor at the given coordinates", () => {
+    const { container } = render(<LiveCursor x={120} y={80} />);
+
+    expect(container.querySelector("[data-live-cursor]")).toHaveStyle({
+      left: "120px",
+      top: "80px",
+    });
+  });
+
+  it("renders the name chip when name is provided", () => {
+    render(<LiveCursor name="Bea" x={0} y={0} />);
+
+    expect(screen.getByText("Bea")).toBeInTheDocument();
+  });
+
+  it("hides the chip when name is null", () => {
+    const { container } = render(<LiveCursor name={null} x={0} y={0} />);
+
+    expect(
+      container.querySelector("[data-live-cursor-chip]"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("applies the color to the pointer and chip", () => {
+    const { container } = render(
+      <LiveCursor color="#5b8def" name="Bea" x={0} y={0} />,
+    );
+
+    expect(
+      container.querySelector("[data-live-cursor-pointer]"),
+    ).toHaveAttribute("fill", "#5b8def");
+    expect(container.querySelector("[data-live-cursor-chip]")).toHaveStyle({
+      "background-color": "#5b8def",
+    });
+  });
+
+  it("renders the optional status line", () => {
+    render(<LiveCursor name="Bea" status="editing" x={0} y={0} />);
+
+    expect(screen.getByText("editing")).toBeInTheDocument();
+  });
+
+  it("includes the user name in the aria-label", () => {
+    render(<LiveCursor name="Bea" x={0} y={0} />);
+
+    expect(screen.getByLabelText("Live cursor: Bea")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/live-cursor/live-cursor.tsx
+++ b/packages/ui/src/components/live-cursor/live-cursor.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type LiveCursorLabels = {
+  /** Aria-label override. Defaults to `"Live cursor"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Live cursor",
+} as const satisfies Required<LiveCursorLabels>;
+
+/**
+ * Props for {@link LiveCursor}.
+ *
+ * @public
+ */
+export type LiveCursorProps = {
+  /** Tailwind / arbitrary CSS color used for the pointer + name chip. Defaults to `var(--foreground)`. */
+  color?: string;
+  /** Localizable strings. */
+  labels?: LiveCursorLabels;
+  /** Display name shown in the chip. Pass `null` to hide the chip. */
+  name?: ReactNode;
+  /** Optional secondary line in the chip (e.g. status, role). */
+  status?: ReactNode;
+  /** Cursor X in canvas pixels. */
+  x: number;
+  /** Cursor Y in canvas pixels. */
+  y: number;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * Remote user's cursor rendered at canvas coordinates with an optional
+ * name + status chip. Pure presentation; the host owns the websocket
+ * stream + maps user ids to colors.
+ *
+ * The wrapper is `pointer-events: none` so host gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <LiveCursor x={420} y={180} name="Bea" color="#5b8def" />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const LiveCursor = forwardRef<HTMLDivElement, LiveCursorProps>(
+  (props, ref) => {
+    const { className, color, labels, name, status, x, y, ...rest } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const resolvedColor = color ?? "var(--foreground)";
+    return (
+      <div
+        aria-label={
+          typeof name === "string"
+            ? `${resolvedLabels.region}: ${name}`
+            : resolvedLabels.region
+        }
+        className={cn(
+          "pointer-events-none absolute z-30 flex items-start gap-1",
+          className,
+        )}
+        data-live-cursor
+        ref={ref}
+        role="img"
+        style={{ left: x, top: y }}
+        {...rest}
+      >
+        <svg
+          aria-hidden="true"
+          className="-ml-1 -mt-1 drop-shadow-sm"
+          data-live-cursor-pointer
+          fill={resolvedColor}
+          height={18}
+          viewBox="0 0 16 18"
+          width={16}
+        >
+          <path d="M0 0 L0 14 L4 11 L7 17 L10 16 L7 10 L13 10 Z" />
+        </svg>
+        {name === null || name === undefined ? null : (
+          <span
+            className="ml-2 mt-2 inline-flex flex-col rounded-md px-1.5 py-0.5 text-[10px] font-medium text-white shadow-sm"
+            data-live-cursor-chip
+            style={{ backgroundColor: resolvedColor }}
+          >
+            <span>{name}</span>
+            {status ? (
+              <span className="text-[9px] opacity-80" data-live-cursor-status>
+                {status}
+              </span>
+            ) : null}
+          </span>
+        )}
+      </div>
+    );
+  },
+);
+LiveCursor.displayName = "LiveCursor";

--- a/packages/ui/src/components/live-cursor/live-cursor.visual.tsx
+++ b/packages/ui/src/components/live-cursor/live-cursor.visual.tsx
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { LiveCursor } from "./live-cursor";
+
+test.describe("LiveCursor Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 240, width: 360 }}
+      >
+        <LiveCursor color="#5b8def" name="Bea" x={80} y={80} />
+        <LiveCursor color="#10b981" name="Lior" status="editing" x={200} y={140} />
+        <LiveCursor color="#f59e0b" name={null} x={300} y={200} />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("live-cursor-default.png");
+  });
+});

--- a/packages/ui/src/components/presence-sync-indicator/index.ts
+++ b/packages/ui/src/components/presence-sync-indicator/index.ts
@@ -1,0 +1,6 @@
+export {
+  PresenceSyncIndicator,
+  type PresenceSyncIndicatorLabels,
+  type PresenceSyncIndicatorProps,
+  type PresenceSyncState,
+} from "./presence-sync-indicator";

--- a/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.mdx
+++ b/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.mdx
@@ -1,0 +1,60 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './presence-sync-indicator.stories'
+
+<Meta of={Stories} />
+
+# PresenceSyncIndicator
+
+Compact pill that surfaces live connection + sync health for the canvas. Stays calm: a single dot + one-line label, with a subtle pulse for transient \`syncing\` / \`reconnecting\` states.
+
+Pure presentation; the host owns the websocket / CRDT loop and maps its diagnostics into one of five canonical states.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/presence-sync-indicator.json
+```
+
+## Import
+
+```tsx
+import { PresenceSyncIndicator } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<PresenceSyncIndicator state="live" status="3 peers" />
+<PresenceSyncIndicator state="reconnecting" status="retry 2/5" />
+```
+
+<Canvas of={Stories.Live} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Syncing
+
+Transient state during diff propagation — the dot pulses blue.
+
+<Canvas of={Stories.Syncing} sourceState="shown" />
+
+## Reconnecting
+
+The dot pulses amber while the host attempts to restore the websocket — pair with a retry counter in \`status\` so users know progress is happening.
+
+<Canvas of={Stories.Reconnecting} sourceState="shown" />
+
+## Offline
+
+Calm muted dot. The host should pair this with a small banner if write actions need to queue locally.
+
+<Canvas of={Stories.Offline} sourceState="shown" />
+
+## Notes
+
+- States map: \`live\` (emerald) · \`syncing\` (blue, pulsing) · \`reconnecting\` (amber, pulsing) · \`offline\` (muted) · \`error\` (red).
+- Each render emits \`data-presence-sync\` + \`data-presence-state\`. The dot emits \`data-presence-sync-dot\`; the optional secondary line emits \`data-presence-sync-status\`.

--- a/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.stories.tsx
+++ b/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PresenceSyncIndicator } from "./presence-sync-indicator";
+
+const meta = {
+  args: {
+    state: "live",
+    status: "3 peers",
+  },
+  component: PresenceSyncIndicator,
+  decorators: [
+    (Story) => (
+      <div className="flex items-start bg-muted/30 p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/PresenceSyncIndicator",
+} satisfies Meta<typeof PresenceSyncIndicator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Live: Story = {};
+
+export const Syncing: Story = {
+  args: { state: "syncing", status: "2 changes" },
+};
+
+export const Reconnecting: Story = {
+  args: { state: "reconnecting", status: "retry 2 / 5" },
+};
+
+export const Offline: Story = {
+  args: { state: "offline", status: undefined },
+};

--- a/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.test.tsx
+++ b/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PresenceSyncIndicator } from "./presence-sync-indicator";
+
+describe("PresenceSyncIndicator", () => {
+  it("renders the humanized state label by default", () => {
+    render(<PresenceSyncIndicator state="live" />);
+
+    expect(screen.getByText("Live")).toBeInTheDocument();
+  });
+
+  it("uses the override label when provided", () => {
+    render(<PresenceSyncIndicator label="Connected" state="live" />);
+
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+  });
+
+  it("propagates state to a data attribute", () => {
+    const { container } = render(
+      <PresenceSyncIndicator state="reconnecting" />,
+    );
+
+    expect(container.querySelector("[data-presence-sync]")).toHaveAttribute(
+      "data-presence-state",
+      "reconnecting",
+    );
+  });
+
+  it("renders the status line when provided", () => {
+    render(<PresenceSyncIndicator state="live" status="3 peers" />);
+
+    expect(screen.getByText("3 peers")).toBeInTheDocument();
+  });
+
+  it("includes the human state in the aria-label", () => {
+    render(<PresenceSyncIndicator state="offline" />);
+
+    expect(screen.getByLabelText("Presence sync: Offline")).toBeInTheDocument();
+  });
+
+  it("animates the dot for transient states", () => {
+    const { container } = render(<PresenceSyncIndicator state="syncing" />);
+
+    const dot = container.querySelector("[data-presence-sync-dot]");
+    expect(dot?.getAttribute("class")).toContain("animate-pulse");
+  });
+});

--- a/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.tsx
+++ b/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Connection / sync state — drives the dot color + animation.
+ *
+ * @public
+ */
+export type PresenceSyncState =
+  | "error"
+  | "live"
+  | "offline"
+  | "reconnecting"
+  | "syncing";
+
+const STATE_LABEL: Record<PresenceSyncState, string> = {
+  error: "Sync error",
+  live: "Live",
+  offline: "Offline",
+  reconnecting: "Reconnecting",
+  syncing: "Syncing",
+};
+
+const STATE_DOT: Record<PresenceSyncState, string> = {
+  error: "bg-red-500",
+  live: "bg-emerald-500",
+  offline: "bg-muted-foreground",
+  reconnecting: "bg-amber-500 animate-pulse",
+  syncing: "bg-blue-500 animate-pulse",
+};
+
+const STATE_TEXT: Record<PresenceSyncState, string> = {
+  error: "text-red-700 dark:text-red-300",
+  live: "text-emerald-700 dark:text-emerald-300",
+  offline: "text-muted-foreground",
+  reconnecting: "text-amber-700 dark:text-amber-300",
+  syncing: "text-blue-700 dark:text-blue-300",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type PresenceSyncIndicatorLabels = {
+  /** Aria-label override. Defaults to `"Presence sync"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Presence sync",
+} as const satisfies Required<PresenceSyncIndicatorLabels>;
+
+/**
+ * Props for {@link PresenceSyncIndicator}.
+ *
+ * @public
+ */
+export type PresenceSyncIndicatorProps = {
+  /** Optional override label (defaults to humanized state name). */
+  label?: ReactNode;
+  /** Localizable strings. */
+  labels?: PresenceSyncIndicatorLabels;
+  /** Connection state. */
+  state: PresenceSyncState;
+  /** Optional secondary line (peer count, latency). */
+  status?: ReactNode;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * Compact pill that surfaces live connection + sync health for the
+ * canvas. Stays calm: a single dot + one-line label, with a subtle
+ * pulse for transient `syncing` / `reconnecting` states.
+ *
+ * Pure presentation; the host owns the websocket / CRDT loop and maps
+ * its diagnostics into one of five canonical states.
+ *
+ * @example
+ * ```tsx
+ * <PresenceSyncIndicator state="live" status="3 peers" />
+ * <PresenceSyncIndicator state="reconnecting" status="retry 2/5" />
+ * ```
+ *
+ * @public
+ */
+export const PresenceSyncIndicator = forwardRef<
+  HTMLDivElement,
+  PresenceSyncIndicatorProps
+>((props, ref) => {
+  const { className, label, labels, state, status, ...rest } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const text = label ?? STATE_LABEL[state];
+  return (
+    <div
+      aria-label={`${resolvedLabels.region}: ${STATE_LABEL[state]}`}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-2 py-1 text-[11px] shadow-sm",
+        className,
+      )}
+      data-presence-state={state}
+      data-presence-sync
+      ref={ref}
+      role="status"
+      {...rest}
+    >
+      <span
+        aria-hidden="true"
+        className={cn("h-1.5 w-1.5 rounded-full", STATE_DOT[state])}
+        data-presence-sync-dot
+      />
+      <span className={cn("font-medium", STATE_TEXT[state])}>{text}</span>
+      {status ? (
+        <span
+          className="text-[10px] text-muted-foreground"
+          data-presence-sync-status
+        >
+          {status}
+        </span>
+      ) : null}
+    </div>
+  );
+});
+PresenceSyncIndicator.displayName = "PresenceSyncIndicator";

--- a/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.visual.tsx
+++ b/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.visual.tsx
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { PresenceSyncIndicator } from "./presence-sync-indicator";
+
+test.describe("PresenceSyncIndicator Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="flex flex-col items-start gap-2 bg-muted/30 p-4">
+        <PresenceSyncIndicator state="live" status="3 peers" />
+        <PresenceSyncIndicator state="syncing" status="2 changes" />
+        <PresenceSyncIndicator state="reconnecting" status="retry 2 / 5" />
+        <PresenceSyncIndicator state="offline" />
+        <PresenceSyncIndicator state="error" status="ws closed" />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "presence-sync-indicator-default.png",
+    );
+  });
+});


### PR DESCRIPTION
Closes #135

## What's in

First batch of #135 — calm canvas collaboration primitives:

- **LiveCursor** — remote user's pointer at canvas coords with name + optional status chip. Custom color via any CSS color value (hex / oklch / var). Pointer SVG + tinted chip. \`pointer-events: none\`.
- **CommentPin** — anchored discussion pin with author initial + unread badge. \`open\` / \`resolved\` states. Optional \`onActivate\` makes the pin a button (otherwise plain span). Centers on the anchor pixel via \`-50% / -50%\` translate.
- **PresenceSyncIndicator** — compact pill for live connection + sync health. States: \`live\` / \`syncing\` / \`reconnecting\` / \`offline\` / \`error\`, with subtle pulse on transient states. Optional secondary line (peers, retry counter).

All three are pure presentation; the host owns the websocket / CRDT loop and maps state in. Wired into the \`@vllnt/ui\` barrel and the shadcn registry.

## Files

- \`packages/ui/src/components/live-cursor/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/comment-pin/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/presence-sync-indicator/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/index.ts\` — barrel exports
- \`apps/registry/registry/default/{live-cursor,comment-pin,presence-sync-indicator}/*.tsx\` — registry shims
- \`apps/registry/registry.json\` — three new entries (alphabetically placed)

## Out of scope (deferred to follow-up #135 PRs)

- \`PresenceStack\` — overlapping avatar dots showing who's present
- \`SelectionPresence\` — overlay marking what other users have selected
- \`ThreadBubble\` — expanded comment thread popup
- \`FollowMode\` — banner / overlay when following another user's view
- \`HandoffBeacon\` — pulse marking that another user just handed work to you

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck: PASS (\`tsc --noEmit --project tsconfig.build.json\`)
- check:use-client: PASS (182 components)
- check:story-coverage: PASS (172 components)
- verify-stories: PASS (no crash risks)
- test: PASS (512 / 512 — incl. 19 new)
- build (\`@vllnt/ui\`): PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)
- [ ] Storybook renders all 12 stories (4 per primitive) without console errors
- [ ] Visual snapshots stable across primitives