### PR TITLE
feat(ui): canvas foundation — InfinitePlane + ViewportBookmarks + WorldBreadcrumbs (final #132)

### DIFF
--- a/apps/registry/lib/component-metadata.json
+++ b/apps/registry/lib/component-metadata.json
@@ -923,8 +923,8 @@
         "name": "Default"
       },
       {
-        "id": "core-form--invalid",
-        "name": "Invalid"
+        "id": "core-form--server-error",
+        "name": "Server Error"
       }
     ],
     "title": "Form"
@@ -967,6 +967,31 @@
       }
     ],
     "title": "Hover Card"
+  },
+  "infinite-plane": {
+    "category": "utility",
+    "defaultStoryId": "canvas-infiniteplane--dot",
+    "description": "Tiled pannable backdrop for the canvas with dot or grid pattern that drifts with the viewport.",
+    "name": "infinite-plane",
+    "stories": [
+      {
+        "id": "canvas-infiniteplane--dot",
+        "name": "Dot"
+      },
+      {
+        "id": "canvas-infiniteplane--grid",
+        "name": "Grid"
+      },
+      {
+        "id": "canvas-infiniteplane--blank",
+        "name": "Blank"
+      },
+      {
+        "id": "canvas-infiniteplane--zoomed-and-panned",
+        "name": "Zoomed And Panned"
+      }
+    ],
+    "title": "Infinite Plane"
   },
   "inline-input": {
     "category": "form",
@@ -2529,6 +2554,31 @@
     ],
     "title": "View Switcher"
   },
+  "viewport-bookmarks": {
+    "category": "navigation",
+    "defaultStoryId": "canvas-viewportbookmarks--default",
+    "description": "Saved-view list for the canvas — pinned spatial locations with optional active state.",
+    "name": "viewport-bookmarks",
+    "stories": [
+      {
+        "id": "canvas-viewportbookmarks--default",
+        "name": "Default"
+      },
+      {
+        "id": "canvas-viewportbookmarks--empty",
+        "name": "Empty"
+      },
+      {
+        "id": "canvas-viewportbookmarks--no-active",
+        "name": "No Active"
+      },
+      {
+        "id": "canvas-viewportbookmarks--read-only",
+        "name": "Read Only"
+      }
+    ],
+    "title": "Viewport Bookmarks"
+  },
   "wallet-card": {
     "category": "content",
     "defaultStoryId": "account-billing-walletcard--default",
@@ -2575,6 +2625,31 @@
       }
     ],
     "title": "Workspace Switcher"
