### PR TITLE
docs(ui): add MDX docs for KPI/dashboard family (5 components)

### DIFF
--- a/packages/ui/src/components/metric-gauge/metric-gauge.mdx
+++ b/packages/ui/src/components/metric-gauge/metric-gauge.mdx
@@ -1,0 +1,46 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './metric-gauge.stories'
+
+<Meta of={Stories} />
+
+# MetricGauge
+
+Real-time arc / dial display for a single percentage or utilization metric. Pure presentation; the host owns the live value and tone.
+
+Distinct from \`ThresholdRing\` (compact canvas overlay): \`MetricGauge\` is a dashboard-tile-scale gauge with a center value + optional label.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/metric-gauge.json
+```
+
+## Import
+
+```tsx
+import { MetricGauge } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<MetricGauge
+  value={0.82}
+  label="Capacity"
+  centerLabel="82 %"
+  tone="warn"
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`StatCard\` and \`OverviewBoard\` to anchor the gauge inside a metric tile.
+- The host should clamp the value to \`0..1\` (the gauge clamps too, but staying explicit keeps intent clear).

--- a/packages/ui/src/components/overview-board/overview-board.mdx
+++ b/packages/ui/src/components/overview-board/overview-board.mdx
@@ -1,0 +1,45 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './overview-board.stories'
+
+<Meta of={Stories} />
+
+# OverviewBoard
+
+Grid of \`OverviewCard\` cells for at-a-glance dashboards — typically a row of headline metrics with consistent spacing and tone. Pure presentation; the host computes the cell list.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/overview-board.json
+```
+
+## Import
+
+```tsx
+import { OverviewBoard, OverviewCard } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<OverviewBoard
+  items={[
+    { id: "runs",  label: "Active runs",  value: "240", tone: "success" },
+    { id: "errs",  label: "Errors / hr",  value: "0",   tone: "neutral" },
+    { id: "p95",   label: "p95 latency",  value: "180ms", tone: "warn" },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`StatCard\` for hero-tile variants and \`StatusBoard\` for service-health surfaces.
+- The grid auto-flows to fit the available width.

--- a/packages/ui/src/components/stat-card/stat-card.mdx
+++ b/packages/ui/src/components/stat-card/stat-card.mdx
@@ -1,0 +1,45 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './stat-card.stories'
+
+<Meta of={Stories} />
+
+# StatCard
+
+Headline KPI tile — a single metric value with label, optional trend delta, and optional supporting context (sparkline slot, footer note). Pure presentation; the host computes the metric from the data store.
+
+Distinct from \`ObjectCard\` (canvas runtime object) and \`OverviewCard\` (overview-board cell): \`StatCard\` is the dashboard-style hero tile.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/stat-card.json
+```
+
+## Import
+
+```tsx
+import { StatCard } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<StatCard
+  label="Active runs"
+  value="240"
+  delta={{ value: "+12 %", direction: "up" }}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`SparklineGrid\` or a slotted sparkline for a quick trend cue.
+- Use \`OverviewBoard\` to lay out a row of stat cards with consistent spacing.

--- a/packages/ui/src/components/status-board/status-board.mdx
+++ b/packages/ui/src/components/status-board/status-board.mdx
@@ -1,0 +1,42 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './status-board.stories'
+
+<Meta of={Stories} />
+
+# StatusBoard
+
+Service-health grid surfacing infrastructure state, queue pressure, and incidents — one row per service with a live status, optional sub-services, and incident summary. Pure presentation; the host owns the health-check pipeline.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/status-board.json
+```
+
+## Import
+
+```tsx
+import { StatusBoard } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<StatusBoard
+  services={services}
+  incidents={openIncidents}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`StatusIndicator\` for individual service rows and \`SeverityBadge\` for incident chips.
+- The board defaults to a calm read so widespread \`operational\` rows feel like the baseline rather than the celebration.

--- a/packages/ui/src/components/usage-breakdown/usage-breakdown.mdx
+++ b/packages/ui/src/components/usage-breakdown/usage-breakdown.mdx
@@ -1,0 +1,46 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './usage-breakdown.stories'
+
+<Meta of={Stories} />
+
+# UsageBreakdown
+
+Stacked horizontal bar showing how a usage budget breaks down across categories — included quota, on-demand consumption, projected overage. Pure presentation; the host computes the segments.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/usage-breakdown.json
+```
+
+## Import
+
+```tsx
+import { UsageBreakdown } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<UsageBreakdown
+  total={1_000_000}
+  segments={[
+    { id: "included", label: "Included",  value: 600_000 },
+    { id: "ondemand", label: "On-demand", value: 250_000 },
+    { id: "overage",  label: "Overage",   value: 50_000, tone: "warn" },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`SubscriptionCard\` or \`WalletCard\` for the billing context tile.
+- Segments render in declared order — pass them in the order the user should read.


### PR DESCRIPTION
## What's in

Adds the missing storybook MDX docs for five KPI / dashboard primitives shipped on \`main\`:

- \`StatCard\` — headline KPI tile with trend delta + optional sparkline slot
- \`OverviewBoard\` — grid of overview cells for at-a-glance dashboards
- \`MetricGauge\` — real-time arc / dial gauge for percentage / utilization
- \`StatusBoard\` — service-health grid with incident summary
- \`UsageBreakdown\` — stacked horizontal bar for budget breakdown

Each MDX file matches the project pattern (install + import + usage + auto-controls + cross-component pairing notes). No code changes — these are documentation files consumed by storybook only.

## Why

Continues the docs-polish track started in PRs #208–#214.

## Files

- \`packages/ui/src/components/stat-card/stat-card.mdx\`
- \`packages/ui/src/components/overview-board/overview-board.mdx\`
- \`packages/ui/src/components/metric-gauge/metric-gauge.mdx\`
- \`packages/ui/src/components/status-board/status-board.mdx\`
- \`packages/ui/src/components/usage-breakdown/usage-breakdown.mdx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck / test / build: not affected (no \`.tsx\` changes)
- build-storybook: PASS

## Test plan

- [ ] CI green
- [ ] Storybook renders the new "Docs" tab for each of the five primitives without console errors