### PR TITLE
docs(ui): add MDX docs for misc-collab family (5 components)

### DIFF
--- a/packages/ui/src/components/annotation/annotation.mdx
+++ b/packages/ui/src/components/annotation/annotation.mdx
@@ -1,0 +1,43 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './annotation.stories'
+
+<Meta of={Stories} />
+
+# Annotation
+
+Inline annotation overlay — short note anchored to a target element with optional pointer arrow. Use to highlight a value, explain a glyph, or call out an interactive element. Pure presentation; the host owns the anchor + visibility state.
+
+Distinct from \`Tooltip\` (transient hover) and \`CommentPin\` (canvas-anchored thread): \`Annotation\` is durable inline copy attached to layout, not a thread.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/annotation.json
+```
+
+## Import
+
+```tsx
+import { Annotation } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<Annotation
+  anchor="top-right"
+  text="Tap any tile to drill in"
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`Tour\` for guided sequences and \`KeyboardShortcutsHelp\` for accessory hints.

--- a/packages/ui/src/components/avatar-group/avatar-group.mdx
+++ b/packages/ui/src/components/avatar-group/avatar-group.mdx
@@ -1,0 +1,43 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './avatar-group.stories'
+
+<Meta of={Stories} />
+
+# AvatarGroup
+
+Static stacked avatar group — overlapping circular avatars with a sane overflow chip. Pure presentation; the host computes the participant list.
+
+Distinct from \`PresenceStack\` (live status + colors): \`AvatarGroup\` is the durable participant grouping with no live presence semantics.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/avatar-group.json
+```
+
+## Import
+
+```tsx
+import { AvatarGroup } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<AvatarGroup
+  max={4}
+  members={members}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`RoleBadge\` for member-row chips and \`PresenceStack\` for live presence variants.

--- a/packages/ui/src/components/live-feed/live-feed.mdx
+++ b/packages/ui/src/components/live-feed/live-feed.mdx
@@ -1,0 +1,41 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './live-feed.stories'
+
+<Meta of={Stories} />
+
+# LiveFeed
+
+Rolling activity stream for surfacing incidents, deploys, and operational signals in real time. Pure presentation; the host owns the websocket / event source.
+
+Distinct from \`ActivityLog\` (durable persistent list) and \`BottomActivityStrip\` (slim canvas chrome): \`LiveFeed\` is the full-height stream typically pinned in a side panel.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/live-feed.json
+```
+
+## Import
+
+```tsx
+import { LiveFeed } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<LiveFeed events={events} />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`SeverityBadge\` for incident chips and \`StatusBoard\` for the service-health grid.
+- The feed scrolls within its own container so the surrounding layout stays calm.

--- a/packages/ui/src/components/mini-map-panel/mini-map-panel.mdx
+++ b/packages/ui/src/components/mini-map-panel/mini-map-panel.mdx
@@ -1,0 +1,44 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './mini-map-panel.stories'
+
+<Meta of={Stories} />
+
+# MiniMapPanel
+
+Birdseye overview of a \`CanvasView\` — a scaled rendering of the world with a viewport rectangle that the host syncs to the live camera. Pure presentation; the host computes the world extent and viewport rect.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/mini-map-panel.json
+```
+
+## Import
+
+```tsx
+import { MiniMapPanel } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<MiniMapPanel
+  world={worldExtent}
+  viewport={viewportRect}
+  markers={objectMarkers}
+  onJumpTo={(x, y) => view.panTo({ x, y })}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`CanvasView\`, \`ZoomHUD\`, and \`ViewportBookmarks\` to round out the navigation chrome.
+- Drop \`onJumpTo\` to render the minimap as a passive overview without click-to-navigate.

--- a/packages/ui/src/components/stepper/stepper.mdx
+++ b/packages/ui/src/components/stepper/stepper.mdx
@@ -1,0 +1,43 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './stepper.stories'
+
+<Meta of={Stories} />
+
+# Stepper
+
+Sequenced step indicator — complete / current / upcoming states with optional labels and connector lines. Pure presentation; the host owns the step list and the active step.
+
+Distinct from \`StepNavigation\` (free-form step list) and \`StepByStep\` (tutorial-style stepper): \`Stepper\` is the lightweight sequential indicator suited to wizards and onboarding.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/stepper.json
+```
+
+## Import
+
+```tsx
+import { Stepper } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<Stepper
+  steps={steps}
+  activeStep={activeIndex}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`Tour\` for fully-guided sequences and \`Form\` for multi-step form wizards.


### PR DESCRIPTION
## What's in

Adds the missing storybook MDX docs for five primitives shipped on \`main\`:

- \`Annotation\` — inline anchored note with optional pointer arrow
- \`AvatarGroup\` — static stacked avatar group with overflow chip
- \`LiveFeed\` — rolling activity stream for incidents / deploys
- \`MiniMapPanel\` — birdseye overview of \`CanvasView\`
- \`Stepper\` — sequenced step indicator (complete / current / upcoming)

Each MDX file matches the project pattern (install + import + usage + auto-controls + cross-component pairing notes). No code changes — these are documentation files consumed by storybook only.

## Why

Continues the docs-polish track started in PRs #208–#218.

## Files

- \`packages/ui/src/components/annotation/annotation.mdx\`
- \`packages/ui/src/components/avatar-group/avatar-group.mdx\`
- \`packages/ui/src/components/live-feed/live-feed.mdx\`
- \`packages/ui/src/components/mini-map-panel/mini-map-panel.mdx\`
- \`packages/ui/src/components/stepper/stepper.mdx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck / test / build: not affected (no \`.tsx\` changes)
- build-storybook: PASS

## Test plan

- [ ] CI green
- [ ] Storybook renders the new "Docs" tab for each of the five primitives without console errors