### PR TITLE
test(ui): add tests for 5 primitives (Checklist + CompletionDialog + Terminal + ShareDialog + ThemeToggle)

### DIFF
--- a/packages/ui/src/components/checklist/checklist.test.tsx
+++ b/packages/ui/src/components/checklist/checklist.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Checklist, type ChecklistItem } from "./checklist";
+
+const items: ChecklistItem[] = [
+  { id: "a", label: "Step A" },
+  { description: "explain", id: "b", label: "Step B" },
+  { id: "c", label: "Step C" },
+];
+
+describe("Checklist", () => {
+  it("renders one entry per item", () => {
+    render(<Checklist items={items} />);
+
+    expect(screen.getByText("Step A")).toBeInTheDocument();
+    expect(screen.getByText("Step B")).toBeInTheDocument();
+    expect(screen.getByText("Step C")).toBeInTheDocument();
+  });
+
+  it("renders the optional description", () => {
+    render(<Checklist items={items} />);
+
+    expect(screen.getByText("explain")).toBeInTheDocument();
+  });
+
+  it("renders the title + progress when provided", () => {
+    render(<Checklist items={items} title="Onboarding" />);
+
+    expect(screen.getByText("Onboarding")).toBeInTheDocument();
+    expect(screen.getByText(/0\/3/)).toBeInTheDocument();
+  });
+
+  it("toggles an item when its row is clicked", () => {
+    render(<Checklist items={items} title="t" />);
+
+    fireEvent.click(screen.getByText("Step A"));
+    expect(screen.getByText(/1\/3/)).toBeInTheDocument();
+  });
+
+  it("invokes onComplete when every item is checked", () => {
+    const onComplete = vi.fn();
+    render(<Checklist items={items} onComplete={onComplete} title="t" />);
+
+    fireEvent.click(screen.getByText("Step A"));
+    fireEvent.click(screen.getByText("Step B"));
+    fireEvent.click(screen.getByText("Step C"));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("All items completed!")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/completion-dialog/completion-dialog.test.tsx
+++ b/packages/ui/src/components/completion-dialog/completion-dialog.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CompletionDialog } from "./completion-dialog";
+
+const baseProps = {
+  onCancel: vi.fn(),
+  onClose: vi.fn(),
+  onConfirm: vi.fn(),
+  title: "Done?",
+};
+
+describe("CompletionDialog", () => {
+  it("renders nothing when isOpen is false", () => {
+    const { container } = render(
+      <CompletionDialog {...baseProps} isOpen={false} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the title and default labels when open", () => {
+    render(<CompletionDialog {...baseProps} isOpen />);
+
+    expect(screen.getByText("Done?")).toBeInTheDocument();
+    expect(screen.getByText("Skip")).toBeInTheDocument();
+    expect(screen.getByText("Done")).toBeInTheDocument();
+  });
+
+  it("uses override labels when provided", () => {
+    render(
+      <CompletionDialog
+        {...baseProps}
+        cancelLabel="Later"
+        confirmLabel="Mark complete"
+        isOpen
+      />,
+    );
+
+    expect(screen.getByText("Later")).toBeInTheDocument();
+    expect(screen.getByText("Mark complete")).toBeInTheDocument();
+  });
+
+  it("invokes onConfirm when the confirm button is clicked", () => {
+    const onConfirm = vi.fn();
+    render(<CompletionDialog {...baseProps} isOpen onConfirm={onConfirm} />);
+
+    fireEvent.click(screen.getByText("Done"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onCancel when the cancel button is clicked", () => {
+    const onCancel = vi.fn();
+    render(<CompletionDialog {...baseProps} isOpen onCancel={onCancel} />);
+
+    fireEvent.click(screen.getByText("Skip"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onClose when Escape is pressed", () => {
+    const onClose = vi.fn();
+    render(<CompletionDialog {...baseProps} isOpen onClose={onClose} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onClose when the close icon button is clicked", () => {
+    const onClose = vi.fn();
+    render(<CompletionDialog {...baseProps} isOpen onClose={onClose} />);
+
+    fireEvent.click(screen.getByLabelText("Close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/share-dialog/share-dialog.test.tsx
+++ b/packages/ui/src/components/share-dialog/share-dialog.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ShareDialog, type SharePlatform } from "./share-dialog";
+
+const platforms: SharePlatform[] = [
+  {
+    buildUrl: (url, title) =>
+      `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(title)}`,
+    key: "x",
+    label: "X",
+  },
+  {
+    buildUrl: (url) =>
+      `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`,
+    key: "linkedin",
+    label: "LinkedIn",
+  },
+];
+
+describe("ShareDialog", () => {
+  it("keeps content closed by default", () => {
+    render(<ShareDialog platforms={platforms} />);
+
+    expect(screen.queryByText("Share")).not.toBeInTheDocument();
+  });
+
+  it("renders the title + platform buttons when open", () => {
+    render(<ShareDialog open platforms={platforms} />);
+
+    expect(screen.getByText("Share")).toBeInTheDocument();
+    expect(screen.getByText("X")).toBeInTheDocument();
+    expect(screen.getByText("LinkedIn")).toBeInTheDocument();
+  });
+
+  it("renders the override title and description", () => {
+    render(
+      <ShareDialog
+        description="Share this run"
+        open
+        platforms={platforms}
+        title="Send"
+      />,
+    );
+
+    expect(screen.getByText("Send")).toBeInTheDocument();
+    expect(screen.getByText("Share this run")).toBeInTheDocument();
+  });
+
+  it("renders the copy-link button with the default label", () => {
+    render(<ShareDialog open platforms={platforms} />);
+
+    expect(screen.getByText("Copy link")).toBeInTheDocument();
+  });
+
+  it("renders the copy-link button with override labels", () => {
+    render(
+      <ShareDialog
+        labels={{ copied: "Copied", copyLink: "Get link" }}
+        open
+        platforms={platforms}
+      />,
+    );
+
+    expect(screen.getByText("Get link")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/terminal/terminal.test.tsx
+++ b/packages/ui/src/components/terminal/terminal.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Terminal } from "./terminal";
+
+const sampleLines = [
+  { content: "install deps", type: "comment" } as const,
+  { content: "pnpm install", type: "command" } as const,
+  { content: "Done in 6.5s", type: "output" } as const,
+];
+
+describe("Terminal", () => {
+  it("renders the title (default + override)", () => {
+    const { rerender } = render(<Terminal lines={sampleLines} />);
+
+    expect(screen.getByText("Terminal")).toBeInTheDocument();
+
+    rerender(<Terminal lines={sampleLines} title="Logs" />);
+    expect(screen.getByText("Logs")).toBeInTheDocument();
+  });
+
+  it("renders one row per line", () => {
+    render(<Terminal lines={sampleLines} />);
+
+    expect(screen.getByText("# install deps")).toBeInTheDocument();
+    expect(screen.getByText("pnpm install")).toBeInTheDocument();
+    expect(screen.getByText("Done in 6.5s")).toBeInTheDocument();
+  });
+
+  it("hides the copy button when copyable is false", () => {
+    render(<Terminal copyable={false} lines={sampleLines} />);
+
+    expect(screen.queryByLabelText(/copy/i)).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/theme-toggle/theme-toggle.test.tsx
+++ b/packages/ui/src/components/theme-toggle/theme-toggle.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { ThemeProvider } from "../theme-provider";
+
+import { ThemeToggle } from "./theme-toggle";
+
+const noop = (): void => undefined;
+
+beforeEach(() => {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: (query: string) => ({
+      addEventListener: noop,
+      addListener: noop,
+      dispatchEvent: () => false,
+      matches: false,
+      media: query,
+      onchange: null,
+      removeEventListener: noop,
+      removeListener: noop,
+    }),
+    writable: true,
+  });
+});
+
+const dict = {
+  theme: {
+    dark: "Dark",
+    light: "Light",
+    system: "System",
+    toggle_theme: "Toggle theme",
+  },
+};
+
+describe("ThemeToggle", () => {
+  it("renders an accessible toggle button", () => {
+    render(
+      <ThemeProvider attribute="class">
+        <ThemeToggle dict={dict} />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByLabelText("Toggle theme")).toBeInTheDocument();
+  });
+
+  it("uses the localized aria-label", () => {
+    render(
+      <ThemeProvider attribute="class">
+        <ThemeToggle
+          dict={{
+            theme: {
+              dark: "Sombre",
+              light: "Clair",
+              system: "Système",
+              toggle_theme: "Changer le thème",
+            },
+          }}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByLabelText("Changer le thème")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What's in

Adds Vitest tests for five primitives shipped on \`main\` without test coverage:

- \`Checklist\` — item rendering + description slot + title / progress + toggle + onComplete + all-checked banner
- \`CompletionDialog\` — closed-when-isOpen-false + open + label override + confirm / cancel / Escape / close handlers
- \`Terminal\` — title (default + override) + per-type line rendering + copyable=false hides copy button
- \`ShareDialog\` — closed-by-default + open with title / platforms + description + override labels
- \`ThemeToggle\` — accessible \`aria-label\` (default + localized)

22 new tests total. \`ThemeToggle\` reuses the \`window.matchMedia\` stub from PR #224 for \`next-themes\`. No source changes — these are net-new test files.

## Why

Continues the tests-coverage track started in PRs #221–#229.

## Files

- \`packages/ui/src/components/checklist/checklist.test.tsx\`
- \`packages/ui/src/components/completion-dialog/completion-dialog.test.tsx\`
- \`packages/ui/src/components/terminal/terminal.test.tsx\`
- \`packages/ui/src/components/share-dialog/share-dialog.test.tsx\`
- \`packages/ui/src/components/theme-toggle/theme-toggle.test.tsx\`

## Quality gates

- lint: PASS (\`pnpm -F @vllnt/ui lint\` clean — full suite)
- typecheck: PASS
- test: PASS (full suite incl. 22 new)
- build: PASS
- build-storybook: PASS

## Test plan

- [ ] CI green (lint + typecheck + build + test + storybook)

Refs #231