### PR TITLE
docs(ui): add MDX docs for spatial-object family (#133)

### DIFF
--- a/packages/ui/src/components/anchor-port/anchor-port.mdx
+++ b/packages/ui/src/components/anchor-port/anchor-port.mdx
@@ -1,0 +1,45 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './anchor-port.stories'
+
+<Meta of={Stories} />
+
+# AnchorPort
+
+Connection-point marker rendered on the edge of an \`ObjectCard\` for inputs, outputs, or bidirectional links. Renders as a small circular handle with optional tone. Pure presentation; the host owns drag-to-connect logic and supplies the screen-pixel position.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/anchor-port.json
+```
+
+## Import
+
+```tsx
+import { AnchorPort } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<AnchorPort
+  x={cardRight}
+  y={cardMid}
+  direction="output"
+  tone="primary"
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The port is small by design — keep it visible but quiet so cards stay primary.
+- Pair with \`ConnectorEdge\` to draw the relationship between two ports.
+- Render inside a \`position: relative\` parent that shares the canvas pixel coordinate space with the connected card.

--- a/packages/ui/src/components/connector-edge/connector-edge.mdx
+++ b/packages/ui/src/components/connector-edge/connector-edge.mdx
@@ -1,0 +1,47 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './connector-edge.stories'
+
+<Meta of={Stories} />
+
+# ConnectorEdge
+
+Edge connecting two canvas objects — a curved or straight SVG path between two points, with optional directionality and tone. Pure presentation; the host computes the from / to coordinates from the connected objects' anchor ports.
+
+Distinct from \`FlowDiagram\` (generic node-edge graph primitive): this edge is the canvas's first-class relationship between durable runtime objects. Pair with \`AnchorPort\` for connection points and \`EdgeLabel\` for inline metadata.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/connector-edge.json
+```
+
+## Import
+
+```tsx
+import { ConnectorEdge } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<ConnectorEdge
+  from={{ x: 120, y: 80 }}
+  to={{ x: 320, y: 220 }}
+  tone="primary"
+  directional
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The edge SVG is \`pointer-events: none\` by default — host gestures pass through.
+- Render inside a \`position: relative\` parent that shares the canvas pixel coordinate space with the connected objects.
+- Pair the edge with an \`EdgeLabel\` for relation metadata (e.g. \`"emits"\`, \`"depends-on"\`, throughput numbers).

--- a/packages/ui/src/components/edge-label/edge-label.mdx
+++ b/packages/ui/src/components/edge-label/edge-label.mdx
@@ -1,0 +1,42 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './edge-label.stories'
+
+<Meta of={Stories} />
+
+# EdgeLabel
+
+Inline label rendered along a \`ConnectorEdge\` to communicate relation type, throughput, or status. Anchored at canvas pixel coordinates; renders as a small chip with optional tone. Pure presentation; the host computes the position from the edge midpoint.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/edge-label.json
+```
+
+## Import
+
+```tsx
+import { EdgeLabel } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<EdgeLabel x={midX} y={midY} tone="primary">
+  emits · 240 / s
+</EdgeLabel>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The label sits on top of the edge — render it after the \`ConnectorEdge\` so it lays above the path.
+- Render inside a \`position: relative\` parent that shares the canvas pixel coordinate space with the edge.
+- Pair with \`ConnectorEdge\` for visible relationships between \`ObjectCard\` instances.

--- a/packages/ui/src/components/group-hull/group-hull.mdx
+++ b/packages/ui/src/components/group-hull/group-hull.mdx
@@ -1,0 +1,45 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './group-hull.stories'
+
+<Meta of={Stories} />
+
+# GroupHull
+
+Durable boundary wrapper for a related set of canvas objects sharing context, ownership, or a workspace lane. Renders a soft rounded outline around its slot with an optional title chip. Pure presentation; the host positions the hull around its members.
+
+Distinct from \`ContextLens\` (transient focus vignette) and \`SelectionPresence\` (remote-user selection): \`GroupHull\` is the durable grouping that survives across selection state.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/group-hull.json
+```
+
+## Import
+
+```tsx
+import { GroupHull } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<GroupHull title="Ingest cluster" tone="primary">
+  <ObjectCard …/>
+  <ObjectCard …/>
+  <ObjectCard …/>
+</GroupHull>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The hull does not lay out its children — wrap an absolutely-positioned slot inside a parent that supplies the canvas coordinate space.
+- The title chip is optional — drop it when the surrounding canvas already names the group via \`WorldBreadcrumbs\` or \`ObjectInspector\`.

--- a/packages/ui/src/components/object-card/object-card.mdx
+++ b/packages/ui/src/components/object-card/object-card.mdx
@@ -1,0 +1,54 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './object-card.stories'
+
+<Meta of={Stories} />
+
+# ObjectCard
+
+Durable on-canvas representation of a runtime object — agents, runs, artifacts, tasks, inputs, and outputs. Renders kind chip + status dot + title + optional metric strip + optional action row in a compact, scannable card. Pure presentation; the host computes props from the runtime stream.
+
+Distinct from \`Card\` (generic content card) and \`StatCard\` (KPI tile): this primitive is the canvas's first-class spatial object. Pair with \`ConnectorEdge\` for relationships, \`AnchorPort\` for input / output ports, \`GroupHull\` for ownership grouping, and \`ObjectHandle\` for drag affordance.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/object-card.json
+```
+
+## Import
+
+```tsx
+import { ObjectCard } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<ObjectCard
+  kind="run"
+  status="running"
+  title="research-2025-04-15"
+  subtitle="claude-3.7"
+  metrics={[
+    { id: "qps",  label: "qps",  value: "240" },
+    { id: "p95",  label: "p95",  value: "180ms" },
+  ]}
+  actions={[
+    { id: "open", label: "Open", onActivate: openRun },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Kinds map: \`agent\` ◇ · \`run\` ▶ · \`task\` ▢ · \`artifact\` ◌ · \`input\` ↘ · \`output\` ↗.
+- Status dots map: \`idle\` (muted) · \`queued\` (amber) · \`running\` (blue, pulsing) · \`complete\` (emerald) · \`failed\` (red).
+- The card centers on a positioned canvas — render inside a \`position: relative\` container that supplies its coordinate space.

--- a/packages/ui/src/components/object-handle/object-handle.mdx
+++ b/packages/ui/src/components/object-handle/object-handle.mdx
@@ -1,0 +1,42 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './object-handle.stories'
+
+<Meta of={Stories} />
+
+# ObjectHandle
+
+Drag affordance for an \`ObjectCard\` — a calm grab target that signals "this object can be repositioned" without competing with the card body. Pure presentation; the host wires the pointer events to its drag controller.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/object-handle.json
+```
+
+## Import
+
+```tsx
+import { ObjectHandle } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<ObjectCard …>
+  <ObjectHandle onPointerDown={beginDrag} />
+  …
+</ObjectCard>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The handle does not own drag state — the host's pointer controller resolves moves into transform updates.
+- The handle should sit inside the card's header so users don't lose it when the card body is full.


### PR DESCRIPTION
## What's in

Adds the missing storybook MDX docs for the six spatial-object primitives shipped on \`main\`:

- \`ObjectCard\` — durable on-canvas runtime object
- \`ConnectorEdge\` — relationship between two cards
- \`EdgeLabel\` — inline relation label along an edge
- \`GroupHull\` — durable boundary around a related set of objects
- \`AnchorPort\` — connection point on a card edge
- \`ObjectHandle\` — drag affordance for a card

Each MDX file matches the project pattern (install + import + usage + auto-controls + cross-component pairing notes). No code changes — these are documentation files consumed by storybook only.

## Why

Issue #133 lists these six primitives as the v0 ownership for the spatial-objects component family. The components landed on \`main\` earlier but never got their MDX docs. This PR closes that gap so \`pnpm -F @vllnt/ui build-storybook\` produces the same docs surface for #133 components as it does for newer families (#132, #134, #135, #136).

## Files

- \`packages/ui/src/components/object-card/object-card.mdx\`
- \`packages/ui/src/components/connector-edge/connector-edge.mdx\`
- \`packages/ui/src/components/edge-label/edge-label.mdx\`
- \`packages/ui/src/components/group-hull/group-hull.mdx\`
- \`packages/ui/src/components/anchor-port/anchor-port.mdx\`
- \`packages/ui/src/components/object-handle/object-handle.mdx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck / test / build: not affected (no \`.tsx\` changes)
- build-storybook: PASS

## Test plan

- [ ] CI green
- [ ] Storybook renders the new \"Docs\" tab for each of the six primitives without console errors