### PR TITLE
docs(ui): add MDX docs for animation/decoration family (5 components)

### DIFF
--- a/packages/ui/src/components/animated-text/animated-text.mdx
+++ b/packages/ui/src/components/animated-text/animated-text.mdx
@@ -1,0 +1,39 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './animated-text.stories'
+
+<Meta of={Stories} />
+
+# AnimatedText
+
+Animated text container that types in characters, fades in words, or rolls between strings. Pure presentation; the host owns the source string and the trigger to start.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/animated-text.json
+```
+
+## Import
+
+```tsx
+import { AnimatedText } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<AnimatedText text="Welcome to the spatial workspace" mode="type" />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`Spinner\` and \`Skeleton\` for staged loading states.
+- Animation respects \`prefers-reduced-motion\` so users with motion sensitivity see the final string immediately.

--- a/packages/ui/src/components/border-beam/border-beam.mdx
+++ b/packages/ui/src/components/border-beam/border-beam.mdx
@@ -1,0 +1,42 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './border-beam.stories'
+
+<Meta of={Stories} />
+
+# BorderBeam
+
+Animated accent beam that travels around the border of a highlighted surface — used to draw the eye to a primary CTA, a freshly-saved card, or an interactive demo target. Pure presentation; the host wraps the target.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/border-beam.json
+```
+
+## Import
+
+```tsx
+import { BorderBeam } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<div className="relative">
+  <BorderBeam />
+  <Card>Highlighted content</Card>
+</div>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair sparingly — too many simultaneous beams reduce the attention-grabbing effect.
+- Animation respects \`prefers-reduced-motion\` so users with motion sensitivity see a static border.

--- a/packages/ui/src/components/countdown-timer/countdown-timer.mdx
+++ b/packages/ui/src/components/countdown-timer/countdown-timer.mdx
@@ -1,0 +1,39 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './countdown-timer.stories'
+
+<Meta of={Stories} />
+
+# CountdownTimer
+
+Live countdown to a target timestamp — renders days / hours / minutes / seconds with a calm reset when the target passes. Pure presentation; the host owns the target time.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/countdown-timer.json
+```
+
+## Import
+
+```tsx
+import { CountdownTimer } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<CountdownTimer target="2026-12-31T00:00:00Z" />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`StatCard\` to anchor the countdown alongside the launch metric or with \`AnnotatedText\` for inline campaign copy.
+- The timer recomputes on a \`requestAnimationFrame\` cadence so it stays in sync with the page even after a tab regains focus.

--- a/packages/ui/src/components/marquee/marquee.mdx
+++ b/packages/ui/src/components/marquee/marquee.mdx
@@ -1,0 +1,43 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './marquee.stories'
+
+<Meta of={Stories} />
+
+# Marquee
+
+Continuous-scroll horizontal strip — wraps any children and loops them across the viewport. Pure presentation; the host slots the items and configures the cadence.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/marquee.json
+```
+
+## Import
+
+```tsx
+import { Marquee } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<Marquee speed={40}>
+  <Logo />
+  <Logo />
+  <Logo />
+</Marquee>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`TickerTape\` for the financial-symbol variant — \`Marquee\` is the generic primitive.
+- The marquee respects \`prefers-reduced-motion\` so users with motion sensitivity see a static row.

--- a/packages/ui/src/components/world-clock-bar/world-clock-bar.mdx
+++ b/packages/ui/src/components/world-clock-bar/world-clock-bar.mdx
@@ -1,0 +1,47 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './world-clock-bar.stories'
+
+<Meta of={Stories} />
+
+# WorldClockBar
+
+Multi-timezone display strip for follow-the-sun teams and operational handoffs. Pure presentation; the host computes the city / timezone list.
+
+Distinct from \`WorldBreadcrumbs\` (spatial canvas trail): this primitive is a chrome strip showing remote-team time, not a spatial location.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/world-clock-bar.json
+```
+
+## Import
+
+```tsx
+import { WorldClockBar } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<WorldClockBar
+  zones={[
+    { id: "sf",   label: "SF",   tz: "America/Los_Angeles" },
+    { id: "nyc",  label: "NYC",  tz: "America/New_York" },
+    { id: "lon",  label: "LON",  tz: "Europe/London" },
+  ]}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`PresenceStack\` and \`PresenceSyncIndicator\` for collaborative shells where remote-team presence matters.
+- The strip updates on a per-minute cadence — it does not need second-level precision.


### PR DESCRIPTION
## What's in

Adds the missing storybook MDX docs for five primitives shipped on \`main\`:

- \`AnimatedText\` — typed / faded / rolled animated text container
- \`Marquee\` — continuous-scroll horizontal strip
- \`BorderBeam\` — animated accent beam around a highlighted surface
- \`CountdownTimer\` — live countdown to a target timestamp
- \`WorldClockBar\` — multi-timezone display strip

Each MDX file matches the project pattern (install + import + usage + auto-controls + cross-component pairing notes). No code changes — these are documentation files consumed by storybook only.

## Why

Continues the docs-polish track started in PRs #208–#217.

## Files

- \`packages/ui/src/components/animated-text/animated-text.mdx\`
- \`packages/ui/src/components/marquee/marquee.mdx\`
- \`packages/ui/src/components/border-beam/border-beam.mdx\`
- \`packages/ui/src/components/countdown-timer/countdown-timer.mdx\`
- \`packages/ui/src/components/world-clock-bar/world-clock-bar.mdx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck / test / build: not affected (no \`.tsx\` changes)
- build-storybook: PASS

## Test plan

- [ ] CI green
- [ ] Storybook renders the new "Docs" tab for each of the five primitives without console errors