### PR TITLE
test(ui): add tests for 5 primitives (ThemeProvider + SidebarProvider + Slider + Resizable + ToggleGroup)

### DIFF
--- a/packages/ui/src/components/resizable/resizable.test.tsx
+++ b/packages/ui/src/components/resizable/resizable.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "./resizable";
+
+describe("ResizablePanelGroup", () => {
+  it("renders panels and handles", () => {
+    render(
+      <ResizablePanelGroup direction="horizontal">
+        <ResizablePanel defaultSize={50}>
+          <span>left-pane</span>
+        </ResizablePanel>
+        <ResizableHandle />
+        <ResizablePanel defaultSize={50}>
+          <span>right-pane</span>
+        </ResizablePanel>
+      </ResizablePanelGroup>,
+    );
+
+    expect(screen.getByText("left-pane")).toBeInTheDocument();
+    expect(screen.getByText("right-pane")).toBeInTheDocument();
+  });
+
+  it("renders the handle with separator role by default", () => {
+    const { container } = render(
+      <ResizablePanelGroup direction="horizontal">
+        <ResizablePanel defaultSize={50}>
+          <span>l</span>
+        </ResizablePanel>
+        <ResizableHandle />
+        <ResizablePanel defaultSize={50}>
+          <span>r</span>
+        </ResizablePanel>
+      </ResizablePanelGroup>,
+    );
+
+    expect(container.querySelector("[role='separator']")).toBeInTheDocument();
+  });
+
+  it("merges the className prop", () => {
+    const { container } = render(
+      <ResizablePanelGroup className="extra" direction="vertical">
+        <ResizablePanel defaultSize={100}>
+          <span>only</span>
+        </ResizablePanel>
+      </ResizablePanelGroup>,
+    );
+
+    expect(container.firstChild).toHaveClass("extra");
+  });
+});

--- a/packages/ui/src/components/sidebar-provider/sidebar-provider.test.tsx
+++ b/packages/ui/src/components/sidebar-provider/sidebar-provider.test.tsx
@@ -1,0 +1,36 @@
+import { act, render, renderHook, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SidebarProvider, useSidebar } from "./sidebar-provider";
+
+describe("SidebarProvider", () => {
+  it("renders its children", () => {
+    render(
+      <SidebarProvider>
+        <span>sidebar-body</span>
+      </SidebarProvider>,
+    );
+
+    expect(screen.getByText("sidebar-body")).toBeInTheDocument();
+  });
+});
+
+describe("useSidebar", () => {
+  it("throws when used outside of SidebarProvider", () => {
+    expect(() => renderHook(() => useSidebar())).toThrow(
+      "useSidebar must be used within SidebarProvider",
+    );
+  });
+
+  it("returns the open + setOpen pair when used inside the provider", () => {
+    const { result } = renderHook(() => useSidebar(), {
+      wrapper: ({ children }) => <SidebarProvider>{children}</SidebarProvider>,
+    });
+
+    expect(result.current.open).toBe(false);
+    act(() => {
+      result.current.setOpen(true);
+    });
+    expect(result.current.open).toBe(true);
+  });
+});

--- a/packages/ui/src/components/slider/slider.test.tsx
+++ b/packages/ui/src/components/slider/slider.test.tsx
@@ -1,0 +1,43 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Slider } from "./slider";
+
+describe("Slider", () => {
+  it("renders the track and thumb", () => {
+    const { container } = render(
+      <Slider defaultValue={[40]} max={100} step={1} />,
+    );
+
+    expect(container.querySelector("[role='slider']")).toBeInTheDocument();
+  });
+
+  it("respects the defaultValue", () => {
+    const { container } = render(
+      <Slider defaultValue={[40]} max={100} step={1} />,
+    );
+
+    expect(container.querySelector("[role='slider']")).toHaveAttribute(
+      "aria-valuenow",
+      "40",
+    );
+  });
+
+  it("disables the slider when the disabled prop is set", () => {
+    const { container } = render(
+      <Slider defaultValue={[40]} disabled max={100} step={1} />,
+    );
+
+    expect(container.querySelector("[role='slider']")).toHaveAttribute(
+      "data-disabled",
+    );
+  });
+
+  it("merges the className prop on the root", () => {
+    const { container } = render(
+      <Slider className="extra" defaultValue={[40]} max={100} step={1} />,
+    );
+
+    expect(container.firstChild).toHaveClass("extra");
+  });
+});

