### PR TITLE
docs(ui): add MDX docs for billing + scope + onboarding (5 components)

### DIFF
--- a/packages/ui/src/components/rating/rating.mdx
+++ b/packages/ui/src/components/rating/rating.mdx
@@ -1,0 +1,43 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './rating.stories'
+
+<Meta of={Stories} />
+
+# Rating
+
+Inline star rating — display-only or interactive (read-only summary or live input). Pure presentation; the host owns the rating value.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/rating.json
+```
+
+## Import
+
+```tsx
+import { Rating } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<Rating
+  value={rating}
+  onValueChange={setRating}
+  max={5}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Drop \`onValueChange\` for a read-only summary — the stars render but no longer respond to clicks.
+- Pair with \`Form\` for labelled feedback surveys.

--- a/packages/ui/src/components/scope-selector/scope-selector.mdx
+++ b/packages/ui/src/components/scope-selector/scope-selector.mdx
@@ -1,0 +1,42 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './scope-selector.stories'
+
+<Meta of={Stories} />
+
+# ScopeSelector
+
+Multi-level scope picker for nested environments, teams, or targets. Renders as a chain of dropdowns or a single popover with a hierarchical tree. Pure presentation; the host owns the scope tree and the selected path.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/scope-selector.json
+```
+
+## Import
+
+```tsx
+import { ScopeSelector } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<ScopeSelector
+  tree={tree}
+  path={selectedPath}
+  onPathChange={setPath}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`WorkspaceSwitcher\` for the top-level workspace switch and \`Combobox\` for free-text scope entry.

--- a/packages/ui/src/components/subscription-card/subscription-card.mdx
+++ b/packages/ui/src/components/subscription-card/subscription-card.mdx
@@ -1,0 +1,43 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './subscription-card.stories'
+
+<Meta of={Stories} />
+
+# SubscriptionCard
+
+Subscription summary tile — current plan, renewal date, billing cycle, and a primary upgrade or manage action. Pure presentation; the host computes the values from the billing store.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/subscription-card.json
+```
+
+## Import
+
+```tsx
+import { SubscriptionCard } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<SubscriptionCard
+  plan="Pro"
+  status="active"
+  renewsAt="2026-06-01"
+  onManage={openBilling}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`PlanBadge\`, \`UsageBreakdown\`, and \`WalletCard\` for the full billing surface.

--- a/packages/ui/src/components/tour/tour.mdx
+++ b/packages/ui/src/components/tour/tour.mdx
@@ -1,0 +1,44 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './tour.stories'
+
+<Meta of={Stories} />
+
+# Tour
+
+Guided product tour — sequence of anchored tooltips highlighting key UI elements with progress + skip / next controls. Pure presentation; the host owns the step list and the active step.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/tour.json
+```
+
+## Import
+
+```tsx
+import { Tour } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<Tour
+  steps={steps}
+  activeStep={step}
+  onStepChange={setStep}
+  onComplete={dismissTour}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`KeyboardShortcutsHelp\` for the keyboard map and \`TutorialCard\` for inline learn-by-doing surfaces.
+- The host stores tour-completion state — the component does not assume a persistence layer.

--- a/packages/ui/src/components/wallet-card/wallet-card.mdx
+++ b/packages/ui/src/components/wallet-card/wallet-card.mdx
@@ -1,0 +1,43 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './wallet-card.stories'
+
+<Meta of={Stories} />
+
+# WalletCard
+
+Credit-balance tile showing available, pending, and last-refreshed details for a usage-based account. Pure presentation; the host computes the balances and refresh state.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/wallet-card.json
+```
+
+## Import
+
+```tsx
+import { WalletCard } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<WalletCard
+  available={1240}
+  pending={80}
+  refreshedAt="3m ago"
+  onTopUp={openTopUp}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`CreditBadge\` for the inline pill and \`UsageBreakdown\` for the budget bar.


### PR DESCRIPTION
## What's in

Adds the missing storybook MDX docs for five primitives shipped on \`main\`:

- \`SubscriptionCard\` — subscription summary tile (plan, renewal, cycle)
- \`WalletCard\` — credit-balance tile (available, pending, refresh)
- \`ScopeSelector\` — multi-level nested-scope picker
- \`Tour\` — guided product tour with anchored tooltip steps
- \`Rating\` — inline star rating, read-only or interactive

Each MDX file matches the project pattern (install + import + usage + auto-controls + cross-component pairing notes). No code changes — these are documentation files consumed by storybook only.

## Why

Continues the docs-polish track started in PRs #208–#215.

## Files

- \`packages/ui/src/components/subscription-card/subscription-card.mdx\`
- \`packages/ui/src/components/wallet-card/wallet-card.mdx\`
- \`packages/ui/src/components/scope-selector/scope-selector.mdx\`
- \`packages/ui/src/components/tour/tour.mdx\`
- \`packages/ui/src/components/rating/rating.mdx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck / test / build: not affected (no \`.tsx\` changes)
- build-storybook: PASS

## Test plan

- [ ] CI green
- [ ] Storybook renders the new "Docs" tab for each of the five primitives without console errors