### PR TITLE
docs(ui): add MDX docs for data-display family (5 components)

### DIFF
--- a/packages/ui/src/components/activity-heatmap/activity-heatmap.mdx
+++ b/packages/ui/src/components/activity-heatmap/activity-heatmap.mdx
@@ -1,0 +1,46 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './activity-heatmap.stories'
+
+<Meta of={Stories} />
+
+# ActivityHeatmap
+
+Calendar-style grid showing activity intensity per day — a contribution-graph-style surface for run frequency, deploy cadence, error volume, or any per-day metric. Pure presentation; the host computes the per-day buckets.
+
+Distinct from \`HeatOverlay\` (free-form canvas heatmap): this primitive is a fixed calendar grid suited to dashboard tiles.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/activity-heatmap.json
+```
+
+## Import
+
+```tsx
+import { ActivityHeatmap } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<ActivityHeatmap
+  days={buckets}
+  start={start}
+  end={end}
+  formatTooltip={(day) => `${day.count} runs on ${day.date}`}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Colors scale by count — pass a custom \`scale\` if your domain has different intensity buckets.
+- Pair with \`StatCard\` or \`OverviewCard\` to anchor the heatmap with a headline metric.

--- a/packages/ui/src/components/activity-log/activity-log.mdx
+++ b/packages/ui/src/components/activity-log/activity-log.mdx
@@ -1,0 +1,44 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './activity-log.stories'
+
+<Meta of={Stories} />
+
+# ActivityLog
+
+Vertical persistent activity log — a chronological list of events with author, timestamp, and message. Pure presentation; the host computes the entries from the audit / event store.
+
+Distinct from \`LiveFeed\` (full-height live event stream) and \`BottomActivityStrip\` (slim canvas event row): \`ActivityLog\` is the durable list, typically paginated and persisted.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/activity-log.json
+```
+
+## Import
+
+```tsx
+import { ActivityLog } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<ActivityLog
+  items={entries}
+  formatTimestamp={(ts) => formatRelative(ts)}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Each entry slots a leading actor avatar, an icon for the event type, and the message body.
+- Pair with \`Pagination\` for long histories or \`Skeleton\` rows for the loading state.

--- a/packages/ui/src/components/candlestick-chart/candlestick-chart.mdx
+++ b/packages/ui/src/components/candlestick-chart/candlestick-chart.mdx
@@ -1,0 +1,43 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './candlestick-chart.stories'
+
+<Meta of={Stories} />
+
+# CandlestickChart
+
+OHLC candlestick chart — open / high / low / close per period, color-coded by direction (up / down). Pure presentation; the host computes the candle list from the time-series store.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/candlestick-chart.json
+```
+
+## Import
+
+```tsx
+import { CandlestickChart } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<CandlestickChart
+  candles={ohlc}
+  width={640}
+  height={240}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`TickerTape\` for a horizontal price strip and \`OrderBook\` for the depth ladder.
+- The chart is SVG-based — render at the size you want; it does not auto-resize.

--- a/packages/ui/src/components/data-list/data-list.mdx
+++ b/packages/ui/src/components/data-list/data-list.mdx
@@ -1,0 +1,46 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './data-list.stories'
+
+<Meta of={Stories} />
+
+# DataList
+
+Compact key / value list — definition-list-style layout for record metadata, audit details, settings summaries. Pure presentation; the host supplies the entries.
+
+Distinct from \`PropertySection\` (canvas inspector): \`DataList\` is the dashboard-style list; \`PropertySection\` is a slot inside the canvas inspector.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/data-list.json
+```
+
+## Import
+
+```tsx
+import { DataList } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<DataList
+  items={[
+    { id: "id",     label: "Run id", value: "research-2025-04-15" },
+    { id: "model",  label: "Model",  value: "claude-3.7" },
+    { id: "owner",  label: "Owner",  value: "bv" },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The list pairs well with \`Card\` or \`StatCard\` to bundle a record's headline metric with its supporting details.

--- a/packages/ui/src/components/data-table/data-table.mdx
+++ b/packages/ui/src/components/data-table/data-table.mdx
@@ -1,0 +1,46 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './data-table.stories'
+
+<Meta of={Stories} />
+
+# DataTable
+
+Sortable, filterable, paginated table for record collections — runs, jobs, transactions, audit rows. Pure presentation for the visual layer; the host owns the data store and resolves sort / filter / page state.
+
+Distinct from \`Table\` (the unstyled HTML primitive): \`DataTable\` adds the canonical column / sort / pagination affordances on top.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/data-table.json
+```
+
+## Import
+
+```tsx
+import { DataTable } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<DataTable
+  columns={columns}
+  data={rows}
+  pagination={{ page, pageSize, total, onPageChange: setPage }}
+  sort={{ key, direction, onChange: setSort }}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`FilterBar\` for filter chips and \`Pagination\` for the page controls if the table doesn't slot them inline.
+- The table is column-driven — pass column definitions with \`accessor\`, \`header\`, \`cell\`, and optional \`sortable\` flags.


### PR DESCRIPTION
## What's in

Adds the missing storybook MDX docs for five data-display primitives shipped on \`main\`:

- \`ActivityHeatmap\` — calendar-style intensity grid for per-day metrics
- \`ActivityLog\` — vertical persistent activity log
- \`CandlestickChart\` — OHLC candlestick chart for time-series data
- \`DataList\` — compact key / value definition list
- \`DataTable\` — sortable / filterable / paginated record table

Each MDX file matches the project pattern (install + import + usage + auto-controls + cross-component pairing notes). No code changes — these are documentation files consumed by storybook only.

## Why

These five components landed on \`main\` previously but never got their MDX docs. Continues the docs-polish track started in PRs #208 (#133 spatial-objects), #209 (AI chat family), and #210 (operator-chrome family).

## Files

- \`packages/ui/src/components/activity-heatmap/activity-heatmap.mdx\`
- \`packages/ui/src/components/activity-log/activity-log.mdx\`
- \`packages/ui/src/components/candlestick-chart/candlestick-chart.mdx\`
- \`packages/ui/src/components/data-list/data-list.mdx\`
- \`packages/ui/src/components/data-table/data-table.mdx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck / test / build: not affected (no \`.tsx\` changes)
- build-storybook: PASS

## Test plan

- [ ] CI green
- [ ] Storybook renders the new "Docs" tab for each of the five primitives without console errors