### PR TITLE
docs(ui): add MDX docs for form-inputs family (5 components)

### DIFF
--- a/packages/ui/src/components/combobox/combobox.mdx
+++ b/packages/ui/src/components/combobox/combobox.mdx
@@ -1,0 +1,45 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './combobox.stories'
+
+<Meta of={Stories} />
+
+# Combobox
+
+Searchable single-select input — text field with a popover of filtered options. Pure presentation; the host owns the option list and the selected value.
+
+Distinct from \`Select\` (native dropdown) and \`MultiSelect\` (multi-value picker): \`Combobox\` is single-select with built-in search.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/combobox.json
+```
+
+## Import
+
+```tsx
+import { Combobox } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<Combobox
+  value={value}
+  onValueChange={setValue}
+  options={options}
+  placeholder="Pick a model"
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`MultiSelect\` for multi-value selection or \`ScopeSelector\` for nested-scope pickers.

--- a/packages/ui/src/components/date-picker/date-picker.mdx
+++ b/packages/ui/src/components/date-picker/date-picker.mdx
@@ -1,0 +1,45 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './date-picker.stories'
+
+<Meta of={Stories} />
+
+# DatePicker
+
+Calendar-popover date input — text field with a calendar grid for picking a single date. Pure presentation; the host owns the date value and supplies the optional min / max bounds.
+
+Pair with \`Calendar\` (the underlying month grid) for embedded calendar UI without the popover.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/date-picker.json
+```
+
+## Import
+
+```tsx
+import { DatePicker } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<DatePicker
+  value={date}
+  onValueChange={setDate}
+  min={today}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The date input is locale-aware via the underlying \`Calendar\` primitive.
+- Pair with \`Form\` and \`Label\` for accessible form composition.

--- a/packages/ui/src/components/file-upload/file-upload.mdx
+++ b/packages/ui/src/components/file-upload/file-upload.mdx
@@ -1,0 +1,43 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './file-upload.stories'
+
+<Meta of={Stories} />
+
+# FileUpload
+
+Drag-and-drop or click-to-browse file input with preview thumbnails and per-file progress / status. Pure presentation; the host wires the actual upload pipeline.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/file-upload.json
+```
+
+## Import
+
+```tsx
+import { FileUpload } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<FileUpload
+  accept="image/*"
+  multiple
+  onFiles={uploadFiles}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`Progress\` for per-file upload progress and \`Toast\` for success / error feedback.
+- The host controls retry / cancel — the component surfaces the affordances but does not own the network.

--- a/packages/ui/src/components/number-input/number-input.mdx
+++ b/packages/ui/src/components/number-input/number-input.mdx
@@ -1,0 +1,45 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './number-input.stories'
+
+<Meta of={Stories} />
+
+# NumberInput
+
+Numeric input with increment / decrement buttons, min / max clamping, and optional step. Pure presentation; the host owns the value.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/number-input.json
+```
+
+## Import
+
+```tsx
+import { NumberInput } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<NumberInput
+  value={count}
+  onValueChange={setCount}
+  min={0}
+  max={10}
+  step={1}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The component clamps the value to the \`min\` / \`max\` range and respects \`step\` for the buttons.
+- Pair with \`Form\` for labelled and validated numeric fields.

--- a/packages/ui/src/components/password-input/password-input.mdx
+++ b/packages/ui/src/components/password-input/password-input.mdx
@@ -1,0 +1,43 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './password-input.stories'
+
+<Meta of={Stories} />
+
+# PasswordInput
+
+Password input with a show / hide toggle. Pure presentation; the host owns the value.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/password-input.json
+```
+
+## Import
+
+```tsx
+import { PasswordInput } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<PasswordInput
+  value={password}
+  onValueChange={setPassword}
+  placeholder="Enter password"
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- The visibility toggle is icon-driven — the input itself stays a native password field for password manager compatibility.
+- Pair with \`Form\` and \`Label\` for accessible form composition.


### PR DESCRIPTION
## What's in

Adds the missing storybook MDX docs for five form-input primitives shipped on \`main\`:

- \`Combobox\` — searchable single-select input
- \`DatePicker\` — calendar-popover date input
- \`FileUpload\` — drag-and-drop / browse file input with preview + per-file status
- \`NumberInput\` — numeric input with +/− buttons + min/max/step
- \`PasswordInput\` — password input with show / hide toggle

Each MDX file matches the project pattern (install + import + usage + auto-controls + cross-component pairing notes). No code changes — these are documentation files consumed by storybook only.

## Why

Continues the docs-polish track started in PRs #208–#211. These five components landed on \`main\` previously but never got their MDX docs.

## Files

- \`packages/ui/src/components/combobox/combobox.mdx\`
- \`packages/ui/src/components/date-picker/date-picker.mdx\`
- \`packages/ui/src/components/file-upload/file-upload.mdx\`
- \`packages/ui/src/components/number-input/number-input.mdx\`
- \`packages/ui/src/components/password-input/password-input.mdx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck / test / build: not affected (no \`.tsx\` changes)
- build-storybook: PASS

## Test plan

- [ ] CI green
- [ ] Storybook renders the new "Docs" tab for each of the five primitives without console errors