### PR TITLE
test(ui): add tests for 5 primitives (Tabs + Sheet + Table + LearningObjectives + ProgressCard)

### DIFF
--- a/packages/ui/src/components/learning-objectives/learning-objectives.test.tsx
+++ b/packages/ui/src/components/learning-objectives/learning-objectives.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  LearningObjectives,
+  Prerequisites,
+  Summary,
+} from "./learning-objectives";
+
+describe("LearningObjectives", () => {
+  it("renders the default title and one entry per objective", () => {
+    render(<LearningObjectives objectives={["Pan", "Zoom", "Drag"]} />);
+
+    expect(screen.getByText("What you'll learn")).toBeInTheDocument();
+    expect(screen.getByText("Pan")).toBeInTheDocument();
+    expect(screen.getByText("Zoom")).toBeInTheDocument();
+    expect(screen.getByText("Drag")).toBeInTheDocument();
+  });
+
+  it("uses the override title when provided", () => {
+    render(<LearningObjectives objectives={["x"]} title="Outcomes" />);
+
+    expect(screen.getByText("Outcomes")).toBeInTheDocument();
+  });
+
+  it("renders the optional estimated time", () => {
+    render(<LearningObjectives estimatedTime="30 min" objectives={["x"]} />);
+
+    expect(screen.getByText("30 min")).toBeInTheDocument();
+  });
+});
+
+describe("Prerequisites", () => {
+  it("renders items + optional level chip", () => {
+    render(
+      <Prerequisites items={["TypeScript", "React"]} level="intermediate" />,
+    );
+
+    expect(screen.getByText("TypeScript")).toBeInTheDocument();
+    expect(screen.getByText("React")).toBeInTheDocument();
+    expect(screen.getByText("intermediate")).toBeInTheDocument();
+  });
+});
+
+describe("Summary", () => {
+  it("renders children + key takeaways", () => {
+    render(
+      <Summary keyTakeaways={["Calm by default", "Composable"]}>
+        <p>Body text.</p>
+      </Summary>,
+    );
+
+    expect(screen.getByText("Body text.")).toBeInTheDocument();
+    expect(screen.getByText("Calm by default")).toBeInTheDocument();
+    expect(screen.getByText("Composable")).toBeInTheDocument();
+    expect(screen.getByText("Key Takeaways")).toBeInTheDocument();
+  });
+
+  it("hides the key-takeaways block when none are provided", () => {
+    render(
+      <Summary>
+        <p>Body</p>
+      </Summary>,
+    );
+
+    expect(screen.queryByText("Key Takeaways")).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/progress-card/progress-card.test.tsx
+++ b/packages/ui/src/components/progress-card/progress-card.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ContentCard } from "./progress-card";
+
+describe("ProgressCard ContentCard", () => {
+  it("renders title + description + badge label", () => {
+    render(
+      <ContentCard
+        badgeLabel="Tutorial"
+        description="Pan, zoom, drag."
+        href="/tutorials/canvas-basics"
+        title="Canvas basics"
+      />,
+    );
+
+    expect(screen.getByText("Canvas basics")).toBeInTheDocument();
+    expect(screen.getByText("Pan, zoom, drag.")).toBeInTheDocument();
+    expect(screen.getByText("Tutorial")).toBeInTheDocument();
+  });
+
+  it("renders metadata items", () => {
+    render(
+      <ContentCard
+        badgeLabel="Tutorial"
+        description="d"
+        href="/x"
+        metadata={["30 min", "10 sections"]}
+        title="t"
+      />,
+    );
+
+    expect(screen.getByText(/30 min/)).toBeInTheDocument();
+    expect(screen.getByText(/10 sections/)).toBeInTheDocument();
+  });
+
+  it("renders tags", () => {
+    render(
+      <ContentCard
+        badgeLabel="Tutorial"
+        description="d"
+        href="/x"
+        tags={["canvas", "interaction"]}
+        title="t"
+      />,
+    );
+
+    expect(screen.getByText("canvas")).toBeInTheDocument();
+    expect(screen.getByText("interaction")).toBeInTheDocument();
+  });
+
+  it("wraps the card in an anchor pointing at href", () => {
+    render(
+      <ContentCard
+        badgeLabel="Tutorial"
+        description="d"
+        href="/tutorials/x"
+        title="t"
+      />,
+    );
+
+    expect(screen.getByText("t").closest("a")).toHaveAttribute(
+      "href",
+      "/tutorials/x",
+    );
+  });
+});

--- a/packages/ui/src/components/sheet/sheet.test.tsx
+++ b/packages/ui/src/components/sheet/sheet.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "./sheet";
+
+describe("Sheet", () => {
+  it("renders the trigger but keeps content closed by default", () => {
+    render(
+      <Sheet>
+        <SheetTrigger>Open sheet</SheetTrigger>
+        <SheetContent>
+          <SheetHeader>
+            <SheetTitle>Title</SheetTitle>
+          </SheetHeader>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    expect(screen.getByText("Open sheet")).toBeInTheDocument();
+    expect(screen.queryByText("Title")).not.toBeInTheDocument();
+  });
+
+  it("renders the content when defaultOpen is true", () => {
+    render(
+      <Sheet defaultOpen>
+        <SheetContent>
+          <SheetHeader>
+            <SheetTitle>Title</SheetTitle>
+            <SheetDescription>Description</SheetDescription>
+          </SheetHeader>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    expect(screen.getByText("Title")).toBeInTheDocument();
+    expect(screen.getByText("Description")).toBeInTheDocument();
+  });
+
+  it("supports the side variant prop", () => {
+    render(
+      <Sheet defaultOpen>
+        <SheetContent side="left">
+          <SheetTitle>Title</SheetTitle>
+          <SheetDescription>Description</SheetDescription>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    expect(screen.getByText("Title")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/table/table.test.tsx
+++ b/packages/ui/src/components/table/table.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./table";
+
+describe("Table", () => {
+  it("renders rows + cells in a table", () => {
+    render(
+      <Table>
+        <TableCaption>Run history</TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead>ID</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>r-1</TableCell>
+            <TableCell>complete</TableCell>
+          </TableRow>
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell colSpan={2}>1 run</TableCell>
+          </TableRow>
+        </TableFooter>
+      </Table>,
+    );
+
+    expect(screen.getByText("Run history")).toBeInTheDocument();
+    expect(screen.getByText("ID")).toBeInTheDocument();
+    expect(screen.getByText("r-1")).toBeInTheDocument();
+    expect(screen.getByText("1 run")).toBeInTheDocument();
+  });
+
+  it("merges the className prop on the root", () => {
+    const { container } = render(
+      <Table className="extra">
+        <TableBody>
+          <TableRow>
+            <TableCell>x</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>,
+    );
+
+    expect(container.querySelector("table")).toHaveClass("extra");
+  });
+});

--- a/packages/ui/src/components/tabs/tabs.test.tsx
+++ b/packages/ui/src/components/tabs/tabs.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs";
+
+describe("Tabs", () => {
+  it("renders the default panel only", () => {
+    render(
+      <Tabs defaultValue="a">
+        <TabsList>
+          <TabsTrigger value="a">A</TabsTrigger>
+          <TabsTrigger value="b">B</TabsTrigger>
+        </TabsList>
+        <TabsContent value="a">Panel A</TabsContent>
+        <TabsContent value="b">Panel B</TabsContent>
+      </Tabs>,
+    );
+
+    expect(screen.getByText("Panel A")).toBeInTheDocument();
+    expect(screen.queryByText("Panel B")).not.toBeInTheDocument();
+  });
+
+  it("switches the active panel when a trigger is clicked", () => {
+    render(
+      <Tabs defaultValue="a">
+        <TabsList>
+          <TabsTrigger value="a">A</TabsTrigger>
+          <TabsTrigger value="b">B</TabsTrigger>
+        </TabsList>
+        <TabsContent value="a">Panel A</TabsContent>
+        <TabsContent value="b">Panel B</TabsContent>
+      </Tabs>,
+    );
+
+    fireEvent.click(screen.getByText("B"));
+
+    expect(screen.getByText("Panel B")).toBeInTheDocument();
+    expect(screen.queryByText("Panel A")).not.toBeInTheDocument();
+  });
+
+  it("invokes onValueChange when a trigger is clicked", () => {
+    const onValueChange = vi.fn();
+    render(
+      <Tabs defaultValue="a" onValueChange={onValueChange}>
+        <TabsList>
+          <TabsTrigger value="a">A</TabsTrigger>
+          <TabsTrigger value="b">B</TabsTrigger>
+        </TabsList>
+        <TabsContent value="a">Panel A</TabsContent>
+        <TabsContent value="b">Panel B</TabsContent>
+      </Tabs>,
+    );
+
+    fireEvent.click(screen.getByText("B"));
+
+    expect(onValueChange).toHaveBeenCalledWith("b");
+  });
+
+  it("propagates aria-selected to the active trigger", () => {
+    render(
+      <Tabs defaultValue="a">
+        <TabsList>
+          <TabsTrigger value="a">A</TabsTrigger>
+          <TabsTrigger value="b">B</TabsTrigger>
+        </TabsList>
+      </Tabs>,
+    );
+
+    expect(screen.getByText("A")).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("B")).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("uses the tablist landmark", () => {
+    const { container } = render(
+      <Tabs defaultValue="a">
+        <TabsList>
+          <TabsTrigger value="a">A</TabsTrigger>
+        </TabsList>
+      </Tabs>,
+    );
+
+    expect(container.querySelector("[role='tablist']")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What's in

Adds Vitest tests for five primitives shipped on \`main\` without test coverage:

- \`Tabs\` (+ \`TabsList\` / \`TabsTrigger\` / \`TabsContent\`) — default panel + click-to-switch + onValueChange + aria-selected + tablist landmark
- \`Sheet\` (+ \`SheetTrigger\` / \`SheetContent\` / \`SheetHeader\` / \`SheetTitle\` / \`SheetDescription\`) — closed by default + defaultOpen + side variant
- \`Table\` (+ \`TableHeader\` / \`TableBody\` / \`TableRow\` / \`TableHead\` / \`TableCell\` / \`TableCaption\` / \`TableFooter\`) — caption + rows + className merge
- \`LearningObjectives\` (+ \`Prerequisites\` / \`Summary\`) — default title + objectives + estimated time + level chip + key takeaways
- \`ProgressCard\` / \`ContentCard\` — title + description + badge + metadata + tags + href wrap

20 new tests total. No source changes — these are net-new test files.

## Why

Continues the tests-coverage track started in PRs #221–#227.

## Files

- \`packages/ui/src/components/tabs/tabs.test.tsx\`
- \`packages/ui/src/components/sheet/sheet.test.tsx\`
- \`packages/ui/src/components/table/table.test.tsx\`
- \`packages/ui/src/components/learning-objectives/learning-objectives.test.tsx\`
- \`packages/ui/src/components/progress-card/progress-card.test.tsx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck: PASS
- test: PASS (full suite incl. 20 new)
- build: PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)

Refs #231