### PR TITLE
test(ui): add tests for 5 primitives (AspectRatio + Breadcrumb + FAQ + Comparison + GlassPanel)

### DIFF
--- a/packages/ui/src/components/aspect-ratio/aspect-ratio.test.tsx
+++ b/packages/ui/src/components/aspect-ratio/aspect-ratio.test.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AspectRatio } from "./aspect-ratio";
+
+describe("AspectRatio", () => {
+  it("renders children inside the ratio container", () => {
+    const { getByText } = render(
+      <AspectRatio ratio={16 / 9}>
+        <span>media</span>
+      </AspectRatio>,
+    );
+
+    expect(getByText("media")).toBeInTheDocument();
+  });
+
+  it("forwards arbitrary props to the root element", () => {
+    const { container } = render(
+      <AspectRatio data-testid="ar" ratio={1}>
+        <span>x</span>
+      </AspectRatio>,
+    );
+
+    expect(container.querySelector("[data-testid='ar']")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/breadcrumb/breadcrumb.test.tsx
+++ b/packages/ui/src/components/breadcrumb/breadcrumb.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Breadcrumb, type BreadcrumbItem } from "./breadcrumb";
+
+const sample: BreadcrumbItem[] = [
+  { href: "/", label: "Home" },
+  { href: "/runs", label: "Runs" },
+  { label: "research-2025" },
+];
+
+describe("Breadcrumb", () => {
+  it("renders one entry per item", () => {
+    render(<Breadcrumb items={sample} />);
+
+    expect(screen.getByText("Home")).toBeInTheDocument();
+    expect(screen.getByText("Runs")).toBeInTheDocument();
+    expect(screen.getByText("research-2025")).toBeInTheDocument();
+  });
+
+  it("renders items with href as links", () => {
+    render(<Breadcrumb items={sample} />);
+
+    expect(screen.getByText("Home").closest("a")).toHaveAttribute("href", "/");
+    expect(screen.getByText("Runs").closest("a")).toHaveAttribute(
+      "href",
+      "/runs",
+    );
+  });
+
+  it("renders the last item as a plain span when href is omitted", () => {
+    render(<Breadcrumb items={sample} />);
+
+    expect(screen.getByText("research-2025").closest("a")).toBeNull();
+  });
+
+  it("uses the breadcrumb landmark", () => {
+    const { container } = render(<Breadcrumb items={sample} />);
+
+    expect(container.querySelector("nav")).toHaveAttribute(
+      "aria-label",
+      "Breadcrumb",
+    );
+  });
+
+  it("respects the separator prop", () => {
+    render(<Breadcrumb items={sample} separator="slash" />);
+
+    expect(screen.getAllByText("/").length).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui/src/components/comparison/comparison.test.tsx
+++ b/packages/ui/src/components/comparison/comparison.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BeforeAfter, Comparison } from "./comparison";
+
+describe("Comparison", () => {
+  it("renders both sides with their titles + items", () => {
+    render(
+      <Comparison
+        after={{ items: ["c", "d"], title: "After", variant: "good" }}
+        before={{ items: ["a", "b"], title: "Before", variant: "bad" }}
+      />,
+    );
+
+    expect(screen.getByText("Before")).toBeInTheDocument();
+    expect(screen.getByText("After")).toBeInTheDocument();
+    expect(screen.getByText("a")).toBeInTheDocument();
+    expect(screen.getByText("d")).toBeInTheDocument();
+  });
+
+  it("renders the optional title", () => {
+    render(
+      <Comparison
+        after={{ items: ["c"], title: "A", variant: "good" }}
+        before={{ items: ["a"], title: "B", variant: "bad" }}
+        title="Comparison"
+      />,
+    );
+
+    expect(screen.getByText("Comparison")).toBeInTheDocument();
+  });
+
+  it("falls back to default variants when not specified", () => {
+    render(
+      <Comparison
+        after={{ items: ["x"], title: "After" }}
+        before={{ items: ["y"], title: "Before" }}
+      />,
+    );
+
+    expect(screen.getByText("Before")).toBeInTheDocument();
+    expect(screen.getByText("After")).toBeInTheDocument();
+  });
+});
+
+describe("BeforeAfter", () => {
+  it("renders both slots and the optional title", () => {
+    render(
+      <BeforeAfter
+        after={<span>after-slot</span>}
+        before={<span>before-slot</span>}
+        title="Refactor"
+      />,
+    );
+
+    expect(screen.getByText("before-slot")).toBeInTheDocument();
+    expect(screen.getByText("after-slot")).toBeInTheDocument();
+    expect(screen.getByText("Refactor")).toBeInTheDocument();
+  });
+
+  it("renders without a title", () => {
+    render(
+      <BeforeAfter
+        after={<span>after-slot</span>}
+        before={<span>before-slot</span>}
+      />,
+    );
+
+    expect(screen.getByText("before-slot")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/faq/faq.test.tsx
+++ b/packages/ui/src/components/faq/faq.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { FAQ, FAQItem } from "./faq";
+
+describe("FAQ", () => {
+  it("renders the title and items", () => {
+    render(
+      <FAQ title="Common questions">
+        <FAQItem question="What does it do?">It tests the FAQ.</FAQItem>
+      </FAQ>,
+    );
+
+    expect(screen.getByText("Common questions")).toBeInTheDocument();
+    expect(screen.getByText("What does it do?")).toBeInTheDocument();
+  });
+
+  it("renders FAQItem closed by default", () => {
+    const { container } = render(
+      <FAQ>
+        <FAQItem question="Q1">Answer 1</FAQItem>
+      </FAQ>,
+    );
+
+    expect(container.querySelector(".overflow-hidden")).toHaveClass("max-h-0");
+  });
+
+  it("opens the item when the trigger is clicked", () => {
+    const { container } = render(
+      <FAQ>
+        <FAQItem question="Q1">Answer 1</FAQItem>
+      </FAQ>,
+    );
+
+    fireEvent.click(screen.getByText("Q1"));
+    expect(container.querySelector(".overflow-hidden")).toHaveClass("max-h-96");
+  });
+
+  it("respects defaultOpen on FAQItem", () => {
+    const { container } = render(
+      <FAQ>
+        <FAQItem defaultOpen question="Q1">
+          Answer 1
+        </FAQItem>
+      </FAQ>,
+    );
+
+    expect(container.querySelector(".overflow-hidden")).toHaveClass("max-h-96");
+  });
+
+  it("falls back to the default title when none is provided", () => {
+    render(
+      <FAQ>
+        <FAQItem question="Q1">A</FAQItem>
+      </FAQ>,
+    );
+
+    expect(screen.getByText("Frequently Asked Questions")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/glass-panel/glass-panel.test.tsx
+++ b/packages/ui/src/components/glass-panel/glass-panel.test.tsx
@@ -1,0 +1,38 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { GlassPanel } from "./glass-panel";
+
+describe("GlassPanel", () => {
+  it("renders children", () => {
+    const { getByText } = render(
+      <GlassPanel>
+        <span>frosted</span>
+      </GlassPanel>,
+    );
+
+    expect(getByText("frosted")).toBeInTheDocument();
+  });
+
+  it("merges the className prop", () => {
+    const { container } = render(
+      <GlassPanel className="custom">
+        <span>x</span>
+      </GlassPanel>,
+    );
+
+    expect(container.firstChild).toHaveClass("custom");
+  });
+
+  it("forwards arbitrary div props", () => {
+    const { container } = render(
+      <GlassPanel data-testid="glass">
+        <span>x</span>
+      </GlassPanel>,
+    );
+
+    expect(
+      container.querySelector("[data-testid='glass']"),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What's in

Adds Vitest tests for five primitives shipped on \`main\` without test coverage:

- \`AspectRatio\` — renders children + forwards props
- \`Breadcrumb\` — items / separator / link href / aria-label
- \`FAQ\` — title fallback + closed-by-default + click-to-open + \`defaultOpen\`
- \`Comparison\` — both sides + optional title + variant fallback (plus \`BeforeAfter\`)
- \`GlassPanel\` — children + className merge + prop forwarding

19 new tests total. No source changes — these are net-new test files.

## Why

Kicks off a tests-coverage polish track. 70 components on \`main\` lack tests; this batch chips away at the gap. Future ticks may continue the track in batches of 5.

## Files

- \`packages/ui/src/components/aspect-ratio/aspect-ratio.test.tsx\`
- \`packages/ui/src/components/breadcrumb/breadcrumb.test.tsx\`
- \`packages/ui/src/components/faq/faq.test.tsx\`
- \`packages/ui/src/components/comparison/comparison.test.tsx\`
- \`packages/ui/src/components/glass-panel/glass-panel.test.tsx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck: PASS
- test: PASS (513 / 513 — incl. 19 new)
- build: PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)

Refs #231