### PR TITLE
test(ui): add tests for 4 primitives (Tooltip + HoverCard + Popover + TableOfContents)

### DIFF
--- a/packages/ui/src/components/hover-card/hover-card.test.tsx
+++ b/packages/ui/src/components/hover-card/hover-card.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "./hover-card";
+
+describe("HoverCard", () => {
+  it("renders the trigger but keeps the content closed by default", () => {
+    render(
+      <HoverCard>
+        <HoverCardTrigger>Hover me</HoverCardTrigger>
+        <HoverCardContent>Card body</HoverCardContent>
+      </HoverCard>,
+    );
+
+    expect(screen.getByText("Hover me")).toBeInTheDocument();
+    expect(screen.queryByText("Card body")).not.toBeInTheDocument();
+  });
+
+  it("renders the content when defaultOpen is true", () => {
+    render(
+      <HoverCard defaultOpen>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardContent>Open card</HoverCardContent>
+      </HoverCard>,
+    );
+
+    expect(screen.getByText("Open card")).toBeInTheDocument();
+  });
+
+  it("merges the className prop on the content", () => {
+    render(
+      <HoverCard defaultOpen>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardContent className="extra">Body</HoverCardContent>
+      </HoverCard>,
+    );
+
+    expect(screen.getByText("Body")).toHaveClass("extra");
+  });
+});

--- a/packages/ui/src/components/popover/popover.test.tsx
+++ b/packages/ui/src/components/popover/popover.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+
+describe("Popover", () => {
+  it("renders the trigger but keeps the content closed by default", () => {
+    render(
+      <Popover>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent>Body</PopoverContent>
+      </Popover>,
+    );
+
+    expect(screen.getByText("Open")).toBeInTheDocument();
+    expect(screen.queryByText("Body")).not.toBeInTheDocument();
+  });
+
+  it("renders the content when defaultOpen is true", () => {
+    render(
+      <Popover defaultOpen>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent>Visible body</PopoverContent>
+      </Popover>,
+    );
+
+    expect(screen.getByText("Visible body")).toBeInTheDocument();
+  });
+
+  it("merges the className prop on the content", () => {
+    render(
+      <Popover defaultOpen>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent className="extra">Body</PopoverContent>
+      </Popover>,
+    );
+
+    expect(screen.getByText("Body")).toHaveClass("extra");
+  });
+});

--- a/packages/ui/src/components/table-of-contents/table-of-contents.test.tsx
+++ b/packages/ui/src/components/table-of-contents/table-of-contents.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TableOfContents } from "./table-of-contents";
+
+const emptyEntries = (): IntersectionObserverEntry[] => [];
+
+class MockIntersectionObserver {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+  takeRecords = vi.fn(emptyEntries);
+  root = null;
+  rootMargin = "";
+  thresholds: readonly number[] = [];
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, "IntersectionObserver", {
+    configurable: true,
+    value: MockIntersectionObserver,
+    writable: true,
+  });
+});
+
+describe("TableOfContents", () => {
+  const sections = [
+    { id: "intro", title: "Introduction" },
+    { id: "design", title: "Design" },
+    { id: "api", title: "API" },
+  ];
+
+  it("renders one button per section", () => {
+    render(<TableOfContents sections={sections} />);
+
+    expect(screen.getByText("Introduction")).toBeInTheDocument();
+    expect(screen.getByText("Design")).toBeInTheDocument();
+    expect(screen.getByText("API")).toBeInTheDocument();
+  });
+
+  it("renders nothing when sections is empty", () => {
+    const { container } = render(<TableOfContents sections={[]} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the on-this-page heading", () => {
+    render(<TableOfContents sections={sections} />);
+
+    expect(screen.getByText("On This Page")).toBeInTheDocument();
+  });
+
+  it("renders sections inside an aside landmark", () => {
+    const { container } = render(<TableOfContents sections={sections} />);
+
+    expect(container.querySelector("aside")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/tooltip/tooltip.test.tsx
+++ b/packages/ui/src/components/tooltip/tooltip.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./tooltip";
+
+describe("Tooltip", () => {
+  it("renders the trigger but keeps the content closed by default", () => {
+    render(
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger>Hover me</TooltipTrigger>
+          <TooltipContent>Tip body</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByText("Hover me")).toBeInTheDocument();
+    expect(screen.queryByText("Tip body")).not.toBeInTheDocument();
+  });
+
+  it("renders the content when defaultOpen is true", () => {
+    render(
+      <TooltipProvider>
+        <Tooltip defaultOpen>
+          <TooltipTrigger>Trigger</TooltipTrigger>
+          <TooltipContent>Open content</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+
+    expect(screen.getAllByText("Open content").length).toBeGreaterThan(0);
+  });
+
+  it("merges the className prop on the content", () => {
+    render(
+      <TooltipProvider>
+        <Tooltip defaultOpen>
+          <TooltipTrigger>Trigger</TooltipTrigger>
+          <TooltipContent className="extra">Body</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+
+    const node = screen.getAllByText("Body")[0];
+    expect(node).toHaveClass("extra");
+  });
+});


### PR DESCRIPTION
## What's in

Adds Vitest tests for four primitives shipped on \`main\` without test coverage:

- \`Tooltip\` — trigger / content rendering + \`defaultOpen\` + className merge on content
- \`HoverCard\` — trigger / content + \`defaultOpen\` + className merge
- \`Popover\` — trigger / content + \`defaultOpen\` + className merge
- \`TableOfContents\` — section button list + empty-state null + on-this-page heading + aside landmark

13 new tests. \`TableOfContents\` needs a \`window.IntersectionObserver\` stub since JSDOM does not implement the API. No source changes — these are net-new test files.

(SidebarToggle was originally in this batch but already has a test on \`main\` — my earlier missing-test scan picked it up by mistake.)

## Why

Continues the tests-coverage track started in PRs #221, #222, #223, #224.

## Files

- \`packages/ui/src/components/tooltip/tooltip.test.tsx\`
- \`packages/ui/src/components/hover-card/hover-card.test.tsx\`
- \`packages/ui/src/components/popover/popover.test.tsx\`
- \`packages/ui/src/components/table-of-contents/table-of-contents.test.tsx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck: PASS
- test: PASS (full suite incl. 13 new)
- build: PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)

Refs #231