### PR TITLE
test(ui): add tests for 5 primitives (BottomBar + Label + BlogCard + ProfileSection + VideoEmbed)

### DIFF
--- a/packages/ui/src/components/blog-card/blog-card.test.tsx
+++ b/packages/ui/src/components/blog-card/blog-card.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BlogCard, ContentCard } from "./blog-card";
+
+const post = {
+  date: "2026-01-15",
+  description: "A short summary of the post.",
+  slug: "first-post",
+  tags: ["news", "release"],
+  title: "First post",
+  updatedDate: "2026-02-01",
+};
+
+describe("ContentCard", () => {
+  it("renders the title and description", () => {
+    render(<ContentCard href="/posts/first-post" post={post} />);
+
+    expect(screen.getByText("First post")).toBeInTheDocument();
+    expect(
+      screen.getByText("A short summary of the post."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the leading tag as a badge", () => {
+    render(<ContentCard href="/posts/first-post" post={post} />);
+
+    expect(screen.getByText("news")).toBeInTheDocument();
+  });
+
+  it("hides the badge when showBadge is false", () => {
+    render(
+      <ContentCard href="/posts/first-post" post={post} showBadge={false} />,
+    );
+
+    expect(screen.queryByText("news")).not.toBeInTheDocument();
+  });
+
+  it("renders the formatted date when formatDate + lang are provided", () => {
+    render(
+      <ContentCard
+        formatDate={(date) => `formatted-${date}`}
+        href="/posts/first-post"
+        lang="en"
+        post={post}
+      />,
+    );
+
+    expect(screen.getByText("formatted-2026-01-15")).toBeInTheDocument();
+  });
+
+  it("renders the read-more affordance when label is supplied", () => {
+    render(
+      <ContentCard
+        href="/posts/first-post"
+        post={post}
+        readMoreLabel="Read more"
+      />,
+    );
+
+    expect(screen.getByText("Read more")).toBeInTheDocument();
+  });
+
+  it("hides the read-more affordance when showReadMore is false", () => {
+    render(
+      <ContentCard
+        href="/posts/first-post"
+        post={post}
+        readMoreLabel="Read more"
+        showReadMore={false}
+      />,
+    );
+
+    expect(screen.queryByText("Read more")).not.toBeInTheDocument();
+  });
+
+  it("wraps the card in a link to the href", () => {
+    render(<ContentCard href="/posts/first-post" post={post} />);
+
+    expect(screen.getByText("First post").closest("a")).toHaveAttribute(
+      "href",
+      "/posts/first-post",
+    );
+  });
+});
+
+describe("BlogCard", () => {
+  it("is the same component as ContentCard", () => {
+    expect(BlogCard).toBe(ContentCard);
+  });
+});

--- a/packages/ui/src/components/bottom-bar/bottom-bar.test.tsx
+++ b/packages/ui/src/components/bottom-bar/bottom-bar.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BottomBar } from "./bottom-bar";
+
+describe("BottomBar", () => {
+  it("renders the leading and trailing slots", () => {
+    render(
+      <BottomBar leading={<span>left</span>} trailing={<span>right</span>} />,
+    );
+
+    expect(screen.getByText("left")).toBeInTheDocument();
+    expect(screen.getByText("right")).toBeInTheDocument();
+  });
+
+  it("renders the optional center slot when provided", () => {
+    render(
+      <BottomBar
+        center={<span>middle</span>}
+        leading={<span>l</span>}
+        trailing={<span>r</span>}
+      />,
+    );
+
+    expect(screen.getByText("middle")).toBeInTheDocument();
+  });
+
+  it("omits the center slot when not provided", () => {
+    render(<BottomBar leading={<span>l</span>} trailing={<span>r</span>} />);
+
+    expect(screen.queryByText("middle")).not.toBeInTheDocument();
+  });
+
+  it("merges the className prop", () => {
+    const { container } = render(
+      <BottomBar className="extra" leading={<span>l</span>} />,
+    );
+
+    expect(container.firstChild).toHaveClass("extra");
+  });
+
+  it("forwards arbitrary div props", () => {
+    const { container } = render(<BottomBar data-testid="bb" />);
+
+    expect(container.querySelector("[data-testid='bb']")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/label/label.test.tsx
+++ b/packages/ui/src/components/label/label.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Label } from "./label";
+
+describe("Label", () => {
+  it("renders its children", () => {
+    render(<Label>Email</Label>);
+
+    expect(screen.getByText("Email")).toBeInTheDocument();
+  });
+
+  it("forwards htmlFor to associate with an input", () => {
+    render(<Label htmlFor="email-field">Email</Label>);
+
+    expect(screen.getByText("Email")).toHaveAttribute("for", "email-field");
+  });
+
+  it("merges the className prop", () => {
+    render(<Label className="custom">Email</Label>);
+
+    expect(screen.getByText("Email")).toHaveClass("custom");
+  });
+
+  it("preserves the default label styling", () => {
+    render(<Label>Email</Label>);
+
+    expect(screen.getByText("Email")).toHaveClass("text-sm");
+  });
+});

--- a/packages/ui/src/components/profile-section/profile-section.test.tsx
+++ b/packages/ui/src/components/profile-section/profile-section.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ProfileSection } from "./profile-section";
+
+const dict = {
+  profile: {
+    name: "bv",
+    tagline: "Building calm spatial UIs",
+  },
+};
+
+describe("ProfileSection", () => {
+  it("renders the name and tagline", () => {
+    render(<ProfileSection dict={dict} />);
+
+    expect(screen.getByText("bv")).toBeInTheDocument();
+    expect(screen.getByText("> Building calm spatial UIs")).toBeInTheDocument();
+  });
+
+  it("uses the compact tagline format when compact is true", () => {
+    render(<ProfileSection compact dict={dict} />);
+
+    expect(screen.getByText("Building calm spatial UIs")).toBeInTheDocument();
+  });
+
+  it("renders the profile image when not compact", () => {
+    render(<ProfileSection dict={dict} />);
+
+    expect(screen.getByAltText("bv Profile")).toBeInTheDocument();
+  });
+
+  it("hides the profile image when compact", () => {
+    render(<ProfileSection compact dict={dict} />);
+
+    expect(screen.queryByAltText("bv Profile")).not.toBeInTheDocument();
+  });
+
+  it("renders social links when provided", () => {
+    render(
+      <ProfileSection
+        dict={dict}
+        socialLinks={[
+          { href: "https://x.com/bv", label: "X" },
+          { href: "https://github.com/bv", label: "GitHub" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("X").closest("a")).toHaveAttribute(
+      "href",
+      "https://x.com/bv",
+    );
+    expect(screen.getByText("GitHub").closest("a")).toHaveAttribute(
+      "href",
+      "https://github.com/bv",
+    );
+  });
+
+  it("hides social links when compact", () => {
+    render(
+      <ProfileSection
+        compact
+        dict={dict}
+        socialLinks={[{ href: "https://x.com/bv", label: "X" }]}
+      />,
+    );
+
+    expect(screen.queryByText("X")).not.toBeInTheDocument();
+  });
+
+  it("uses the override imageAlt when provided", () => {
+    render(<ProfileSection dict={dict} imageAlt="custom alt" />);
+
+    expect(screen.getByAltText("custom alt")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/video-embed/video-embed.test.tsx
+++ b/packages/ui/src/components/video-embed/video-embed.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { VideoEmbed } from "./video-embed";
+
+describe("VideoEmbed", () => {
+  it("renders the title caption", () => {
+    render(<VideoEmbed src="https://youtube.com/watch?v=abc" title="Demo" />);
+
+    expect(screen.getByText("Demo")).toBeInTheDocument();
+  });
+
+  it("starts in the play-button state and swaps to an iframe when clicked", () => {
+    const { container } = render(
+      <VideoEmbed src="https://youtube.com/watch?v=abc" title="Demo" />,
+    );
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(container.querySelector("iframe")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(container.querySelector("iframe")).toBeInTheDocument();
+  });
+
+  it("rewrites a YouTube watch URL to an embed URL", () => {
+    const { container } = render(
+      <VideoEmbed src="https://youtube.com/watch?v=abc" title="Demo" />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(container.querySelector("iframe")).toHaveAttribute(
+      "src",
+      "https://www.youtube.com/embed/abc?autoplay=1",
+    );
+  });
+
+  it("rewrites a Vimeo URL to a player URL", () => {
+    const { container } = render(
+      <VideoEmbed src="https://vimeo.com/12345" title="Demo" type="vimeo" />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(container.querySelector("iframe")).toHaveAttribute(
+      "src",
+      "https://player.vimeo.com/video/12345?autoplay=1",
+    );
+  });
+
+  it("uses a custom URL as-is when type is custom", () => {
+    const { container } = render(
+      <VideoEmbed
+        src="https://example.com/video.mp4"
+        title="Demo"
+        type="custom"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(container.querySelector("iframe")).toHaveAttribute(
+      "src",
+      "https://example.com/video.mp4?autoplay=1",
+    );
+  });
+
+  it("renders the thumbnail image when one is provided", () => {
+    render(
+      <VideoEmbed
+        src="https://youtube.com/watch?v=abc"
+        thumbnail="/poster.png"
+        title="Demo"
+      />,
+    );
+
+    expect(screen.getByAltText("Demo")).toHaveAttribute("src", "/poster.png");
+  });
+});


### PR DESCRIPTION
## What's in

Adds Vitest tests for five primitives shipped on \`main\` without test coverage:

- \`BottomBar\` — leading / center / trailing slots + className merge + prop forwarding
- \`Label\` — children + \`htmlFor\` + className merge + default styling
- \`BlogCard\` / \`ContentCard\` — title / description / badge / formatted date / read-more affordance + href wrap
- \`ProfileSection\` — name / tagline / image / social links + compact mode + \`imageAlt\` override
- \`VideoEmbed\` — title caption + play-button → iframe swap + URL rewrites for YouTube / Vimeo / custom + thumbnail

30 new tests total. No source changes — these are net-new test files.

## Why

Continues the tests-coverage track started in PR #221. After this PR, 60 components on \`main\` still lack tests; future ticks may continue the track in batches of 5.

## Files

- \`packages/ui/src/components/bottom-bar/bottom-bar.test.tsx\`
- \`packages/ui/src/components/label/label.test.tsx\`
- \`packages/ui/src/components/blog-card/blog-card.test.tsx\`
- \`packages/ui/src/components/profile-section/profile-section.test.tsx\`
- \`packages/ui/src/components/video-embed/video-embed.test.tsx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck: PASS
- test: PASS (542 / 542 — incl. 30 new)
- build: PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)

Refs #231