### PR TITLE
feat(ui): collab primitives — PresenceStack + SelectionPresence + ThreadBubble (partial #135)

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1407,6 +1407,21 @@
       "category": "overlay"
     },
     {
+      "name": "presence-stack",
+      "type": "registry:component",
+      "title": "Presence Stack",
+      "description": "Overlapping live-presence avatars with status dots and a sane overflow chip.",
+      "files": [
+        {
+          "path": "registry/default/presence-stack/presence-stack.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "data"
+    },
+    {
       "name": "pro-tip",
       "type": "registry:component",
       "title": "Pro Tip",
@@ -1647,6 +1662,21 @@
       "registryDependencies": [],
       "dependencies": [],
       "category": "form"
+    },
+    {
+      "name": "selection-presence",
+      "type": "registry:component",
+      "title": "Selection Presence",
+      "description": "Dashed-border overlay marking what another user has selected on the canvas.",
+      "files": [
+        {
+          "path": "registry/default/selection-presence/selection-presence.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "utility"
     },
     {
       "name": "separator",
@@ -2088,6 +2118,21 @@
         "lucide-react"
       ],
       "category": "learning"
+    },
+    {
+      "name": "thread-bubble",
+      "type": "registry:component",
+      "title": "Thread Bubble",
+      "description": "Expanded discussion bubble for an anchored canvas comment thread.",
+      "files": [
+        {
+          "path": "registry/default/thread-bubble/thread-bubble.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "utility"
     },
     {
       "name": "ticker-tape",

--- a/apps/registry/registry/default/presence-stack/presence-stack.tsx
+++ b/apps/registry/registry/default/presence-stack/presence-stack.tsx
@@ -1,0 +1,7 @@
+export {
+  PresenceStack,
+  type PresenceStackLabels,
+  type PresenceStackProps,
+  type PresenceStatus,
+  type PresenceUser,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/selection-presence/selection-presence.tsx
+++ b/apps/registry/registry/default/selection-presence/selection-presence.tsx
@@ -1,0 +1,5 @@
+export {
+  SelectionPresence,
+  type SelectionPresenceLabels,
+  type SelectionPresenceProps,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/thread-bubble/thread-bubble.tsx
+++ b/apps/registry/registry/default/thread-bubble/thread-bubble.tsx
@@ -1,0 +1,6 @@
+export {
+  ThreadBubble,
+  type ThreadBubbleLabels,
+  type ThreadBubbleProps,
+  type ThreadMessage,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -760,6 +760,24 @@ export {
   type ObjectCardProps,
 } from "./object-card";
 export { ObjectHandle, type ObjectHandleProps } from "./object-handle";
+export {
+  PresenceStack,
+  type PresenceStackLabels,
+  type PresenceStackProps,
+  type PresenceStatus,
+  type PresenceUser,
+} from "./presence-stack";
+export {
+  SelectionPresence,
+  type SelectionPresenceLabels,
+  type SelectionPresenceProps,
+} from "./selection-presence";
+export {
+  ThreadBubble,
+  type ThreadBubbleLabels,
+  type ThreadBubbleProps,
+  type ThreadMessage,
+} from "./thread-bubble";
 
 // AI/Chat components
 export {

--- a/packages/ui/src/components/presence-stack/index.ts
+++ b/packages/ui/src/components/presence-stack/index.ts
@@ -1,0 +1,7 @@
+export {
+  PresenceStack,
+  type PresenceStackLabels,
+  type PresenceStackProps,
+  type PresenceStatus,
+  type PresenceUser,
+} from "./presence-stack";

--- a/packages/ui/src/components/presence-stack/presence-stack.mdx
+++ b/packages/ui/src/components/presence-stack/presence-stack.mdx
@@ -1,0 +1,68 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './presence-stack.stories'
+
+<Meta of={Stories} />
+
+# PresenceStack
+
+Overlapping live-presence avatars showing who is currently inhabiting the canvas. Each avatar carries an accent color, an initial, and a status dot. Distinct from \`AvatarGroup\` (a static participant grouping): this primitive is built around live status + a sane overflow + interactive expansion.
+
+Pure presentation; the host owns the websocket roster + maps user ids to colors.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/presence-stack.json
+```
+
+## Import
+
+```tsx
+import { PresenceStack } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<PresenceStack
+  max={4}
+  users={[
+    { id: "1", initial: "B", color: "#5b8def", name: "Bea" },
+    { id: "2", initial: "L", color: "#10b981", name: "Lior", status: "away" },
+    { id: "3", initial: "S", color: "#f59e0b", name: "Sam", status: "idle" },
+  ]}
+  onOverflowActivate={() => openRoster()}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Solo
+
+A single user renders without overflow.
+
+<Canvas of={Stories.Solo} sourceState="shown" />
+
+## No overflow
+
+Raise \`max\` past the user count for a no-overflow stack. Drop \`onOverflowActivate\` and the chip (when it does render) becomes a plain span.
+
+<Canvas of={Stories.NoOverflow} sourceState="shown" />
+
+## All away
+
+Mixed away / idle / offline statuses render their corner dots accordingly while keeping the avatar palette.
+
+<Canvas of={Stories.AllAway} sourceState="shown" />
+
+## Notes
+
+- Statuses map: \`active\` (emerald) · \`away\` (amber) · \`idle\` (muted) · \`offline\` (faint muted).
+- \`color\` accepts any CSS color value (hex / oklch / var). Falls back to \`var(--foreground)\`.
+- Each avatar emits \`data-presence-stack-user\` (= id) + \`data-presence-stack-status\`. The corner dot emits \`data-presence-stack-dot\`. The overflow chip emits \`data-presence-stack-overflow\`.

--- a/packages/ui/src/components/presence-stack/presence-stack.stories.tsx
+++ b/packages/ui/src/components/presence-stack/presence-stack.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PresenceStack } from "./presence-stack";
+
+const noop = (): void => undefined;
+
+const meta = {
+  args: {
+    max: 4,
+    onOverflowActivate: noop,
+    users: [
+      { color: "#5b8def", id: "1", initial: "B", name: "Bea" },
+      { color: "#10b981", id: "2", initial: "L", name: "Lior", status: "away" },
+      { color: "#f59e0b", id: "3", initial: "S", name: "Sam", status: "idle" },
+      { color: "#a855f7", id: "4", initial: "M", name: "Mira" },
+      { color: "#ef4444", id: "5", initial: "R", name: "Rae", status: "offline" },
+      { color: "#0ea5e9", id: "6", initial: "K", name: "Kim" },
+    ],
+  },
+  component: PresenceStack,
+  decorators: [
+    (Story) => (
+      <div className="bg-muted/30 p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/PresenceStack",
+} satisfies Meta<typeof PresenceStack>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Solo: Story = {
+  args: {
+    users: [
+      { color: "#5b8def", id: "1", initial: "B", name: "Bea" },
+    ],
+  },
+};
+
+export const NoOverflow: Story = {
+  args: {
+    max: 10,
+    onOverflowActivate: undefined,
+  },
+};
+
+export const AllAway: Story = {
+  args: {
+    users: [
+      { color: "#5b8def", id: "1", initial: "B", name: "Bea", status: "away" },
+      { color: "#10b981", id: "2", initial: "L", name: "Lior", status: "idle" },
+      { color: "#f59e0b", id: "3", initial: "S", name: "Sam", status: "offline" },
+    ],
+  },
+};

--- a/packages/ui/src/components/presence-stack/presence-stack.test.tsx
+++ b/packages/ui/src/components/presence-stack/presence-stack.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PresenceStack, type PresenceUser } from "./presence-stack";
+
+const sample: PresenceUser[] = [
+  { color: "#5b8def", id: "1", initial: "B", name: "Bea" },
+  { color: "#10b981", id: "2", initial: "L", name: "Lior", status: "away" },
+  { color: "#f59e0b", id: "3", initial: "S", name: "Sam", status: "idle" },
+];
+
+describe("PresenceStack", () => {
+  it("renders one avatar per visible user", () => {
+    const { container } = render(<PresenceStack users={sample} />);
+
+    expect(
+      container.querySelectorAll("[data-presence-stack-user]"),
+    ).toHaveLength(3);
+  });
+
+  it("propagates the user accent color to the avatar background", () => {
+    const { container } = render(<PresenceStack users={sample} />);
+
+    expect(
+      container.querySelector("[data-presence-stack-user='1']"),
+    ).toHaveStyle({ "background-color": "#5b8def" });
+  });
+
+  it("propagates status to a data attribute", () => {
+    const { container } = render(<PresenceStack users={sample} />);
+
+    expect(
+      container.querySelector("[data-presence-stack-user='2']"),
+    ).toHaveAttribute("data-presence-stack-status", "away");
+  });
+
+  it("renders the overflow chip when users exceed max", () => {
+    render(<PresenceStack max={2} users={sample} />);
+
+    expect(screen.getByText("+1")).toBeInTheDocument();
+    expect(screen.getByLabelText("1 more")).toBeInTheDocument();
+  });
+
+  it("renders the overflow as a button when onOverflowActivate is provided", () => {
+    const handleClick = vi.fn();
+    render(
+      <PresenceStack max={2} onOverflowActivate={handleClick} users={sample} />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the overflow as a plain span when no handler is provided", () => {
+    render(<PresenceStack max={2} users={sample} />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("uses the user name as a hover title", () => {
+    const { container } = render(<PresenceStack users={sample} />);
+
+    expect(
+      container.querySelector("[data-presence-stack-user='1']"),
+    ).toHaveAttribute("title", "Bea");
+  });
+});

--- a/packages/ui/src/components/presence-stack/presence-stack.tsx
+++ b/packages/ui/src/components/presence-stack/presence-stack.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Presence status — drives the corner dot color.
+ *
+ * @public
+ */
+export type PresenceStatus = "active" | "away" | "idle" | "offline";
+
+const STATUS_DOT: Record<PresenceStatus, string> = {
+  active: "bg-emerald-500",
+  away: "bg-amber-500",
+  idle: "bg-muted-foreground",
+  offline: "bg-muted-foreground/40",
+};
+
+/**
+ * One user in the presence stack.
+ *
+ * @public
+ */
+export type PresenceUser = {
+  /** Optional accent color (hex / oklch / var). Drives the avatar fill. */
+  color?: string;
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Avatar initial / glyph. */
+  initial: ReactNode;
+  /** Display name shown on hover (`title` attribute). */
+  name?: string;
+  /** Optional status. Defaults to `"active"`. */
+  status?: PresenceStatus;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type PresenceStackLabels = {
+  /** Suffix for the overflow chip. Defaults to `"more"`. */
+  overflowSuffix?: string;
+  /** Aria-label override. Defaults to `"Live presence"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  overflowSuffix: "more",
+  region: "Live presence",
+} as const satisfies Required<PresenceStackLabels>;
+
+/**
+ * Props for {@link PresenceStack}.
+ *
+ * @public
+ */
+export type PresenceStackProps = {
+  /** Localizable strings. */
+  labels?: PresenceStackLabels;
+  /** Cap the rendered users; the rest collapse into a `+N` chip. Defaults to `5`. */
+  max?: number;
+  /** Optional click handler for the overflow chip. */
+  onOverflowActivate?: () => void;
+  /** Users sorted in render order (most-relevant first). */
+  users: PresenceUser[];
+} & ComponentPropsWithoutRef<"div">;
+
+const Avatar = (props: { user: PresenceUser }): React.ReactElement => {
+  const { user } = props;
+  const status = user.status ?? "active";
+  return (
+    <span
+      className="relative -ml-2 inline-flex h-7 w-7 items-center justify-center rounded-full border-2 border-background text-[11px] font-semibold text-white shadow-sm first:ml-0"
+      data-presence-stack-status={status}
+      data-presence-stack-user={user.id}
+      style={{ backgroundColor: user.color ?? "var(--foreground)" }}
+      title={user.name}
+    >
+      {user.initial}
+      <span
+        aria-hidden="true"
+        className={cn(
+          "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border border-background",
+          STATUS_DOT[status],
+        )}
+        data-presence-stack-dot
+      />
+    </span>
+  );
+};
+
+/**
+ * Overlapping live-presence avatars showing who is in the canvas right
+ * now. Each avatar carries an accent color, an initial, and a status
+ * dot. Distinct from `AvatarGroup` (a static participant grouping):
+ * this primitive centers on live status, a sane overflow, and
+ * interactive expansion.
+ *
+ * Pure presentation; the host owns the websocket roster + maps user
+ * ids to colors.
+ *
+ * @example
+ * ```tsx
+ * <PresenceStack
+ *   max={4}
+ *   users={[
+ *     { id: "1", initial: "B", color: "#5b8def", name: "Bea" },
+ *     { id: "2", initial: "L", color: "#10b981", name: "Lior", status: "away" },
+ *     { id: "3", initial: "S", color: "#f59e0b", name: "Sam", status: "idle" },
+ *   ]}
+ *   onOverflowActivate={() => openRoster()}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const PresenceStack = forwardRef<HTMLDivElement, PresenceStackProps>(
+  (props, ref) => {
+    const {
+      className,
+      labels,
+      max = 5,
+      onOverflowActivate,
+      users,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const visible = max >= users.length ? users : users.slice(0, max);
+    const hidden = users.length - visible.length;
+    const handleOverflow = (): void => {
+      onOverflowActivate?.();
+    };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn("inline-flex items-center pl-2", className)}
+        data-presence-stack
+        ref={ref}
+        role="group"
+        {...rest}
+      >
+        {visible.map((user) => (
+          <Avatar key={user.id} user={user} />
+        ))}
+        {hidden > 0
+          ? renderOverflow({
+              count: hidden,
+              handleClick: handleOverflow,
+              handlerProvided: Boolean(onOverflowActivate),
+              labels: resolvedLabels,
+            })
+          : null}
+      </div>
+    );
+  },
+);
+PresenceStack.displayName = "PresenceStack";
+
+const renderOverflow = (input: {
+  count: number;
+  handleClick: () => void;
+  handlerProvided: boolean;
+  labels: Required<PresenceStackLabels>;
+}): React.ReactElement => {
+  const text = `+${input.count}`;
+  const aria = `${input.count} ${input.labels.overflowSuffix}`;
+  const className =
+    "relative -ml-2 inline-flex h-7 min-w-7 items-center justify-center rounded-full border-2 border-background bg-muted px-1.5 text-[10px] font-semibold text-muted-foreground shadow-sm";
+  if (input.handlerProvided) {
+    return (
+      <button
+        aria-label={aria}
+        className={cn(
+          className,
+          "transition-colors hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        )}
+        data-presence-stack-overflow
+        onClick={input.handleClick}
+        type="button"
+      >
+        {text}
+      </button>
+    );
+  }
+  return (
+    <span aria-label={aria} className={className} data-presence-stack-overflow>
+      {text}
+    </span>
+  );
+};

--- a/packages/ui/src/components/presence-stack/presence-stack.visual.tsx
+++ b/packages/ui/src/components/presence-stack/presence-stack.visual.tsx
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { PresenceStack } from "./presence-stack";
+
+test.describe("PresenceStack Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="bg-muted/30 p-4">
+        <PresenceStack
+          max={4}
+          users={[
+            { color: "#5b8def", id: "1", initial: "B", name: "Bea" },
+            { color: "#10b981", id: "2", initial: "L", name: "Lior", status: "away" },
+            { color: "#f59e0b", id: "3", initial: "S", name: "Sam", status: "idle" },
+            { color: "#a855f7", id: "4", initial: "M", name: "Mira" },
+            { color: "#ef4444", id: "5", initial: "R", name: "Rae", status: "offline" },
+            { color: "#0ea5e9", id: "6", initial: "K", name: "Kim" },
+          ]}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("presence-stack-default.png");
+  });
+});

--- a/packages/ui/src/components/selection-presence/index.ts
+++ b/packages/ui/src/components/selection-presence/index.ts
@@ -1,0 +1,5 @@
+export {
+  SelectionPresence,
+  type SelectionPresenceLabels,
+  type SelectionPresenceProps,
+} from "./selection-presence";

--- a/packages/ui/src/components/selection-presence/selection-presence.mdx
+++ b/packages/ui/src/components/selection-presence/selection-presence.mdx
@@ -1,0 +1,67 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './selection-presence.stories'
+
+<Meta of={Stories} />
+
+# SelectionPresence
+
+Overlay marking what another user has selected on the canvas. The dashed border + soft fill stay calm so they communicate "someone-else's-selection" without blocking primary content. Pure presentation; the host computes the rect from the remote user's viewport and supplies an accent color per user.
+
+The wrapper is \`pointer-events: none\` so host gestures pass through.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/selection-presence.json
+```
+
+## Import
+
+```tsx
+import { SelectionPresence } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<div className="relative h-screen w-screen">
+  <Canvas />
+  <SelectionPresence
+    x={120} y={80} width={240} height={120}
+    color="#5b8def"
+    name="Bea"
+  />
+</div>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Warm tone
+
+Switch to a warm accent for a different user — same calm dashed border, different color signal.
+
+<Canvas of={Stories.Warm} sourceState="shown" />
+
+## Chip hidden
+
+Pass \`name={null}\` to hide the corner chip when the canvas already shows the user via \`PresenceStack\` or \`LiveCursor\`.
+
+<Canvas of={Stories.ChipHidden} sourceState="shown" />
+
+## Tall
+
+Selections of any aspect ratio render the same way.
+
+<Canvas of={Stories.Tall} sourceState="shown" />
+
+## Notes
+
+- Fill is computed with a \`color-mix\` call that blends the resolved accent color at 10 % into transparent, so the rectangle keeps the accent without darkening the canvas.
+- \`color\` accepts any CSS color value (hex / oklch / var). Defaults to \`var(--foreground)\`.
+- Each render emits \`data-selection-presence\`. The optional chip emits \`data-selection-presence-chip\`.

--- a/packages/ui/src/components/selection-presence/selection-presence.stories.tsx
+++ b/packages/ui/src/components/selection-presence/selection-presence.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { SelectionPresence } from "./selection-presence";
+
+const meta = {
+  args: {
+    color: "#5b8def",
+    height: 80,
+    name: "Bea",
+    width: 140,
+    x: 60,
+    y: 60,
+  },
+  component: SelectionPresence,
+  decorators: [
+    (Story) => (
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 220, width: 280 }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/SelectionPresence",
+} satisfies Meta<typeof SelectionPresence>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Warm: Story = {
+  args: { color: "#f59e0b", name: "Sam" },
+};
+
+export const ChipHidden: Story = {
+  args: { name: null },
+};
+
+export const Tall: Story = {
+  args: { height: 160, width: 80 },
+};

--- a/packages/ui/src/components/selection-presence/selection-presence.test.tsx
+++ b/packages/ui/src/components/selection-presence/selection-presence.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SelectionPresence } from "./selection-presence";
+
+describe("SelectionPresence", () => {
+  it("positions and sizes the rectangle from props", () => {
+    const { container } = render(
+      <SelectionPresence height={80} width={120} x={50} y={30} />,
+    );
+
+    const overlay = container.querySelector("[data-selection-presence]");
+    expect(overlay).toHaveStyle({
+      height: "80px",
+      left: "50px",
+      top: "30px",
+      width: "120px",
+    });
+  });
+
+  it("applies the accent color to the border", () => {
+    const { container } = render(
+      <SelectionPresence color="#5b8def" height={80} width={120} x={0} y={0} />,
+    );
+
+    expect(container.querySelector("[data-selection-presence]")).toHaveStyle({
+      "border-color": "#5b8def",
+    });
+  });
+
+  it("renders the name chip when name is provided", () => {
+    render(
+      <SelectionPresence height={80} name="Bea" width={120} x={0} y={0} />,
+    );
+
+    expect(screen.getByText("Bea")).toBeInTheDocument();
+  });
+
+  it("hides the chip when name is null", () => {
+    const { container } = render(
+      <SelectionPresence height={80} name={null} width={120} x={0} y={0} />,
+    );
+
+    expect(
+      container.querySelector("[data-selection-presence-chip]"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("includes the user name in the aria-label", () => {
+    render(
+      <SelectionPresence height={80} name="Bea" width={120} x={0} y={0} />,
+    );
+
+    expect(
+      screen.getByLabelText("Selection presence: Bea"),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/selection-presence/selection-presence.tsx
+++ b/packages/ui/src/components/selection-presence/selection-presence.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type SelectionPresenceLabels = {
+  /** Aria-label override. Defaults to `"Selection presence"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Selection presence",
+} as const satisfies Required<SelectionPresenceLabels>;
+
+/**
+ * Props for {@link SelectionPresence}.
+ *
+ * @public
+ */
+export type SelectionPresenceProps = {
+  /** Tailwind / CSS color used for the border + chip. Defaults to `var(--foreground)`. */
+  color?: string;
+  /** Selection rectangle height in pixels. */
+  height: number;
+  /** Localizable strings. */
+  labels?: SelectionPresenceLabels;
+  /** Optional name shown in the corner chip (e.g. owner of the selection). */
+  name?: ReactNode;
+  /** Selection rectangle width in pixels. */
+  width: number;
+  /** Selection rectangle X (top-left) in canvas pixels. */
+  x: number;
+  /** Selection rectangle Y (top-left) in canvas pixels. */
+  y: number;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * Overlay marking what another user has selected on the canvas. The
+ * dashed border + soft fill stay calm so they communicate
+ * "someone-else's-selection" without blocking primary content. Pure
+ * presentation; the host computes the rect from the remote user's
+ * viewport and supplies an accent color per user.
+ *
+ * The wrapper is `pointer-events: none` so host gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <SelectionPresence
+ *     x={120} y={80} width={240} height={120}
+ *     color="#5b8def"
+ *     name="Bea"
+ *   />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const SelectionPresence = forwardRef<
+  HTMLDivElement,
+  SelectionPresenceProps
+>((props, ref) => {
+  const { className, color, height, labels, name, width, x, y, ...rest } =
+    props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const accent = color ?? "var(--foreground)";
+  const ariaLabel =
+    typeof name === "string"
+      ? `${resolvedLabels.region}: ${name}`
+      : resolvedLabels.region;
+  return (
+    <div
+      aria-label={ariaLabel}
+      className={cn(
+        "pointer-events-none absolute z-20 rounded-md border-2 border-dashed",
+        className,
+      )}
+      data-selection-presence
+      ref={ref}
+      role="img"
+      style={{
+        backgroundColor: `color-mix(in srgb, ${accent} 10%, transparent)`,
+        borderColor: accent,
+        height,
+        left: x,
+        top: y,
+        width,
+      }}
+      {...rest}
+    >
+      {name === null || name === undefined ? null : (
+        <span
+          className="absolute -top-5 left-0 inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-medium text-white shadow-sm"
+          data-selection-presence-chip
+          style={{ backgroundColor: accent }}
+        >
+          {name}
+        </span>
+      )}
+    </div>
+  );
+});
+SelectionPresence.displayName = "SelectionPresence";

--- a/packages/ui/src/components/selection-presence/selection-presence.visual.tsx
+++ b/packages/ui/src/components/selection-presence/selection-presence.visual.tsx
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { SelectionPresence } from "./selection-presence";
+
+test.describe("SelectionPresence Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div
+        className="relative bg-muted/30"
+        style={{ height: 240, width: 360 }}
+      >
+        <SelectionPresence
+          color="#5b8def"
+          height={80}
+          name="Bea"
+          width={120}
+          x={40}
+          y={50}
+        />
+        <SelectionPresence
+          color="#10b981"
+          height={50}
+          name="Lior"
+          width={140}
+          x={180}
+          y={140}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "selection-presence-default.png",
+    );
+  });
+});

--- a/packages/ui/src/components/thread-bubble/index.ts
+++ b/packages/ui/src/components/thread-bubble/index.ts
@@ -1,0 +1,6 @@
+export {
+  ThreadBubble,
+  type ThreadBubbleLabels,
+  type ThreadBubbleProps,
+  type ThreadMessage,
+} from "./thread-bubble";

--- a/packages/ui/src/components/thread-bubble/thread-bubble.mdx
+++ b/packages/ui/src/components/thread-bubble/thread-bubble.mdx
@@ -1,0 +1,67 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './thread-bubble.stories'
+
+<Meta of={Stories} />
+
+# ThreadBubble
+
+Expanded discussion bubble for an anchored canvas comment thread. Renders a stacked message list plus an optional reply slot via \`footer\`. Pair with \`CommentPin\`: pin marks the location, bubble holds the conversation.
+
+Pure presentation; the host owns the message store + supplies the resolve handler when threading is enabled.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/thread-bubble.json
+```
+
+## Import
+
+```tsx
+import { ThreadBubble } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<ThreadBubble
+  title="research-2025"
+  messages={[
+    { id: "1", author: "Bea", authorColor: "#5b8def", body: "Why fallback?", ts: "12s" },
+    { id: "2", author: "Lior", authorColor: "#10b981", body: "p95 spike — see graph", ts: "9s" },
+  ]}
+  footer={<ReplyInput onSubmit={post} />}
+  onResolve={resolve}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Empty
+
+A thread with no messages yet — useful when a pin is created before the first reply lands.
+
+<Canvas of={Stories.Empty} sourceState="shown" />
+
+## With footer
+
+Slot any reply input via \`footer\`. The bubble doesn't own input state — the host wires it up.
+
+<Canvas of={Stories.WithFooter} sourceState="shown" />
+
+## Read only
+
+Drop \`onResolve\` and the resolve button hides — useful for archived or read-only views.
+
+<Canvas of={Stories.ReadOnly} sourceState="shown" />
+
+## Notes
+
+- Each message emits \`data-thread-bubble-message\` (= id). Author / timestamp / body emit \`data-thread-bubble-author\`, \`data-thread-bubble-ts\`, \`data-thread-bubble-body\`.
+- The wrapper emits \`data-thread-bubble\`; the message list emits \`data-thread-bubble-list\`; the optional title emits \`data-thread-bubble-title\`; the resolve button emits \`data-thread-bubble-resolve\`; the footer emits \`data-thread-bubble-footer\`.

--- a/packages/ui/src/components/thread-bubble/thread-bubble.stories.tsx
+++ b/packages/ui/src/components/thread-bubble/thread-bubble.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ThreadBubble } from "./thread-bubble";
+
+const noop = (): void => undefined;
+
+const meta = {
+  args: {
+    messages: [
+      {
+        author: "Bea",
+        authorColor: "#5b8def",
+        body: "Why are we routing to fallback right now?",
+        id: "1",
+        ts: "12s",
+      },
+      {
+        author: "Lior",
+        authorColor: "#10b981",
+        body: "p95 spike on primary — see graph.",
+        id: "2",
+        ts: "9s",
+      },
+      {
+        author: "Sam",
+        authorColor: "#f59e0b",
+        body: "Will keep an eye on it for the next hour.",
+        id: "3",
+        ts: "now",
+      },
+    ],
+    onResolve: noop,
+    title: "research-2025",
+  },
+  component: ThreadBubble,
+  decorators: [
+    (Story) => (
+      <div className="bg-muted/30 p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/ThreadBubble",
+} satisfies Meta<typeof ThreadBubble>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: { messages: [] },
+};
+
+export const WithFooter: Story = {
+  args: {
+    footer: (
+      <input
+        className="w-full rounded-md border border-border bg-background px-2 py-1 text-xs"
+        placeholder="Reply…"
+      />
+    ),
+  },
+};
+
+export const ReadOnly: Story = {
+  args: { onResolve: undefined },
+};

--- a/packages/ui/src/components/thread-bubble/thread-bubble.test.tsx
+++ b/packages/ui/src/components/thread-bubble/thread-bubble.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ThreadBubble, type ThreadMessage } from "./thread-bubble";
+
+const sample: ThreadMessage[] = [
+  {
+    author: "Bea",
+    authorColor: "#5b8def",
+    body: "Why fallback?",
+    id: "1",
+    ts: "12s",
+  },
+  {
+    author: "Lior",
+    authorColor: "#10b981",
+    body: "p95 spike",
+    id: "2",
+    ts: "9s",
+  },
+];
+
+describe("ThreadBubble", () => {
+  it("renders one entry per message", () => {
+    const { container } = render(<ThreadBubble messages={sample} />);
+
+    expect(
+      container.querySelectorAll("[data-thread-bubble-message]"),
+    ).toHaveLength(2);
+  });
+
+  it("renders the empty state when there are no messages", () => {
+    const { container } = render(<ThreadBubble messages={[]} />);
+
+    expect(
+      container.querySelector("[data-thread-bubble-state='empty']"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the title when provided", () => {
+    render(<ThreadBubble messages={sample} title="research-2025" />);
+
+    expect(screen.getByText("research-2025")).toBeInTheDocument();
+  });
+
+  it("invokes onResolve when the resolve button is clicked", () => {
+    const handleResolve = vi.fn();
+    render(
+      <ThreadBubble messages={sample} onResolve={handleResolve} title="x" />,
+    );
+
+    fireEvent.click(screen.getByText("Resolve"));
+    expect(handleResolve).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the resolve button when no handler is provided", () => {
+    render(<ThreadBubble messages={sample} />);
+
+    expect(screen.queryByText("Resolve")).not.toBeInTheDocument();
+  });
+
+  it("applies the author color when provided", () => {
+    const { container } = render(<ThreadBubble messages={sample} />);
+
+    const author = container.querySelector("[data-thread-bubble-author]");
+    expect(author).toHaveStyle({ color: "#5b8def" });
+  });
+
+  it("renders the footer slot when provided", () => {
+    render(
+      <ThreadBubble
+        footer={<div data-testid="footer">reply</div>}
+        messages={sample}
+      />,
+    );
+
+    expect(screen.getByTestId("footer")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/thread-bubble/thread-bubble.tsx
+++ b/packages/ui/src/components/thread-bubble/thread-bubble.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * One message in a thread bubble.
+ *
+ * @public
+ */
+export type ThreadMessage = {
+  /** Author display name. */
+  author: ReactNode;
+  /** Optional accent color for the author chip. */
+  authorColor?: string;
+  /** Message body — rendered as-is, can be plain text or a `ReactNode`. */
+  body: ReactNode;
+  /** Stable identifier — used as the React key + analytics hook. */
+  id: string;
+  /** Pre-formatted timestamp (host owns formatting). */
+  ts?: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type ThreadBubbleLabels = {
+  /** Empty-state copy. Defaults to `"No replies yet"`. */
+  empty?: string;
+  /** Aria-label override. Defaults to `"Comment thread"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No replies yet",
+  region: "Comment thread",
+} as const satisfies Required<ThreadBubbleLabels>;
+
+/**
+ * Props for {@link ThreadBubble}.
+ *
+ * @public
+ */
+export type ThreadBubbleProps = {
+  /** Optional footer slot — typically a reply input. */
+  footer?: ReactNode;
+  /** Localizable strings. */
+  labels?: ThreadBubbleLabels;
+  /** Messages newest-last. */
+  messages: ThreadMessage[];
+  /** Optional resolve handler. When provided, a "Resolve" button appears in the header. */
+  onResolve?: () => void;
+  /** Optional thread title (e.g. anchored object name). */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const Message = (props: { message: ThreadMessage }): React.ReactElement => {
+  const { message } = props;
+  return (
+    <li className="space-y-0.5" data-thread-bubble-message={message.id}>
+      <header className="flex items-baseline justify-between gap-2 text-[10px]">
+        <span
+          className="font-semibold"
+          data-thread-bubble-author
+          style={
+            message.authorColor ? { color: message.authorColor } : undefined
+          }
+        >
+          {message.author}
+        </span>
+        {message.ts ? (
+          <span className="text-muted-foreground" data-thread-bubble-ts>
+            {message.ts}
+          </span>
+        ) : null}
+      </header>
+      <p className="text-xs text-foreground" data-thread-bubble-body>
+        {message.body}
+      </p>
+    </li>
+  );
+};
+
+/**
+ * Expanded discussion bubble for an anchored canvas comment thread.
+ * Renders a stacked message list plus an optional reply slot via
+ * `footer`. Pair with {@link "../comment-pin/comment-pin".CommentPin}: pin marks the location,
+ * bubble holds the conversation.
+ *
+ * Pure presentation; the host owns the message store + supplies the
+ * resolve handler for hosts that allow threading.
+ *
+ * @example
+ * ```tsx
+ * <ThreadBubble
+ *   title="research-2025"
+ *   messages={[
+ *     { id: "1", author: "Bea", authorColor: "#5b8def", body: "Why fallback?", ts: "12s" },
+ *     { id: "2", author: "Lior", authorColor: "#10b981", body: "p95 spike — see graph", ts: "9s" },
+ *   ]}
+ *   footer={<ReplyInput onSubmit={post} />}
+ *   onResolve={resolve}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const ThreadBubble = forwardRef<HTMLElement, ThreadBubbleProps>(
+  (props, ref) => {
+    const { className, footer, labels, messages, onResolve, title, ...rest } =
+      props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const handleResolve = (): void => {
+      onResolve?.();
+    };
+    return (
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "flex w-72 flex-col gap-2 rounded-lg border border-border bg-background p-3 text-foreground shadow-md",
+          className,
+        )}
+        data-thread-bubble
+        ref={ref}
+        {...rest}
+      >
+        {title || onResolve ? (
+          <header className="flex items-center justify-between gap-2 text-[11px] uppercase tracking-wide text-muted-foreground">
+            {title ? (
+              <span className="truncate font-semibold" data-thread-bubble-title>
+                {title}
+              </span>
+            ) : (
+              <span aria-hidden="true" />
+            )}
+            {onResolve ? (
+              <button
+                className="rounded-full border border-border px-2 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                data-thread-bubble-resolve
+                onClick={handleResolve}
+                type="button"
+              >
+                Resolve
+              </button>
+            ) : null}
+          </header>
+        ) : null}
+        {messages.length === 0 ? (
+          <p
+            className="px-1 py-2 text-center text-[11px] text-muted-foreground"
+            data-thread-bubble-state="empty"
+          >
+            {resolvedLabels.empty}
+          </p>
+        ) : (
+          <ul className="space-y-2 overflow-y-auto" data-thread-bubble-list>
+            {messages.map((message) => (
+              <Message key={message.id} message={message} />
+            ))}
+          </ul>
+        )}
+        {footer ? (
+          <footer
+            className="border-t border-border pt-2"
+            data-thread-bubble-footer
+          >
+            {footer}
+          </footer>
+        ) : null}
+      </section>
+    );
+  },
+);
+ThreadBubble.displayName = "ThreadBubble";

--- a/packages/ui/src/components/thread-bubble/thread-bubble.visual.tsx
+++ b/packages/ui/src/components/thread-bubble/thread-bubble.visual.tsx
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { ThreadBubble } from "./thread-bubble";
+
+test.describe("ThreadBubble Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="bg-muted/30 p-4">
+        <ThreadBubble
+          messages={[
+            {
+              author: "Bea",
+              authorColor: "#5b8def",
+              body: "Why are we routing to fallback right now?",
+              id: "1",
+              ts: "12s",
+            },
+            {
+              author: "Lior",
+              authorColor: "#10b981",
+              body: "p95 spike on primary — see graph.",
+              id: "2",
+              ts: "9s",
+            },
+            {
+              author: "Sam",
+              authorColor: "#f59e0b",
+              body: "Will keep an eye on it for the next hour.",
+              id: "3",
+              ts: "now",
+            },
+          ]}
+          title="research-2025"
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("thread-bubble-default.png");
+  });
+});


### PR DESCRIPTION
Closes #135

## What's in

Three more #135 canvas collaboration primitives:

- **PresenceStack** — overlapping live-presence avatars with status dots (\`active\` / \`away\` / \`idle\` / \`offline\`) and a sane \`+N\` overflow chip. The overflow becomes a button when \`onOverflowActivate\` is supplied. Distinct from \`AvatarGroup\` (a static participant grouping): this primitive centers on live status and interactive expansion.
- **SelectionPresence** — dashed-border overlay marking what another user has selected on the canvas. Soft \`color-mix\` fill so the rectangle keeps the accent without darkening the canvas. Optional corner chip with the user name. \`pointer-events: none\`.
- **ThreadBubble** — expanded discussion bubble for an anchored canvas comment thread. Stacked message list with author / timestamp / body, optional title, optional resolve button, optional \`footer\` slot for a reply input. Empty-state copy when there are no messages yet. Pair with \`CommentPin\`.

All three are pure presentation; the host owns the websocket / message store. Wired into the \`@vllnt/ui\` barrel and the shadcn registry.

## Files

- \`packages/ui/src/components/presence-stack/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/selection-presence/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/thread-bubble/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/index.ts\` — barrel exports
- \`apps/registry/registry/default/{presence-stack,selection-presence,thread-bubble}/*.tsx\` — registry shims
- \`apps/registry/registry.json\` — three new entries (alphabetically placed)

## Stacks with PR #205

PR #205 shipped \`LiveCursor\` + \`CommentPin\` + \`PresenceSyncIndicator\`. Together with this PR that's 6 / 8 of #135. Remaining: \`FollowMode\`, \`HandoffBeacon\`.

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck: PASS (\`tsc --noEmit --project tsconfig.build.json\`)
- check:use-client: PASS (182 components)
- check:story-coverage: PASS (172 components)
- verify-stories: PASS (no crash risks)
- test: PASS (512 / 512 — incl. 19 new)
- build (\`@vllnt/ui\`): PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)
- [ ] Storybook renders all 12 stories (4 per primitive) without console errors
- [ ] Visual snapshots stable across primitives