### PR TITLE
docs(ui): add MDX docs for badges/indicators family (5 components)

### DIFF
--- a/packages/ui/src/components/credit-badge/credit-badge.mdx
+++ b/packages/ui/src/components/credit-badge/credit-badge.mdx
@@ -1,0 +1,38 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './credit-badge.stories'
+
+<Meta of={Stories} />
+
+# CreditBadge
+
+Compact pill that surfaces a user's available / pending credit balance. Pure presentation; the host computes the numeric balance and renders the badge alongside other account chips.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/credit-badge.json
+```
+
+## Import
+
+```tsx
+import { CreditBadge } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<CreditBadge available={1240} pending={80} />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`PlanBadge\`, \`RoleBadge\`, and \`WalletCard\` for billing-context surfaces.

--- a/packages/ui/src/components/plan-badge/plan-badge.mdx
+++ b/packages/ui/src/components/plan-badge/plan-badge.mdx
@@ -1,0 +1,38 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './plan-badge.stories'
+
+<Meta of={Stories} />
+
+# PlanBadge
+
+Subscription-tier indicator pill — \`free\` / \`pro\` / \`team\` / \`enterprise\`. Used in pricing tables, billing summaries, and account headers. Pure presentation.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/plan-badge.json
+```
+
+## Import
+
+```tsx
+import { PlanBadge } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<PlanBadge tier="pro" />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`SubscriptionCard\` for the billing summary tile and \`PricingTable\` for plan comparison surfaces.

--- a/packages/ui/src/components/role-badge/role-badge.mdx
+++ b/packages/ui/src/components/role-badge/role-badge.mdx
@@ -1,0 +1,38 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './role-badge.stories'
+
+<Meta of={Stories} />
+
+# RoleBadge
+
+Account-role pill — \`owner\` / \`admin\` / \`member\` / \`billing\`. Used in member lists, audit logs, and access panels. Pure presentation.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/role-badge.json
+```
+
+## Import
+
+```tsx
+import { RoleBadge } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<RoleBadge role="admin" />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`AvatarGroup\` for member rows and \`PlanBadge\` for combined account surfaces.

--- a/packages/ui/src/components/severity-badge/severity-badge.mdx
+++ b/packages/ui/src/components/severity-badge/severity-badge.mdx
@@ -1,0 +1,39 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './severity-badge.stories'
+
+<Meta of={Stories} />
+
+# SeverityBadge
+
+Incident-severity pill — \`info\` / \`warn\` / \`error\` / \`critical\`. Used in incident lists, alert panels, and audit rows. Pure presentation.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/severity-badge.json
+```
+
+## Import
+
+```tsx
+import { SeverityBadge } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<SeverityBadge severity="error" />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`StatusBoard\` and \`LiveFeed\` for incident surfaces.
+- Distinct from \`StatusIndicator\` (live system state): \`SeverityBadge\` describes a discrete event's severity, not a long-lived status.

--- a/packages/ui/src/components/status-indicator/status-indicator.mdx
+++ b/packages/ui/src/components/status-indicator/status-indicator.mdx
@@ -1,0 +1,39 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './status-indicator.stories'
+
+<Meta of={Stories} />
+
+# StatusIndicator
+
+Live system-state dot + label — \`operational\` / \`degraded\` / \`outage\` / \`maintenance\`. Pure presentation; the host computes the status from the health-check pipeline.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/status-indicator.json
+```
+
+## Import
+
+```tsx
+import { StatusIndicator } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<StatusIndicator status="operational" label="API" />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`StatusBoard\` for the full health grid and \`LiveFeed\` for the rolling event stream.
+- Distinct from \`SeverityBadge\` (one-shot incident severity): \`StatusIndicator\` reads as a live dot.


### PR DESCRIPTION
## What's in

Adds the missing storybook MDX docs for five badge/indicator primitives shipped on \`main\`:

- \`CreditBadge\` — available / pending balance pill
- \`PlanBadge\` — subscription tier pill
- \`RoleBadge\` — account role pill
- \`SeverityBadge\` — incident severity pill
- \`StatusIndicator\` — live system-state dot + label

Each MDX file matches the project pattern (install + import + usage + auto-controls + cross-component pairing notes). No code changes — these are documentation files consumed by storybook only.

## Why

Continues the docs-polish track started in PRs #208–#212.

## Files

- \`packages/ui/src/components/credit-badge/credit-badge.mdx\`
- \`packages/ui/src/components/plan-badge/plan-badge.mdx\`
- \`packages/ui/src/components/role-badge/role-badge.mdx\`
- \`packages/ui/src/components/severity-badge/severity-badge.mdx\`
- \`packages/ui/src/components/status-indicator/status-indicator.mdx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck / test / build: not affected (no \`.tsx\` changes)
- build-storybook: PASS

## Test plan

- [ ] CI green
- [ ] Storybook renders the new "Docs" tab for each of the five primitives without console errors