### PR TITLE
docs(ui): add MDX docs for operator-chrome family (5 components)

### DIFF
--- a/packages/ui/src/components/bottom-bar/bottom-bar.mdx
+++ b/packages/ui/src/components/bottom-bar/bottom-bar.mdx
@@ -1,0 +1,45 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './bottom-bar.stories'
+
+<Meta of={Stories} />
+
+# BottomBar
+
+Slim chrome strip pinned to the bottom of \`CanvasShell\` — calm host for activity strips, status pills, and ambient indicators. Pure presentation; the host slots whatever runtime surfaces belong here.
+
+Pair with \`BottomActivityStrip\` for the live event chips, \`PresenceSyncIndicator\` for the connection pill, and \`ZoomHUD\` for the zoom affordance.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/bottom-bar.json
+```
+
+## Import
+
+```tsx
+import { BottomBar } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<BottomBar>
+  <PresenceSyncIndicator state="live" />
+  <BottomActivityStrip events={recent} />
+  <ZoomHUD …/>
+</BottomBar>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The bar stays full-width and quiet by default — let slotted children carry the visual weight.
+- Distinct from \`Toast\` / \`Alert\` (transient notifications): \`BottomBar\` is durable chrome.

--- a/packages/ui/src/components/canvas-shell/canvas-shell.mdx
+++ b/packages/ui/src/components/canvas-shell/canvas-shell.mdx
@@ -1,0 +1,48 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './canvas-shell.stories'
+
+<Meta of={Stories} />
+
+# CanvasShell
+
+Top-level layout shell for the spatial workspace — slots for the top bar, left rail, right dock, bottom bar, and the central canvas viewport, with sane insets for fixed chrome. Pure presentation; the host fills each slot and supplies the route configuration.
+
+Pair with \`TopBar\`, \`LeftRail\`, \`RightDock\`, \`BottomBar\`, and \`CanvasView\` to assemble the full operator surface. Distinct from \`Sidebar\` / \`NavbarSaas\`: those are document / marketing chrome; \`CanvasShell\` is the spatial control plane.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/canvas-shell.json
+```
+
+## Import
+
+```tsx
+import { CanvasShell } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<CanvasShell
+  topBar={<TopBar …/>}
+  leftRail={<LeftRail …/>}
+  rightDock={<RightDock …/>}
+  bottomBar={<BottomBar …/>}
+>
+  <CanvasView …/>
+</CanvasShell>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The shell handles fixed-chrome insets so the central viewport fills the remaining space.
+- Drop any slot you don't need (e.g. omit \`bottomBar\` for surfaces without an activity strip).

--- a/packages/ui/src/components/canvas-view/canvas-view.mdx
+++ b/packages/ui/src/components/canvas-view/canvas-view.mdx
@@ -1,0 +1,50 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './canvas-view.stories'
+
+<Meta of={Stories} />
+
+# CanvasView
+
+Pannable / zoomable viewport for the spatial workspace. Owns the viewport transform (pan + zoom) and exposes an imperative handle for the host to programmatically jump or animate the camera. Children render in canvas pixel coordinate space.
+
+Pair with \`InfinitePlane\` for the dotted backdrop, \`MiniMapPanel\` for the overview, and \`ZoomHUD\` for the zoom affordance. Distinct from \`FlowDiagram\` (generic node-edge graph): \`CanvasView\` is the product-canvas viewport.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/canvas-view.json
+```
+
+## Import
+
+```tsx
+import { CanvasView } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+const ref = useRef<CanvasViewHandle>(null)
+
+<CanvasView
+  ref={ref}
+  initialViewport={{ x: 0, y: 0, zoom: 1 }}
+  onViewportChange={setViewport}
+>
+  <ObjectCard …/>
+  <ObjectCard …/>
+</CanvasView>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The handle exposes \`panTo\`, \`zoomTo\`, and \`fit\` so the host can wire \`ViewportBookmarks\` and \`WorldBreadcrumbs\` to camera transitions.
+- Pointer + wheel + keyboard interactions are scoped to the viewport so nested children keep their own scroll / focus.

--- a/packages/ui/src/components/chat-dock-section/chat-dock-section.mdx
+++ b/packages/ui/src/components/chat-dock-section/chat-dock-section.mdx
@@ -1,0 +1,45 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './chat-dock-section.stories'
+
+<Meta of={Stories} />
+
+# ChatDockSection
+
+Sidebar section that hosts a compact chat thread — typically slotted into the right dock or left rail of \`CanvasShell\` to keep an AI assistant alongside the spatial workspace. Pure presentation; the host owns the message list + composer.
+
+Distinct from full chat surfaces — \`ChatDockSection\` is intentionally narrow + scrollable for long threads in a side dock.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/chat-dock-section.json
+```
+
+## Import
+
+```tsx
+import { ChatDockSection } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<ChatDockSection
+  title="Assistant"
+  messages={messages}
+  composer={<AIChatInput …/>}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`AIMessageBubble\` to render the messages list and \`AIChatInput\` for the composer.
+- The section is scrollable on its own so the surrounding dock layout stays calm.

--- a/packages/ui/src/components/glass-panel/glass-panel.mdx
+++ b/packages/ui/src/components/glass-panel/glass-panel.mdx
@@ -1,0 +1,41 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './glass-panel.stories'
+
+<Meta of={Stories} />
+
+# GlassPanel
+
+Frosted-glass surface for floating chrome that sits on top of the canvas — dock panels, hovering toolbars, transient overlays. Translucent background with a soft border, optional rounded radius. Pure presentation; the host slots whatever content belongs above the canvas.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/glass-panel.json
+```
+
+## Import
+
+```tsx
+import { GlassPanel } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<GlassPanel className="absolute right-4 top-4 p-3">
+  <ObjectInspector …/>
+</GlassPanel>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The panel keeps its own background so it reads as a discrete surface even when the canvas behind it is busy.
+- Stack with \`backdrop-blur\` parents sparingly — too many overlapping frosted layers reduce readability.


### PR DESCRIPTION
## What's in

Adds the missing storybook MDX docs for five operator-chrome primitives shipped on \`main\`:

- \`CanvasShell\` — top-level layout shell with top / left / right / bottom slots around a central canvas
- \`CanvasView\` — pannable / zoomable viewport with imperative camera handle
- \`BottomBar\` — slim chrome strip pinned to the bottom of the shell
- \`ChatDockSection\` — sidebar section that hosts a compact chat thread
- \`GlassPanel\` — frosted-glass surface for floating chrome above the canvas

Each MDX file matches the project pattern (install + import + usage + auto-controls + cross-component pairing notes). No code changes — these are documentation files consumed by storybook only.

## Why

These five components landed on \`main\` previously but never got their MDX docs. This PR closes that gap so \`pnpm -F @vllnt/ui build-storybook\` produces the same docs surface for the operator-chrome family as it does for newer families. Continues the docs-polish track started in PRs #208 (#133 spatial-objects) and #209 (AI chat family).

## Files

- \`packages/ui/src/components/canvas-shell/canvas-shell.mdx\`
- \`packages/ui/src/components/canvas-view/canvas-view.mdx\`
- \`packages/ui/src/components/bottom-bar/bottom-bar.mdx\`
- \`packages/ui/src/components/chat-dock-section/chat-dock-section.mdx\`
- \`packages/ui/src/components/glass-panel/glass-panel.mdx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck / test / build: not affected (no \`.tsx\` changes)
- build-storybook: PASS

## Test plan

- [ ] CI green
- [ ] Storybook renders the new "Docs" tab for each of the five primitives without console errors