### PR TITLE
docs(ui): add MDX docs for AI chat family (5 components)

### DIFF
--- a/packages/ui/src/components/ai-chat-input/ai-chat-input.mdx
+++ b/packages/ui/src/components/ai-chat-input/ai-chat-input.mdx
@@ -1,0 +1,44 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './ai-chat-input.stories'
+
+<Meta of={Stories} />
+
+# AIChatInput
+
+Composer for AI chat surfaces — multi-line text area with submit affordance, optional model selector slot, and submission state. Pure presentation; the host owns the model state, submit handler, and any attachment / tool-selection UI.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ai-chat-input.json
+```
+
+## Import
+
+```tsx
+import { AIChatInput } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<AIChatInput
+  value={draft}
+  onValueChange={setDraft}
+  onSubmit={post}
+  placeholder="Ask anything…"
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The composer is rooted in a native form element so Enter-to-submit + native form events work out of the box.
+- Pair with \`AIMessageBubble\` (the rendered conversation) and \`AIStreamingText\` (the live answer) to form a complete chat surface.

--- a/packages/ui/src/components/ai-message-bubble/ai-message-bubble.mdx
+++ b/packages/ui/src/components/ai-message-bubble/ai-message-bubble.mdx
@@ -1,0 +1,44 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './ai-message-bubble.stories'
+
+<Meta of={Stories} />
+
+# AIMessageBubble
+
+Single chat message bubble — \`user\` / \`assistant\` / \`system\` roles, timestamp slot, optional tool-call slot. Pure presentation; the host owns the message store and renders bubbles in order.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ai-message-bubble.json
+```
+
+## Import
+
+```tsx
+import { AIMessageBubble } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<AIMessageBubble role="user" timestamp="12s">
+  Why is p95 spiking on the primary handler?
+</AIMessageBubble>
+<AIMessageBubble role="assistant" timestamp="9s">
+  …
+</AIMessageBubble>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Roles map: \`user\` (right-aligned, accent fill) · \`assistant\` (left-aligned, muted fill) · \`system\` (muted, full-width).
+- Pair with \`AIStreamingText\` for the actively-streaming assistant answer, and with \`AIToolCallDisplay\` to render tool invocations inline.

--- a/packages/ui/src/components/ai-source-citation/ai-source-citation.mdx
+++ b/packages/ui/src/components/ai-source-citation/ai-source-citation.mdx
@@ -1,0 +1,45 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './ai-source-citation.stories'
+
+<Meta of={Stories} />
+
+# AISourceCitation
+
+Inline citation chip linking to the source the AI used for a claim. Renders as a small numbered or labelled anchor that the user can hover for a preview and click to open the source. Pure presentation; the host computes the citation list from the model's tool / retrieval output.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ai-source-citation.json
+```
+
+## Import
+
+```tsx
+import { AISourceCitation } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<p>
+  …observed a p95 regression of 220 ms
+  <AISourceCitation index={1} href="/runs/research-2025#metrics">
+    research-2025 metrics
+  </AISourceCitation>
+  during the rollout.
+</p>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The chip is rooted in a native anchor element so it inherits keyboard activation, right-click → open in new tab, and screen-reader semantics for free.
+- Pair with \`AIMessageBubble\` to render assistant answers with footnote-style citations.

--- a/packages/ui/src/components/ai-streaming-text/ai-streaming-text.mdx
+++ b/packages/ui/src/components/ai-streaming-text/ai-streaming-text.mdx
@@ -1,0 +1,41 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './ai-streaming-text.stories'
+
+<Meta of={Stories} />
+
+# AIStreamingText
+
+Live-streaming text container with a calm caret affordance for the actively-typing AI response. Pure presentation; the host owns the token stream and writes into the slot as deltas arrive.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ai-streaming-text.json
+```
+
+## Import
+
+```tsx
+import { AIStreamingText } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<AIStreamingText streaming={isStreaming}>
+  {currentBuffer}
+</AIStreamingText>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The caret renders only while \`streaming\` is true so completed messages stay calm.
+- Pair with \`AIMessageBubble\` to host the streaming answer inside the assistant turn.

--- a/packages/ui/src/components/ai-tool-call-display/ai-tool-call-display.mdx
+++ b/packages/ui/src/components/ai-tool-call-display/ai-tool-call-display.mdx
@@ -1,0 +1,44 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './ai-tool-call-display.stories'
+
+<Meta of={Stories} />
+
+# AIToolCallDisplay
+
+Inline tool-call summary rendered inside an assistant message — tool name, status, and an optional collapsible payload. Pure presentation; the host owns the tool-execution state and renders one display per call.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ai-tool-call-display.json
+```
+
+## Import
+
+```tsx
+import { AIToolCallDisplay } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<AIToolCallDisplay
+  name="run_query"
+  status="running"
+>
+  {{ sql: "SELECT * FROM runs WHERE status = 'failed'" }}
+</AIToolCallDisplay>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Statuses map: \`queued\` · \`running\` (pulsing) · \`complete\` · \`error\`.
+- Pair with \`AIMessageBubble\` to render tool calls inline within the assistant turn.


### PR DESCRIPTION
## What's in

Adds the missing storybook MDX docs for the five AI-chat primitives shipped on \`main\`:

- \`AIChatInput\` — composer with multi-line text + submit affordance
- \`AIMessageBubble\` — single chat message with role / timestamp slot
- \`AISourceCitation\` — inline citation chip linking to a source
- \`AIStreamingText\` — live-streaming text container with caret
- \`AIToolCallDisplay\` — inline tool-call summary with status

Each MDX file matches the project pattern (install + import + usage + auto-controls + cross-component pairing notes). No code changes — these are documentation files consumed by storybook only.

## Why

These five components landed on \`main\` previously but never got their MDX docs. This PR closes that gap so \`pnpm -F @vllnt/ui build-storybook\` produces the same docs surface for the AI chat family as it does for newer families.

## Files

- \`packages/ui/src/components/ai-chat-input/ai-chat-input.mdx\`
- \`packages/ui/src/components/ai-message-bubble/ai-message-bubble.mdx\`
- \`packages/ui/src/components/ai-source-citation/ai-source-citation.mdx\`
- \`packages/ui/src/components/ai-streaming-text/ai-streaming-text.mdx\`
- \`packages/ui/src/components/ai-tool-call-display/ai-tool-call-display.mdx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck / test / build: not affected (no \`.tsx\` changes)
- build-storybook: PASS

## Test plan

- [ ] CI green
- [ ] Storybook renders the new "Docs" tab for each of the five primitives without console errors