--- a/packages/ui/src/components/theme-provider/theme-provider.test.tsx
+++ b/packages/ui/src/components/theme-provider/theme-provider.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { ThemeProvider } from "./theme-provider";
+
+const noop = (): void => undefined;
+
+beforeEach(() => {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: (query: string) => ({
+      addEventListener: noop,
+      addListener: noop,
+      dispatchEvent: () => false,
+      matches: false,
+      media: query,
+      onchange: null,
+      removeEventListener: noop,
+      removeListener: noop,
+    }),
+    writable: true,
+  });
+});
+
+describe("ThemeProvider", () => {
+  it("renders its children", () => {
+    render(
+      <ThemeProvider>
+        <span>themed-content</span>
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText("themed-content")).toBeInTheDocument();
+  });
+
+  it("forwards next-themes props", () => {
+    render(
+      <ThemeProvider attribute="class" defaultTheme="dark">
+        <span>themed-content</span>
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText("themed-content")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/toggle-group/toggle-group.test.tsx
+++ b/packages/ui/src/components/toggle-group/toggle-group.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ToggleGroup, ToggleGroupItem } from "./toggle-group";
+
+describe("ToggleGroup", () => {
+  it("renders children items", () => {
+    render(
+      <ToggleGroup type="single">
+        <ToggleGroupItem value="a">A</ToggleGroupItem>
+        <ToggleGroupItem value="b">B</ToggleGroupItem>
+      </ToggleGroup>,
+    );
+
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.getByText("B")).toBeInTheDocument();
+  });
+
+  it("invokes onValueChange when an item is clicked (single)", () => {
+    const onValueChange = vi.fn();
+    render(
+      <ToggleGroup onValueChange={onValueChange} type="single">
+        <ToggleGroupItem value="a">A</ToggleGroupItem>
+        <ToggleGroupItem value="b">B</ToggleGroupItem>
+      </ToggleGroup>,
+    );
+
+    fireEvent.click(screen.getByText("B"));
+    expect(onValueChange).toHaveBeenCalledWith("b");
+  });
+
+  it("respects the value prop (controlled)", () => {
+    render(
+      <ToggleGroup type="single" value="a">
+        <ToggleGroupItem value="a">A</ToggleGroupItem>
+        <ToggleGroupItem value="b">B</ToggleGroupItem>
+      </ToggleGroup>,
+    );
+
+    expect(screen.getByText("A")).toHaveAttribute("data-state", "on");
+    expect(screen.getByText("B")).toHaveAttribute("data-state", "off");
+  });
+
+  it("merges the className prop on the root", () => {
+    const { container } = render(
+      <ToggleGroup className="extra" type="single">
+        <ToggleGroupItem value="a">A</ToggleGroupItem>
+      </ToggleGroup>,
+    );
+
+    expect(container.firstChild).toHaveClass("extra");
+  });
+});


### PR DESCRIPTION
## What's in

Adds Vitest tests for five primitives shipped on \`main\` without test coverage:

- \`ThemeProvider\` — children rendering + next-themes prop forwarding (with a window.matchMedia stub since JSDOM doesn't implement it)
- \`SidebarProvider\` + \`useSidebar\` — context rendering + throw-outside-provider guard + open / setOpen pair
- \`Slider\` — track / thumb rendering + defaultValue + disabled state + className merge
- \`Resizable\` (\`ResizablePanelGroup\` / \`ResizablePanel\` / \`ResizableHandle\`) — panel rendering + separator role + className merge
- \`ToggleGroup\` (+ \`ToggleGroupItem\`) — children + onValueChange + controlled value + className merge

16 new tests total. No source changes — these are net-new test files.

## Why

Continues the tests-coverage track started in PRs #221, #222, #223. After this PR, ~50 components on \`main\` still lack tests; future ticks may continue the track in batches of 5.

## Files

- \`packages/ui/src/components/theme-provider/theme-provider.test.tsx\`
- \`packages/ui/src/components/sidebar-provider/sidebar-provider.test.tsx\`
- \`packages/ui/src/components/slider/slider.test.tsx\`
- \`packages/ui/src/components/resizable/resizable.test.tsx\`
- \`packages/ui/src/components/toggle-group/toggle-group.test.tsx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck: PASS
- test: PASS (full suite incl. 16 new)
- build: PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)

Refs #231