### PR TITLE
docs(ui): add MDX docs for financial/market family (5 components)

### DIFF
--- a/packages/ui/src/components/market-treemap/market-treemap.mdx
+++ b/packages/ui/src/components/market-treemap/market-treemap.mdx
@@ -1,0 +1,43 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './market-treemap.stories'
+
+<Meta of={Stories} />
+
+# MarketTreemap
+
+Treemap-style heatmap of market constituents — each cell sized by weight (market cap, volume) and colored by direction (up / down). Pure presentation; the host computes the per-cell values.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/market-treemap.json
+```
+
+## Import
+
+```tsx
+import { MarketTreemap } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<MarketTreemap
+  cells={cells}
+  width={640}
+  height={360}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`TickerTape\` for the horizontal price strip and \`SparklineGrid\` for per-row mini-charts.
+- The treemap is SVG-based — render at the size you want.

--- a/packages/ui/src/components/number-ticker/number-ticker.mdx
+++ b/packages/ui/src/components/number-ticker/number-ticker.mdx
@@ -1,0 +1,39 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './number-ticker.stories'
+
+<Meta of={Stories} />
+
+# NumberTicker
+
+Animated numeric value that rolls between updates — useful for live counters (active users, revenue, errors). Pure presentation; the host owns the value.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/number-ticker.json
+```
+
+## Import
+
+```tsx
+import { NumberTicker } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<NumberTicker value={liveValue} />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`StatCard\` and \`OverviewCard\` for headline metric tiles.
+- Animation respects \`prefers-reduced-motion\` so users with motion sensitivity see the value snap rather than roll.

--- a/packages/ui/src/components/order-book/order-book.mdx
+++ b/packages/ui/src/components/order-book/order-book.mdx
@@ -1,0 +1,43 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './order-book.stories'
+
+<Meta of={Stories} />
+
+# OrderBook
+
+Level-II bid / ask depth ladder with cumulative size bars and a spread readout. Pure presentation; the host computes the bid + ask levels.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/order-book.json
+```
+
+## Import
+
+```tsx
+import { OrderBook } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<OrderBook
+  bids={bids}
+  asks={asks}
+  precision={2}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`CandlestickChart\` for price action and \`TickerTape\` for the spot strip.
+- The bars represent cumulative size relative to the largest level so the visual stays readable across a wide range of book sizes.

--- a/packages/ui/src/components/sparkline-grid/sparkline-grid.mdx
+++ b/packages/ui/src/components/sparkline-grid/sparkline-grid.mdx
@@ -1,0 +1,39 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './sparkline-grid.stories'
+
+<Meta of={Stories} />
+
+# SparklineGrid
+
+Grid of compact sparkline charts — one mini line chart per row showing recent trend at a glance. Pure presentation; the host computes the per-row series.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/sparkline-grid.json
+```
+
+## Import
+
+```tsx
+import { SparklineGrid } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<SparklineGrid rows={rows} />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`MarketTreemap\` and \`OrderBook\` for a complete market overview.
+- Each row renders a name, the current value, the change, and the sparkline — keep the row count modest so the grid stays scannable.

--- a/packages/ui/src/components/ticker-tape/ticker-tape.mdx
+++ b/packages/ui/src/components/ticker-tape/ticker-tape.mdx
@@ -1,0 +1,39 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './ticker-tape.stories'
+
+<Meta of={Stories} />
+
+# TickerTape
+
+Marquee-style scrolling symbol tape with price + change badges. Pure presentation; the host computes the symbol list and scroll cadence.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ticker-tape.json
+```
+
+## Import
+
+```tsx
+import { TickerTape } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<TickerTape symbols={symbols} />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`MarketTreemap\` and \`CandlestickChart\` for a full market surface.
+- The marquee respects \`prefers-reduced-motion\` so users with motion sensitivity see a static row.


### PR DESCRIPTION
## What's in

Adds the missing storybook MDX docs for five financial / market primitives shipped on \`main\`:

- \`MarketTreemap\` — weighted treemap heatmap of market constituents
- \`OrderBook\` — Level-II bid / ask depth ladder
- \`SparklineGrid\` — grid of compact sparkline charts
- \`TickerTape\` — marquee-style scrolling symbol tape
- \`NumberTicker\` — animated rolling numeric value

Each MDX file matches the project pattern (install + import + usage + auto-controls + cross-component pairing notes). No code changes — these are documentation files consumed by storybook only.

## Why

Continues the docs-polish track started in PRs #208–#213.

## Files

- \`packages/ui/src/components/market-treemap/market-treemap.mdx\`
- \`packages/ui/src/components/order-book/order-book.mdx\`
- \`packages/ui/src/components/sparkline-grid/sparkline-grid.mdx\`
- \`packages/ui/src/components/ticker-tape/ticker-tape.mdx\`
- \`packages/ui/src/components/number-ticker/number-ticker.mdx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck / test / build: not affected (no \`.tsx\` changes)
- build-storybook: PASS

## Test plan

- [ ] CI green
- [ ] Storybook renders the new "Docs" tab for each of the five primitives without console errors