### PR TITLE
test(ui): add tests for 5 canvas-shell primitives

### DIFF
--- a/packages/ui/src/components/chat-dock-section/chat-dock-section.test.tsx
+++ b/packages/ui/src/components/chat-dock-section/chat-dock-section.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { type ChatDockMessage, ChatDockSection } from "./chat-dock-section";
+
+const sample: ChatDockMessage[] = [
+  { body: "How do I retry a failed run?", id: "1", speaker: "Bea" },
+  { body: "Click retry on the run row.", id: "2", speaker: "Assistant" },
+];
+
+describe("ChatDockSection", () => {
+  it("renders one entry per message", () => {
+    render(<ChatDockSection messages={sample} />);
+
+    expect(
+      screen.getByText("How do I retry a failed run?"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Click retry on the run row.")).toBeInTheDocument();
+  });
+
+  it("renders the speaker for each message", () => {
+    render(<ChatDockSection messages={sample} title="Helper" />);
+
+    expect(screen.getByText("Bea")).toBeInTheDocument();
+    expect(screen.getByText("Assistant")).toBeInTheDocument();
+  });
+
+  it("renders the optional context label", () => {
+    render(
+      <ChatDockSection contextLabel="Spatial workspace" messages={sample} />,
+    );
+
+    expect(screen.getByText("Spatial workspace")).toBeInTheDocument();
+  });
+
+  it("falls back to the default title and composer placeholder", () => {
+    render(<ChatDockSection messages={[]} />);
+
+    expect(screen.getByText("Assistant")).toBeInTheDocument();
+    expect(
+      screen.getByText("Ask about runs, errors, or pending work…"),
+    ).toBeInTheDocument();
+  });
+
+  it("uses the override title and placeholder when provided", () => {
+    render(
+      <ChatDockSection
+        composerPlaceholder="Type a question…"
+        messages={[]}
+        title="Helper"
+      />,
+    );
+
+    expect(screen.getByText("Helper")).toBeInTheDocument();
+    expect(screen.getByText("Type a question…")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/left-rail/left-rail.test.tsx
+++ b/packages/ui/src/components/left-rail/left-rail.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { LeftRail } from "./left-rail";
+
+describe("LeftRail", () => {
+  it("renders children inside the rail", () => {
+    render(
+      <LeftRail>
+        <span>nav-item</span>
+      </LeftRail>,
+    );
+
+    expect(screen.getByText("nav-item")).toBeInTheDocument();
+  });
+
+  it("renders the optional title", () => {
+    render(
+      <LeftRail title="Workspace">
+        <span>nav</span>
+      </LeftRail>,
+    );
+
+    expect(screen.getByText("Workspace")).toBeInTheDocument();
+  });
+
+  it("renders the optional footer", () => {
+    render(
+      <LeftRail footer={<span>foot</span>}>
+        <span>nav</span>
+      </LeftRail>,
+    );
+
+    expect(screen.getByText("foot")).toBeInTheDocument();
+  });
+
+  it("uses an aside landmark", () => {
+    const { container } = render(<LeftRail>nav</LeftRail>);
+
+    expect(container.querySelector("aside")).toBeInTheDocument();
+  });
+
+  it("merges the className prop", () => {
+    const { container } = render(<LeftRail className="extra">nav</LeftRail>);
+
+    expect(container.firstChild).toHaveClass("extra");
+  });
+});

--- a/packages/ui/src/components/mini-map-panel/mini-map-panel.test.tsx
+++ b/packages/ui/src/components/mini-map-panel/mini-map-panel.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MiniMapPanel } from "./mini-map-panel";
+
+const baseProps = {
+  viewport: { height: 300, width: 400, x: 100, y: 50, zoom: 2 },
+  world: { height: 600, width: 800 },
+};
+
+describe("MiniMapPanel", () => {
+  it("renders the default title and zoom percent", () => {
+    render(<MiniMapPanel {...baseProps} />);
+
+    expect(screen.getByText("Overview")).toBeInTheDocument();
+    expect(screen.getByText("Zoom 200%")).toBeInTheDocument();
+  });
+
+  it("uses the override title when provided", () => {
+    render(<MiniMapPanel {...baseProps} title="Map" />);
+
+    expect(screen.getByText("Map")).toBeInTheDocument();
+  });
+
+  it("renders one element per marker", () => {
+    const { container } = render(
+      <MiniMapPanel
+        {...baseProps}
+        markers={[
+          { id: "a", x: 100, y: 100 },
+          { id: "b", label: "Hot", x: 400, y: 200 },
+        ]}
+      />,
+    );
+
+    expect(container.querySelectorAll("[title='Hot']")).toHaveLength(1);
+    expect(container.querySelectorAll(".size-1\\.5")).toHaveLength(2);
+  });
+
+  it("merges the className prop", () => {
+    const { container } = render(
+      <MiniMapPanel {...baseProps} className="extra" />,
+    );
+
+    expect(container.firstChild).toHaveClass("extra");
+  });
+
+  it("clamps the viewport rectangle to the world bounds", () => {
+    const { container } = render(
+      <MiniMapPanel
+        {...baseProps}
+        viewport={{ height: 100, width: 100, x: 1000, y: 1000, zoom: 1 }}
+      />,
+    );
+
+    const rect = container.querySelector(".bg-transparent");
+    expect(rect).not.toBeNull();
+  });
+});

--- a/packages/ui/src/components/right-dock/right-dock.test.tsx
+++ b/packages/ui/src/components/right-dock/right-dock.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RightDock } from "./right-dock";
+
+describe("RightDock", () => {
+  it("renders children inside the dock", () => {
+    render(
+      <RightDock>
+        <span>panel</span>
+      </RightDock>,
+    );
+
+    expect(screen.getByText("panel")).toBeInTheDocument();
+  });
+
+  it("renders the optional title", () => {
+    render(<RightDock title="Inspector">body</RightDock>);
+
+    expect(screen.getByText("Inspector")).toBeInTheDocument();
+  });
+
+  it("renders the optional header slot", () => {
+    render(
+      <RightDock header={<span>actions</span>} title="Inspector">
+        body
+      </RightDock>,
+    );
+
+    expect(screen.getByText("actions")).toBeInTheDocument();
+  });
+
+  it("renders the optional footer slot", () => {
+    render(<RightDock footer={<span>footer-bar</span>}>body</RightDock>);
+
+    expect(screen.getByText("footer-bar")).toBeInTheDocument();
+  });
+
+  it("uses an aside landmark", () => {
+    const { container } = render(<RightDock>body</RightDock>);
+
+    expect(container.querySelector("aside")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/zoom-hud/zoom-hud.test.tsx
+++ b/packages/ui/src/components/zoom-hud/zoom-hud.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ZoomHUD } from "./zoom-hud";
+
+describe("ZoomHUD", () => {
+  it("renders the zoom percentage", () => {
+    render(<ZoomHUD zoom={1.42} />);
+
+    expect(screen.getByText("142%")).toBeInTheDocument();
+  });
+
+  it("invokes onZoomIn when the zoom-in button is clicked", () => {
+    const onZoomIn = vi.fn();
+    render(<ZoomHUD onZoomIn={onZoomIn} zoom={1} />);
+
+    fireEvent.click(screen.getByLabelText("Zoom in"));
+    expect(onZoomIn).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onZoomOut when the zoom-out button is clicked", () => {
+    const onZoomOut = vi.fn();
+    render(<ZoomHUD onZoomOut={onZoomOut} zoom={1} />);
+
+    fireEvent.click(screen.getByLabelText("Zoom out"));
+    expect(onZoomOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onReset when the reset button is clicked", () => {
+    const onReset = vi.fn();
+    render(<ZoomHUD onReset={onReset} zoom={1} />);
+
+    fireEvent.click(screen.getByLabelText("Reset zoom"));
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("rounds the zoom to the nearest percent", () => {
+    render(<ZoomHUD zoom={0.755} />);
+
+    expect(screen.getByText("76%")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What's in

Adds Vitest tests for five canvas-shell primitives shipped on \`main\` without test coverage:

- \`LeftRail\` — children + title / footer slots + aside landmark + className merge
- \`RightDock\` — children + title / header / footer slots + aside landmark
- \`ZoomHUD\` — zoom percentage display + rounding + zoom-in / zoom-out / reset click handlers
- \`ChatDockSection\` — message list + speaker rendering + context label + default title + composer placeholder
- \`MiniMapPanel\` — title / zoom display + marker rendering + className merge + viewport rect

25 new tests total. No source changes — these are net-new test files.

## Why

Continues the tests-coverage track started in PRs #221 and #222. After this PR, ~55 components on \`main\` still lack tests; future ticks may continue the track in batches of 5.

## Files

- \`packages/ui/src/components/left-rail/left-rail.test.tsx\`
- \`packages/ui/src/components/right-dock/right-dock.test.tsx\`
- \`packages/ui/src/components/zoom-hud/zoom-hud.test.tsx\`
- \`packages/ui/src/components/chat-dock-section/chat-dock-section.test.tsx\`
- \`packages/ui/src/components/mini-map-panel/mini-map-panel.test.tsx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck: PASS
- test: PASS (full suite incl. 25 new)
- build: PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)

Refs #231