### PR TITLE
test(ui): add tests for 5 primitives (TopBar + ShareSection + Toast + InputOTP + KeyboardShortcutsHelp)

### DIFF
--- a/packages/ui/src/components/input-otp/input-otp.test.tsx
+++ b/packages/ui/src/components/input-otp/input-otp.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { InputOTP, InputOTPGroup, InputOTPSeparator } from "./input-otp";
+
+describe("InputOTP", () => {
+  it("renders the underlying input with the requested length", () => {
+    const { container } = render(
+      <InputOTP maxLength={6}>
+        <InputOTPGroup>
+          <span>a</span>
+        </InputOTPGroup>
+      </InputOTP>,
+    );
+
+    expect(container.querySelector("input")).toHaveAttribute("maxlength", "6");
+  });
+
+  it("merges the className prop on the input", () => {
+    const { container } = render(
+      <InputOTP className="extra" maxLength={4}>
+        <InputOTPGroup>
+          <span>x</span>
+        </InputOTPGroup>
+      </InputOTP>,
+    );
+
+    const input = container.querySelector("input");
+    expect(input?.getAttribute("class") ?? "").toContain("extra");
+  });
+});
+
+describe("InputOTPGroup", () => {
+  it("renders its children", () => {
+    render(
+      <InputOTPGroup>
+        <span>slot-a</span>
+        <span>slot-b</span>
+      </InputOTPGroup>,
+    );
+
+    expect(screen.getByText("slot-a")).toBeInTheDocument();
+    expect(screen.getByText("slot-b")).toBeInTheDocument();
+  });
+});
+
+describe("InputOTPSeparator", () => {
+  it("renders with the separator role", () => {
+    render(<InputOTPSeparator />);
+
+    expect(screen.getByRole("separator")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/keyboard-shortcuts-help/keyboard-shortcuts-help.test.tsx
+++ b/packages/ui/src/components/keyboard-shortcuts-help/keyboard-shortcuts-help.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { KeyboardShortcutsHelp } from "./keyboard-shortcuts-help";
+
+const shortcuts = [
+  { description: "Pan canvas", keys: ["Space", "Drag"] },
+  { description: "Zoom in", keys: ["Cmd", "+"] },
+];
+
+describe("KeyboardShortcutsHelp", () => {
+  it("renders nothing when isOpen is false", () => {
+    const { container } = render(
+      <KeyboardShortcutsHelp
+        isOpen={false}
+        onClose={vi.fn()}
+        shortcuts={shortcuts}
+      />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the title and shortcut rows when open", () => {
+    render(
+      <KeyboardShortcutsHelp isOpen onClose={vi.fn()} shortcuts={shortcuts} />,
+    );
+
+    expect(screen.getByText("Keyboard Shortcuts")).toBeInTheDocument();
+    expect(screen.getByText("Pan canvas")).toBeInTheDocument();
+    expect(screen.getByText("Zoom in")).toBeInTheDocument();
+  });
+
+  it("uses the override title when provided", () => {
+    render(
+      <KeyboardShortcutsHelp
+        isOpen
+        onClose={vi.fn()}
+        shortcuts={shortcuts}
+        title="Hotkeys"
+      />,
+    );
+
+    expect(screen.getByText("Hotkeys")).toBeInTheDocument();
+  });
+
+  it("invokes onClose when Escape is pressed", () => {
+    const handleClose = vi.fn();
+    render(
+      <KeyboardShortcutsHelp
+        isOpen
+        onClose={handleClose}
+        shortcuts={shortcuts}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onClose when the close button is clicked", () => {
+    const handleClose = vi.fn();
+    render(
+      <KeyboardShortcutsHelp
+        isOpen
+        onClose={handleClose}
+        shortcuts={shortcuts}
+      />,
+    );
+
+    const closeButton = screen.getByRole("button");
+    fireEvent.click(closeButton);
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/share-section/share-section.test.tsx
+++ b/packages/ui/src/components/share-section/share-section.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ShareSection } from "./share-section";
+
+const baseProps = {
+  shareOn: "Share on",
+  shareTitle: "Share this post",
+  title: "First post",
+  url: "https://example.com/posts/first",
+};
+
+describe("ShareSection", () => {
+  it("renders the share title", () => {
+    render(<ShareSection {...baseProps} />);
+
+    expect(screen.getByText("Share this post")).toBeInTheDocument();
+  });
+
+  it("renders one anchor per default platform", () => {
+    render(<ShareSection {...baseProps} />);
+
+    expect(screen.getByText(/X$/)).toBeInTheDocument();
+    expect(screen.getByText(/LinkedIn$/)).toBeInTheDocument();
+    expect(screen.getByText(/Facebook$/)).toBeInTheDocument();
+    expect(screen.getByText(/Mastodon$/)).toBeInTheDocument();
+    expect(screen.getByText(/Bluesky$/)).toBeInTheDocument();
+    expect(screen.getByText(/Threads$/)).toBeInTheDocument();
+  });
+
+  it("builds a Twitter intent URL with the encoded post URL + title", () => {
+    render(<ShareSection {...baseProps} />);
+
+    const anchor = screen.getByText(/X$/).closest("a");
+    expect(anchor).toHaveAttribute(
+      "href",
+      "https://twitter.com/intent/tweet?url=https%3A%2F%2Fexample.com%2Fposts%2Ffirst&text=First%20post",
+    );
+  });
+
+  it("opens links in a new tab with safe rel", () => {
+    render(<ShareSection {...baseProps} />);
+
+    const anchor = screen.getByText(/X$/).closest("a");
+    expect(anchor).toHaveAttribute("target", "_blank");
+    expect(anchor).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders only the supplied platforms", () => {
+    render(
+      <ShareSection {...baseProps} platforms={[{ key: "x", label: "X" }]} />,
+    );
+
+    expect(screen.getByText(/X$/)).toBeInTheDocument();
+    expect(screen.queryByText(/LinkedIn$/)).not.toBeInTheDocument();
+  });
+
+  it("uses the buildUrl override when provided", () => {
+    render(
+      <ShareSection
+        {...baseProps}
+        buildUrl={(_p, url) => `https://my-share?url=${url}`}
+        platforms={[{ key: "x", label: "X" }]}
+      />,
+    );
+
+    const anchor = screen.getByText(/X$/).closest("a");
+    expect(anchor).toHaveAttribute(
+      "href",
+      "https://my-share?url=https://example.com/posts/first",
+    );
+  });
+});

--- a/packages/ui/src/components/toast/toast.test.tsx
+++ b/packages/ui/src/components/toast/toast.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastDescription,
+  ToastTitle,
+} from "./toast";
+
+describe("Toast", () => {
+  it("renders children", () => {
+    render(
+      <Toast>
+        <span>body</span>
+      </Toast>,
+    );
+
+    expect(screen.getByText("body")).toBeInTheDocument();
+  });
+
+  it("applies the destructive variant class", () => {
+    const { container } = render(<Toast variant="destructive">x</Toast>);
+
+    expect(container.firstChild).toHaveClass("destructive");
+  });
+
+  it("merges the className prop", () => {
+    const { container } = render(<Toast className="extra">x</Toast>);
+
+    expect(container.firstChild).toHaveClass("extra");
+  });
+});
+
+describe("ToastTitle + ToastDescription", () => {
+  it("renders title and description", () => {
+    render(
+      <Toast>
+        <ToastTitle>Saved</ToastTitle>
+        <ToastDescription>Run completed.</ToastDescription>
+      </Toast>,
+    );
+
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+    expect(screen.getByText("Run completed.")).toBeInTheDocument();
+  });
+});
+
+describe("ToastClose", () => {
+  it("invokes onClick when clicked", () => {
+    const handleClose = vi.fn();
+    render(<ToastClose onClick={handleClose} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits the data-toast-close attribute for analytics", () => {
+    render(<ToastClose />);
+
+    expect(screen.getByRole("button")).toHaveAttribute("data-toast-close");
+  });
+});
+
+describe("ToastAction", () => {
+  it("renders children + invokes onClick", () => {
+    const handleClick = vi.fn();
+    render(
+      <ToastAction altText="retry" onClick={handleClick}>
+        Retry
+      </ToastAction>,
+    );
+
+    fireEvent.click(screen.getByText("Retry"));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/top-bar/top-bar.test.tsx
+++ b/packages/ui/src/components/top-bar/top-bar.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TopBar } from "./top-bar";
+
+describe("TopBar", () => {
+  it("renders the title and subtitle slots", () => {
+    render(<TopBar subtitle="environment" title="Production" />);
+
+    expect(screen.getByText("Production")).toBeInTheDocument();
+    expect(screen.getByText("environment")).toBeInTheDocument();
+  });
+
+  it("renders the leading and trailing slots", () => {
+    render(
+      <TopBar
+        leading={<span>left</span>}
+        title="t"
+        trailing={<span>right</span>}
+      />,
+    );
+
+    expect(screen.getByText("left")).toBeInTheDocument();
+    expect(screen.getByText("right")).toBeInTheDocument();
+  });
+
+  it("renders children in the center slot", () => {
+    render(
+      <TopBar title="t">
+        <span>middle</span>
+      </TopBar>,
+    );
+
+    expect(screen.getByText("middle")).toBeInTheDocument();
+  });
+
+  it("uses a header landmark", () => {
+    const { container } = render(<TopBar title="t" />);
+
+    expect(container.querySelector("header")).toBeInTheDocument();
+  });
+
+  it("merges the className prop", () => {
+    const { container } = render(<TopBar className="extra" title="t" />);
+
+    expect(container.firstChild).toHaveClass("extra");
+  });
+});


### PR DESCRIPTION
## What's in

Adds Vitest tests for five primitives shipped on \`main\` without test coverage:

- \`TopBar\` — title / subtitle / leading / trailing / center slots + \`<header>\` landmark + className merge
- \`ShareSection\` — share title + default platforms + Twitter intent URL + new-tab safety + override platforms + \`buildUrl\` override
- \`Toast\` (+ \`ToastTitle\` / \`ToastDescription\` / \`ToastClose\` / \`ToastAction\`) — variant class + click handlers + close-button data attribute
- \`InputOTP\` (+ \`InputOTPGroup\` / \`InputOTPSeparator\`) — \`maxlength\` propagation + className merge + group children + separator role
- \`KeyboardShortcutsHelp\` — closed renders null, open renders title + shortcut rows, override title, \`Escape\` and close-button both invoke \`onClose\`

27 new tests total. No source changes — these are net-new test files.

## Why

Continues the tests-coverage track started in PRs #221, #222, #223, #224, #225.

## Files

- \`packages/ui/src/components/top-bar/top-bar.test.tsx\`
- \`packages/ui/src/components/share-section/share-section.test.tsx\`
- \`packages/ui/src/components/toast/toast.test.tsx\`
- \`packages/ui/src/components/input-otp/input-otp.test.tsx\`
- \`packages/ui/src/components/keyboard-shortcuts-help/keyboard-shortcuts-help.test.tsx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck: PASS
- test: PASS (full suite incl. 27 new)
- build: PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)

Refs #231