### PR TITLE
docs(ui): add MDX docs for shell-tail family (5 components)

### DIFF
--- a/packages/ui/src/components/left-rail/left-rail.mdx
+++ b/packages/ui/src/components/left-rail/left-rail.mdx
@@ -1,0 +1,45 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './left-rail.stories'
+
+<Meta of={Stories} />
+
+# LeftRail
+
+Vertical chrome rail pinned to the left of \`CanvasShell\` — narrow column for primary navigation, workspace pivots, and key affordances. Pure presentation; the host slots whatever items belong here.
+
+Distinct from \`Sidebar\` (document chrome) and \`NavbarSaas\` (marketing chrome): \`LeftRail\` is the operator-shell rail.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/left-rail.json
+```
+
+## Import
+
+```tsx
+import { LeftRail } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<LeftRail>
+  <WorkspaceSwitcher …/>
+  <NavItem icon="canvas" label="Canvas" />
+  <NavItem icon="runs"   label="Runs" />
+  <NavItem icon="alerts" label="Alerts" />
+</LeftRail>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`TopBar\`, \`RightDock\`, \`BottomBar\` and \`CanvasView\` to assemble the full operator surface via \`CanvasShell\`.

--- a/packages/ui/src/components/right-dock/right-dock.mdx
+++ b/packages/ui/src/components/right-dock/right-dock.mdx
@@ -1,0 +1,42 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './right-dock.stories'
+
+<Meta of={Stories} />
+
+# RightDock
+
+Vertical chrome dock pinned to the right of \`CanvasShell\` — host for inspector panels, runtime overviews, routing / policy sections, and ambient secondary surfaces. Pure presentation; the host slots whatever inspector or panel belongs here.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/right-dock.json
+```
+
+## Import
+
+```tsx
+import { RightDock } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<RightDock>
+  <RuntimeOverviewPanel …/>
+  <ObjectInspector …/>
+  <PolicyDeliveryPanel …/>
+</RightDock>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`ObjectInspector\`, \`PropertySection\`, \`RelationshipInspector\`, \`RuntimeOverviewPanel\`, \`RoutingAssignmentPanel\`, and \`PolicyDeliveryPanel\` to fill the dock.

--- a/packages/ui/src/components/top-bar/top-bar.mdx
+++ b/packages/ui/src/components/top-bar/top-bar.mdx
@@ -1,0 +1,45 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './top-bar.stories'
+
+<Meta of={Stories} />
+
+# TopBar
+
+Top chrome bar pinned to the top of \`CanvasShell\` — host for breadcrumbs, viewport bookmarks, presence stack, command-palette trigger, and account chips. Pure presentation; the host slots its chrome.
+
+Distinct from \`NavbarSaas\` (marketing nav) and \`Sidebar\` (document chrome): \`TopBar\` is the operator-shell top strip.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/top-bar.json
+```
+
+## Import
+
+```tsx
+import { TopBar } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<TopBar>
+  <WorldBreadcrumbs …/>
+  <ViewportBookmarks …/>
+  <PresenceStack …/>
+  <PresenceSyncIndicator …/>
+</TopBar>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`WorldBreadcrumbs\` for spatial location, \`ViewportBookmarks\` for saved views, and \`PresenceStack\` for live collaboration.

--- a/packages/ui/src/components/workspace-switcher/workspace-switcher.mdx
+++ b/packages/ui/src/components/workspace-switcher/workspace-switcher.mdx
@@ -1,0 +1,43 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './workspace-switcher.stories'
+
+<Meta of={Stories} />
+
+# WorkspaceSwitcher
+
+Segmented workspace picker for switching between canvas views and operational contexts (e.g. development / staging / production, project A / project B). Pure presentation; the host owns the workspace list and the active id.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/workspace-switcher.json
+```
+
+## Import
+
+```tsx
+import { WorkspaceSwitcher } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<WorkspaceSwitcher
+  workspaces={workspaces}
+  activeId={active}
+  onSelect={setActive}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`LeftRail\` (typically slotted at the top) or \`TopBar\` to anchor workspace switching.
+- For nested or hierarchical scopes, prefer \`ScopeSelector\` instead.

--- a/packages/ui/src/components/zoom-hud/zoom-hud.mdx
+++ b/packages/ui/src/components/zoom-hud/zoom-hud.mdx
@@ -1,0 +1,44 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './zoom-hud.stories'
+
+<Meta of={Stories} />
+
+# ZoomHUD
+
+Compact zoom affordance for \`CanvasView\` — current zoom percentage with +, −, and fit / reset buttons. Pure presentation; the host wires the buttons to the viewport's imperative camera handle.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/zoom-hud.json
+```
+
+## Import
+
+```tsx
+import { ZoomHUD } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<ZoomHUD
+  zoom={zoom}
+  onZoomIn={() => view.zoomTo(zoom * 1.2)}
+  onZoomOut={() => view.zoomTo(zoom / 1.2)}
+  onFit={() => view.fit()}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`CanvasView\` for the viewport, \`MiniMapPanel\` for the overview, and \`ViewportBookmarks\` for saved views.
+- The HUD displays the zoom as a percentage — keep the host's zoom factor consistent (e.g. \`1.0\` reads as \`100 %\`).


### PR DESCRIPTION
## What's in

Adds the missing storybook MDX docs for five canvas-shell primitives shipped on \`main\`:

- \`LeftRail\` — vertical chrome rail pinned to the left of \`CanvasShell\`
- \`RightDock\` — vertical chrome dock pinned to the right
- \`TopBar\` — top chrome bar host for breadcrumbs / bookmarks / presence
- \`WorkspaceSwitcher\` — segmented workspace picker
- \`ZoomHUD\` — compact zoom affordance for \`CanvasView\`

Each MDX file matches the project pattern (install + import + usage + auto-controls + cross-component pairing notes). No code changes — these are documentation files consumed by storybook only.

## Why

Continues the docs-polish track started in PRs #208–#216.

## Files

- \`packages/ui/src/components/left-rail/left-rail.mdx\`
- \`packages/ui/src/components/right-dock/right-dock.mdx\`
- \`packages/ui/src/components/top-bar/top-bar.mdx\`
- \`packages/ui/src/components/workspace-switcher/workspace-switcher.mdx\`
- \`packages/ui/src/components/zoom-hud/zoom-hud.mdx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck / test / build: not affected (no \`.tsx\` changes)
- build-storybook: PASS

## Test plan

- [ ] CI green
- [ ] Storybook renders the new "Docs" tab for each of the five primitives without console errors