### PR TITLE
docs(ui): add MDX docs for the final 3 undocumented components

### DIFF
--- a/packages/ui/src/components/curriculum/curriculum.mdx
+++ b/packages/ui/src/components/curriculum/curriculum.mdx
@@ -1,0 +1,44 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './curriculum.stories'
+
+<Meta of={Stories} />
+
+# Curriculum
+
+Course-layout container for a sequence of lessons or modules — title, progress, optional intro, and a stack of lesson rows. Pure presentation; the host owns the lesson list and the active step.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/curriculum.json
+```
+
+## Import
+
+```tsx
+import { Curriculum } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<Curriculum
+  title="Spatial workspace 101"
+  lessons={lessons}
+  activeLessonId={current}
+  onLessonSelect={openLesson}
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`Flashcard\` for in-lesson review and \`StepByStep\` for tutorial-style walkthroughs.
+- Drop \`onLessonSelect\` for read-only catalog views.

--- a/packages/ui/src/components/flashcard/flashcard.mdx
+++ b/packages/ui/src/components/flashcard/flashcard.mdx
@@ -1,0 +1,42 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './flashcard.stories'
+
+<Meta of={Stories} />
+
+# Flashcard
+
+Two-sided card for spaced-repetition review — front holds the prompt, back holds the answer, click / tap or keyboard space to flip. Pure presentation; the host owns the deck and the current card index.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/flashcard.json
+```
+
+## Import
+
+```tsx
+import { Flashcard } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<Flashcard
+  front="What does \`pointer-events: none\` do?"
+  back="Lets host gestures pass through the element."
+/>
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`Curriculum\` for course-context decks and \`Quiz\` for graded review.
+- The flip animation respects \`prefers-reduced-motion\` so users with motion sensitivity see an instant flip.

--- a/packages/ui/src/components/watchlist/watchlist.mdx
+++ b/packages/ui/src/components/watchlist/watchlist.mdx
@@ -1,0 +1,39 @@
+import { Meta, Primary, Controls, Story, Canvas, Source } from '@storybook/addon-docs/blocks'
+import * as Stories from './watchlist.stories'
+
+<Meta of={Stories} />
+
+# Watchlist
+
+Compact list of pinned symbols / objects — one row per item with a leading glyph, a primary label, a value, and a change badge. Pure presentation; the host computes the row data.
+
+<Primary />
+
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/watchlist.json
+```
+
+## Import
+
+```tsx
+import { Watchlist } from '@vllnt/ui'
+```
+
+## Usage
+
+```tsx
+<Watchlist items={pinned} onSelect={openSymbol} />
+```
+
+<Canvas of={Stories.Default} sourceState="shown" />
+
+## API Reference
+
+<Controls />
+
+## Notes
+
+- Pair with \`TickerTape\` for the horizontal price strip and \`SparklineGrid\` for per-row mini-charts.
+- The list keeps its rows compact so it fits inside a sidebar without dominating the layout.


### PR DESCRIPTION
## What's in

Adds the last three storybook MDX docs for components on \`main\` that didn't yet ship one:

- \`Curriculum\` — course layout for a sequence of lessons / modules
- \`Flashcard\` — two-sided card for spaced-repetition review
- \`Watchlist\` — compact list of pinned symbols / objects

After this PR every component on \`main\` ships with its storybook docs page. Each MDX file matches the project pattern (install + import + usage + auto-controls + cross-component pairing notes). No code changes — these are documentation files consumed by storybook only.

## Why

Closes the docs-polish track started in PRs #208–#219. The track added MDX docs to ~58 components on \`main\` that landed before the project pattern crystallised. After this PR, \`pnpm -F @vllnt/ui build-storybook\` produces a uniform docs surface across the entire library.

## Files

- \`packages/ui/src/components/curriculum/curriculum.mdx\`
- \`packages/ui/src/components/flashcard/flashcard.mdx\`
- \`packages/ui/src/components/watchlist/watchlist.mdx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck / test / build: not affected (no \`.tsx\` changes)
- build-storybook: PASS

## Test plan

- [ ] CI green
- [ ] Storybook renders the new "Docs" tab for each of the three primitives without console errors