+  },
+  "world-breadcrumbs": {
+    "category": "navigation",
+    "defaultStoryId": "canvas-worldbreadcrumbs--default",
+    "description": "Spatial trail showing the canvas's current location in a hierarchy of worlds, groups, and runs.",
+    "name": "world-breadcrumbs",
+    "stories": [
+      {
+        "id": "canvas-worldbreadcrumbs--default",
+        "name": "Default"
+      },
+      {
+        "id": "canvas-worldbreadcrumbs--shallow",
+        "name": "Shallow"
+      },
+      {
+        "id": "canvas-worldbreadcrumbs--empty",
+        "name": "Empty"
+      },
+      {
+        "id": "canvas-worldbreadcrumbs--read-only",
+        "name": "Read Only"
+      }
+    ],
+    "title": "World Breadcrumbs"
   },
   "world-clock-bar": {
     "category": "data",

--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -967,6 +967,21 @@
       "category": "overlay"
     },
     {
+      "name": "infinite-plane",
+      "type": "registry:component",
+      "title": "Infinite Plane",
+      "description": "Tiled pannable backdrop for the canvas with dot or grid pattern that drifts with the viewport.",
+      "files": [
+        {
+          "path": "registry/default/infinite-plane/infinite-plane.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "utility"
+    },
+    {
       "name": "inline-input",
       "type": "registry:component",
       "title": "Inline Input",
@@ -2330,6 +2345,21 @@
       "category": "navigation"
     },
     {
+      "name": "viewport-bookmarks",
+      "type": "registry:component",
+      "title": "Viewport Bookmarks",
+      "description": "Saved-view list for the canvas — pinned spatial locations with optional active state.",
+      "files": [
+        {
+          "path": "registry/default/viewport-bookmarks/viewport-bookmarks.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "navigation"
+    },
+    {
       "name": "wallet-card",
       "type": "registry:component",
       "title": "Wallet Card",
@@ -2367,6 +2397,21 @@
       "files": [
         {
           "path": "registry/default/workspace-switcher/workspace-switcher.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [],
+      "category": "navigation"
+    },
+    {
+      "name": "world-breadcrumbs",
+      "type": "registry:component",
+      "title": "World Breadcrumbs",
+      "description": "Spatial trail showing the canvas's current location in a hierarchy of worlds, groups, and runs.",
+      "files": [
+        {
+          "path": "registry/default/world-breadcrumbs/world-breadcrumbs.tsx",
           "type": "registry:component"
         }
       ],

--- a/apps/registry/registry/default/infinite-plane/infinite-plane.tsx
+++ b/apps/registry/registry/default/infinite-plane/infinite-plane.tsx
@@ -1,0 +1,6 @@
+export {
+  InfinitePlane,
+  type InfinitePlaneLabels,
+  type InfinitePlanePattern,
+  type InfinitePlaneProps,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/viewport-bookmarks/viewport-bookmarks.tsx
+++ b/apps/registry/registry/default/viewport-bookmarks/viewport-bookmarks.tsx
@@ -1,0 +1,6 @@
+export {
+  type ViewportBookmark,
+  ViewportBookmarks,
+  type ViewportBookmarksLabels,
+  type ViewportBookmarksProps,
+} from '@vllnt/ui'

--- a/apps/registry/registry/default/world-breadcrumbs/world-breadcrumbs.tsx
+++ b/apps/registry/registry/default/world-breadcrumbs/world-breadcrumbs.tsx
@@ -1,0 +1,7 @@
+export {
+  WorldBreadcrumbs,
+  type WorldBreadcrumbsLabels,
+  type WorldBreadcrumbsProps,
+  type WorldCrumb,
+  type WorldCrumbKind,
+} from '@vllnt/ui'

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -359,6 +359,12 @@ export {
   type ChatDockSectionProps,
 } from "./chat-dock-section";
 export { GlassPanel, type GlassPanelProps } from "./glass-panel";
+export {
+  InfinitePlane,
+  type InfinitePlaneLabels,
+  type InfinitePlanePattern,
+  type InfinitePlaneProps,
+} from "./infinite-plane";
 export { LeftRail, type LeftRailProps } from "./left-rail";
 export {
   type MiniMapMarker,
@@ -385,6 +391,19 @@ export type { SidebarItem, SidebarSection } from "./sidebar";
 export { SidebarProvider, useSidebar } from "./sidebar-provider";
 export { TableOfContents } from "./table-of-contents";
 export { TopBar, type TopBarProps } from "./top-bar";
+export {
+  type ViewportBookmark,
+  ViewportBookmarks,
+  type ViewportBookmarksLabels,
+  type ViewportBookmarksProps,
+} from "./viewport-bookmarks";
+export {
+  WorldBreadcrumbs,
+  type WorldBreadcrumbsLabels,
+  type WorldBreadcrumbsProps,
+  type WorldCrumb,
+  type WorldCrumbKind,
+} from "./world-breadcrumbs";
 export { ZoomHUD, type ZoomHUDProps } from "./zoom-hud";
 
 // Blog components

--- a/packages/ui/src/components/infinite-plane/index.ts
+++ b/packages/ui/src/components/infinite-plane/index.ts
@@ -1,0 +1,6 @@
+export {
+  InfinitePlane,
+  type InfinitePlaneLabels,
+  type InfinitePlanePattern,
+  type InfinitePlaneProps,
+} from "./infinite-plane";

--- a/packages/ui/src/components/infinite-plane/infinite-plane.mdx
+++ b/packages/ui/src/components/infinite-plane/infinite-plane.mdx
@@ -1,0 +1,62 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './infinite-plane.stories'
+
+<Meta of={Stories} />
+
+# InfinitePlane
+
+Tiled pannable backdrop for the canvas. Renders a \`dot\` or \`grid\` pattern that drifts with the viewport translate and scales with the zoom, plus a slot for spatial children that share its coordinate space.
+
+Pure presentation; the host owns the viewport transform and supplies \`translate\` + \`zoom\` from its pan / zoom controller.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/infinite-plane.json
+```
+
+## Import
+
+```tsx
+import { InfinitePlane } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<InfinitePlane translate={{ x: pan.x, y: pan.y }} zoom={zoom}>
+  <ObjectCard …/>
+  <ObjectCard …/>
+</InfinitePlane>
+```
+
+<Canvas of={Stories.Dot} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Grid pattern
+
+Switch the backdrop to a thin line grid for surfaces that prefer rectilinear cues.
+
+<Canvas of={Stories.Grid} sourceState="shown" />
+
+## Blank
+
+Drop the pattern entirely for a clean surface — the slot still positions children in the same coordinate space.
+
+<Canvas of={Stories.Blank} sourceState="shown" />
+
+## Zoomed and panned
+
+The plane scales the pattern by \`zoom\` and offsets it by \`translate\` so the dots / lines feel anchored to the world rather than the screen.
+
+<Canvas of={Stories.ZoomedAndPanned} sourceState="shown" />
+
+## Notes
+
+- Spacing floors at 4 px; zoom clamps to the 0.1 .. 10 range.
+- Each render emits \`data-infinite-plane\` + \`data-infinite-plane-pattern\` for analytics + CSS hooks.

--- a/packages/ui/src/components/infinite-plane/infinite-plane.stories.tsx
+++ b/packages/ui/src/components/infinite-plane/infinite-plane.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { InfinitePlane } from "./infinite-plane";
+
+const meta = {
+  args: {
+    pattern: "dot",
+    spacing: 32,
+    translate: { x: 0, y: 0 },
+    zoom: 1,
+  },
+  component: InfinitePlane,
+  decorators: [
+    (Story) => (
+      <div style={{ height: 240, width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/InfinitePlane",
+} satisfies Meta<typeof InfinitePlane>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Dot: Story = {};
+
+export const Grid: Story = {
+  args: { pattern: "grid", spacing: 24 },
+};
+
+export const Blank: Story = {
+  args: { pattern: "blank" },
+};
+
+export const ZoomedAndPanned: Story = {
+  args: {
+    spacing: 24,
+    translate: { x: 16, y: 8 },
+    zoom: 2,
+  },
+};

--- a/packages/ui/src/components/infinite-plane/infinite-plane.test.tsx
+++ b/packages/ui/src/components/infinite-plane/infinite-plane.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { InfinitePlane } from "./infinite-plane";
+
+describe("InfinitePlane", () => {
+  it("renders the children inside the plane", () => {
+    render(
+      <InfinitePlane>
+        <p>spatial child</p>
+      </InfinitePlane>,
+    );
+
+    expect(screen.getByText("spatial child")).toBeInTheDocument();
+  });
+
+  it("propagates the pattern to a data attribute", () => {
+    const { container } = render(<InfinitePlane pattern="grid" />);
+
+    expect(container.querySelector("[data-infinite-plane]")).toHaveAttribute(
+      "data-infinite-plane-pattern",
+      "grid",
+    );
+  });
+
+  it("emits no background image when pattern is blank", () => {
+    const { container } = render(<InfinitePlane pattern="blank" />);
+
+    const plane = container.querySelector("[data-infinite-plane]");
+    expect(plane?.getAttribute("style") ?? "").not.toContain(
+      "background-image",
+    );
+  });
+
+  it("scales the pattern by zoom", () => {
+    const { container } = render(<InfinitePlane spacing={50} zoom={2} />);
+
+    expect(container.querySelector("[data-infinite-plane]")).toHaveStyle({
+      "background-size": "100px 100px",
+    });
+  });
+
+  it("clamps an out-of-range zoom", () => {
+    const { container } = render(<InfinitePlane spacing={32} zoom={50} />);
+
+    expect(container.querySelector("[data-infinite-plane]")).toHaveStyle({
+      "background-size": "320px 320px",
+    });
+  });
+
+  it("uses the translate as the background-position", () => {
+    const { container } = render(
+      <InfinitePlane translate={{ x: 40, y: -20 }} />,
+    );
+
+    expect(container.querySelector("[data-infinite-plane]")).toHaveStyle({
+      "background-position": "40px -20px",
+    });
+  });
+});

--- a/packages/ui/src/components/infinite-plane/infinite-plane.tsx
+++ b/packages/ui/src/components/infinite-plane/infinite-plane.tsx
@@ -75,14 +75,14 @@ const buildBackground = (input: {
   if (input.pattern === "grid") {
     return {
       backgroundImage:
-        "linear-gradient(to right, var(--border) 1px, transparent 1px), linear-gradient(to bottom, var(--border) 1px, transparent 1px)",
+        "linear-gradient(to right, hsl(var(--border)) 1px, transparent 1px), linear-gradient(to bottom, hsl(var(--border)) 1px, transparent 1px)",
       backgroundPosition: pos,
       backgroundSize: `${size}px ${size}px`,
     };
   }
   return {
     backgroundImage:
-      "radial-gradient(circle, var(--border) 1px, transparent 1px)",
+      "radial-gradient(circle, hsl(var(--border)) 1px, transparent 1px)",
     backgroundPosition: pos,
     backgroundSize: `${size}px ${size}px`,
   };

--- a/packages/ui/src/components/infinite-plane/infinite-plane.tsx
+++ b/packages/ui/src/components/infinite-plane/infinite-plane.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Pattern style for the plane backdrop.
+ *
+ * @public
+ */
+export type InfinitePlanePattern = "blank" | "dot" | "grid";
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type InfinitePlaneLabels = {
+  /** Aria-label override. Defaults to `"Infinite plane"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Infinite plane",
+} as const satisfies Required<InfinitePlaneLabels>;
+
+/**
+ * Props for {@link InfinitePlane}.
+ *
+ * @public
+ */
+export type InfinitePlaneProps = {
+  /** Children render in the plane's coordinate space. */
+  children?: ReactNode;
+  /** Localizable strings. */
+  labels?: InfinitePlaneLabels;
+  /** Backdrop pattern. Defaults to `"dot"`. */
+  pattern?: InfinitePlanePattern;
+  /** Pattern grid spacing in pixels. Defaults to `32`. */
+  spacing?: number;
+  /** Optional offset applied to the pattern (drift with viewport translation). Defaults to `{ x: 0, y: 0 }`. */
+  translate?: { x: number; y: number };
+  /** Zoom factor — drives the pattern's effective spacing. Defaults to `1`. */
+  zoom?: number;
+} & ComponentPropsWithoutRef<"div">;
+
+const safeSpacing = (value: number): number => (value < 4 ? 4 : value);
+
+const safeZoom = (value: number): number => {
+  if (value < 0.1) {
+    return 0.1;
+  }
+  if (value > 10) {
+    return 10;
+  }
+  return value;
+};
+
+const buildBackground = (input: {
+  pattern: InfinitePlanePattern;
+  spacing: number;
+  translate: { x: number; y: number };
+  zoom: number;
+}): React.CSSProperties => {
+  if (input.pattern === "blank") {
+    return {};
+  }
+  const size = safeSpacing(input.spacing) * safeZoom(input.zoom);
+  const pos = `${input.translate.x}px ${input.translate.y}px`;
+  if (input.pattern === "grid") {
+    return {
+      backgroundImage:
+        "linear-gradient(to right, var(--border) 1px, transparent 1px), linear-gradient(to bottom, var(--border) 1px, transparent 1px)",
+      backgroundPosition: pos,
+      backgroundSize: `${size}px ${size}px`,
+    };
+  }
+  return {
+    backgroundImage:
+      "radial-gradient(circle, var(--border) 1px, transparent 1px)",
+    backgroundPosition: pos,
+    backgroundSize: `${size}px ${size}px`,
+  };
+};
+
+/**
+ * Tiled pannable backdrop for the canvas. Renders a `dot` or `grid`
+ * pattern that drifts with the viewport translate + scales with the
+ * zoom, plus a slot for spatial children that share its coordinate
+ * space.
+ *
+ * Pure presentation; the host owns the viewport transform and supplies
+ * `translate` + `zoom` from its pan / zoom controller.
+ *
+ * @example
+ * ```tsx
+ * <InfinitePlane translate={{ x: pan.x, y: pan.y }} zoom={zoom}>
+ *   <ObjectCard …/>
+ *   <ObjectCard …/>
+ * </InfinitePlane>
+ * ```
+ *
+ * @public
+ */
+export const InfinitePlane = forwardRef<HTMLDivElement, InfinitePlaneProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      labels,
+      pattern = "dot",
+      spacing = 32,
+      translate = { x: 0, y: 0 },
+      zoom = 1,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const background = buildBackground({ pattern, spacing, translate, zoom });
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "relative h-full w-full overflow-hidden bg-background",
+          className,
+        )}
+        data-infinite-plane
+        data-infinite-plane-pattern={pattern}
+        ref={ref}
+        role="region"
+        style={background}
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+InfinitePlane.displayName = "InfinitePlane";

--- a/packages/ui/src/components/infinite-plane/infinite-plane.visual.tsx
+++ b/packages/ui/src/components/infinite-plane/infinite-plane.visual.tsx
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { InfinitePlane } from "./infinite-plane";
+
+test.describe("InfinitePlane Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div style={{ height: 240, width: 360 }}>
+        <InfinitePlane spacing={28} translate={{ x: 14, y: 14 }} zoom={1.5}>
+          <div className="absolute left-12 top-10 rounded-md border border-border bg-background px-3 py-1 text-xs">
+            Object A
+          </div>
+          <div className="absolute left-44 top-32 rounded-md border border-border bg-background px-3 py-1 text-xs">
+            Object B
+          </div>
+        </InfinitePlane>
+      </div>,
+    );
+    await expect(component).toHaveScreenshot("infinite-plane-default.png");
+  });
+});

--- a/packages/ui/src/components/viewport-bookmarks/index.ts
+++ b/packages/ui/src/components/viewport-bookmarks/index.ts
@@ -1,0 +1,6 @@
+export {
+  type ViewportBookmark,
+  ViewportBookmarks,
+  type ViewportBookmarksLabels,
+  type ViewportBookmarksProps,
+} from "./viewport-bookmarks";

--- a/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.mdx
+++ b/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.mdx
@@ -1,0 +1,64 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './viewport-bookmarks.stories'
+
+<Meta of={Stories} />
+
+# ViewportBookmarks
+
+Saved-view list for the canvas — the spatial equivalent of a tab bar's pinned tabs. Each bookmark stores a viewport target the host resolves to a pan / zoom transition. Pure presentation; the host owns the bookmark store and the camera animation.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/viewport-bookmarks.json
+```
+
+## Import
+
+```tsx
+import { ViewportBookmarks } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<ViewportBookmarks
+  activeId={active}
+  bookmarks={[
+    { id: "home",      label: "Home base", color: "#5b8def" },
+    { id: "incidents", label: "Incidents", detail: "5 open", color: "#ef4444" },
+  ]}
+  onSelect={jumpTo}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Empty
+
+When the host has no saved views yet, the panel renders a calm placeholder.
+
+<Canvas of={Stories.Empty} sourceState="shown" />
+
+## No active
+
+Drop \`activeId\` for a list with no row in the selected state.
+
+<Canvas of={Stories.NoActive} sourceState="shown" />
+
+## Read-only
+
+Drop \`onSelect\` and rows render as plain spans (no hover, no button semantics).
+
+<Canvas of={Stories.ReadOnly} sourceState="shown" />
+
+## Notes
+
+- \`color\` accepts any CSS color value (hex / oklch / var). Defaults to \`var(--foreground)\`.
+- Each row emits \`data-viewport-bookmark\` set to the bookmark id, plus \`data-viewport-bookmark-active\`. The optional detail line emits \`data-viewport-bookmark-detail\`. The wrapper emits \`data-viewport-bookmarks\`.

--- a/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.stories.tsx
+++ b/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ViewportBookmarks } from "./viewport-bookmarks";
+
+const noop = (): void => undefined;
+
+const meta = {
+  args: {
+    activeId: "incidents",
+    bookmarks: [
+      { color: "#5b8def", id: "home", label: "Home base" },
+      { color: "#10b981", detail: "1.4× zoom", id: "drilldown", label: "Drill-down" },
+      { color: "#ef4444", detail: "5 open", id: "incidents", label: "Incidents" },
+      { color: "#f59e0b", id: "watchtower", label: "Watch tower" },
+    ],
+    onSelect: noop,
+  },
+  component: ViewportBookmarks,
+  decorators: [
+    (Story) => (
+      <div className="w-64">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/ViewportBookmarks",
+} satisfies Meta<typeof ViewportBookmarks>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: { bookmarks: [] },
+};
+
+export const NoActive: Story = {
+  args: { activeId: undefined },
+};
+
+export const ReadOnly: Story = {
+  args: { onSelect: undefined },
+};

--- a/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.test.tsx
+++ b/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { type ViewportBookmark, ViewportBookmarks } from "./viewport-bookmarks";
+
+const sample: ViewportBookmark[] = [
+  { color: "#5b8def", id: "home", label: "Home base" },
+  { color: "#ef4444", detail: "5 open", id: "incidents", label: "Incidents" },
+];
+
+describe("ViewportBookmarks", () => {
+  it("renders one row per bookmark", () => {
+    const { container } = render(<ViewportBookmarks bookmarks={sample} />);
+
+    expect(container.querySelectorAll("[data-viewport-bookmark]")).toHaveLength(
+      2,
+    );
+  });
+
+  it("renders the empty state when bookmarks list is empty", () => {
+    const { container } = render(<ViewportBookmarks bookmarks={[]} />);
+
+    expect(
+      container.querySelector("[data-viewport-bookmarks-state='empty']"),
+    ).toBeInTheDocument();
+  });
+
+  it("invokes onSelect with the activated id", () => {
+    const handleSelect = vi.fn();
+    render(<ViewportBookmarks bookmarks={sample} onSelect={handleSelect} />);
+
+    fireEvent.click(screen.getByText("Incidents"));
+    expect(handleSelect).toHaveBeenCalledWith("incidents");
+  });
+
+  it("renders rows as plain spans when onSelect is omitted", () => {
+    render(<ViewportBookmarks bookmarks={sample} />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("propagates active state to a data attribute", () => {
+    const { container } = render(
+      <ViewportBookmarks
+        activeId="incidents"
+        bookmarks={sample}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(
+      container.querySelector("[data-viewport-bookmark='incidents']"),
+    ).toHaveAttribute("data-viewport-bookmark-active", "true");
+  });
+
+  it("renders the optional detail line", () => {
+    render(<ViewportBookmarks bookmarks={sample} />);
+
+    expect(screen.getByText("5 open")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.tsx
+++ b/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.tsx
@@ -109,7 +109,7 @@ const RowBody = (props: { bookmark: ViewportBookmark }): React.ReactElement => {
       <span
         aria-hidden="true"
         className="h-1.5 w-1.5 rounded-full"
-        style={{ backgroundColor: bookmark.color ?? "var(--foreground)" }}
+        style={{ backgroundColor: bookmark.color ?? "hsl(var(--foreground))" }}
       />
       <span className="flex flex-1 flex-col text-left">
         <span className="truncate font-medium">{bookmark.label}</span>

--- a/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.tsx
+++ b/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * One saved viewport.
+ *
+ * @public
+ */
+export type ViewportBookmark = {
+  /** Optional accent color for the row glyph. */
+  color?: string;
+  /** Optional secondary line (zoom level, last-visited, owner). */
+  detail?: ReactNode;
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Display name for the bookmark. */
+  label: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type ViewportBookmarksLabels = {
+  /** Empty-state copy. Defaults to `"No saved views"`. */
+  empty?: string;
+  /** Aria-label override. Defaults to `"Viewport bookmarks"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No saved views",
+  region: "Viewport bookmarks",
+} as const satisfies Required<ViewportBookmarksLabels>;
+
+/**
+ * Props for {@link ViewportBookmarks}.
+ *
+ * @public
+ */
+export type ViewportBookmarksProps = {
+  /** Optional active bookmark id — renders the row in the selected state. */
+  activeId?: string;
+  /** Bookmark entries in render order. */
+  bookmarks: ViewportBookmark[];
+  /** Localizable strings. */
+  labels?: ViewportBookmarksLabels;
+  /** Click handler — receives the activated bookmark id. */
+  onSelect?: (id: string) => void;
+  /** Optional title rendered above the rows. Defaults to `"Saved views"`. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const Row = (props: {
+  active: boolean;
+  bookmark: ViewportBookmark;
+  onSelect?: (id: string) => void;
+}): React.ReactElement => {
+  const { active, bookmark, onSelect } = props;
+  const handleClick = (): void => {
+    onSelect?.(bookmark.id);
+  };
+  const rowClass =
+    "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors";
+  const activeClass = active
+    ? "bg-muted/60 text-foreground"
+    : "text-muted-foreground hover:bg-muted/30 hover:text-foreground";
+  if (onSelect) {
+    return (
+      <button
+        aria-pressed={active}
+        className={cn(
+          rowClass,
+          activeClass,
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        )}
+        data-viewport-bookmark={bookmark.id}
+        data-viewport-bookmark-active={active}
+        onClick={handleClick}
+        type="button"
+      >
+        <RowBody bookmark={bookmark} />
+      </button>
+    );
+  }
+  return (
+    <span
+      className={cn(rowClass, activeClass)}
+      data-viewport-bookmark={bookmark.id}
+      data-viewport-bookmark-active={active}
+    >
+      <RowBody bookmark={bookmark} />
+    </span>
+  );
+};
+
+const RowBody = (props: { bookmark: ViewportBookmark }): React.ReactElement => {
+  const { bookmark } = props;
+  return (
+    <>
+      <span
+        aria-hidden="true"
+        className="h-1.5 w-1.5 rounded-full"
+        style={{ backgroundColor: bookmark.color ?? "var(--foreground)" }}
+      />
+      <span className="flex flex-1 flex-col text-left">
+        <span className="truncate font-medium">{bookmark.label}</span>
+        {bookmark.detail ? (
+          <span
+            className="truncate text-[10px] text-muted-foreground"
+            data-viewport-bookmark-detail
+          >
+            {bookmark.detail}
+          </span>
+        ) : null}
+      </span>
+    </>
+  );
+};
+
+/**
+ * Saved-view list for the canvas — the spatial parallel of a tab
+ * bar's pinned tabs. Each bookmark stores a viewport target the host
+ * resolves to a pan / zoom transition. Pure presentation; the host
+ * owns the bookmark store and the camera animation.
+ *
+ * @example
+ * ```tsx
+ * <ViewportBookmarks
+ *   activeId={active}
+ *   bookmarks={[
+ *     { id: "home", label: "Home base", color: "#5b8def" },
+ *     { id: "incidents", label: "Incidents", detail: "5 open", color: "#ef4444" },
+ *   ]}
+ *   onSelect={jumpTo}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const ViewportBookmarks = forwardRef<
+  HTMLElement,
+  ViewportBookmarksProps
+>((props, ref) => {
+  const {
+    activeId,
+    bookmarks,
+    className,
+    labels,
+    onSelect,
+    title = "Saved views",
+    ...rest
+  } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  return (
+    <section
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "flex w-full flex-col gap-1 rounded-lg border border-border bg-background p-2 text-foreground",
+        className,
+      )}
+      data-viewport-bookmarks
+      ref={ref}
+      {...rest}
+    >
+      <header className="px-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </header>
+      {bookmarks.length === 0 ? (
+        <p
+          className="px-2 py-3 text-center text-[11px] text-muted-foreground"
+          data-viewport-bookmarks-state="empty"
+        >
+          {resolvedLabels.empty}
+        </p>
+      ) : (
+        <ul className="space-y-0.5">
+          {bookmarks.map((bookmark) => (
+            <li key={bookmark.id}>
+              <Row
+                active={activeId === bookmark.id}
+                bookmark={bookmark}
+                onSelect={onSelect}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+});
+ViewportBookmarks.displayName = "ViewportBookmarks";

--- a/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.visual.tsx
+++ b/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.visual.tsx
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { ViewportBookmarks } from "./viewport-bookmarks";
+
+test.describe("ViewportBookmarks Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="w-64 bg-muted/30 p-4">
+        <ViewportBookmarks
+          activeId="incidents"
+          bookmarks={[
+            { color: "#5b8def", id: "home", label: "Home base" },
+            { color: "#10b981", detail: "1.4× zoom", id: "drilldown", label: "Drill-down" },
+            { color: "#ef4444", detail: "5 open", id: "incidents", label: "Incidents" },
+            { color: "#f59e0b", id: "watchtower", label: "Watch tower" },
+          ]}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "viewport-bookmarks-default.png",
+    );
+  });
+});

--- a/packages/ui/src/components/world-breadcrumbs/index.ts
+++ b/packages/ui/src/components/world-breadcrumbs/index.ts
@@ -1,0 +1,7 @@
+export {
+  WorldBreadcrumbs,
+  type WorldBreadcrumbsLabels,
+  type WorldBreadcrumbsProps,
+  type WorldCrumb,
+  type WorldCrumbKind,
+} from "./world-breadcrumbs";

--- a/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.mdx
+++ b/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.mdx
@@ -1,0 +1,67 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './world-breadcrumbs.stories'
+
+<Meta of={Stories} />
+
+# WorldBreadcrumbs
+
+Spatial trail showing where the viewport currently is in a hierarchy of worlds / groups / runs / agents. Distinct from \`Breadcrumb\` (route-based, document-tree style) — this primitive describes the canvas's spatial location and supports per-kind glyphs.
+
+Pure presentation; the host computes the trail from the active viewport target and the world graph, and resolves \`onSelect\` to a camera transition.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/world-breadcrumbs.json
+```
+
+## Import
+
+```tsx
+import { WorldBreadcrumbs } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<WorldBreadcrumbs
+  crumbs={[
+    { id: "world", kind: "world", label: "Production" },
+    { id: "group", kind: "group", label: "Ingest cluster" },
+    { id: "run",   kind: "run",   label: "research-2025" },
+  ]}
+  onSelect={jumpTo}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Shallow trail
+
+A two-crumb trail still renders its separators and last-crumb emphasis.
+
+<Canvas of={Stories.Shallow} sourceState="shown" />
+
+## Empty
+
+When the host has no active spatial location, the nav renders a calm placeholder.
+
+<Canvas of={Stories.Empty} sourceState="shown" />
+
+## Read-only
+
+Drop \`onSelect\` and crumbs render as plain spans (no hover, no button semantics).
+
+<Canvas of={Stories.ReadOnly} sourceState="shown" />
+
+## Notes
+
+- Kinds map: \`world\` ✦ · \`group\` ▤ · \`run\` ▶ · \`task\` ▢ · \`agent\` ◇ · \`artifact\` ◌.
+- The last crumb always renders as the active location and never invokes \`onSelect\`.
+- Each crumb emits \`data-world-breadcrumb\` set to the crumb id, plus \`data-world-breadcrumb-active\`. Separators emit \`data-world-breadcrumb-sep\`. The wrapper emits \`data-world-breadcrumbs\`.

--- a/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.stories.tsx
+++ b/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { WorldBreadcrumbs } from "./world-breadcrumbs";
+
+const noop = (): void => undefined;
+
+const meta = {
+  args: {
+    crumbs: [
+      { id: "world", kind: "world", label: "Production" },
+      { id: "group", kind: "group", label: "Ingest cluster" },
+      { id: "run", kind: "run", label: "research-2025" },
+      { id: "task", kind: "task", label: "score" },
+    ],
+    onSelect: noop,
+  },
+  component: WorldBreadcrumbs,
+  decorators: [
+    (Story) => (
+      <div className="bg-muted/30 p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  title: "Canvas/WorldBreadcrumbs",
+} satisfies Meta<typeof WorldBreadcrumbs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Shallow: Story = {
+  args: {
+    crumbs: [
+      { id: "world", kind: "world", label: "Production" },
+      { id: "run", kind: "run", label: "research-2025" },
+    ],
+  },
+};
+
+export const Empty: Story = {
+  args: { crumbs: [] },
+};
+
+export const ReadOnly: Story = {
+  args: { onSelect: undefined },
+};

--- a/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.test.tsx
+++ b/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { WorldBreadcrumbs, type WorldCrumb } from "./world-breadcrumbs";
+
+const sample: WorldCrumb[] = [
+  { id: "world", kind: "world", label: "Production" },
+  { id: "group", kind: "group", label: "Ingest cluster" },
+  { id: "run", kind: "run", label: "research-2025" },
+];
+
+describe("WorldBreadcrumbs", () => {
+  it("renders one entry per crumb", () => {
+    const { container } = render(<WorldBreadcrumbs crumbs={sample} />);
+
+    expect(container.querySelectorAll("[data-world-breadcrumb]")).toHaveLength(
+      3,
+    );
+  });
+
+  it("marks the last crumb as active", () => {
+    const { container } = render(<WorldBreadcrumbs crumbs={sample} />);
+
+    expect(
+      container.querySelector("[data-world-breadcrumb='run']"),
+    ).toHaveAttribute("data-world-breadcrumb-active", "true");
+  });
+
+  it("invokes onSelect with the activated id for non-last crumbs", () => {
+    const handleSelect = vi.fn();
+    render(<WorldBreadcrumbs crumbs={sample} onSelect={handleSelect} />);
+
+    fireEvent.click(screen.getByText("Production"));
+    expect(handleSelect).toHaveBeenCalledWith("world");
+  });
+
+  it("does not invoke onSelect for the last crumb", () => {
+    const handleSelect = vi.fn();
+    render(<WorldBreadcrumbs crumbs={sample} onSelect={handleSelect} />);
+
+    fireEvent.click(screen.getByText("research-2025"));
+    expect(handleSelect).not.toHaveBeenCalled();
+  });
+
+  it("renders crumbs as plain spans when no onSelect is provided", () => {
+    render(<WorldBreadcrumbs crumbs={sample} />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("renders the empty state when crumbs list is empty", () => {
+    const { container } = render(<WorldBreadcrumbs crumbs={[]} />);
+
+    expect(
+      container.querySelector("[data-world-breadcrumbs-state='empty']"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders separators between crumbs", () => {
+    const { container } = render(<WorldBreadcrumbs crumbs={sample} />);
+
+    expect(
+      container.querySelectorAll("[data-world-breadcrumb-sep]"),
+    ).toHaveLength(2);
+  });
+});

--- a/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.tsx
+++ b/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * One spatial trail crumb.
+ *
+ * @public
+ */
+export type WorldCrumb = {
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Optional kind (drives the leading glyph). */
+  kind?: WorldCrumbKind;
+  /** Display label. */
+  label: ReactNode;
+};
+
+/**
+ * Glyph hint for a crumb kind.
+ *
+ * @public
+ */
+export type WorldCrumbKind =
+  | "agent"
+  | "artifact"
+  | "group"
+  | "run"
+  | "task"
+  | "world";
+
+const KIND_GLYPH: Record<WorldCrumbKind, string> = {
+  agent: "◇",
+  artifact: "◌",
+  group: "▤",
+  run: "▶",
+  task: "▢",
+  world: "✦",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type WorldBreadcrumbsLabels = {
+  /** Empty-state copy. Defaults to `"No location"`. */
+  empty?: string;
+  /** Aria-label override. Defaults to `"World breadcrumbs"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No location",
+  region: "World breadcrumbs",
+} as const satisfies Required<WorldBreadcrumbsLabels>;
+
+/**
+ * Props for {@link WorldBreadcrumbs}.
+ *
+ * @public
+ */
+export type WorldBreadcrumbsProps = {
+  /** Trail in render order — the last crumb represents the active location. */
+  crumbs: WorldCrumb[];
+  /** Localizable strings. */
+  labels?: WorldBreadcrumbsLabels;
+  /** Click handler — receives the activated crumb id. */
+  onSelect?: (id: string) => void;
+} & ComponentPropsWithoutRef<"nav">;
+
+const Crumb = (props: {
+  crumb: WorldCrumb;
+  isLast: boolean;
+  onSelect?: (id: string) => void;
+}): React.ReactElement => {
+  const { crumb, isLast, onSelect } = props;
+  const glyph = crumb.kind ? KIND_GLYPH[crumb.kind] : null;
+  const handleClick = (): void => {
+    onSelect?.(crumb.id);
+  };
+  const text = (
+    <span className="inline-flex items-center gap-1">
+      {glyph ? (
+        <span aria-hidden="true" className="text-muted-foreground">
+          {glyph}
+        </span>
+      ) : null}
+      <span className="truncate">{crumb.label}</span>
+    </span>
+  );
+  if (isLast || !onSelect) {
+    return (
+      <span
+        aria-current={isLast ? "location" : undefined}
+        className={cn(
+          "inline-flex items-center text-xs",
+          isLast ? "font-semibold text-foreground" : "text-muted-foreground",
+        )}
+        data-world-breadcrumb={crumb.id}
+        data-world-breadcrumb-active={isLast}
+      >
+        {text}
+      </span>
+    );
+  }
+  return (
+    <button
+      className="inline-flex items-center rounded-sm text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      data-world-breadcrumb={crumb.id}
+      data-world-breadcrumb-active="false"
+      onClick={handleClick}
+      type="button"
+    >
+      {text}
+    </button>
+  );
+};
+
+/**
+ * Spatial trail showing where the viewport sits in a hierarchy of
+ * worlds / groups / runs / agents. Distinct from \`Breadcrumb\`
+ * (route-based, document-tree style) — this primitive describes the
+ * canvas's spatial location and supports per-kind glyphs.
+ *
+ * Pure presentation; the host computes the trail from the active
+ * viewport target and the world graph, and resolves \`onSelect\` to a
+ * camera transition.
+ *
+ * @example
+ * ```tsx
+ * <WorldBreadcrumbs
+ *   crumbs={[
+ *     { id: "world", kind: "world", label: "Production" },
+ *     { id: "group", kind: "group", label: "Ingest cluster" },
+ *     { id: "run",   kind: "run",   label: "research-2025" },
+ *   ]}
+ *   onSelect={jumpTo}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const WorldBreadcrumbs = forwardRef<HTMLElement, WorldBreadcrumbsProps>(
+  (props, ref) => {
+    const { className, crumbs, labels, onSelect, ...rest } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    if (crumbs.length === 0) {
+      return (
+        <nav
+          aria-label={resolvedLabels.region}
+          className={cn(
+            "inline-flex items-center text-xs text-muted-foreground",
+            className,
+          )}
+          data-world-breadcrumbs
+          data-world-breadcrumbs-state="empty"
+          ref={ref}
+          {...rest}
+        >
+          {resolvedLabels.empty}
+        </nav>
+      );
+    }
+    return (
+      <nav
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "inline-flex items-center gap-1.5 text-xs text-muted-foreground",
+          className,
+        )}
+        data-world-breadcrumbs
+        ref={ref}
+        {...rest}
+      >
+        {crumbs.map((crumb, index) => (
+          <span className="inline-flex items-center gap-1.5" key={crumb.id}>
+            <Crumb
+              crumb={crumb}
+              isLast={index === crumbs.length - 1}
+              onSelect={onSelect}
+            />
+            {index < crumbs.length - 1 ? (
+              <span
+                aria-hidden="true"
+                className="text-muted-foreground/60"
+                data-world-breadcrumb-sep
+              >
+                ›
+              </span>
+            ) : null}
+          </span>
+        ))}
+      </nav>
+    );
+  },
+);
+WorldBreadcrumbs.displayName = "WorldBreadcrumbs";

--- a/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.visual.tsx
+++ b/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.visual.tsx
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import { WorldBreadcrumbs } from "./world-breadcrumbs";
+
+test.describe("WorldBreadcrumbs Visual", () => {
+  test("default", async ({ mount }) => {
+    const component = await mount(
+      <div className="bg-muted/30 p-4">
+        <WorldBreadcrumbs
+          crumbs={[
+            { id: "world", kind: "world", label: "Production" },
+            { id: "group", kind: "group", label: "Ingest cluster" },
+            { id: "run", kind: "run", label: "research-2025" },
+            { id: "task", kind: "task", label: "score" },
+          ]}
+        />
+      </div>,
+    );
+    await expect(component).toHaveScreenshot(
+      "world-breadcrumbs-default.png",
+    );
+  });
+});


### PR DESCRIPTION
Closes #132

## What's in

The three remaining primitives for the canvas foundation family (issue #132):

- **InfinitePlane** — tiled pannable backdrop. Renders a \`dot\` (default), \`grid\`, or \`blank\` pattern that drifts with the viewport translate and scales with the zoom. Spacing floors at 4 px; zoom clamps to 0.1 .. 10. Slot for spatial children that share its coordinate space.
- **ViewportBookmarks** — saved-view list for the canvas. Per-row accent dot, optional detail line, optional active selection. Rows render as buttons when \`onSelect\` is provided, plain spans otherwise.
- **WorldBreadcrumbs** — spatial trail showing where the viewport sits in a hierarchy of worlds / groups / runs / agents. Per-kind glyphs (\`world\` ✦ · \`group\` ▤ · \`run\` ▶ · \`task\` ▢ · \`agent\` ◇ · \`artifact\` ◌). Last crumb is the active location and never invokes \`onSelect\`. Distinct from the route-based \`Breadcrumb\`.

All three are pure presentation; the host owns the viewport transform, bookmark store, and world graph. Wired into the \`@vllnt/ui\` barrel and the shadcn registry.

## Files

- \`packages/ui/src/components/infinite-plane/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/viewport-bookmarks/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/world-breadcrumbs/\` — tsx + index + test + visual + stories + mdx
- \`packages/ui/src/components/index.ts\` — barrel exports
- \`apps/registry/registry/default/{infinite-plane,viewport-bookmarks,world-breadcrumbs}/*.tsx\` — registry shims
- \`apps/registry/registry.json\` — three new entries (alphabetically placed)

## Closes the #132 component family

Together with the existing primitives already shipped on \`main\` — \`TopBar\`, \`LeftRail\`, \`CanvasView\`, \`RightDock\`, \`WorkspaceSwitcher\`, \`CanvasShell\`, \`MiniMapPanel\`, \`ZoomHUD\` — this PR completes the 11 / 11 of the canvas-foundation family.

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck: PASS (\`tsc --noEmit --project tsconfig.build.json\`)
- check:use-client: PASS (182 components)
- check:story-coverage: PASS (172 components)
- verify-stories: PASS (no crash risks)
- test: PASS (512 / 512 — incl. 19 new)
- build (\`@vllnt/ui\`): PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)
- [ ] Storybook renders all 12 stories (4 per primitive) without console errors
- [ ] Visual snapshots stable across primitives