### PR TITLE
feat(registry): hybrid CLI installs — leaf source + @vllnt/ui for siblings

### DIFF
--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -10,7 +10,8 @@
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "registry:build": "shadcn build",
+    "registry:build": "tsx scripts/inline-component-source.ts && shadcn build",
+    "registry:sync-shims": "tsx scripts/inline-component-source.ts",
     "sync-storybook": "tsx scripts/sync-from-storybook.ts"
   },
   "dependencies": {

--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -15,7 +15,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -30,7 +32,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -45,7 +49,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -61,6 +67,7 @@
       ],
       "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "lucide-react"
       ],
       "category": "ai"
@@ -76,11 +83,9 @@
           "type": "registry:component"
         }
       ],
-      "registryDependencies": [
-        "badge",
-        "button"
-      ],
+      "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "lucide-react"
       ],
       "category": "ai"
@@ -98,6 +103,7 @@
       ],
       "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "lucide-react"
       ],
       "category": "learning"
@@ -115,9 +121,28 @@
       ],
       "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "class-variance-authority"
       ],
       "category": "learning"
+    },
+    {
+      "name": "ai-sidebar",
+      "type": "registry:component",
+      "title": "AI Sidebar",
+      "description": "Slide-out AI assistant panel with provider, header / content / footer slots, and a standalone trigger.",
+      "files": [
+        {
+          "path": "registry/default/ai-sidebar/ai-sidebar.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1",
+        "lucide-react"
+      ],
+      "category": "ai"
     },
     {
       "name": "ai-source-citation",
@@ -132,6 +157,7 @@
       ],
       "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "lucide-react"
       ],
       "category": "learning"
@@ -148,27 +174,10 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
-      "category": "learning"
-    },
-    {
-      "name": "ai-sidebar",
-      "type": "registry:component",
-      "title": "AI Sidebar",
-      "description": "Slide-out AI assistant panel with provider, header / content / footer slots, and a standalone trigger.",
-      "files": [
-        {
-          "path": "registry/default/ai-sidebar/ai-sidebar.tsx",
-          "type": "registry:component"
-        }
-      ],
-      "registryDependencies": [
-        "button"
-      ],
       "dependencies": [
-        "lucide-react"
+        "@vllnt/ui@^0.2.1"
       ],
-      "category": "ai"
+      "category": "learning"
     },
     {
       "name": "ai-tool-call-display",
@@ -183,6 +192,7 @@
       ],
       "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "class-variance-authority",
         "lucide-react"
       ],
@@ -200,7 +210,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -215,7 +227,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "overlay"
     },
     {
@@ -230,7 +244,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -245,7 +261,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -260,7 +278,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -275,7 +295,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -305,7 +327,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -319,12 +343,10 @@
           "type": "registry:component"
         }
       ],
-      "registryDependencies": [
-        "button",
-        "input",
-        "switch"
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
       ],
-      "dependencies": [],
       "category": "billing"
     },
     {
@@ -339,7 +361,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "core"
     },
     {
@@ -354,7 +378,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -369,7 +395,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "core"
     },
     {
@@ -385,6 +413,7 @@
       ],
       "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "lucide-react",
         "class-variance-authority",
         "@radix-ui/react-slot"
@@ -418,7 +447,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -433,7 +464,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -448,7 +481,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -463,7 +498,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -478,7 +515,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "core"
     },
     {
@@ -493,7 +532,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "form"
     },
     {
@@ -508,7 +549,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -523,7 +566,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -538,7 +583,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -553,7 +600,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -568,7 +617,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -583,7 +634,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -598,7 +651,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "form"
     },
     {
@@ -613,23 +668,10 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
-      "category": "core"
-    },
-    {
-      "name": "chronological-timeline",
-      "type": "registry:component",
-      "title": "Chronological Timeline",
-      "description": "Media-rich, scroll-driven chronological timeline with alternating cards, image/video/audio media, and a progress strip.",
-      "files": [
-        {
-          "path": "registry/default/chronological-timeline/chronological-timeline.tsx",
-          "type": "registry:component"
-        }
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
       ],
-      "registryDependencies": [],
-      "dependencies": [],
-      "category": "data-display"
+      "category": "core"
     },
     {
       "name": "checklist",
@@ -643,7 +685,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -658,7 +702,26 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
+      "category": "data-display"
+    },
+    {
+      "name": "chronological-timeline",
+      "type": "registry:component",
+      "title": "Chronological Timeline",
+      "description": "Media-rich, scroll-driven chronological timeline with alternating cards, image/video/audio media, and a progress strip.",
+      "files": [
+        {
+          "path": "registry/default/chronological-timeline/chronological-timeline.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data-display"
     },
     {
@@ -672,10 +735,9 @@
           "type": "registry:component"
         }
       ],
-      "registryDependencies": [
-        "badge"
-      ],
+      "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "lucide-react"
       ],
       "category": "educational"
@@ -692,28 +754,10 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
-      "category": "content"
-    },
-    {
-      "name": "copy-button",
-      "type": "registry:component",
-      "title": "Copy Button",
-      "description": "Click-to-copy utility with confirmation feedback and a useCopyToClipboard hook.",
-      "files": [
-        {
-          "path": "registry/default/copy-button/copy-button.tsx",
-          "type": "registry:component"
-        }
-      ],
-      "registryDependencies": [
-        "button",
-        "tooltip"
-      ],
       "dependencies": [
-        "lucide-react"
+        "@vllnt/ui@^0.2.1"
       ],
-      "category": "core"
+      "category": "content"
     },
     {
       "name": "code-playground",
@@ -727,7 +771,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -742,7 +788,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -757,7 +805,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "form"
     },
     {
@@ -772,7 +822,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "overlay"
     },
     {
@@ -787,7 +839,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -802,7 +856,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -817,7 +873,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -832,7 +890,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -847,7 +907,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -862,7 +924,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -877,8 +941,28 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "overlay"
+    },
+    {
+      "name": "copy-button",
+      "type": "registry:component",
+      "title": "Copy Button",
+      "description": "Click-to-copy utility with confirmation feedback and a useCopyToClipboard hook.",
+      "files": [
+        {
+          "path": "registry/default/copy-button/copy-button.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1",
+        "lucide-react"
+      ],
+      "category": "core"
     },
     {
       "name": "countdown-timer",
@@ -892,7 +976,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -907,7 +993,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -922,7 +1010,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -938,6 +1028,7 @@
       ],
       "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "@tanstack/react-table"
       ],
       "category": "data"
@@ -954,7 +1045,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "form"
     },
     {
@@ -969,22 +1062,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
-      "category": "overlay"
-    },
-    {
-      "name": "drawer",
-      "type": "registry:component",
-      "title": "Drawer",
-      "description": "Slide-out panel anchored to the screen edge.",
-      "files": [
-        {
-          "path": "registry/default/drawer/drawer.tsx",
-          "type": "registry:component"
-        }
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
       ],
-      "registryDependencies": [],
-      "dependencies": [],
       "category": "overlay"
     },
     {
@@ -1000,9 +1080,27 @@
       ],
       "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "class-variance-authority"
       ],
       "category": "content"
+    },
+    {
+      "name": "drawer",
+      "type": "registry:component",
+      "title": "Drawer",
+      "description": "Slide-out panel anchored to the screen edge.",
+      "files": [
+        {
+          "path": "registry/default/drawer/drawer.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
+      "category": "overlay"
     },
     {
       "name": "dropdown-menu",
@@ -1016,7 +1114,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "overlay"
     },
     {
@@ -1031,7 +1131,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "overlay"
     },
     {
@@ -1047,6 +1149,7 @@
       ],
       "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "class-variance-authority"
       ],
       "category": "core"
@@ -1063,7 +1166,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "educational"
     },
     {
@@ -1078,7 +1183,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -1093,7 +1200,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -1108,7 +1217,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "form"
     },
     {
@@ -1123,7 +1234,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "form"
     },
     {
@@ -1138,7 +1251,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -1153,7 +1268,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -1168,7 +1285,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data-display"
     },
     {
@@ -1183,7 +1302,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -1198,7 +1319,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data-display"
     },
     {
@@ -1212,11 +1335,10 @@
           "type": "registry:component"
         }
       ],
-      "registryDependencies": [
-        "input",
-        "label"
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
       ],
-      "dependencies": [],
       "category": "form"
     },
     {
@@ -1231,7 +1353,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -1246,7 +1370,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data-display"
     },
     {
@@ -1261,7 +1387,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data-display"
     },
     {
@@ -1276,7 +1404,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -1291,7 +1421,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data-display"
     },
     {
@@ -1306,7 +1438,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data-display"
     },
     {
@@ -1321,27 +1455,10 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
-      "category": "data"
-    },
-    {
-      "name": "horizontal-scroll-row",
-      "type": "registry:component",
-      "title": "Horizontal Scroll Row",
-      "description": "Horizontal scroll container with snap scrolling, chevron navigation, and hidden scrollbar.",
-      "files": [
-        {
-          "path": "registry/default/horizontal-scroll-row/horizontal-scroll-row.tsx",
-          "type": "registry:component"
-        }
-      ],
-      "registryDependencies": [
-        "button"
-      ],
       "dependencies": [
-        "lucide-react"
+        "@vllnt/ui@^0.2.1"
       ],
-      "category": "navigation"
+      "category": "data"
     },
     {
       "name": "historic-timeline",
@@ -1355,8 +1472,46 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data-display"
+    },
+    {
+      "name": "historical-figure-card",
+      "type": "registry:component",
+      "title": "Historical Figure Card",
+      "description": "Profile card with portrait, lifespan timeline, fields, works, quote, connections, and an expandable biography section.",
+      "files": [
+        {
+          "path": "registry/default/historical-figure-card/historical-figure-card.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1",
+        "lucide-react"
+      ],
+      "category": "educational"
+    },
+    {
+      "name": "horizontal-scroll-row",
+      "type": "registry:component",
+      "title": "Horizontal Scroll Row",
+      "description": "Horizontal scroll container with snap scrolling, chevron navigation, and hidden scrollbar.",
+      "files": [
+        {
+          "path": "registry/default/horizontal-scroll-row/horizontal-scroll-row.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1",
+        "lucide-react"
+      ],
+      "category": "navigation"
     },
     {
       "name": "hover-card",
@@ -1370,28 +1525,10 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
-      "category": "overlay"
-    },
-    {
-      "name": "historical-figure-card",
-      "type": "registry:component",
-      "title": "Historical Figure Card",
-      "description": "Profile card with portrait, lifespan timeline, fields, works, quote, connections, and an expandable biography section.",
-      "files": [
-        {
-          "path": "registry/default/historical-figure-card/historical-figure-card.tsx",
-          "type": "registry:component"
-        }
-      ],
-      "registryDependencies": [
-        "avatar",
-        "badge"
-      ],
       "dependencies": [
-        "lucide-react"
+        "@vllnt/ui@^0.2.1"
       ],
-      "category": "educational"
+      "category": "overlay"
     },
     {
       "name": "infinite-plane",
@@ -1405,7 +1542,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -1420,23 +1559,10 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
-      "category": "form"
-    },
-    {
-      "name": "interactive-timeline",
-      "type": "registry:component",
-      "title": "Interactive Timeline",
-      "description": "Zoomable, pannable, multi-track timeline with category filter, today marker, and click-to-select events.",
-      "files": [
-        {
-          "path": "registry/default/interactive-timeline/interactive-timeline.tsx",
-          "type": "registry:component"
-        }
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
       ],
-      "registryDependencies": [],
-      "dependencies": [],
-      "category": "data-display"
+      "category": "form"
     },
     {
       "name": "input",
@@ -1450,7 +1576,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "core"
     },
     {
@@ -1465,8 +1593,27 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "form"
+    },
+    {
+      "name": "interactive-timeline",
+      "type": "registry:component",
+      "title": "Interactive Timeline",
+      "description": "Zoomable, pannable, multi-track timeline with category filter, today marker, and click-to-select events.",
+      "files": [
+        {
+          "path": "registry/default/interactive-timeline/interactive-timeline.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
+      "category": "data-display"
     },
     {
       "name": "jarvis-dock",
@@ -1480,7 +1627,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -1496,6 +1645,7 @@
       ],
       "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "class-variance-authority"
       ],
       "category": "core"
@@ -1512,7 +1662,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -1527,7 +1679,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -1541,11 +1695,9 @@
           "type": "registry:component"
         }
       ],
-      "registryDependencies": [
-        "button",
-        "input"
-      ],
+      "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "lucide-react"
       ],
       "category": "educational"
@@ -1562,7 +1714,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -1577,7 +1731,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -1592,7 +1748,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -1622,7 +1780,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -1637,22 +1797,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
-      "category": "data"
-    },
-    {
-      "name": "market-treemap",
-      "type": "registry:component",
-      "title": "Market Treemap",
-      "description": "Sector-style market heatmap using weighted tiles and signed performance colors.",
-      "files": [
-        {
-          "path": "registry/default/market-treemap/market-treemap.tsx",
-          "type": "registry:component"
-        }
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
       ],
-      "registryDependencies": [],
-      "dependencies": [],
       "category": "data"
     },
     {
@@ -1667,23 +1814,10 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
-      "category": "data-display"
-    },
-    {
-      "name": "marquee",
-      "type": "registry:component",
-      "title": "Marquee",
-      "description": "Continuously scrolling content lane for badges, logos, and status chips.",
-      "files": [
-        {
-          "path": "registry/default/marquee/marquee.tsx",
-          "type": "registry:component"
-        }
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
       ],
-      "registryDependencies": [],
-      "dependencies": [],
-      "category": "utility"
+      "category": "data-display"
     },
     {
       "name": "map-timeline",
@@ -1697,8 +1831,44 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data-display"
+    },
+    {
+      "name": "market-treemap",
+      "type": "registry:component",
+      "title": "Market Treemap",
+      "description": "Sector-style market heatmap using weighted tiles and signed performance colors.",
+      "files": [
+        {
+          "path": "registry/default/market-treemap/market-treemap.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
+      "category": "data"
+    },
+    {
+      "name": "marquee",
+      "type": "registry:component",
+      "title": "Marquee",
+      "description": "Continuously scrolling content lane for badges, logos, and status chips.",
+      "files": [
+        {
+          "path": "registry/default/marquee/marquee.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
+      "category": "utility"
     },
     {
       "name": "mdx-content",
@@ -1712,7 +1882,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -1727,7 +1899,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -1742,7 +1916,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -1757,7 +1933,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -1772,7 +1950,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -1786,11 +1966,9 @@
           "type": "registry:component"
         }
       ],
-      "registryDependencies": [
-        "badge",
-        "button"
-      ],
+      "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "lucide-react"
       ],
       "category": "ai"
@@ -1807,7 +1985,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "form"
     },
     {
@@ -1821,13 +2001,10 @@
           "type": "registry:component"
         }
       ],
-      "registryDependencies": [
-        "badge",
-        "button",
-        "command",
-        "popover"
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
       ],
-      "dependencies": [],
       "category": "form"
     },
     {
@@ -1842,7 +2019,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -1857,7 +2036,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -1872,7 +2053,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -1886,11 +2069,9 @@
           "type": "registry:component"
         }
       ],
-      "registryDependencies": [
-        "button",
-        "input"
-      ],
+      "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "lucide-react"
       ],
       "category": "form"
@@ -1907,7 +2088,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "form"
     },
     {
@@ -1922,7 +2105,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -1937,7 +2122,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -1952,7 +2139,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -1967,7 +2156,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -1982,7 +2173,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -1997,7 +2190,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -2012,7 +2207,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "educational"
     },
     {
@@ -2027,7 +2224,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "form"
     },
     {
@@ -2042,7 +2241,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -2057,7 +2258,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -2072,7 +2275,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -2087,7 +2292,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "overlay"
     },
     {
@@ -2102,7 +2309,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -2117,7 +2326,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -2131,13 +2342,29 @@
           "type": "registry:component"
         }
       ],
-      "registryDependencies": [
-        "button"
-      ],
+      "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "lucide-react"
       ],
       "category": "billing"
+    },
+    {
+      "name": "primary-source-viewer",
+      "type": "registry:component",
+      "title": "Primary Source Viewer",
+      "description": "Document viewer for historical primary sources with zoom, rotate, region annotations, transcription panel, and metadata footer.",
+      "files": [
+        {
+          "path": "registry/default/primary-source-viewer/primary-source-viewer.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
+      "category": "data-display"
     },
     {
       "name": "pro-tip",
@@ -2151,7 +2378,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -2166,23 +2395,10 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
-      "category": "learning"
-    },
-    {
-      "name": "primary-source-viewer",
-      "type": "registry:component",
-      "title": "Primary Source Viewer",
-      "description": "Document viewer for historical primary sources with zoom, rotate, region annotations, transcription panel, and metadata footer.",
-      "files": [
-        {
-          "path": "registry/default/primary-source-viewer/primary-source-viewer.tsx",
-          "type": "registry:component"
-        }
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
       ],
-      "registryDependencies": [],
-      "dependencies": [],
-      "category": "data-display"
+      "category": "learning"
     },
     {
       "name": "progress-bar",
@@ -2196,29 +2412,10 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
-      "category": "data"
-    },
-    {
-      "name": "prompt-templates",
-      "type": "registry:component",
-      "title": "Prompt Templates",
-      "description": "Searchable prompt template gallery with category filter, variable fill-in form, and onSelect.",
-      "files": [
-        {
-          "path": "registry/default/prompt-templates/prompt-templates.tsx",
-          "type": "registry:component"
-        }
-      ],
-      "registryDependencies": [
-        "badge",
-        "button",
-        "input"
-      ],
       "dependencies": [
-        "lucide-react"
+        "@vllnt/ui@^0.2.1"
       ],
-      "category": "ai"
+      "category": "data"
     },
     {
       "name": "progress-card",
@@ -2232,8 +2429,28 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
+    },
+    {
+      "name": "prompt-templates",
+      "type": "registry:component",
+      "title": "Prompt Templates",
+      "description": "Searchable prompt template gallery with category filter, variable fill-in form, and onSelect.",
+      "files": [
+        {
+          "path": "registry/default/prompt-templates/prompt-templates.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1",
+        "lucide-react"
+      ],
+      "category": "ai"
     },
     {
       "name": "property-section",
@@ -2247,7 +2464,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -2262,7 +2481,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -2277,7 +2498,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "core"
     },
     {
@@ -2292,7 +2515,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -2307,7 +2532,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -2322,7 +2549,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -2337,7 +2566,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -2352,7 +2583,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -2367,7 +2600,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data-display"
     },
     {
@@ -2382,7 +2617,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -2397,7 +2634,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -2412,7 +2651,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -2427,38 +2668,10 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "form"
-    },
-    {
-      "name": "selection-halo",
-      "type": "registry:component",
-      "title": "Selection Halo",
-      "description": "Local-user selection halo with corner handles + label slot for spatial canvases.",
-      "files": [
-        {
-          "path": "registry/default/selection-halo/selection-halo.tsx",
-          "type": "registry:component"
-        }
-      ],
-      "registryDependencies": [],
-      "dependencies": [],
-      "category": "data-display"
-    },
-    {
-      "name": "snap-guides",
-      "type": "registry:component",
-      "title": "Snap Guides",
-      "description": "Alignment guide overlay — dashed vertical and horizontal lines that surface during a drag.",
-      "files": [
-        {
-          "path": "registry/default/snap-guides/snap-guides.tsx",
-          "type": "registry:component"
-        }
-      ],
-      "registryDependencies": [],
-      "dependencies": [],
-      "category": "data-display"
     },
     {
       "name": "scroll-area",
@@ -2472,7 +2685,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -2487,7 +2702,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "form"
     },
     {
@@ -2502,7 +2719,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -2516,10 +2735,10 @@
           "type": "registry:component"
         }
       ],
-      "registryDependencies": [
-        "toggle-group"
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
       ],
-      "dependencies": [],
       "category": "form"
     },
     {
@@ -2534,8 +2753,27 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "form"
+    },
+    {
+      "name": "selection-halo",
+      "type": "registry:component",
+      "title": "Selection Halo",
+      "description": "Local-user selection halo with corner handles + label slot for spatial canvases.",
+      "files": [
+        {
+          "path": "registry/default/selection-halo/selection-halo.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
+      "category": "data-display"
     },
     {
       "name": "selection-presence",
@@ -2549,7 +2787,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -2564,7 +2804,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "core"
     },
     {
@@ -2579,7 +2821,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -2594,7 +2838,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -2609,7 +2855,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "overlay"
     },
     {
@@ -2624,7 +2872,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -2639,7 +2889,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -2655,6 +2907,7 @@
       ],
       "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "lucide-react"
       ],
       "category": "navigation"
@@ -2671,7 +2924,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "core"
     },
     {
@@ -2686,7 +2941,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "core"
     },
     {
@@ -2701,8 +2958,27 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
+    },
+    {
+      "name": "snap-guides",
+      "type": "registry:component",
+      "title": "Snap Guides",
+      "description": "Alignment guide overlay — dashed vertical and horizontal lines that surface during a drag.",
+      "files": [
+        {
+          "path": "registry/default/snap-guides/snap-guides.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
+      "category": "data-display"
     },
     {
       "name": "sparkline-grid",
@@ -2716,7 +2992,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -2731,7 +3009,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -2746,7 +3026,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -2761,7 +3043,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -2776,7 +3060,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -2791,7 +3077,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -2806,7 +3094,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -2821,7 +3111,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -2836,7 +3128,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -2851,7 +3145,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -2866,7 +3162,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data-display"
     },
     {
@@ -2881,7 +3179,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -2896,7 +3196,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -2911,7 +3213,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -2926,7 +3230,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -2941,7 +3247,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -2955,10 +3263,10 @@
           "type": "registry:component"
         }
       ],
-      "registryDependencies": [
-        "badge"
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
       ],
-      "dependencies": [],
       "category": "form"
     },
     {
@@ -2973,7 +3281,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -2988,7 +3298,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "core"
     },
     {
@@ -3003,7 +3315,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -3018,7 +3332,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -3034,6 +3350,7 @@
       ],
       "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "lucide-react"
       ],
       "category": "learning"
@@ -3050,7 +3367,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "utility"
     },
     {
@@ -3065,7 +3384,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -3080,7 +3401,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -3096,6 +3419,7 @@
       ],
       "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "class-variance-authority"
       ],
       "category": "content"
@@ -3112,25 +3436,10 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "form"
-    },
-    {
-      "name": "transaction-list",
-      "type": "registry:component",
-      "title": "Transaction List",
-      "description": "Chronological credit/debit history with locale-aware currency formatting and a pinned subscription row.",
-      "files": [
-        {
-          "path": "registry/default/transaction-list/transaction-list.tsx",
-          "type": "registry:component"
-        }
-      ],
-      "registryDependencies": [
-        "badge"
-      ],
-      "dependencies": [],
-      "category": "billing"
     },
     {
       "name": "tldr-section",
@@ -3144,7 +3453,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -3159,7 +3470,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "overlay"
     },
     {
@@ -3174,7 +3487,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "core"
     },
     {
@@ -3189,23 +3504,10 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
-      "category": "core"
-    },
-    {
-      "name": "tree-view",
-      "type": "registry:component",
-      "title": "Tree View",
-      "description": "Hierarchical tree component for nested data with controlled state, single/multi-select, and keyboard navigation.",
-      "files": [
-        {
-          "path": "registry/default/tree-view/tree-view.tsx",
-          "type": "registry:component"
-        }
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
       ],
-      "registryDependencies": [],
-      "dependencies": [],
-      "category": "data-display"
+      "category": "core"
     },
     {
       "name": "tooltip",
@@ -3219,7 +3521,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "overlay"
     },
     {
@@ -3234,7 +3538,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -3249,8 +3555,44 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
+    },
+    {
+      "name": "transaction-list",
+      "type": "registry:component",
+      "title": "Transaction List",
+      "description": "Chronological credit/debit history with locale-aware currency formatting and a pinned subscription row.",
+      "files": [
+        {
+          "path": "registry/default/transaction-list/transaction-list.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
+      "category": "billing"
+    },
+    {
+      "name": "tree-view",
+      "type": "registry:component",
+      "title": "Tree View",
+      "description": "Hierarchical tree component for nested data with controlled state, single/multi-select, and keyboard navigation.",
+      "files": [
+        {
+          "path": "registry/default/tree-view/tree-view.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
+      "category": "data-display"
     },
     {
       "name": "tutorial-card",
@@ -3264,7 +3606,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -3279,7 +3623,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -3294,7 +3640,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -3309,7 +3657,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -3324,7 +3674,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "learning"
     },
     {
@@ -3339,7 +3691,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -3354,7 +3708,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -3369,7 +3725,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -3384,7 +3742,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -3399,7 +3759,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "content"
     },
     {
@@ -3414,7 +3776,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -3429,7 +3793,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -3444,7 +3810,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "navigation"
     },
     {
@@ -3459,7 +3827,9 @@
         }
       ],
       "registryDependencies": [],
-      "dependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1"
+      ],
       "category": "data"
     },
     {
@@ -3475,6 +3845,7 @@
       ],
       "registryDependencies": [],
       "dependencies": [
+        "@vllnt/ui@^0.2.1",
         "lucide-react"
       ],
       "category": "overlay"

--- a/apps/registry/registry/default/accordion/accordion.tsx
+++ b/apps/registry/registry/default/accordion/accordion.tsx
@@ -1,102 +1,120 @@
-'use client'
+"use client";
 
-import { createContext, useCallback, useContext, useMemo, useState } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
 
-import type { ReactNode } from 'react'
+import type { ReactNode } from "react";
 
-import { cn } from '../../../lib/utils'
+import { cn } from "@vllnt/ui";
 
 // Context for accordion state
 type AccordionContextValue = {
-  openItems: Set<string>
-  toggleItem: (value: string) => void
-  type: 'multiple' | 'single'
-}
+  openItems: Set<string>;
+  toggleItem: (value: string) => void;
+  type: "multiple" | "single";
+};
 
-const AccordionContext = createContext<AccordionContextValue | null>(null)
+const AccordionContext = createContext<AccordionContextValue | null>(null);
 
 function useAccordionContext(): AccordionContextValue {
-  const context = useContext(AccordionContext)
+  const context = useContext(AccordionContext);
   if (!context) {
-    throw new Error('AccordionItem must be used within an Accordion')
+    throw new Error("AccordionItem must be used within an Accordion");
   }
-  return context
+  return context;
 }
 
 export type AccordionProps = {
-  children: ReactNode
-  className?: string
-  defaultValue?: string | string[]
-  type?: 'multiple' | 'single'
-}
+  children: ReactNode;
+  className?: string;
+  defaultValue?: string | string[];
+  type?: "multiple" | "single";
+};
 
 function Accordion({
   children,
   className,
   defaultValue,
-  type = 'single',
+  type = "single",
 }: AccordionProps): React.ReactNode {
   const [openItems, setOpenItems] = useState<Set<string>>(() => {
-    if (!defaultValue) return new Set()
-    if (Array.isArray(defaultValue)) return new Set(defaultValue)
-    return new Set([defaultValue])
-  })
+    if (!defaultValue) return new Set();
+    if (Array.isArray(defaultValue)) return new Set(defaultValue);
+    return new Set([defaultValue]);
+  });
 
   const toggleItem = useCallback(
     (value: string) => {
       setOpenItems((previous) => {
-        const newSet = new Set(previous)
+        const newSet = new Set(previous);
         if (newSet.has(value)) {
-          newSet.delete(value)
+          newSet.delete(value);
         } else {
-          if (type === 'single') {
-            newSet.clear()
+          if (type === "single") {
+            newSet.clear();
           }
-          newSet.add(value)
+          newSet.add(value);
         }
-        return newSet
-      })
+        return newSet;
+      });
     },
     [type],
-  )
+  );
 
   const contextValue = useMemo(
     () => ({ openItems, toggleItem, type }),
     [openItems, toggleItem, type],
-  )
+  );
 
   return (
     <AccordionContext.Provider value={contextValue}>
-      <div className={cn('my-6 divide-y divide-border rounded-lg border', className)}>
+      <div
+        className={cn(
+          "my-6 divide-y divide-border rounded-lg border",
+          className,
+        )}
+      >
         {children}
       </div>
     </AccordionContext.Provider>
-  )
+  );
 }
 
 export type AccordionItemProps = {
-  children: ReactNode
-  className?: string
-  value: string
-}
+  children: ReactNode;
+  className?: string;
+  value: string;
+};
 
-function AccordionItem({ children, className, value }: AccordionItemProps): React.ReactNode {
+function AccordionItem({
+  children,
+  className,
+  value,
+}: AccordionItemProps): React.ReactNode {
   return (
     <div
-      className={cn('first:rounded-t-lg last:rounded-b-lg overflow-hidden', className)}
+      className={cn(
+        "first:rounded-t-lg last:rounded-b-lg overflow-hidden",
+        className,
+      )}
       data-value={value}
     >
       {children}
     </div>
-  )
+  );
 }
 
 export type AccordionTriggerProps = {
-  children: ReactNode
-  className?: string
-  icon?: ReactNode
-  value: string
-}
+  children: ReactNode;
+  className?: string;
+  icon?: ReactNode;
+  value: string;
+};
 
 function AccordionTrigger({
   children,
@@ -104,20 +122,20 @@ function AccordionTrigger({
   icon,
   value,
 }: AccordionTriggerProps): React.ReactNode {
-  const { openItems, toggleItem } = useAccordionContext()
-  const isOpen = openItems.has(value)
+  const { openItems, toggleItem } = useAccordionContext();
+  const isOpen = openItems.has(value);
 
   return (
     <button
       aria-expanded={isOpen}
       className={cn(
-        'w-full flex items-center justify-between p-4 text-left font-medium transition-colors',
-        'hover:bg-muted/50',
-        isOpen && 'bg-muted/30',
+        "w-full flex items-center justify-between p-4 text-left font-medium transition-colors",
+        "hover:bg-muted/50",
+        isOpen && "bg-muted/30",
         className,
       )}
       onClick={() => {
-        toggleItem(value)
+        toggleItem(value);
       }}
       type="button"
     >
@@ -125,8 +143,8 @@ function AccordionTrigger({
       {icon ? (
         <span
           className={cn(
-            'h-4 w-4 flex-shrink-0 transition-transform duration-200',
-            isOpen && 'rotate-180',
+            "h-4 w-4 flex-shrink-0 transition-transform duration-200",
+            isOpen && "rotate-180",
           )}
         >
           {icon}
@@ -134,47 +152,61 @@ function AccordionTrigger({
       ) : (
         <svg
           className={cn(
-            'h-4 w-4 flex-shrink-0 transition-transform duration-200',
-            isOpen && 'rotate-180',
+            "h-4 w-4 flex-shrink-0 transition-transform duration-200",
+            isOpen && "rotate-180",
           )}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
         >
-          <path d="m6 9 6 6 6-6" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+          <path
+            d="m6 9 6 6 6-6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+          />
         </svg>
       )}
     </button>
-  )
+  );
 }
 
 export type AccordionContentProps = {
-  children: ReactNode
-  className?: string
-  value: string
-}
+  children: ReactNode;
+  className?: string;
+  value: string;
+};
 
-function AccordionContent({ children, className, value }: AccordionContentProps): React.ReactNode {
-  const { openItems } = useAccordionContext()
-  const isOpen = openItems.has(value)
+function AccordionContent({
+  children,
+  className,
+  value,
+}: AccordionContentProps): React.ReactNode {
+  const { openItems } = useAccordionContext();
+  const isOpen = openItems.has(value);
 
   return (
     <div
       className={cn(
-        'overflow-hidden transition-all duration-200',
-        isOpen ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0',
+        "overflow-hidden transition-all duration-200",
+        isOpen ? "max-h-[1000px] opacity-100" : "max-h-0 opacity-0",
       )}
     >
-      <div className={cn('p-4 pt-0 text-sm text-muted-foreground [&>p]:mb-2 [&>pre]:my-2', className)}>
+      <div
+        className={cn(
+          "p-4 pt-0 text-sm text-muted-foreground [&>p]:mb-2 [&>pre]:my-2",
+          className,
+        )}
+      >
         {children}
       </div>
     </div>
-  )
+  );
 }
 
 // Attach sub-components
-Accordion.Item = AccordionItem
-Accordion.Trigger = AccordionTrigger
-Accordion.Content = AccordionContent
+Accordion.Item = AccordionItem;
+Accordion.Trigger = AccordionTrigger;
+Accordion.Content = AccordionContent;
 
-export { Accordion, AccordionContent, AccordionItem, AccordionTrigger }
+export { Accordion, AccordionContent, AccordionItem, AccordionTrigger };

--- a/apps/registry/registry/default/activity-heatmap/activity-heatmap.tsx
+++ b/apps/registry/registry/default/activity-heatmap/activity-heatmap.tsx
@@ -1,1 +1,240 @@
-export * from "@vllnt/ui";
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type ActivityHeatmapItem = {
+  count: number;
+  date: string;
+};
+
+export type ActivityHeatmapProps = React.ComponentPropsWithoutRef<"div"> & {
+  data: ActivityHeatmapItem[];
+  description?: string;
+  endDate?: Date | number | string;
+  title?: string;
+  weeks?: number;
+};
+
+type DayCell = {
+  count: number;
+  date: Date;
+  key: string;
+  level: number;
+};
+
+const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const VISIBLE_DAY_LABELS = new Set(["Mon", "Wed", "Fri"]);
+const LEVEL_CLASS_NAMES = [
+  "bg-muted",
+  "bg-emerald-500/25",
+  "bg-emerald-500/45",
+  "bg-emerald-500/65",
+  "bg-emerald-500",
+];
+
+function normalizeDate(input: Date | number | string): Date {
+  if (input instanceof Date) {
+    return new Date(input.getTime());
+  }
+
+  return new Date(input);
+}
+
+function toUtcDate(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+}
+
+function addUtcDays(date: Date, days: number): Date {
+  return new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate() + days,
+    ),
+  );
+}
+
+function formatDayKey(date: Date): string {
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
+}
+
+function getIntensityLevel(count: number, maxCount: number): number {
+  if (count <= 0 || maxCount <= 0) {
+    return 0;
+  }
+
+  const ratio = count / maxCount;
+
+  if (ratio < 0.25) {
+    return 1;
+  }
+
+  if (ratio < 0.5) {
+    return 2;
+  }
+
+  if (ratio < 0.75) {
+    return 3;
+  }
+
+  return 4;
+}
+
+function getGridData(
+  data: ActivityHeatmapItem[],
+  endDate: Date,
+  weeks: number,
+): DayCell[][] {
+  const normalizedEnd = toUtcDate(endDate);
+  const startDate = addUtcDays(normalizedEnd, -(weeks * 7 - 1));
+  const countsByDate = new Map<string, number>();
+
+  data.forEach((item) => {
+    const normalizedDate = toUtcDate(normalizeDate(item.date));
+    countsByDate.set(formatDayKey(normalizedDate), item.count);
+  });
+
+  const maxCount = Math.max(...data.map((item) => item.count), 0);
+
+  return Array.from({ length: weeks }, (_, weekIndex) => {
+    return Array.from({ length: 7 }, (_, dayIndex) => {
+      const date = addUtcDays(startDate, weekIndex * 7 + dayIndex);
+      const key = formatDayKey(date);
+      const count = countsByDate.get(key) ?? 0;
+
+      return {
+        count,
+        date,
+        key,
+        level: getIntensityLevel(count, maxCount),
+      };
+    });
+  });
+}
+
+function formatMonthLabel(date: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    timeZone: "UTC",
+  }).format(date);
+}
+
+function formatTooltip(date: Date, count: number): string {
+  const formattedDate = new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(date);
+
+  return `${count} activity ${count === 1 ? "event" : "events"} on ${formattedDate}`;
+}
+
+function HeatmapGrid({
+  gridData,
+  weeks,
+}: {
+  gridData: DayCell[][];
+  weeks: number;
+}) {
+  return (
+    <div className="min-w-[640px] space-y-3">
+      <div
+        className="grid gap-2 text-xs text-muted-foreground"
+        style={{ gridTemplateColumns: `40px repeat(${weeks}, minmax(0, 1fr))` }}
+      >
+        <span />
+        {gridData.map((week) => (
+          <span className="text-center" key={`month-${week[0]?.key}`}>
+            {week[0] && week[0].date.getUTCDate() <= 7
+              ? formatMonthLabel(week[0].date)
+              : ""}
+          </span>
+        ))}
+      </div>
+
+      <div
+        className="grid gap-2"
+        style={{ gridTemplateColumns: `40px repeat(${weeks}, minmax(0, 1fr))` }}
+      >
+        <div className="grid grid-rows-7 gap-2 pt-1 text-xs text-muted-foreground">
+          {WEEKDAY_LABELS.map((label) => (
+            <span className="h-4 leading-4" key={label}>
+              {VISIBLE_DAY_LABELS.has(label) ? label : ""}
+            </span>
+          ))}
+        </div>
+
+        {gridData.map((week) => (
+          <div className="grid grid-rows-7 gap-2" key={`week-${week[0]?.key}`}>
+            {week.map((day) => (
+              <div
+                className={cn(
+                  "h-4 rounded-sm border border-border/40 transition-colors",
+                  LEVEL_CLASS_NAMES[day.level],
+                )}
+                key={day.key}
+                role="img"
+                title={formatTooltip(day.date, day.count)}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex items-center justify-end gap-2 text-xs text-muted-foreground">
+        <span>Less</span>
+        {LEVEL_CLASS_NAMES.map((className, index) => (
+          <span
+            className={cn(
+              "h-3 w-3 rounded-[3px] border border-border/40",
+              className,
+            )}
+            key={`legend-${index}`}
+          />
+        ))}
+        <span>More</span>
+      </div>
+    </div>
+  );
+}
+
+export const ActivityHeatmap = React.forwardRef<
+  HTMLDivElement,
+  ActivityHeatmapProps
+>(
+  (
+    {
+      className,
+      data,
+      description,
+      endDate = new Date(),
+      title = "Activity heatmap",
+      weeks = 12,
+      ...props
+    },
+    ref,
+  ) => {
+    const normalizedEndDate = normalizeDate(endDate);
+    const gridData = getGridData(data, normalizedEndDate, weeks);
+
+    return (
+      <div className={cn("space-y-4", className)} ref={ref} {...props}>
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
+          {description ? (
+            <p className="text-sm text-muted-foreground">{description}</p>
+          ) : null}
+        </div>
+
+        <div className="overflow-x-auto rounded-lg border bg-card p-4 shadow-sm">
+          <HeatmapGrid gridData={gridData} weeks={weeks} />
+        </div>
+      </div>
+    );
+  },
+);
+
+ActivityHeatmap.displayName = "ActivityHeatmap";

--- a/apps/registry/registry/default/activity-log/activity-log.tsx
+++ b/apps/registry/registry/default/activity-log/activity-log.tsx
@@ -1,6 +1,357 @@
-export {
-  ActivityLog,
-  type ActivityLogItem,
-  type ActivityLogProps,
-  type ActivityLogTone,
+"use client";
+
+import { forwardRef, useMemo, useState } from "react";
+
+import { ArrowRight, ChevronLeft, ChevronRight } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Avatar, AvatarFallback } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
 } from "@vllnt/ui";
+import { ScrollArea } from "@vllnt/ui";
+import { Separator } from "@vllnt/ui";
+
+export type ActivityLogTone = "danger" | "default" | "success" | "warning";
+
+export type ActivityLogItem = {
+  action: string;
+  actor: string;
+  description?: string;
+  id: string;
+  scope?: string;
+  target?: string;
+  timestamp: string;
+  tone?: ActivityLogTone;
+};
+
+export type ActivityLogProps = React.ComponentPropsWithoutRef<typeof Card> & {
+  defaultPage?: number;
+  description?: string;
+  emptyMessage?: string;
+  items: ActivityLogItem[];
+  onPageChange?: (page: number) => void;
+  page?: number;
+  pageSize?: number;
+  title?: string;
+};
+
+type ActivityToneConfig = {
+  badgeClassName: string;
+  markerClassName: string;
+};
+
+type ActivityRowProps = {
+  item: ActivityLogItem;
+};
+
+type PaginationControlsProps = {
+  currentPage: number;
+  onPageChange: (page: number) => void;
+  pageNumbers: number[];
+  totalPages: number;
+};
+
+const toneConfig: Record<ActivityLogTone, ActivityToneConfig> = {
+  danger: {
+    badgeClassName:
+      "border-destructive/20 bg-destructive/10 text-destructive dark:text-destructive",
+    markerClassName: "bg-destructive",
+  },
+  default: {
+    badgeClassName: "border-border bg-muted text-muted-foreground",
+    markerClassName: "bg-primary",
+  },
+  success: {
+    badgeClassName:
+      "border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+    markerClassName: "bg-emerald-500",
+  },
+  warning: {
+    badgeClassName:
+      "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+    markerClassName: "bg-amber-500",
+  },
+};
+
+function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .map((segment) => segment[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+function buildPageNumbers(currentPage: number, totalPages: number): number[] {
+  if (totalPages <= 1) return [1];
+
+  const start = Math.max(1, currentPage - 1);
+  const end = Math.min(totalPages, start + 2);
+  const normalizedStart = Math.max(1, end - 2);
+
+  return Array.from(
+    { length: end - normalizedStart + 1 },
+    (_, index) => normalizedStart + index,
+  );
+}
+
+function ActivityLogHeader({
+  currentPage,
+  description,
+  title,
+  totalPages,
+}: {
+  currentPage: number;
+  description?: string;
+  title: string;
+  totalPages: number;
+}) {
+  return (
+    <CardHeader>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <CardTitle>{title}</CardTitle>
+          {description ? (
+            <CardDescription>{description}</CardDescription>
+          ) : null}
+        </div>
+        <Badge className="w-fit" variant="outline">
+          Page {currentPage} of {totalPages}
+        </Badge>
+      </div>
+    </CardHeader>
+  );
+}
+
+function PaginationControls({
+  currentPage,
+  onPageChange,
+  pageNumbers,
+  totalPages,
+}: PaginationControlsProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button
+        disabled={currentPage === 1}
+        onClick={() => {
+          onPageChange(currentPage - 1);
+        }}
+        size="sm"
+        variant="outline"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Previous
+      </Button>
+      {pageNumbers.map((pageNumber) => (
+        <Button
+          aria-label={`Go to page ${pageNumber}`}
+          key={pageNumber}
+          onClick={() => {
+            onPageChange(pageNumber);
+          }}
+          size="sm"
+          variant={pageNumber === currentPage ? "default" : "outline"}
+        >
+          {pageNumber}
+        </Button>
+      ))}
+      <Button
+        disabled={currentPage === totalPages}
+        onClick={() => {
+          onPageChange(currentPage + 1);
+        }}
+        size="sm"
+        variant="outline"
+      >
+        Next
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
+function ActivityRow({ item }: ActivityRowProps) {
+  const palette = toneConfig[item.tone ?? "default"];
+
+  return (
+    <li className="relative pl-12">
+      <span
+        aria-hidden="true"
+        className="absolute bottom-[-1.5rem] left-[18px] top-11 w-px bg-border last:hidden"
+      />
+      <span
+        aria-hidden="true"
+        className={cn(
+          "absolute left-4 top-3 h-3 w-3 rounded-full ring-4 ring-background",
+          palette.markerClassName,
+        )}
+      />
+      <div className="rounded-lg border bg-background/70 p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex min-w-0 items-start gap-3">
+            <Avatar className="h-9 w-9 border bg-muted">
+              <AvatarFallback>{getInitials(item.actor)}</AvatarFallback>
+            </Avatar>
+            <div className="min-w-0 space-y-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-medium text-foreground">
+                  {item.actor}
+                </span>
+                <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="text-sm text-muted-foreground">
+                  {item.action}
+                </span>
+                {item.target ? (
+                  <span className="truncate text-sm font-medium text-foreground">
+                    {item.target}
+                  </span>
+                ) : null}
+              </div>
+              {item.description ? (
+                <p className="text-sm text-muted-foreground">
+                  {item.description}
+                </p>
+              ) : null}
+            </div>
+          </div>
+          <div className="flex shrink-0 flex-wrap items-center gap-2 sm:justify-end">
+            {item.scope ? (
+              <Badge className={palette.badgeClassName} variant="outline">
+                {item.scope}
+              </Badge>
+            ) : null}
+            <span className="text-xs text-muted-foreground">
+              {item.timestamp}
+            </span>
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function ActivityLogBody({
+  currentPage,
+  emptyMessage,
+  items,
+  onPageChange,
+  pageNumbers,
+  pageSize,
+  totalPages,
+}: {
+  currentPage: number;
+  emptyMessage: string;
+  items: ActivityLogItem[];
+  onPageChange: (page: number) => void;
+  pageNumbers: number[];
+  pageSize: number;
+  totalPages: number;
+}) {
+  const visibleItems = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return items.slice(start, start + pageSize);
+  }, [currentPage, items, pageSize]);
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <ScrollArea className="max-h-[26rem] pr-4">
+        <ol className="space-y-4 pb-2">
+          {visibleItems.map((item) => (
+            <ActivityRow item={item} key={item.id} />
+          ))}
+        </ol>
+      </ScrollArea>
+      <Separator />
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-muted-foreground">
+          Showing {(currentPage - 1) * pageSize + 1}
+          {" - "}
+          {(currentPage - 1) * pageSize + visibleItems.length} of {items.length}
+        </p>
+        <PaginationControls
+          currentPage={currentPage}
+          onPageChange={onPageChange}
+          pageNumbers={pageNumbers}
+          totalPages={totalPages}
+        />
+      </div>
+    </>
+  );
+}
+
+const ActivityLog = forwardRef<HTMLDivElement, ActivityLogProps>(
+  (
+    {
+      className,
+      defaultPage = 1,
+      description,
+      emptyMessage = "No activity recorded yet.",
+      items,
+      onPageChange,
+      page,
+      pageSize = 5,
+      title = "Activity log",
+      ...props
+    },
+    ref,
+  ) => {
+    const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+    const [uncontrolledPage, setUncontrolledPage] = useState(defaultPage);
+    const currentPage = Math.min(
+      Math.max(page ?? uncontrolledPage, 1),
+      totalPages,
+    );
+    const pageNumbers = useMemo(
+      () => buildPageNumbers(currentPage, totalPages),
+      [currentPage, totalPages],
+    );
+
+    function handlePageChange(nextPage: number) {
+      if (page === undefined) {
+        setUncontrolledPage(nextPage);
+      }
+      onPageChange?.(nextPage);
+    }
+
+    return (
+      <Card className={cn("w-full", className)} ref={ref} {...props}>
+        <ActivityLogHeader
+          currentPage={currentPage}
+          description={description}
+          title={title}
+          totalPages={totalPages}
+        />
+        <CardContent className="space-y-4">
+          <ActivityLogBody
+            currentPage={currentPage}
+            emptyMessage={emptyMessage}
+            items={items}
+            onPageChange={handlePageChange}
+            pageNumbers={pageNumbers}
+            pageSize={pageSize}
+            totalPages={totalPages}
+          />
+        </CardContent>
+      </Card>
+    );
+  },
+);
+
+ActivityLog.displayName = "ActivityLog";
+
+export { ActivityLog };

--- a/apps/registry/registry/default/agent-activity/agent-activity.tsx
+++ b/apps/registry/registry/default/agent-activity/agent-activity.tsx
@@ -1,10 +1,505 @@
-// Re-export from @vllnt/ui package
-export {
-  AgentActivity,
-  AgentStep,
-  AgentStepDetail,
-  AgentStepDuration,
-  AgentStepProgress,
-  AgentStepTitle,
-  useAgentStepStatus,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  Circle,
+  Loader2,
+  MinusCircle,
+} from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Status state for a single {@link AgentStep}.
+ *
+ * @public
+ */
+export type AgentStepStatus =
+  | "completed"
+  | "error"
+  | "pending"
+  | "running"
+  | "skipped";
+
+/**
+ * Status state for the parent {@link AgentActivity}.
+ *
+ * @public
+ */
+export type AgentActivityStatus = "completed" | "error" | "idle" | "running";
+
+const STATUS_CLASSES: Record<
+  AgentStepStatus,
+  { iconClass: string; ringClass: string; rowClass: string }
+> = {
+  completed: {
+    iconClass: "text-emerald-600 dark:text-emerald-400",
+    ringClass: "ring-emerald-500/30",
+    rowClass: "border-border bg-background",
+  },
+  error: {
+    iconClass: "text-destructive",
+    ringClass: "ring-destructive/40",
+    rowClass: "border-destructive/40 bg-destructive/5",
+  },
+  pending: {
+    iconClass: "text-muted-foreground",
+    ringClass: "ring-border",
+    rowClass: "border-border bg-muted/20 text-muted-foreground",
+  },
+  running: {
+    iconClass: "text-primary",
+    ringClass: "ring-primary/30",
+    rowClass: "border-primary/30 bg-primary/5",
+  },
+  skipped: {
+    iconClass: "text-muted-foreground/60",
+    ringClass: "ring-border",
+    rowClass: "border-border bg-background text-muted-foreground/80",
+  },
+};
+
+const DEFAULT_STATUS_ICON: Record<AgentStepStatus, ReactNode> = {
+  completed: <CheckCircle2 aria-hidden="true" className="h-4 w-4" />,
+  error: <AlertTriangle aria-hidden="true" className="h-4 w-4" />,
+  pending: <Circle aria-hidden="true" className="h-4 w-4" />,
+  running: <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />,
+  skipped: <MinusCircle aria-hidden="true" className="h-4 w-4" />,
+};
+
+type StepContextValue = {
+  status: AgentStepStatus;
+};
+
+const StepContext = createContext<StepContextValue>({ status: "pending" });
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type AgentActivityLabels = {
+  /** Caption above the steps list. Defaults to `"Activity"`. */
+  activity?: string;
+  /** Caption for the collapse-details toggle. Defaults to `"Hide details"`. */
+  collapse?: string;
+  /** Aria-label for the elapsed-time region. Defaults to `"Elapsed"`. */
+  elapsed?: string;
+  /** Caption for the expand-details toggle. Defaults to `"Show details"`. */
+  expand?: string;
+};
+
+const DEFAULT_LABELS = {
+  activity: "Activity",
+  collapse: "Hide details",
+  elapsed: "Elapsed",
+  expand: "Show details",
+} as const satisfies Required<AgentActivityLabels>;
+
+/**
+ * Props for {@link AgentActivity}.
+ *
+ * @public
+ */
+export type AgentActivityProps = {
+  /** Optional total elapsed time string shown in the header. */
+  elapsed?: ReactNode;
+  /** Localizable strings. */
+  labels?: AgentActivityLabels;
+  /** Top-level agent status. Defaults to `"idle"`. */
+  status?: AgentActivityStatus;
+} & ComponentPropsWithoutRef<"section">;
+
+const ACTIVITY_LIVE_REGION_ROLE: Record<AgentActivityStatus, "log" | "status"> =
+  {
+    completed: "status",
+    error: "status",
+    idle: "status",
+    running: "log",
+  };
+
+/**
+ * Visual display of an AI agent's execution chain — steps taken, tools
+ * called, decisions made, and current progress. Composes {@link AgentStep}
+ * children. Use `aria-live="polite"` on the log so assistive tech reads
+ * new steps as the agent progresses without stealing focus.
+ *
+ * @example
+ * ```tsx
+ * <AgentActivity status="running" elapsed="3.2s">
+ *   <AgentStep status="completed" icon={<Search />}>
+ *     <AgentStepTitle>Searching codebase</AgentStepTitle>
+ *     <AgentStepDetail>Found 12 files matching "auth".</AgentStepDetail>
+ *     <AgentStepDuration>1.2s</AgentStepDuration>
+ *   </AgentStep>
+ *   <AgentStep status="running" icon={<Code />}>
+ *     <AgentStepTitle>Writing fix</AgentStepTitle>
+ *     <AgentStepProgress value={60} />
+ *   </AgentStep>
+ * </AgentActivity>
+ * ```
+ *
+ * @public
+ */
+export const AgentActivity = forwardRef<HTMLElement, AgentActivityProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      elapsed,
+      labels,
+      status = "idle",
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <section
+        aria-live={status === "running" ? "polite" : "off"}
+        className={cn(
+          "flex flex-col gap-3 rounded-2xl border bg-background p-4",
+          className,
+        )}
+        data-status={status}
+        ref={ref}
+        role={ACTIVITY_LIVE_REGION_ROLE[status]}
+        {...rest}
+      >
+        <header className="flex items-center justify-between gap-3">
+          <h3 className="text-sm font-semibold tracking-tight text-foreground">
+            {resolvedLabels.activity}
+          </h3>
+          {elapsed ? (
+            <span
+              aria-label={resolvedLabels.elapsed}
+              className="text-xs font-mono text-muted-foreground"
+            >
+              {elapsed}
+            </span>
+          ) : null}
+        </header>
+        <ol className="flex flex-col gap-2">{children}</ol>
+      </section>
+    );
+  },
+);
+AgentActivity.displayName = "AgentActivity";
+
+/**
+ * Props for {@link AgentStep}.
+ *
+ * @public
+ */
+export type AgentStepProps = {
+  /** When false, the step renders the toggle but starts collapsed. */
+  defaultOpen?: boolean;
+  /** Optional icon shown to the left of the title. */
+  icon?: ReactNode;
+  /** Step status. */
+  status: AgentStepStatus;
+} & ComponentPropsWithoutRef<"li">;
+
+type ContentSplit = {
+  body: ReactNode[];
+  header: ReactNode[];
+};
+
+function getDisplayName(value: unknown): string | undefined {
+  if (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    "displayName" in value &&
+    typeof value.displayName === "string"
+  ) {
+    return value.displayName;
+  }
+  return undefined;
+}
+
+function isAgentStepDetailElement(child: ReactNode): boolean {
+  if (child === null || typeof child !== "object") return false;
+  if (!("type" in child)) return false;
+  return getDisplayName(child.type) === "AgentStepDetail";
+}
+
+function splitChildren(children: ReactNode): ContentSplit {
+  const items = Array.isArray(children)
+    ? (children as ReactNode[])
+    : [children];
+  return items.reduce<ContentSplit>(
+    (split, child) => {
+      if (isAgentStepDetailElement(child)) {
+        split.body.push(child);
+      } else {
+        split.header.push(child);
+      }
+      return split;
+    },
+    { body: [], header: [] },
+  );
+}
+
+/**
+ * One row inside an {@link AgentActivity}. The component partitions
+ * children into an always-visible header (title, duration, progress) and a
+ * collapsible body (any number of {@link AgentStepDetail} blocks).
+ *
+ * @public
+ */
+type StepRowProps = {
+  detailsId: string;
+  hasDetails: boolean;
+  header: ReactNode;
+  icon: ReactNode;
+  iconClass: string;
+  labels: Required<AgentActivityLabels>;
+  onToggle: () => void;
+  open: boolean;
+};
+
+function StepRow({
+  detailsId,
+  hasDetails,
+  header,
+  icon,
+  iconClass,
+  labels,
+  onToggle,
+  open,
+}: StepRowProps): ReactNode {
+  return (
+    <div className="flex items-start gap-3 px-3 py-2">
+      <span
+        aria-hidden="true"
+        className={cn(
+          "mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center",
+          iconClass,
+        )}
+      >
+        {icon}
+      </span>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">{header}</div>
+      {hasDetails ? (
+        <button
+          aria-controls={detailsId}
+          aria-expanded={open}
+          aria-label={open ? labels.collapse : labels.expand}
+          className="ml-auto inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          onClick={onToggle}
+          type="button"
+        >
+          <ChevronDown
+            aria-hidden="true"
+            className={cn(
+              "h-4 w-4 transition-transform",
+              open ? "rotate-180" : "rotate-0",
+            )}
+          />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+export const AgentStep = forwardRef<HTMLLIElement, AgentStepProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      defaultOpen = true,
+      icon,
+      status,
+      ...rest
+    } = props;
+    const split = useMemo(() => splitChildren(children), [children]);
+    const palette = STATUS_CLASSES[status];
+    const hasDetails = split.body.length > 0;
+    const [open, setOpen] = useState(defaultOpen);
+    const detailsId = useId();
+
+    const handleToggle = useCallback(() => {
+      setOpen((value) => !value);
+    }, []);
+
+    const contextValue = useMemo<StepContextValue>(
+      () => ({ status }),
+      [status],
+    );
+    const resolvedIcon = icon ?? DEFAULT_STATUS_ICON[status];
+
+    return (
+      <li
+        className={cn(
+          "rounded-xl border ring-1",
+          palette.rowClass,
+          palette.ringClass,
+          className,
+        )}
+        data-status={status}
+        ref={ref}
+        {...rest}
+      >
+        <StepContext.Provider value={contextValue}>
+          <StepRow
+            detailsId={detailsId}
+            hasDetails={hasDetails}
+            header={split.header}
+            icon={resolvedIcon}
+            iconClass={palette.iconClass}
+            labels={DEFAULT_LABELS}
+            onToggle={handleToggle}
+            open={open}
+          />
+          {hasDetails && open ? (
+            <div
+              className="border-t border-border/60 px-3 py-2 text-xs"
+              id={detailsId}
+            >
+              <div className="flex flex-col gap-2 pl-8">{split.body}</div>
+            </div>
+          ) : null}
+        </StepContext.Provider>
+      </li>
+    );
+  },
+);
+AgentStep.displayName = "AgentStep";
+
+/**
+ * Props for {@link AgentStepTitle}.
+ *
+ * @public
+ */
+export type AgentStepTitleProps = ComponentPropsWithoutRef<"p">;
+
+/**
+ * Title slot for an {@link AgentStep}.
+ *
+ * @public
+ */
+export const AgentStepTitle = forwardRef<
+  HTMLParagraphElement,
+  AgentStepTitleProps
+>(({ className, ...rest }, ref) => (
+  <p
+    className={cn(
+      "text-sm font-medium leading-tight text-foreground",
+      className,
+    )}
+    ref={ref}
+    {...rest}
+  />
+));
+AgentStepTitle.displayName = "AgentStepTitle";
+
+/**
+ * Props for {@link AgentStepDuration}.
+ *
+ * @public
+ */
+export type AgentStepDurationProps = ComponentPropsWithoutRef<"span">;
+
+/**
+ * Duration badge for an {@link AgentStep}.
+ *
+ * @public
+ */
+export const AgentStepDuration = forwardRef<
+  HTMLSpanElement,
+  AgentStepDurationProps
+>(({ className, ...rest }, ref) => (
+  <span
+    className={cn("font-mono text-xs text-muted-foreground", className)}
+    ref={ref}
+    {...rest}
+  />
+));
+AgentStepDuration.displayName = "AgentStepDuration";
+
+/**
+ * Props for {@link AgentStepProgress}.
+ *
+ * @public
+ */
+export type AgentStepProgressProps = {
+  /** Optional aria-label override. Defaults to `"Step progress"`. */
+  label?: string;
+  /** Progress value, 0–100. */
+  value: number;
+} & Omit<ComponentPropsWithoutRef<"div">, "role">;
+
+/**
+ * Progress bar for a running {@link AgentStep}.
+ *
+ * @public
+ */
+export const AgentStepProgress = forwardRef<
+  HTMLDivElement,
+  AgentStepProgressProps
+>(({ className, label = "Step progress", value, ...rest }, ref) => {
+  const clamped = Math.max(0, Math.min(100, value));
+  return (
+    <div
+      aria-label={label}
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={clamped}
+      className={cn("h-1.5 w-full rounded-full bg-muted", className)}
+      ref={ref}
+      role="progressbar"
+      {...rest}
+    >
+      <span
+        className="block h-full rounded-full bg-primary transition-[width]"
+        style={{ width: `${clamped.toString()}%` }}
+      />
+    </div>
+  );
+});
+AgentStepProgress.displayName = "AgentStepProgress";
+
+/**
+ * Props for {@link AgentStepDetail}.
+ *
+ * @public
+ */
+export type AgentStepDetailProps = ComponentPropsWithoutRef<"div">;
+
+/**
+ * Collapsible detail block inside an {@link AgentStep} (tool output, log
+ * snippet, anything secondary).
+ *
+ * @public
+ */
+export const AgentStepDetail = forwardRef<HTMLDivElement, AgentStepDetailProps>(
+  ({ className, ...rest }, ref) => (
+    <div
+      className={cn("text-xs text-muted-foreground", className)}
+      ref={ref}
+      {...rest}
+    />
+  ),
+);
+AgentStepDetail.displayName = "AgentStepDetail";
+
+/**
+ * Hook for reading the current step's status from inside a custom child.
+ *
+ * @public
+ */
+export function useAgentStepStatus(): AgentStepStatus {
+  return useContext(StepContext).status;
+}

--- a/apps/registry/registry/default/ai-artifact/ai-artifact.tsx
+++ b/apps/registry/registry/default/ai-artifact/ai-artifact.tsx
@@ -1,13 +1,702 @@
-// Re-export from @vllnt/ui package
-export {
-  AIArtifact,
-  AIArtifactContent,
-  AIArtifactCopyButton,
-  AIArtifactDownloadButton,
-  AIArtifactEditButton,
-  AIArtifactFullscreenButton,
-  AIArtifactToolbar,
-  AIArtifactVersion,
-  AIArtifactVersions,
-  useAIArtifact,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+import {
+  Check,
+  Copy,
+  Download,
+  Maximize2,
+  Minimize2,
+  Pencil,
+} from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+
+const COPIED_TIMEOUT_MS = 2000;
+
+/**
+ * Artifact rendering type for {@link AIArtifact}. Drives the visual badge
+ * but consumers render the actual content inside {@link AIArtifactContent}.
+ *
+ * @public
+ */
+export type AIArtifactType =
+  | "code"
+  | "custom"
+  | "diagram"
+  | "document"
+  | "html"
+  | "image"
+  | "table";
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type AIArtifactLabels = {
+  /** Aria-label after a successful copy. Defaults to `"Copied"`. */
+  copied?: string;
+  /** Aria-label for the copy control. Defaults to `"Copy"`. */
+  copy?: string;
+  /** Aria-label for the download control. Defaults to `"Download"`. */
+  download?: string;
+  /** Aria-label for the edit control. Defaults to `"Edit"`. */
+  edit?: string;
+  /** Aria-label for the fullscreen control when collapsed. Defaults to `"Enter fullscreen"`. */
+  enterFullscreen?: string;
+  /** Aria-label for the fullscreen control when expanded. Defaults to `"Exit fullscreen"`. */
+  exitFullscreen?: string;
+  /** Aria-label for the version list. Defaults to `"Versions"`. */
+  versions?: string;
+};
+
+const DEFAULT_LABELS = {
+  copied: "Copied",
+  copy: "Copy",
+  download: "Download",
+  edit: "Edit",
+  enterFullscreen: "Enter fullscreen",
+  exitFullscreen: "Exit fullscreen",
+  versions: "Versions",
+} as const satisfies Required<AIArtifactLabels>;
+
+type AIArtifactContextValue = {
+  copied: boolean;
+  copy: () => Promise<boolean>;
+  download: () => void;
+  filename: string;
+  fullscreen: boolean;
+  hasOnEdit: boolean;
+  labels: Required<AIArtifactLabels>;
+  onEdit: () => void;
+  toggleFullscreen: () => void;
+  type: AIArtifactType;
+  value: string;
+};
+
+const NO_OP = (): void => {
+  return;
+};
+
+const DEFAULT_CONTEXT: AIArtifactContextValue = {
+  copied: false,
+  copy: async () => false,
+  download: NO_OP,
+  filename: "artifact.txt",
+  fullscreen: false,
+  hasOnEdit: false,
+  labels: DEFAULT_LABELS,
+  onEdit: NO_OP,
+  toggleFullscreen: NO_OP,
+  type: "code",
+  value: "",
+};
+
+const AIArtifactContext =
+  createContext<AIArtifactContextValue>(DEFAULT_CONTEXT);
+
+/**
+ * Hook for reading the artifact's state from inside a custom child.
+ *
+ * @public
+ */
+export function useAIArtifact(): AIArtifactContextValue {
+  return useContext(AIArtifactContext);
+}
+
+function pickExtension(type: AIArtifactType, language: string): string {
+  if (language) return language;
+  switch (type) {
+    case "code":
+      return "txt";
+    case "custom":
+      return "txt";
+    case "diagram":
+      return "mmd";
+    case "document":
+      return "md";
+    case "html":
+      return "html";
+    case "image":
+      return "png";
+    case "table":
+      return "csv";
+  }
+}
+
+const SLUG_INVALID_CHARS = /[^\da-z]+/g;
+const SLUG_TRIM = /^-+|-+$/g;
+
+type FilenameInput = {
+  filename?: string;
+  language: string;
+  title: ReactNode;
+  type: AIArtifactType;
+};
+
+function buildFilename({
+  filename,
+  language,
+  title,
+  type,
+}: FilenameInput): string {
+  if (filename) return filename;
+  const base =
+    typeof title === "string" && title.length > 0 ? title : "artifact";
+  const slug = base
+    .toLowerCase()
+    .replaceAll(SLUG_INVALID_CHARS, "-")
+    .replaceAll(SLUG_TRIM, "");
+  const safeBase = slug.length > 0 ? slug : "artifact";
+  return `${safeBase}.${pickExtension(type, language)}`;
+}
+
+async function writeToClipboard(value: string): Promise<boolean> {
+  if (
+    typeof navigator === "undefined" ||
+    typeof navigator.clipboard?.writeText !== "function"
+  ) {
+    return false;
+  }
+  try {
+    await navigator.clipboard.writeText(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function downloadValueAsFile(value: string, filename: string): void {
+  if (typeof document === "undefined") return;
+  const blob = new Blob([value], { type: "text/plain;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.style.display = "none";
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Props for {@link AIArtifact}.
+ *
+ * @public
+ */
+export type AIArtifactProps = {
+  /** Initial fullscreen state. */
+  defaultFullscreen?: boolean;
+  /** Override the auto-derived filename for downloads. */
+  filename?: string;
+  /** Localizable strings. */
+  labels?: AIArtifactLabels;
+  /** Optional language tag rendered next to the title (e.g. `tsx`). */
+  language?: string;
+  /** Fires when the user clicks the edit control. */
+  onEdit?: () => void;
+  /** Subtitle / sub-headline. */
+  subtitle?: ReactNode;
+  /** Primary title. */
+  title?: ReactNode;
+  /** Artifact type — drives the badge and default download extension. */
+  type?: AIArtifactType;
+  /** Raw text content used by the copy + download controls. */
+  value?: string;
+} & ComponentPropsWithoutRef<"section">;
+
+type ArtifactHeaderProps = {
+  language: string;
+  subtitle?: ReactNode;
+  title?: ReactNode;
+  type: AIArtifactType;
+};
+
+function ArtifactHeader({
+  language,
+  subtitle,
+  title,
+  type,
+}: ArtifactHeaderProps): ReactNode {
+  if (!title && !subtitle && !language) return null;
+  return (
+    <header className="flex flex-col gap-1">
+      <div className="flex flex-wrap items-center gap-2">
+        {title ? (
+          <h3 className="text-sm font-semibold tracking-tight text-foreground">
+            {title}
+          </h3>
+        ) : null}
+        <Badge variant="secondary">{language || type}</Badge>
+      </div>
+      {subtitle ? (
+        <p className="text-xs text-muted-foreground">{subtitle}</p>
+      ) : null}
+    </header>
+  );
+}
+
+/**
+ * Rendered output area for AI-generated content — code previews, documents,
+ * diagrams, or any custom artifact. Composes {@link Badge} + {@link Button}.
+ *
+ * The compound family pairs a root context with action buttons and a
+ * content slot:
+ *
+ * - {@link AIArtifactToolbar} — wraps the action row.
+ * - {@link AIArtifactCopyButton} / {@link AIArtifactDownloadButton} —
+ *   wired to `value` + `filename` automatically.
+ * - {@link AIArtifactEditButton} — fires `onEdit`; hidden when no
+ *   handler exists.
+ * - {@link AIArtifactFullscreenButton} — toggles `data-fullscreen` on the
+ *   root so consumers can drive the layout via CSS.
+ * - {@link AIArtifactContent} — scrollable body slot for the actual
+ *   payload (code block, MDX, mermaid output, iframe, etc.).
+ * - {@link AIArtifactVersions} / {@link AIArtifactVersion} — version
+ *   navigator at the bottom.
+ *
+ * @example
+ * ```tsx
+ * <AIArtifact
+ *   type="code"
+ *   title="UserProfile.tsx"
+ *   language="tsx"
+ *   value={generatedCode}
+ *   onEdit={openEditor}
+ * >
+ *   <AIArtifactToolbar>
+ *     <AIArtifactCopyButton />
+ *     <AIArtifactEditButton />
+ *     <AIArtifactDownloadButton />
+ *     <AIArtifactFullscreenButton />
+ *   </AIArtifactToolbar>
+ *   <AIArtifactContent>
+ *     <CodeBlock language="tsx">{generatedCode}</CodeBlock>
+ *   </AIArtifactContent>
+ * </AIArtifact>
+ * ```
+ *
+ * @public
+ */
+type ControllerOptions = {
+  defaultFullscreen: boolean;
+  filename?: string;
+  labels: Required<AIArtifactLabels>;
+  language: string;
+  onEdit?: () => void;
+  title: ReactNode;
+  type: AIArtifactType;
+  value: string;
+};
+
+function useArtifactController(
+  options: ControllerOptions,
+): AIArtifactContextValue {
+  const {
+    defaultFullscreen,
+    filename,
+    labels,
+    language,
+    onEdit,
+    title,
+    type,
+    value,
+  } = options;
+  const [fullscreen, setFullscreen] = useState(defaultFullscreen);
+  const [copied, setCopied] = useState(false);
+  const resolvedFilename = useMemo(
+    () => buildFilename({ filename, language, title, type }),
+    [filename, language, title, type],
+  );
+
+  const copy = useCallback(async () => {
+    const ok = await writeToClipboard(value);
+    if (!ok) return false;
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, COPIED_TIMEOUT_MS);
+    return true;
+  }, [value]);
+
+  const download = useCallback(() => {
+    downloadValueAsFile(value, resolvedFilename);
+  }, [resolvedFilename, value]);
+
+  const toggleFullscreen = useCallback(() => {
+    setFullscreen((current) => !current);
+  }, []);
+
+  const triggerEdit = useCallback(() => {
+    onEdit?.();
+  }, [onEdit]);
+
+  return useMemo<AIArtifactContextValue>(
+    () => ({
+      copied,
+      copy,
+      download,
+      filename: resolvedFilename,
+      fullscreen,
+      hasOnEdit: onEdit !== undefined,
+      labels,
+      onEdit: triggerEdit,
+      toggleFullscreen,
+      type,
+      value,
+    }),
+    [
+      copied,
+      copy,
+      download,
+      fullscreen,
+      labels,
+      onEdit,
+      resolvedFilename,
+      toggleFullscreen,
+      triggerEdit,
+      type,
+      value,
+    ],
+  );
+}
+
+export const AIArtifact = forwardRef<HTMLElement, AIArtifactProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      defaultFullscreen = false,
+      filename,
+      labels,
+      language = "",
+      onEdit,
+      subtitle,
+      title,
+      type = "code",
+      value = "",
+      ...rest
+    } = props;
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const contextValue = useArtifactController({
+      defaultFullscreen,
+      filename,
+      labels: resolvedLabels,
+      language,
+      onEdit,
+      title,
+      type,
+      value,
+    });
+
+    return (
+      <AIArtifactContext.Provider value={contextValue}>
+        <section
+          aria-label={typeof title === "string" ? title : undefined}
+          className={cn(
+            "flex flex-col gap-3 rounded-2xl border bg-background p-4",
+            className,
+          )}
+          data-fullscreen={contextValue.fullscreen ? "true" : "false"}
+          data-type={type}
+          ref={ref}
+          {...rest}
+        >
+          <ArtifactHeader
+            language={language}
+            subtitle={subtitle}
+            title={title}
+            type={type}
+          />
+          {children}
+        </section>
+      </AIArtifactContext.Provider>
+    );
+  },
+);
+AIArtifact.displayName = "AIArtifact";
+
+/**
+ * Toolbar slot — wraps action buttons in a horizontal row.
+ *
+ * @public
+ */
+export const AIArtifactToolbar = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ className, ...rest }, ref) => (
+  <div
+    className={cn(
+      "flex flex-wrap items-center gap-1.5 border-b border-border pb-2",
+      className,
+    )}
+    ref={ref}
+    role="toolbar"
+    {...rest}
+  />
+));
+AIArtifactToolbar.displayName = "AIArtifactToolbar";
+
+type ToolbarButtonProps = Omit<
+  ComponentPropsWithoutRef<"button">,
+  "children" | "type"
+>;
+
+/**
+ * Copy-to-clipboard control for the artifact's `value`. Visually flips to
+ * a check after a successful copy.
+ *
+ * @public
+ */
+export const AIArtifactCopyButton = forwardRef<
+  HTMLButtonElement,
+  ToolbarButtonProps
+>(({ className, onClick, ...rest }, ref) => {
+  const { copied, copy, labels } = useAIArtifact();
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      void copy();
+    },
+    [copy, onClick],
+  );
+  return (
+    <Button
+      aria-label={copied ? labels.copied : labels.copy}
+      className={cn("h-8 w-8", className)}
+      onClick={handleClick}
+      ref={ref}
+      size="icon"
+      type="button"
+      variant="ghost"
+      {...rest}
+    >
+      {copied ? (
+        <Check aria-hidden="true" className="h-4 w-4" />
+      ) : (
+        <Copy aria-hidden="true" className="h-4 w-4" />
+      )}
+    </Button>
+  );
+});
+AIArtifactCopyButton.displayName = "AIArtifactCopyButton";
+
+/**
+ * Edit control. Renders nothing when the artifact has no `onEdit`
+ * handler so consumers do not have to conditionally hide it.
+ *
+ * @public
+ */
+export const AIArtifactEditButton = forwardRef<
+  HTMLButtonElement,
+  ToolbarButtonProps
+>(({ className, onClick, ...rest }, ref) => {
+  const { hasOnEdit, labels, onEdit } = useAIArtifact();
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      onEdit();
+    },
+    [onClick, onEdit],
+  );
+  if (!hasOnEdit) return null;
+  return (
+    <Button
+      aria-label={labels.edit}
+      className={cn("h-8 w-8", className)}
+      onClick={handleClick}
+      ref={ref}
+      size="icon"
+      type="button"
+      variant="ghost"
+      {...rest}
+    >
+      <Pencil aria-hidden="true" className="h-4 w-4" />
+    </Button>
+  );
+});
+AIArtifactEditButton.displayName = "AIArtifactEditButton";
+
+/**
+ * Download control — saves the artifact's `value` as a file with an
+ * auto-derived (or overridden) filename.
+ *
+ * @public
+ */
+export const AIArtifactDownloadButton = forwardRef<
+  HTMLButtonElement,
+  ToolbarButtonProps
+>(({ className, onClick, ...rest }, ref) => {
+  const { download, labels } = useAIArtifact();
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      download();
+    },
+    [download, onClick],
+  );
+  return (
+    <Button
+      aria-label={labels.download}
+      className={cn("h-8 w-8", className)}
+      onClick={handleClick}
+      ref={ref}
+      size="icon"
+      type="button"
+      variant="ghost"
+      {...rest}
+    >
+      <Download aria-hidden="true" className="h-4 w-4" />
+    </Button>
+  );
+});
+AIArtifactDownloadButton.displayName = "AIArtifactDownloadButton";
+
+/**
+ * Fullscreen toggle. Updates the root's `data-fullscreen` attribute so
+ * consumers can drive layout changes via CSS or React state on
+ * {@link useAIArtifact}.
+ *
+ * @public
+ */
+export const AIArtifactFullscreenButton = forwardRef<
+  HTMLButtonElement,
+  ToolbarButtonProps
+>(({ className, onClick, ...rest }, ref) => {
+  const { fullscreen, labels, toggleFullscreen } = useAIArtifact();
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      toggleFullscreen();
+    },
+    [onClick, toggleFullscreen],
+  );
+  return (
+    <Button
+      aria-label={fullscreen ? labels.exitFullscreen : labels.enterFullscreen}
+      aria-pressed={fullscreen}
+      className={cn("h-8 w-8", className)}
+      onClick={handleClick}
+      ref={ref}
+      size="icon"
+      type="button"
+      variant="ghost"
+      {...rest}
+    >
+      {fullscreen ? (
+        <Minimize2 aria-hidden="true" className="h-4 w-4" />
+      ) : (
+        <Maximize2 aria-hidden="true" className="h-4 w-4" />
+      )}
+    </Button>
+  );
+});
+AIArtifactFullscreenButton.displayName = "AIArtifactFullscreenButton";
+
+/**
+ * Scrollable body slot. Render the actual payload here (code block,
+ * markdown, mermaid output, sandboxed iframe, etc.).
+ *
+ * @public
+ */
+export const AIArtifactContent = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ className, ...rest }, ref) => (
+  <div
+    className={cn(
+      "min-h-[6rem] overflow-auto rounded-lg border border-border bg-muted/20 p-3 text-sm text-foreground",
+      className,
+    )}
+    ref={ref}
+    {...rest}
+  />
+));
+AIArtifactContent.displayName = "AIArtifactContent";
+
+/**
+ * Version navigator container.
+ *
+ * @public
+ */
+export const AIArtifactVersions = forwardRef<
+  HTMLElement,
+  ComponentPropsWithoutRef<"nav">
+>(({ children, className, ...rest }, ref) => {
+  const { labels } = useAIArtifact();
+  return (
+    <nav
+      aria-label={labels.versions}
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 border-t border-border pt-2",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      {children}
+    </nav>
+  );
+});
+AIArtifactVersions.displayName = "AIArtifactVersions";
+
+/**
+ * Props for {@link AIArtifactVersion}.
+ *
+ * @public
+ */
+export type AIArtifactVersionProps = {
+  /** When true, renders with active styling and `aria-current="true"`. */
+  active?: boolean;
+  /** Caption for the chip. */
+  label: ReactNode;
+} & Omit<ComponentPropsWithoutRef<"button">, "type">;
+
+/**
+ * Single chip inside an {@link AIArtifactVersions}. Emits `onClick` so
+ * consumers can drive version state externally.
+ *
+ * @public
+ */
+export const AIArtifactVersion = forwardRef<
+  HTMLButtonElement,
+  AIArtifactVersionProps
+>(({ active = false, className, label, ...rest }, ref) => (
+  <button
+    aria-current={active ? "true" : undefined}
+    className={cn(
+      "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      active
+        ? "border-primary bg-primary text-primary-foreground"
+        : "border-border bg-background text-muted-foreground hover:bg-accent",
+      className,
+    )}
+    ref={ref}
+    type="button"
+    {...rest}
+  >
+    {label}
+  </button>
+));
+AIArtifactVersion.displayName = "AIArtifactVersion";

--- a/apps/registry/registry/default/ai-chat-input/ai-chat-input.tsx
+++ b/apps/registry/registry/default/ai-chat-input/ai-chat-input.tsx
@@ -1,2 +1,146 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import { cva } from "class-variance-authority";
+import { LoaderCircle, SendHorizontal } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import { Textarea } from "@vllnt/ui";
+
+const formShellVariants = cva(
+  "rounded-2xl border border-border/70 bg-background shadow-sm",
+);
+
+function AIChatInputFooter({
+  currentLength,
+  helperText,
+  isSubmitDisabled,
+  isSubmitting,
+  maxLength,
+  status,
+  submitLabel,
+}: {
+  currentLength: number;
+  helperText?: string;
+  isSubmitDisabled: boolean;
+  isSubmitting: boolean;
+  maxLength?: number;
+  status?: string;
+  submitLabel: string;
+}) {
+  return (
+    <div className="flex flex-col gap-3 border-t border-border/60 pt-3 sm:flex-row sm:items-end sm:justify-between">
+      <div className="space-y-1 text-xs text-muted-foreground">
+        {helperText ? <p>{helperText}</p> : null}
+        <div className="flex flex-wrap items-center gap-2">
+          {status ? <span>{status}</span> : null}
+          {typeof maxLength === "number" ? (
+            <span>
+              {currentLength}/{maxLength}
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <Button
+        className="self-start rounded-full px-4 sm:self-auto"
+        disabled={isSubmitDisabled}
+        type="submit"
+      >
+        {isSubmitting ? (
+          <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+        ) : (
+          <SendHorizontal className="mr-2 h-4 w-4" />
+        )}
+        {submitLabel}
+      </Button>
+    </div>
+  );
+}
+
+export type AIChatInputProps = React.ComponentPropsWithoutRef<"form"> & {
+  /** Disables editing and submit actions. */
+  disabled?: boolean;
+  /** Optional helper text shown below the prompt field. */
+  helperText?: string;
+  /** Whether the submit action is in progress. */
+  isSubmitting?: boolean;
+  /** Called whenever the textarea value changes. */
+  onValueChange?: (value: string) => void;
+  /** Optional status text shown beside helper copy. */
+  status?: string;
+  /** Label for the submit button. */
+  submitLabel?: string;
+  /** Props forwarded to the textarea primitive. */
+  textareaProps?: React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+  /** Optional controls rendered above the footer row. */
+  toolbar?: React.ReactNode;
+  /** Controlled textarea value. */
+  value?: string;
+};
+
+const AIChatInput = forwardRef<HTMLFormElement, AIChatInputProps>(
+  (
+    {
+      className,
+      disabled = false,
+      helperText,
+      isSubmitting = false,
+      onSubmit,
+      onValueChange,
+      status,
+      submitLabel = "Send",
+      textareaProps,
+      toolbar,
+      value,
+      ...props
+    },
+    ref,
+  ) => {
+    const currentValue = value ?? "";
+    const maxLength = textareaProps?.maxLength;
+    const isSubmitDisabled =
+      disabled || isSubmitting || currentValue.trim().length === 0;
+
+    return (
+      <form
+        className={cn(formShellVariants(), "w-full p-3", className)}
+        onSubmit={onSubmit}
+        ref={ref}
+        {...props}
+      >
+        <div className="space-y-3">
+          <Textarea
+            className="min-h-[120px] resize-none rounded-xl border-0 bg-transparent px-1 py-1 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+            disabled={disabled}
+            onChange={(event) => {
+              textareaProps?.onChange?.(event);
+              onValueChange?.(event.target.value);
+            }}
+            placeholder="Ask a follow-up question, paste context, or describe what you need..."
+            value={value}
+            {...textareaProps}
+          />
+
+          {toolbar ? (
+            <div className="flex flex-wrap gap-2">{toolbar}</div>
+          ) : null}
+
+          <AIChatInputFooter
+            currentLength={currentValue.length}
+            helperText={helperText}
+            isSubmitDisabled={isSubmitDisabled}
+            isSubmitting={isSubmitting}
+            maxLength={maxLength}
+            status={status}
+            submitLabel={submitLabel}
+          />
+        </div>
+      </form>
+    );
+  },
+);
+
+AIChatInput.displayName = "AIChatInput";
+
+export { AIChatInput };

--- a/apps/registry/registry/default/ai-message-bubble/ai-message-bubble.tsx
+++ b/apps/registry/registry/default/ai-message-bubble/ai-message-bubble.tsx
@@ -1,2 +1,141 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+import { Avatar, AvatarFallback } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+
+const bubbleVariants = cva(
+  "rounded-2xl border px-4 py-3 shadow-sm transition-colors",
+  {
+    defaultVariants: {
+      messageRole: "assistant",
+    },
+    variants: {
+      messageRole: {
+        assistant: "border-border bg-card text-card-foreground",
+        system: "border-border/80 bg-muted/60 text-foreground",
+        tool: "border-border bg-muted/40 text-foreground",
+        user: "border-primary/20 bg-primary/10 text-foreground",
+      },
+    },
+  },
+);
+
+function AIMessageMeta({
+  author,
+  isUser,
+  status,
+  timestamp,
+}: {
+  author?: string;
+  isUser: boolean;
+  status?: string;
+  timestamp?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-2 text-xs text-muted-foreground",
+        isUser ? "justify-end" : "justify-start",
+      )}
+    >
+      {author ? (
+        <span className="font-medium text-foreground">{author}</span>
+      ) : null}
+      {timestamp ? <span>{timestamp}</span> : null}
+      {status ? (
+        <Badge
+          className="rounded-full px-2 py-0 text-[10px]"
+          variant="secondary"
+        >
+          {status}
+        </Badge>
+      ) : null}
+    </div>
+  );
+}
+
+export type AIMessageBubbleProps = React.ComponentPropsWithoutRef<"div"> &
+  VariantProps<typeof bubbleVariants> & {
+    /** Optional short label describing the speaker. */
+    author?: string;
+    /** Bubble body content. */
+    children: React.ReactNode;
+    /** Optional status badge for the message. */
+    status?: string;
+    /** Optional timestamp or relative time label. */
+    timestamp?: string;
+  };
+
+const AIMessageBubble = forwardRef<HTMLDivElement, AIMessageBubbleProps>(
+  (
+    {
+      author,
+      children,
+      className,
+      messageRole = "assistant",
+      status,
+      timestamp,
+      ...props
+    },
+    ref,
+  ) => {
+    const resolvedMessageRole = messageRole ?? "assistant";
+    const isUser = resolvedMessageRole === "user";
+    const fallbackLabel = (author ?? resolvedMessageRole)
+      .charAt(0)
+      .toUpperCase();
+
+    return (
+      <div
+        className={cn("flex w-full", isUser ? "justify-end" : "justify-start")}
+      >
+        <div
+          className={cn(
+            "flex w-full max-w-3xl gap-3",
+            isUser ? "flex-row-reverse text-right" : "flex-row",
+          )}
+        >
+          <Avatar className="mt-0.5 h-8 w-8 border border-border/70">
+            <AvatarFallback className="bg-muted text-[11px] font-medium uppercase text-muted-foreground">
+              {fallbackLabel}
+            </AvatarFallback>
+          </Avatar>
+
+          <div
+            className={cn(
+              "min-w-0 space-y-2",
+              isUser ? "items-end" : "items-start",
+            )}
+          >
+            <AIMessageMeta
+              author={author}
+              isUser={isUser}
+              status={status}
+              timestamp={timestamp}
+            />
+
+            <div
+              className={cn(
+                bubbleVariants({ messageRole: resolvedMessageRole }),
+                className,
+              )}
+              ref={ref}
+              {...props}
+            >
+              <div className="text-sm leading-6 whitespace-pre-wrap">
+                {children}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+
+AIMessageBubble.displayName = "AIMessageBubble";
+
+export { AIMessageBubble };

--- a/apps/registry/registry/default/ai-sidebar/ai-sidebar.tsx
+++ b/apps/registry/registry/default/ai-sidebar/ai-sidebar.tsx
@@ -1,12 +1,441 @@
-// Re-export from @vllnt/ui package
-export {
-  AISidebar,
-  AISidebarClose,
-  AISidebarContent,
-  AISidebarFooter,
-  AISidebarHeader,
-  AISidebarProvider,
-  AISidebarTitle,
-  AISidebarTrigger,
-  useAISidebar,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import { Bot, MessageSquarePlus, X } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+
+const DEFAULT_WIDTH = 400;
+const MIN_WIDTH = 280;
+const MAX_WIDTH = 720;
+
+/**
+ * Side of the viewport the sidebar attaches to.
+ *
+ * @public
+ */
+export type AISidebarPosition = "left" | "right";
+
+/**
+ * Localizable strings for {@link AISidebar} subcomponents.
+ *
+ * @public
+ */
+export type AISidebarLabels = {
+  /** Aria-label for the close control. Defaults to `"Close assistant"`. */
+  close?: string;
+  /** Default heading text for {@link AISidebarTitle}. */
+  defaultTitle?: string;
+  /** Aria-label for the open trigger. Defaults to `"Open AI assistant"`. */
+  open?: string;
+};
+
+const DEFAULT_LABELS = {
+  close: "Close assistant",
+  defaultTitle: "AI Assistant",
+  open: "Open AI assistant",
+} as const satisfies Required<AISidebarLabels>;
+
+type AISidebarContextValue = {
+  close: () => void;
+  labels: Required<AISidebarLabels>;
+  open: () => void;
+  openState: boolean;
+  position: AISidebarPosition;
+  setOpen: (next: boolean) => void;
+  toggle: () => void;
+  width: number;
+};
+
+const NO_OP = (): void => {
+  return;
+};
+
+const DEFAULT_CONTEXT: AISidebarContextValue = {
+  close: NO_OP,
+  labels: DEFAULT_LABELS,
+  open: NO_OP,
+  openState: false,
+  position: "right",
+  setOpen: NO_OP,
+  toggle: NO_OP,
+  width: DEFAULT_WIDTH,
+};
+
+const AISidebarContext = createContext<AISidebarContextValue>(DEFAULT_CONTEXT);
+
+/**
+ * Hook for reading sidebar state from anywhere inside an
+ * {@link AISidebarProvider}.
+ *
+ * @public
+ */
+export function useAISidebar(): AISidebarContextValue {
+  return useContext(AISidebarContext);
+}
+
+/**
+ * Props for {@link AISidebarProvider}.
+ *
+ * @public
+ */
+export type AISidebarProviderProps = {
+  children?: ReactNode;
+  /** Initial open state when uncontrolled. Defaults to `false`. */
+  defaultOpen?: boolean;
+  /** Initial position. Defaults to `"right"`. */
+  defaultPosition?: AISidebarPosition;
+  /** Initial width in px. Defaults to `400`. */
+  defaultWidth?: number;
+  /** Localizable strings. */
+  labels?: AISidebarLabels;
+  /** Fires when the open state changes (controlled or uncontrolled). */
+  onOpenChange?: (open: boolean) => void;
+  /** Controlled open state. */
+  open?: boolean;
+};
+
+function clampWidth(value: number): number {
+  return Math.min(Math.max(value, MIN_WIDTH), MAX_WIDTH);
+}
+
+/**
+ * Provider for the AI sidebar context. Wrap your app shell with this so
+ * {@link AISidebar}, {@link AISidebarTrigger}, and {@link useAISidebar}
+ * share the same state.
+ *
+ * @public
+ */
+export function AISidebarProvider({
+  children,
+  defaultOpen = false,
+  defaultPosition = "right",
+  defaultWidth = DEFAULT_WIDTH,
+  labels,
+  onOpenChange,
+  open: controlledOpen,
+}: AISidebarProviderProps): ReactNode {
+  const resolvedLabels = useMemo(
+    () => ({ ...DEFAULT_LABELS, ...labels }),
+    [labels],
+  );
+  const [uncontrolled, setUncontrolled] = useState(defaultOpen);
+  const isControlled = controlledOpen !== undefined;
+  const openState = isControlled ? controlledOpen : uncontrolled;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlled) setUncontrolled(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  const open = useCallback(() => {
+    setOpen(true);
+  }, [setOpen]);
+  const close = useCallback(() => {
+    setOpen(false);
+  }, [setOpen]);
+  const toggle = useCallback(() => {
+    setOpen(!openState);
+  }, [openState, setOpen]);
+
+  const value = useMemo<AISidebarContextValue>(
+    () => ({
+      close,
+      labels: resolvedLabels,
+      open,
+      openState,
+      position: defaultPosition,
+      setOpen,
+      toggle,
+      width: clampWidth(defaultWidth),
+    }),
+    [
+      close,
+      defaultPosition,
+      defaultWidth,
+      open,
+      openState,
+      resolvedLabels,
+      setOpen,
+      toggle,
+    ],
+  );
+
+  return (
+    <AISidebarContext.Provider value={value}>
+      {children}
+    </AISidebarContext.Provider>
+  );
+}
+
+/**
+ * Props for {@link AISidebar}.
+ *
+ * @public
+ */
+export type AISidebarProps = {
+  /** When true, pressing Escape closes the sidebar. Defaults to `true`. */
+  closeOnEscape?: boolean;
+} & ComponentPropsWithoutRef<"aside">;
+
+function useEscapeToClose(
+  enabled: boolean,
+  isOpen: boolean,
+  onClose: () => void,
+): void {
+  useEffect(() => {
+    if (!enabled || !isOpen) return;
+    const handler = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+
+    return () => {
+      document.removeEventListener("keydown", handler);
+    };
+  }, [enabled, isOpen, onClose]);
+}
+
+/**
+ * Slide-out AI assistant panel anchored to the left or right edge. Renders
+ * an `<aside role="complementary">` so screen readers announce it as a
+ * complementary region. Sets `aria-hidden` on close so its content is
+ * skipped by assistive tech.
+ *
+ * @example
+ * ```tsx
+ * <AISidebarProvider defaultOpen={false}>
+ *   <AISidebar>
+ *     <AISidebarHeader>
+ *       <AISidebarTitle>AI Assistant</AISidebarTitle>
+ *       <AISidebarClose />
+ *     </AISidebarHeader>
+ *     <AISidebarContent>{messages}</AISidebarContent>
+ *     <AISidebarFooter>{composer}</AISidebarFooter>
+ *   </AISidebar>
+ *   <AISidebarTrigger />
+ *   <main>{children}</main>
+ * </AISidebarProvider>
+ * ```
+ *
+ * @public
+ */
+export const AISidebar = forwardRef<HTMLElement, AISidebarProps>(
+  (props, ref) => {
+    const { children, className, closeOnEscape = true, ...rest } = props;
+    const { close, labels, openState, position, width } = useAISidebar();
+    useEscapeToClose(closeOnEscape, openState, close);
+
+    return (
+      <aside
+        aria-hidden={!openState}
+        aria-label={labels.defaultTitle}
+        className={cn(
+          "fixed top-0 z-40 flex h-full flex-col border-border bg-background shadow-lg transition-transform duration-200 ease-out",
+          position === "right" ? "right-0 border-l" : "left-0 border-r",
+          openState
+            ? "translate-x-0"
+            : position === "right"
+              ? "translate-x-full"
+              : "-translate-x-full",
+          "max-w-full",
+          className,
+        )}
+        data-state={openState ? "open" : "closed"}
+        ref={ref}
+        style={{ width: `${width.toString()}px` }}
+        {...rest}
+      >
+        {children}
+      </aside>
+    );
+  },
+);
+AISidebar.displayName = "AISidebar";
+
+/**
+ * Header slot for an {@link AISidebar}. Use to host the title, model
+ * selector, and the close control.
+ *
+ * @public
+ */
+export const AISidebarHeader = forwardRef<
+  HTMLElement,
+  ComponentPropsWithoutRef<"header">
+>(({ children, className, ...rest }, ref) => (
+  <header
+    className={cn(
+      "flex items-center gap-2 border-b border-border px-4 py-3",
+      className,
+    )}
+    ref={ref}
+    {...rest}
+  >
+    {children}
+  </header>
+));
+AISidebarHeader.displayName = "AISidebarHeader";
+
+/**
+ * Title slot for {@link AISidebarHeader}. Defaults to the localized title
+ * from the provider whenever the consumer omits children.
+ *
+ * @public
+ */
+export const AISidebarTitle = forwardRef<
+  HTMLHeadingElement,
+  ComponentPropsWithoutRef<"h2">
+>(({ children, className, ...rest }, ref) => {
+  const { labels } = useAISidebar();
+  return (
+    <h2
+      className={cn(
+        "flex flex-1 items-center gap-2 text-sm font-semibold tracking-tight text-foreground",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      <Bot aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
+      {children ?? labels.defaultTitle}
+    </h2>
+  );
+});
+AISidebarTitle.displayName = "AISidebarTitle";
+
+/**
+ * Close-button slot for {@link AISidebarHeader}.
+ *
+ * @public
+ */
+export const AISidebarClose = forwardRef<
+  HTMLButtonElement,
+  Omit<ComponentPropsWithoutRef<"button">, "type">
+>(({ className, onClick, ...rest }, ref) => {
+  const { close, labels } = useAISidebar();
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      close();
+    },
+    [close, onClick],
+  );
+  return (
+    <Button
+      aria-label={labels.close}
+      className={cn("h-8 w-8", className)}
+      onClick={handleClick}
+      ref={ref}
+      size="icon"
+      type="button"
+      variant="ghost"
+      {...rest}
+    >
+      <X aria-hidden="true" className="h-4 w-4" />
+    </Button>
+  );
+});
+AISidebarClose.displayName = "AISidebarClose";
+
+/**
+ * Scrollable middle section of {@link AISidebar}.
+ *
+ * @public
+ */
+export const AISidebarContent = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ children, className, ...rest }, ref) => (
+  <div
+    className={cn("flex flex-1 flex-col gap-2 overflow-y-auto p-4", className)}
+    ref={ref}
+    {...rest}
+  >
+    {children}
+  </div>
+));
+AISidebarContent.displayName = "AISidebarContent";
+
+/**
+ * Bottom slot of {@link AISidebar}, typically the chat composer.
+ *
+ * @public
+ */
+export const AISidebarFooter = forwardRef<
+  HTMLElement,
+  ComponentPropsWithoutRef<"footer">
+>(({ children, className, ...rest }, ref) => (
+  <footer
+    className={cn("border-t border-border bg-background px-4 py-3", className)}
+    ref={ref}
+    {...rest}
+  >
+    {children}
+  </footer>
+));
+AISidebarFooter.displayName = "AISidebarFooter";
+
+/**
+ * Props for {@link AISidebarTrigger}.
+ *
+ * @public
+ */
+export type AISidebarTriggerProps = Omit<
+  ComponentPropsWithoutRef<"button">,
+  "type"
+>;
+
+/**
+ * Standalone control that opens the sidebar. Place anywhere inside an
+ * {@link AISidebarProvider}. Falls back to the default icon + label when
+ * the consumer omits children.
+ *
+ * @public
+ */
+export const AISidebarTrigger = forwardRef<
+  HTMLButtonElement,
+  AISidebarTriggerProps
+>(({ children, className, onClick, ...rest }, ref) => {
+  const { labels, openState, toggle } = useAISidebar();
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      toggle();
+    },
+    [onClick, toggle],
+  );
+  return (
+    <Button
+      aria-expanded={openState}
+      aria-label={children ? undefined : labels.open}
+      className={cn(className)}
+      data-state={openState ? "open" : "closed"}
+      onClick={handleClick}
+      ref={ref}
+      size={children ? "sm" : "icon"}
+      type="button"
+      variant="outline"
+      {...rest}
+    >
+      {children ?? <MessageSquarePlus aria-hidden="true" className="h-4 w-4" />}
+    </Button>
+  );
+});
+AISidebarTrigger.displayName = "AISidebarTrigger";

--- a/apps/registry/registry/default/ai-source-citation/ai-source-citation.tsx
+++ b/apps/registry/registry/default/ai-source-citation/ai-source-citation.tsx
@@ -1,2 +1,60 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import { ExternalLink, Quote } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+export type AISourceCitationProps = React.ComponentPropsWithoutRef<"a"> & {
+  /** Optional short excerpt from the cited source. */
+  snippet?: string;
+  /** Source label such as domain, document, or collection. */
+  source: string;
+  /** Primary citation title. */
+  title: string;
+};
+
+const AISourceCitation = forwardRef<HTMLAnchorElement, AISourceCitationProps>(
+  (
+    { className, href, snippet, source, target = "_blank", title, ...props },
+    ref,
+  ) => {
+    return (
+      <a
+        className={cn(
+          "group inline-flex max-w-full flex-col gap-2 rounded-xl border border-border/70 bg-background px-3 py-2 text-left shadow-sm transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          className,
+        )}
+        href={href}
+        ref={ref}
+        rel={target === "_blank" ? "noreferrer" : undefined}
+        target={target}
+        {...props}
+      >
+        <div className="flex items-start gap-2">
+          <Quote className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-foreground">
+                  {title}
+                </p>
+                <p className="text-xs text-muted-foreground">{source}</p>
+              </div>
+              <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+            </div>
+          </div>
+        </div>
+
+        {snippet ? (
+          <p className="line-clamp-3 text-sm leading-6 text-muted-foreground">
+            {snippet}
+          </p>
+        ) : null}
+      </a>
+    );
+  },
+);
+
+AISourceCitation.displayName = "AISourceCitation";
+
+export { AISourceCitation };

--- a/apps/registry/registry/default/ai-streaming-text/ai-streaming-text.tsx
+++ b/apps/registry/registry/default/ai-streaming-text/ai-streaming-text.tsx
@@ -1,2 +1,54 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type AIStreamingTextProps = React.ComponentPropsWithoutRef<"div"> & {
+  /** Cursor glyph shown while streaming. */
+  cursor?: string;
+  /** Whether new content is still arriving. */
+  isStreaming?: boolean;
+  /** Whether to show the streaming cursor. */
+  showCursor?: boolean;
+  /** Text content available from the stream. */
+  text: string;
+};
+
+const AIStreamingText = forwardRef<HTMLDivElement, AIStreamingTextProps>(
+  (
+    {
+      className,
+      cursor = "▍",
+      isStreaming = false,
+      showCursor = true,
+      text,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <div
+        aria-live={isStreaming ? "polite" : undefined}
+        className={cn(
+          "text-sm leading-6 text-foreground whitespace-pre-wrap",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      >
+        {text}
+        {isStreaming && showCursor ? (
+          <span
+            aria-hidden="true"
+            className="ml-0.5 inline-block animate-pulse text-muted-foreground"
+          >
+            {cursor}
+          </span>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+AIStreamingText.displayName = "AIStreamingText";
+
+export { AIStreamingText };

--- a/apps/registry/registry/default/ai-tool-call-display/ai-tool-call-display.tsx
+++ b/apps/registry/registry/default/ai-tool-call-display/ai-tool-call-display.tsx
@@ -1,2 +1,128 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import { cva } from "class-variance-authority";
+import { AlertCircle, CheckCircle2, Clock3, Wrench } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+
+const statusVariants = cva(
+  "rounded-full px-2 py-0 text-[10px] uppercase tracking-wide",
+  {
+    defaultVariants: {
+      status: "queued",
+    },
+    variants: {
+      status: {
+        complete: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+        error: "bg-red-500/10 text-red-700 dark:text-red-300",
+        queued: "bg-muted text-muted-foreground",
+        running: "bg-blue-500/10 text-blue-700 dark:text-blue-300",
+      },
+    },
+  },
+);
+
+export type AIToolCallStatus = "complete" | "error" | "queued" | "running";
+
+export type AIToolCallDisplayProps = React.ComponentPropsWithoutRef<"div"> & {
+  /** Short description of the tool output. */
+  description?: string;
+  /** Optional execution duration label. */
+  duration?: string;
+  /** Serialized tool arguments or input payload. */
+  input?: string;
+  /** Serialized tool result or output payload. */
+  output?: string;
+  /** Current tool execution state. */
+  status?: AIToolCallStatus;
+  /** Name of the tool. */
+  toolName: string;
+};
+
+const statusIconMap: Record<AIToolCallStatus, React.ReactNode> = {
+  complete: <CheckCircle2 className="h-4 w-4" />,
+  error: <AlertCircle className="h-4 w-4" />,
+  queued: <Clock3 className="h-4 w-4" />,
+  running: <Wrench className="h-4 w-4 animate-pulse" />,
+};
+
+const AIToolCallDisplay = forwardRef<HTMLDivElement, AIToolCallDisplayProps>(
+  (
+    {
+      className,
+      description,
+      duration,
+      input,
+      output,
+      status = "queued",
+      toolName,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <div
+        className={cn(
+          "rounded-2xl border border-border/70 bg-card p-4 shadow-sm",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      >
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 space-y-1">
+            <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+              {statusIconMap[status]}
+              <span>{toolName}</span>
+            </div>
+            {description ? (
+              <p className="text-sm text-muted-foreground">{description}</p>
+            ) : null}
+          </div>
+
+          <div className="flex items-center gap-2">
+            {duration ? (
+              <span className="text-xs text-muted-foreground">{duration}</span>
+            ) : null}
+            <Badge className={statusVariants({ status })} variant="secondary">
+              {status}
+            </Badge>
+          </div>
+        </div>
+
+        {input ? (
+          <details
+            className="mt-4 rounded-xl border border-border/60 bg-muted/20 p-3"
+            open={status !== "complete"}
+          >
+            <summary className="cursor-pointer text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Tool input
+            </summary>
+            <pre className="mt-3 overflow-x-auto whitespace-pre-wrap text-xs leading-5 text-foreground">
+              {input}
+            </pre>
+          </details>
+        ) : null}
+
+        {output ? (
+          <details
+            className="mt-3 rounded-xl border border-border/60 bg-muted/20 p-3"
+            open={status !== "complete"}
+          >
+            <summary className="cursor-pointer text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Tool output
+            </summary>
+            <pre className="mt-3 overflow-x-auto whitespace-pre-wrap text-xs leading-5 text-foreground">
+              {output}
+            </pre>
+          </details>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+AIToolCallDisplay.displayName = "AIToolCallDisplay";
+
+export { AIToolCallDisplay };

--- a/apps/registry/registry/default/alert-dialog/alert-dialog.tsx
+++ b/apps/registry/registry/default/alert-dialog/alert-dialog.tsx
@@ -1,1 +1,142 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+
+import { cn } from "@vllnt/ui";
+import { buttonVariants } from "@vllnt/ui";
+
+const AlertDialog = AlertDialogPrimitive.Root;
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
+
+const AlertDialogTitle = forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    className={cn("text-lg font-semibold", className)}
+    ref={ref}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    className={cn("text-sm text-muted-foreground", className)}
+    ref={ref}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    className={cn(buttonVariants(), className)}
+    ref={ref}
+    {...props}
+  />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/apps/registry/registry/default/alert-pulse/alert-pulse.tsx
+++ b/apps/registry/registry/default/alert-pulse/alert-pulse.tsx
@@ -1,6 +1,146 @@
-export {
-  AlertPulse,
-  type AlertPulseLabels,
-  type AlertPulseProps,
-  type AlertPulseSeverity,
-} from '@vllnt/ui'
+"use client";
+
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Severity tone of an alert pulse — drives the ring color.
+ *
+ * @public
+ */
+export type AlertPulseSeverity = "error" | "info" | "warn";
+
+const SEVERITY_STROKE: Record<AlertPulseSeverity, string> = {
+  error: "stroke-red-500",
+  info: "stroke-blue-500",
+  warn: "stroke-amber-500",
+};
+
+const SEVERITY_FILL: Record<AlertPulseSeverity, string> = {
+  error: "fill-red-500/20",
+  info: "fill-blue-500/20",
+  warn: "fill-amber-500/20",
+};
+
+const SEVERITY_LABEL: Record<AlertPulseSeverity, string> = {
+  error: "Error",
+  info: "Info",
+  warn: "Warning",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type AlertPulseLabels = {
+  /** Override for the aria-label. Defaults to severity name. */
+  region?: string;
+};
+
+/**
+ * Props for {@link AlertPulse}.
+ *
+ * @public
+ */
+export type AlertPulseProps = {
+  /** Center X of the pulse in canvas pixels. */
+  cx: number;
+  /** Center Y of the pulse in canvas pixels. */
+  cy: number;
+  /** Localizable strings. */
+  labels?: AlertPulseLabels;
+  /** Outer ring radius in pixels. Defaults to `36`. */
+  radius?: number;
+  /** Disable the pulse animation. Useful for snapshots. Defaults to `false`. */
+  reducedMotion?: boolean;
+  /** Severity tone. Defaults to `"warn"`. */
+  severity?: AlertPulseSeverity;
+} & ComponentPropsWithoutRef<"svg">;
+
+const safeRadius = (value: number): number => (value < 6 ? 6 : value);
+
+/**
+ * Pulsing ring overlay drawn around an alerting canvas object. The
+ * outer ring expands and fades to communicate "attention here";
+ * the inner ring stays put so the object remains anchored. Pure
+ * presentation; the host computes the center + severity from the
+ * runtime alert stream.
+ *
+ * Render inside a `position: relative` parent that shares the canvas
+ * pixel coordinate space; the SVG is `pointer-events: none` so host
+ * gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <AlertPulse cx={480} cy={320} severity="error" />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const AlertPulse = forwardRef<SVGSVGElement, AlertPulseProps>(
+  (props, ref) => {
+    const {
+      className,
+      cx,
+      cy,
+      labels,
+      radius = 36,
+      reducedMotion = false,
+      severity = "warn",
+      ...rest
+    } = props;
+    const r = safeRadius(radius);
+    const ariaLabel = labels?.region ?? SEVERITY_LABEL[severity];
+    const size = r * 2 + 24;
+    return (
+      <svg
+        aria-label={ariaLabel}
+        className={cn(
+          "pointer-events-none absolute z-20 overflow-visible",
+          className,
+        )}
+        data-alert-pulse
+        data-alert-severity={severity}
+        height={size}
+        ref={ref}
+        role="img"
+        style={{
+          left: cx - size / 2,
+          top: cy - size / 2,
+        }}
+        width={size}
+        {...rest}
+      >
+        <circle
+          className={cn("origin-center", SEVERITY_STROKE[severity])}
+          cx={size / 2}
+          cy={size / 2}
+          fill="none"
+          r={r}
+          strokeOpacity={0.7}
+          strokeWidth={2}
+        />
+        <circle
+          className={cn(
+            "origin-center",
+            SEVERITY_STROKE[severity],
+            SEVERITY_FILL[severity],
+            reducedMotion ? null : "animate-ping",
+          )}
+          cx={size / 2}
+          cy={size / 2}
+          data-alert-pulse-ring
+          r={r}
+          strokeOpacity={0.4}
+          strokeWidth={2}
+        />
+      </svg>
+    );
+  },
+);
+AlertPulse.displayName = "AlertPulse";

--- a/apps/registry/registry/default/alert/alert.tsx
+++ b/apps/registry/registry/default/alert/alert.tsx
@@ -1,1 +1,62 @@
-export * from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  {
+    defaultVariants: {
+      variant: "default",
+    },
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+  },
+);
+
+const Alert = forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    className={cn(alertVariants({ variant }), className)}
+    ref={ref}
+    role="alert"
+    {...props}
+  />
+));
+Alert.displayName = "Alert";
+
+const AlertTitle = forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ children, className, ...props }, ref) => (
+  <h5
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    ref={ref}
+    {...props}
+  >
+    {children}
+  </h5>
+));
+AlertTitle.displayName = "AlertTitle";
+
+const AlertDescription = forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    ref={ref}
+    {...props}
+  />
+));
+AlertDescription.displayName = "AlertDescription";
+
+export { Alert, AlertDescription, AlertTitle, alertVariants };

--- a/apps/registry/registry/default/anchor-port/anchor-port.tsx
+++ b/apps/registry/registry/default/anchor-port/anchor-port.tsx
@@ -1,1 +1,66 @@
-export { AnchorPort, type AnchorPortProps } from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type AnchorPortProps = React.ComponentPropsWithoutRef<"span"> & {
+  side?: "bottom" | "left" | "right" | "top";
+  state?: "active" | "blocked" | "idle";
+  tone?: "bidirectional" | "input" | "output";
+};
+
+const toneClasses: Record<NonNullable<AnchorPortProps["tone"]>, string> = {
+  bidirectional:
+    "border-violet-500/40 bg-violet-500/15 text-violet-700 dark:text-violet-300",
+  input: "border-sky-500/40 bg-sky-500/15 text-sky-700 dark:text-sky-300",
+  output:
+    "border-emerald-500/40 bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+};
+
+const stateClasses: Record<NonNullable<AnchorPortProps["state"]>, string> = {
+  active: "scale-100 opacity-100",
+  blocked: "opacity-60 saturate-50",
+  idle: "opacity-80",
+};
+
+const sideClasses: Record<NonNullable<AnchorPortProps["side"]>, string> = {
+  bottom: "self-end",
+  left: "self-start",
+  right: "self-end",
+  top: "self-start",
+};
+
+const AnchorPort = forwardRef<HTMLSpanElement, AnchorPortProps>(
+  (
+    {
+      className,
+      side = "right",
+      state = "idle",
+      tone = "bidirectional",
+      ...props
+    },
+    ref,
+  ) => (
+    <span
+      aria-label={props["aria-label"] ?? `${tone} ${side} port ${state}`}
+      className={cn(
+        "inline-flex size-7 items-center justify-center rounded-full border shadow-sm",
+        toneClasses[tone],
+        stateClasses[state],
+        sideClasses[side],
+        className,
+      )}
+      data-side={side}
+      data-state={state}
+      data-tone={tone}
+      ref={ref}
+      role="img"
+      {...props}
+    >
+      <span className="size-2.5 rounded-full bg-current" />
+    </span>
+  ),
+);
+
+AnchorPort.displayName = "AnchorPort";
+
+export { AnchorPort };

--- a/apps/registry/registry/default/animated-text/animated-text.tsx
+++ b/apps/registry/registry/default/animated-text/animated-text.tsx
@@ -1,2 +1,470 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+
+const GLYPH_SEGMENTER = new Intl.Segmenter(undefined, {
+  granularity: "grapheme",
+});
+
+const ASCII_RANDOM_CHARACTERS = Array.from({ length: 94 }, (_, index) =>
+  String.fromCodePoint(index + 33),
+).join("");
+const TERMINAL_RANDOM_CHARACTERS = "│┃─━┄┅┈┉┌┐└┘├┤┬┴┼╭╮╯╰╱╲╳";
+const BLOCK_RANDOM_CHARACTERS = "░▒▓█▌▐▀▄■□▪▫▖▗▘▙▚▛▜▝▞▟";
+const UNICODE_SYMBOL_RANDOM_CHARACTERS = "◆◇◈○●◎◉◌◍◐◑◒◓◔◕◢◣◤◥◦※✦✧✱✶✷✹";
+const MATRIX_RANDOM_CHARACTERS = `${ASCII_RANDOM_CHARACTERS}${TERMINAL_RANDOM_CHARACTERS}${BLOCK_RANDOM_CHARACTERS}${UNICODE_SYMBOL_RANDOM_CHARACTERS}`;
+
+export const ANIMATED_TEXT_RANDOM_CHARACTER_PRESETS = {
+  ascii: ASCII_RANDOM_CHARACTERS,
+  binary: "01",
+  blocks: BLOCK_RANDOM_CHARACTERS,
+  matrix: MATRIX_RANDOM_CHARACTERS,
+  symbols: UNICODE_SYMBOL_RANDOM_CHARACTERS,
+  terminal: TERMINAL_RANDOM_CHARACTERS,
+} as const;
+
+const DEFAULT_RANDOM_CHARACTERS = ANIMATED_TEXT_RANDOM_CHARACTER_PRESETS.matrix;
+
+type AnimatedTextSplit = "character" | "word";
+export type AnimatedTextVariant =
+  | "decipher"
+  | "matrix"
+  | "reveal"
+  | "terminal"
+  | "typewriter";
+export type AnimatedTextDirection = "center-out" | "end" | "random" | "start";
+export type AnimatedTextRandomCharacterPreset =
+  keyof typeof ANIMATED_TEXT_RANDOM_CHARACTER_PRESETS;
+
+type SegmentFrame = {
+  content: string;
+  isRevealed: boolean;
+  key: string;
+  style?: React.CSSProperties;
+};
+
+export type AnimatedTextProps = React.ComponentPropsWithoutRef<"p"> & {
+  cursor?: boolean;
+  cursorChar?: string;
+  direction?: AnimatedTextDirection;
+  duration?: number;
+  randomCharacters?: string;
+  randomCharactersPreset?: AnimatedTextRandomCharacterPreset;
+  randomness?: number;
+  splitBy?: AnimatedTextSplit;
+  stagger?: number;
+  text: string;
+  variant?: AnimatedTextVariant;
+};
+
+function getSegments(text: string, splitBy: AnimatedTextSplit): string[] {
+  if (splitBy === "character") {
+    const segmenter = new Intl.Segmenter(undefined, {
+      granularity: "grapheme",
+    });
+
+    return Array.from(segmenter.segment(text), ({ segment }) => segment);
+  }
+
+  return text.match(/\S+\s*/g) ?? [];
+}
+
+function getGlyphs(text: string): string[] {
+  return Array.from(GLYPH_SEGMENTER.segment(text), ({ segment }) => segment);
+}
+
+function getRandomMatrixGlyph(randomCharacters: string): string {
+  const glyphs = getGlyphs(randomCharacters);
+
+  return glyphs[Math.floor(Math.random() * glyphs.length)] ?? glyphs[0] ?? "0";
+}
+
+function getResolvedRandomCharacters(
+  randomCharacters: string | undefined,
+  randomCharactersPreset: AnimatedTextRandomCharacterPreset,
+): string {
+  if (randomCharacters && randomCharacters.length > 0) {
+    return randomCharacters;
+  }
+
+  return (
+    ANIMATED_TEXT_RANDOM_CHARACTER_PRESETS[randomCharactersPreset] ??
+    DEFAULT_RANDOM_CHARACTERS
+  );
+}
+
+function getCursorToneClass(variant: AnimatedTextVariant): string {
+  return variant === "matrix" || variant === "decipher"
+    ? "text-primary"
+    : "text-foreground";
+}
+
+function buildRevealFrames(
+  segments: string[],
+  stagger: number,
+): SegmentFrame[] {
+  return segments.map((segment, index) => ({
+    content: segment,
+    isRevealed: true,
+    key: `${segment}-${index}`,
+    style: {
+      animationDelay: `${index * stagger}ms`,
+    },
+  }));
+}
+
+function buildIndexOrder(
+  direction: AnimatedTextDirection,
+  length: number,
+): number[] {
+  if (direction === "end") {
+    return Array.from({ length }, (_, index) => length - index - 1);
+  }
+
+  if (direction === "random") {
+    return Array.from({ length }, (_, index) => index).sort(
+      () => Math.random() - 0.5,
+    );
+  }
+
+  if (direction === "center-out") {
+    const center = (length - 1) / 2;
+
+    return Array.from({ length }, (_, index) => index).sort((left, right) => {
+      const leftDistance = Math.abs(left - center);
+      const rightDistance = Math.abs(right - center);
+
+      if (leftDistance === rightDistance) {
+        return left - right;
+      }
+
+      return leftDistance - rightDistance;
+    });
+  }
+
+  return Array.from({ length }, (_, index) => index);
+}
+
+function buildRevealPlan(
+  direction: AnimatedTextDirection,
+  length: number,
+  randomness: number,
+): number[] {
+  const orderedIndices = buildIndexOrder(direction, length);
+  const revealPlan = Array.from({ length }, () => 0);
+  const jitterRange = Math.max(0, Math.round(randomness * 4));
+
+  orderedIndices.forEach((segmentIndex, revealIndex) => {
+    const jitter =
+      jitterRange > 0 ? Math.floor(Math.random() * (jitterRange + 1)) : 0;
+    revealPlan[segmentIndex] = revealIndex + jitter;
+  });
+
+  return revealPlan;
+}
+
+function useRevealProgress(active: boolean, length: number, stagger: number) {
+  const [progress, setProgress] = React.useState(0);
+
+  React.useEffect(() => {
+    if (!active) {
+      setProgress(length);
+      return;
+    }
+
+    setProgress(0);
+
+    const revealInterval = window.setInterval(
+      () => {
+        setProgress((current) => {
+          if (current >= length + 4) {
+            window.clearInterval(revealInterval);
+            return current;
+          }
+
+          return current + 1;
+        });
+      },
+      Math.max(16, stagger),
+    );
+
+    return () => {
+      window.clearInterval(revealInterval);
+    };
+  }, [active, length, stagger]);
+
+  return progress;
+}
+
+function useMatrixFrame({
+  active,
+  progress,
+  randomCharacters,
+  revealPlan,
+  segments,
+}: {
+  active: boolean;
+  progress: number;
+  randomCharacters: string;
+  revealPlan: number[];
+  segments: string[];
+}) {
+  const [matrixFrame, setMatrixFrame] = React.useState(() =>
+    segments.map(() => getRandomMatrixGlyph(randomCharacters)),
+  );
+
+  React.useEffect(() => {
+    if (!active) {
+      return;
+    }
+
+    setMatrixFrame(segments.map(() => getRandomMatrixGlyph(randomCharacters)));
+
+    const scrambleInterval = window.setInterval(() => {
+      setMatrixFrame((current) =>
+        current.map((glyph, index) => {
+          const isWhitespace = /^\s+$/.test(segments[index] ?? "");
+          const isRevealed = progress >= (revealPlan[index] ?? 0);
+
+          if (isWhitespace || isRevealed) {
+            return glyph;
+          }
+
+          return getRandomMatrixGlyph(randomCharacters);
+        }),
+      );
+    }, 48);
+
+    return () => {
+      window.clearInterval(scrambleInterval);
+    };
+  }, [active, progress, randomCharacters, revealPlan, segments]);
+
+  return matrixFrame;
+}
+
+function buildOldSchoolFrames({
+  matrixFrame,
+  progress,
+  randomCharacters,
+  revealPlan,
+  segments,
+  variant,
+}: {
+  matrixFrame: string[];
+  progress: number;
+  randomCharacters: string;
+  revealPlan: number[];
+  segments: string[];
+  variant: Exclude<AnimatedTextVariant, "reveal">;
+}): SegmentFrame[] {
+  return segments.map((segment, index) => {
+    const isWhitespace = /^\s+$/.test(segment);
+    const revealStep = revealPlan[index] ?? 0;
+    const isRevealed = progress >= revealStep;
+
+    let content = "";
+    if (variant === "matrix" || variant === "decipher") {
+      content = isWhitespace
+        ? segment
+        : isRevealed
+          ? segment
+          : (matrixFrame[index] ?? getRandomMatrixGlyph(randomCharacters));
+    } else if (isRevealed) {
+      content = segment;
+    }
+
+    return {
+      content,
+      isRevealed,
+      key: `${segment}-${index}`,
+    };
+  });
+}
+
+function useAnimatedTextFrames({
+  direction,
+  randomCharacters,
+  randomness,
+  segments,
+  stagger,
+  variant,
+}: {
+  direction: AnimatedTextDirection;
+  randomCharacters: string;
+  randomness: number;
+  segments: string[];
+  stagger: number;
+  variant: AnimatedTextVariant;
+}): SegmentFrame[] {
+  const isOldSchool = variant !== "reveal";
+  const revealPlan = React.useMemo(
+    () =>
+      isOldSchool
+        ? buildRevealPlan(direction, segments.length, randomness)
+        : Array.from({ length: segments.length }, (_, index) => index),
+    [direction, isOldSchool, randomness, segments.length],
+  );
+  const progress = useRevealProgress(isOldSchool, segments.length, stagger);
+  const matrixFrame = useMatrixFrame({
+    active: variant === "matrix" || variant === "decipher",
+    progress,
+    randomCharacters,
+    revealPlan,
+    segments,
+  });
+
+  return React.useMemo(() => {
+    if (!isOldSchool) {
+      return buildRevealFrames(segments, stagger);
+    }
+
+    return buildOldSchoolFrames({
+      matrixFrame,
+      progress,
+      randomCharacters,
+      revealPlan,
+      segments,
+      variant,
+    });
+  }, [
+    isOldSchool,
+    matrixFrame,
+    progress,
+    randomCharacters,
+    revealPlan,
+    segments,
+    stagger,
+    variant,
+  ]);
+}
+
+function getSegmentClasses(
+  variant: AnimatedTextVariant,
+  isRevealed: boolean,
+): string {
+  if (variant === "reveal") {
+    return "inline-block whitespace-pre opacity-0 [animation-duration:var(--vllnt-animated-text-duration)] [animation-fill-mode:forwards] [animation-name:vllnt-animated-text-reveal] [animation-timing-function:cubic-bezier(0.16,1,0.3,1)]";
+  }
+
+  if (variant === "matrix" || variant === "decipher") {
+    return cn(
+      "inline-block whitespace-pre font-mono tracking-[0.08em] transition-colors duration-150",
+      isRevealed ? "text-foreground" : "text-primary/75",
+    );
+  }
+
+  return "inline-block whitespace-pre font-mono";
+}
+
+function getContainerClasses(variant: AnimatedTextVariant): string {
+  if (variant === "matrix" || variant === "decipher") {
+    return "flex flex-wrap font-mono leading-relaxed tracking-[0.08em]";
+  }
+
+  if (variant === "terminal" || variant === "typewriter") {
+    return "flex flex-wrap font-mono leading-relaxed";
+  }
+
+  return "flex flex-wrap leading-relaxed";
+}
+
+function AnimatedTextCursor({
+  cursorChar,
+  cursorToneClass,
+}: {
+  cursorChar: string;
+  cursorToneClass: string;
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "ml-0.5 inline-block whitespace-pre font-mono [animation:vllnt-terminal-cursor-blink_1s_steps(1,end)_infinite]",
+        cursorToneClass,
+      )}
+    >
+      {cursorChar}
+    </span>
+  );
+}
+
+export const AnimatedText = React.forwardRef<
+  HTMLParagraphElement,
+  AnimatedTextProps
+>(
+  (
+    {
+      className,
+      cursor = true,
+      cursorChar = "█",
+      direction = "start",
+      duration = 600,
+      randomCharacters,
+      randomCharactersPreset = "matrix",
+      randomness = 0,
+      splitBy = "word",
+      stagger = 70,
+      text,
+      variant = "terminal",
+      ...props
+    },
+    ref,
+  ) => {
+    const resolvedRandomCharacters = getResolvedRandomCharacters(
+      randomCharacters,
+      randomCharactersPreset,
+    );
+    const resolvedSplitBy = variant === "reveal" ? splitBy : "character";
+    const segments = React.useMemo(
+      () => getSegments(text, resolvedSplitBy),
+      [resolvedSplitBy, text],
+    );
+    const segmentFrames = useAnimatedTextFrames({
+      direction,
+      randomCharacters: resolvedRandomCharacters,
+      randomness,
+      segments,
+      stagger,
+      variant,
+    });
+    const showCursor =
+      cursor &&
+      variant !== "reveal" &&
+      segmentFrames.some((frame) => !frame.isRevealed);
+    const cursorToneClass = getCursorToneClass(variant);
+
+    return (
+      <p
+        aria-label={text}
+        className={cn(getContainerClasses(variant), className)}
+        ref={ref}
+        style={{
+          ["--vllnt-animated-text-duration" as string]: `${duration}ms`,
+        }}
+        {...props}
+      >
+        {segmentFrames.map((segmentFrame) => (
+          <span
+            aria-hidden="true"
+            className={getSegmentClasses(variant, segmentFrame.isRevealed)}
+            key={segmentFrame.key}
+            style={segmentFrame.style}
+          >
+            {segmentFrame.content}
+          </span>
+        ))}
+        {showCursor ? (
+          <AnimatedTextCursor
+            cursorChar={cursorChar}
+            cursorToneClass={cursorToneClass}
+          />
+        ) : null}
+      </p>
+    );
+  },
+);
+
+AnimatedText.displayName = "AnimatedText";

--- a/apps/registry/registry/default/annotation/annotation.tsx
+++ b/apps/registry/registry/default/annotation/annotation.tsx
@@ -1,2 +1,74 @@
-// Re-export from @vllnt/ui package
-export { Annotation, Highlight } from '@vllnt/ui'
+"use client";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+import { Popover, PopoverContent, PopoverTrigger } from "@vllnt/ui";
+
+const toneClasses = {
+  amber: "bg-amber-500/20 text-amber-950 dark:text-amber-100",
+  emerald: "bg-emerald-500/20 text-emerald-950 dark:text-emerald-100",
+  rose: "bg-rose-500/20 text-rose-950 dark:text-rose-100",
+  sky: "bg-sky-500/20 text-sky-950 dark:text-sky-100",
+};
+
+export type HighlightProps = {
+  children: ReactNode;
+  className?: string;
+  tone?: keyof typeof toneClasses;
+};
+
+export function Highlight({
+  children,
+  className,
+  tone = "amber",
+}: HighlightProps): ReactNode {
+  return (
+    <mark className={cn("rounded px-1 py-0.5", toneClasses[tone], className)}>
+      {children}
+    </mark>
+  );
+}
+
+export type AnnotationProps = {
+  annotation: ReactNode;
+  children: ReactNode;
+  className?: string;
+  label?: string;
+  tone?: keyof typeof toneClasses;
+};
+
+export function Annotation({
+  annotation,
+  children,
+  className,
+  label = "Annotation",
+  tone = "amber",
+}: AnnotationProps): ReactNode {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          className={cn(
+            "inline-flex items-center gap-1 rounded-sm text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            className,
+          )}
+          type="button"
+        >
+          <Highlight tone={tone}>{children}</Highlight>
+          <span className="text-[10px] font-semibold text-primary align-super">
+            +
+          </span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="max-w-xs space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          {label}
+        </p>
+        <div className="text-sm text-muted-foreground [&>p]:mb-2">
+          {annotation}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/registry/registry/default/aspect-ratio/aspect-ratio.tsx
+++ b/apps/registry/registry/default/aspect-ratio/aspect-ratio.tsx
@@ -1,1 +1,7 @@
-export * from '@vllnt/ui'
+"use client";
+
+import * as AspectRatioPrimitive from "@radix-ui/react-aspect-ratio";
+
+const AspectRatio = AspectRatioPrimitive.Root;
+
+export { AspectRatio };

--- a/apps/registry/registry/default/auto-reload/auto-reload.tsx
+++ b/apps/registry/registry/default/auto-reload/auto-reload.tsx
@@ -1,2 +1,572 @@
-// Re-export from @vllnt/ui package
-export { AutoReload } from '@vllnt/ui'
+"use client";
+
+import {
+  type ChangeEvent,
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import { Input } from "@vllnt/ui";
+import { Switch } from "@vllnt/ui";
+
+const CENTS_PER_UNIT = 100;
+const DEFAULT_LOCALE = "en-US";
+const DEFAULT_CURRENCY = "USD";
+const DEFAULT_STEP_CENTS = 100;
+
+/**
+ * Snapshot passed to {@link AutoReloadProps.onSave}.
+ *
+ * @public
+ */
+export type AutoReloadSavePayload = {
+  reloadAmountCents: number;
+  thresholdCents: number;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type AutoReloadLabels = {
+  /** Caption for the disabled banner. */
+  disabledFallback?: string;
+  /** Caption for the toggle headline. Defaults to `"Auto-reload"`. */
+  heading?: string;
+  /** Helper line under the toggle headline. Defaults to `"Automatically reload credits when balance is low."`. */
+  helper?: string;
+  /** Helper line under the reload-amount input. */
+  reloadHelper?: string;
+  /** Caption for the reload-amount input. Defaults to `"Reload amount"`. */
+  reloadLabel?: string;
+  /** Caption for the save button. Defaults to `"Save settings"`. */
+  save?: string;
+  /** Caption for the save button while saving. Defaults to `"Saving…"`. */
+  saving?: string;
+  /** Helper line under the threshold input. */
+  thresholdHelper?: string;
+  /** Caption for the threshold input. Defaults to `"Threshold"`. */
+  thresholdLabel?: string;
+};
+
+const DEFAULT_LABELS = {
+  disabledFallback: "Auto-reload is unavailable for this account.",
+  heading: "Auto-reload",
+  helper: "Automatically reload credits when balance is low.",
+  reloadHelper: "Amount to add when the threshold is hit.",
+  reloadLabel: "Reload amount",
+  save: "Save settings",
+  saving: "Saving…",
+  thresholdHelper: "Reload when the balance drops below this.",
+  thresholdLabel: "Threshold",
+} as const satisfies Required<AutoReloadLabels>;
+
+/**
+ * Props for {@link AutoReload}.
+ *
+ * @public
+ */
+export type AutoReloadProps = {
+  /** Currency code (ISO 4217). Defaults to `"USD"`. */
+  currency?: string;
+  /** Override the symbol displayed inside the inputs (e.g. `"€"`). */
+  currencySymbol?: string;
+  /** Initial enabled state when uncontrolled. */
+  defaultEnabled?: boolean;
+  /** Initial reload-amount value (cents) when uncontrolled. */
+  defaultReloadAmountCents?: number;
+  /** Initial threshold value (cents) when uncontrolled. */
+  defaultThresholdCents?: number;
+  /** When true, the consumer cannot interact with the control. */
+  disabled?: boolean;
+  /** Caption rendered with `disabled`. */
+  disabledMessage?: ReactNode;
+  /** Controlled enabled state. */
+  enabled?: boolean;
+  /** When true, the save button renders as loading + disabled. */
+  isSaving?: boolean;
+  /** Localizable strings. */
+  labels?: AutoReloadLabels;
+  /** BCP-47 locale tag. Defaults to `"en-US"`. */
+  locale?: string;
+  /** Highest allowed amount (cents). */
+  maxAmountCents?: number;
+  /** Lowest allowed amount (cents). Defaults to `100`. */
+  minAmountCents?: number;
+  /** Fires when the user clicks save. */
+  onSave?: (payload: AutoReloadSavePayload) => void;
+  /** Fires when the toggle changes. */
+  onToggle?: (enabled: boolean) => void;
+  /** Controlled reload-amount value (cents). */
+  reloadAmountCents?: number;
+  /** Step granularity for the inputs (cents). Defaults to `100`. */
+  stepCents?: number;
+  /** Controlled threshold value (cents). */
+  thresholdCents?: number;
+} & ComponentPropsWithoutRef<"div">;
+
+function centsToValue(cents: number): string {
+  return (cents / CENTS_PER_UNIT).toFixed(2);
+}
+
+function valueToCents(value: string): number {
+  const parsed = Number.parseFloat(value);
+  if (Number.isNaN(parsed)) return 0;
+  return Math.round(parsed * CENTS_PER_UNIT);
+}
+
+function getCurrencySymbol(locale: string, currency: string): string {
+  const formatted = new Intl.NumberFormat(locale, {
+    currency,
+    style: "currency",
+  }).format(0);
+  const symbol = formatted.replaceAll(/[\d\s,.]/g, "");
+  return symbol.length > 0 ? symbol : currency;
+}
+
+type ReloadFormProps = {
+  currencyDisplay: string;
+  isSaving: boolean;
+  labels: Required<AutoReloadLabels>;
+  maxAmountCents?: number;
+  minAmountCents: number;
+  onSave: () => void;
+  reloadAmount: number;
+  reloadAmountId: string;
+  setReloadAmount: (value: number) => void;
+  setThreshold: (value: number) => void;
+  stepCents: number;
+  threshold: number;
+  thresholdId: string;
+};
+
+function ReloadFormFields({
+  currencyDisplay,
+  isSaving,
+  labels,
+  maxAmountCents,
+  minAmountCents,
+  onSave,
+  reloadAmount,
+  reloadAmountId,
+  setReloadAmount,
+  setThreshold,
+  stepCents,
+  threshold,
+  thresholdId,
+}: ReloadFormProps): ReactNode {
+  const handleThreshold = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setThreshold(valueToCents(event.target.value));
+    },
+    [setThreshold],
+  );
+  const handleReload = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setReloadAmount(valueToCents(event.target.value));
+    },
+    [setReloadAmount],
+  );
+  const step = (stepCents / CENTS_PER_UNIT).toFixed(2);
+  const min = (minAmountCents / CENTS_PER_UNIT).toFixed(2);
+  const max =
+    maxAmountCents === undefined
+      ? undefined
+      : (maxAmountCents / CENTS_PER_UNIT).toFixed(2);
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <NumericField
+          currencyDisplay={currencyDisplay}
+          helper={labels.thresholdHelper}
+          id={thresholdId}
+          label={labels.thresholdLabel}
+          max={max}
+          min={min}
+          onChange={handleThreshold}
+          step={step}
+          value={centsToValue(threshold)}
+        />
+        <NumericField
+          currencyDisplay={currencyDisplay}
+          helper={labels.reloadHelper}
+          id={reloadAmountId}
+          label={labels.reloadLabel}
+          max={max}
+          min={min}
+          onChange={handleReload}
+          step={step}
+          value={centsToValue(reloadAmount)}
+        />
+      </div>
+      <div>
+        <Button disabled={isSaving} onClick={onSave} type="button">
+          {isSaving ? labels.saving : labels.save}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+type NumericFieldProps = {
+  currencyDisplay: string;
+  helper?: string;
+  id: string;
+  label: string;
+  max?: string;
+  min?: string;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  step: string;
+  value: string;
+};
+
+function NumericField({
+  currencyDisplay,
+  helper,
+  id,
+  label,
+  max,
+  min,
+  onChange,
+  step,
+  value,
+}: NumericFieldProps): ReactNode {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-sm font-medium text-foreground" htmlFor={id}>
+        {label} ({currencyDisplay})
+      </label>
+      <Input
+        id={id}
+        inputMode="decimal"
+        max={max}
+        min={min}
+        onChange={onChange}
+        step={step}
+        type="number"
+        value={value}
+      />
+      {helper ? (
+        <p className="text-xs text-muted-foreground">{helper}</p>
+      ) : null}
+    </div>
+  );
+}
+
+type ToggleHeaderProps = {
+  enabled: boolean;
+  heading: string;
+  helper: string;
+  id: string;
+  onCheckedChange: (next: boolean) => void;
+};
+
+function ToggleHeader({
+  enabled,
+  heading,
+  helper,
+  id,
+  onCheckedChange,
+}: ToggleHeaderProps): ReactNode {
+  const helperId = `${id}-helper`;
+  return (
+    <header className="flex items-start justify-between gap-3">
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-semibold text-foreground" id={id}>
+          {heading}
+        </span>
+        <span className="text-xs text-muted-foreground" id={helperId}>
+          {helper}
+        </span>
+      </div>
+      <Switch
+        aria-describedby={helperId}
+        aria-labelledby={id}
+        checked={enabled}
+        onCheckedChange={onCheckedChange}
+      />
+    </header>
+  );
+}
+
+type ControllerOptions = {
+  defaultEnabled: boolean;
+  defaultReloadAmountCents: number;
+  defaultThresholdCents: number;
+  enabled?: boolean;
+  onToggle?: (enabled: boolean) => void;
+  reloadAmountCents?: number;
+  thresholdCents?: number;
+};
+
+type ControllerState = {
+  enabled: boolean;
+  handleToggle: (next: boolean) => void;
+  reloadAmount: number;
+  setReloadAmount: (value: number) => void;
+  setThreshold: (value: number) => void;
+  threshold: number;
+};
+
+function useAutoReloadController(options: ControllerOptions): ControllerState {
+  const {
+    defaultEnabled,
+    defaultReloadAmountCents,
+    defaultThresholdCents,
+    enabled: controlledEnabled,
+    onToggle,
+    reloadAmountCents: controlledReload,
+    thresholdCents: controlledThreshold,
+  } = options;
+  const [uncontrolledEnabled, setUncontrolledEnabled] =
+    useState(defaultEnabled);
+  const [threshold, setThreshold] = useState(defaultThresholdCents);
+  const [reloadAmount, setReloadAmount] = useState(defaultReloadAmountCents);
+  const enabled = controlledEnabled ?? uncontrolledEnabled;
+
+  const handleToggle = useCallback(
+    (next: boolean) => {
+      if (controlledEnabled === undefined) setUncontrolledEnabled(next);
+      onToggle?.(next);
+    },
+    [controlledEnabled, onToggle],
+  );
+
+  return {
+    enabled,
+    handleToggle,
+    reloadAmount: controlledReload ?? reloadAmount,
+    setReloadAmount,
+    setThreshold,
+    threshold: controlledThreshold ?? threshold,
+  };
+}
+
+/**
+ * Toggle + collapsible configuration form for automatic credit reloading.
+ * Composes {@link Switch}, {@link Input}, and {@link Button}. Renders a
+ * disabled banner when the consumer passes `disabled` so the control can
+ * advertise itself before the user has access (e.g. before subscribing).
+ *
+ * Values flow through the component in **minor units** (cents). Inputs
+ * display the corresponding currency unit; consumers receive the cents
+ * value from `onSave`.
+ *
+ * @example
+ * ```tsx
+ * <AutoReload
+ *   enabled={settings.autoReloadEnabled}
+ *   thresholdCents={settings.thresholdCents}
+ *   reloadAmountCents={settings.reloadAmountCents}
+ *   currency="EUR"
+ *   onToggle={handleToggle}
+ *   onSave={handleSave}
+ *   isSaving={isSaving}
+ * />
+ * ```
+ *
+ * @public
+ */
+type DisabledBannerProps = {
+  className?: string;
+  message: ReactNode;
+} & ComponentPropsWithoutRef<"div">;
+
+const DisabledBanner = forwardRef<HTMLDivElement, DisabledBannerProps>(
+  ({ className, message, ...rest }, ref) => (
+    <div
+      aria-disabled="true"
+      className={cn(
+        "flex items-start gap-3 rounded-2xl border border-dashed border-border bg-muted/30 p-4 text-sm text-muted-foreground",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      {message}
+    </div>
+  ),
+);
+DisabledBanner.displayName = "AutoReload.DisabledBanner";
+
+type ActivePanelProps = {
+  className?: string;
+  controller: ControllerState;
+  currencyDisplay: string;
+  isSaving: boolean;
+  labels: Required<AutoReloadLabels>;
+  maxAmountCents?: number;
+  minAmountCents: number;
+  onSave: () => void;
+  reloadAmountId: string;
+  stepCents: number;
+  thresholdId: string;
+  toggleId: string;
+} & ComponentPropsWithoutRef<"div">;
+
+const ActivePanel = forwardRef<HTMLDivElement, ActivePanelProps>(
+  (props, ref) => {
+    const {
+      className,
+      controller,
+      currencyDisplay,
+      isSaving,
+      labels,
+      maxAmountCents,
+      minAmountCents,
+      onSave,
+      reloadAmountId,
+      stepCents,
+      thresholdId,
+      toggleId,
+      ...rest
+    } = props;
+    return (
+      <div
+        className={cn(
+          "flex flex-col gap-4 rounded-2xl border bg-background p-4",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <ToggleHeader
+          enabled={controller.enabled}
+          heading={labels.heading}
+          helper={labels.helper}
+          id={toggleId}
+          onCheckedChange={controller.handleToggle}
+        />
+        {controller.enabled ? (
+          <ReloadFormFields
+            currencyDisplay={currencyDisplay}
+            isSaving={isSaving}
+            labels={labels}
+            maxAmountCents={maxAmountCents}
+            minAmountCents={minAmountCents}
+            onSave={onSave}
+            reloadAmount={controller.reloadAmount}
+            reloadAmountId={reloadAmountId}
+            setReloadAmount={controller.setReloadAmount}
+            setThreshold={controller.setThreshold}
+            stepCents={stepCents}
+            threshold={controller.threshold}
+            thresholdId={thresholdId}
+          />
+        ) : null}
+      </div>
+    );
+  },
+);
+ActivePanel.displayName = "AutoReload.ActivePanel";
+
+type AutoReloadInternalState = {
+  controller: ControllerState;
+  currencyDisplay: string;
+  handleSave: () => void;
+  reloadAmountId: string;
+  resolvedLabels: Required<AutoReloadLabels>;
+  thresholdId: string;
+  toggleId: string;
+};
+
+function useAutoReloadInternals(
+  props: AutoReloadProps,
+): AutoReloadInternalState {
+  const {
+    currency = DEFAULT_CURRENCY,
+    currencySymbol,
+    defaultEnabled = false,
+    defaultReloadAmountCents = 2000,
+    defaultThresholdCents = 1000,
+    enabled: controlledEnabled,
+    labels,
+    locale = DEFAULT_LOCALE,
+    onSave,
+    onToggle,
+    reloadAmountCents: controlledReload,
+    thresholdCents: controlledThreshold,
+  } = props;
+  const resolvedLabels = useMemo(
+    () => ({ ...DEFAULT_LABELS, ...labels }),
+    [labels],
+  );
+  const toggleId = useId();
+  const thresholdId = useId();
+  const reloadAmountId = useId();
+  const controller = useAutoReloadController({
+    defaultEnabled,
+    defaultReloadAmountCents,
+    defaultThresholdCents,
+    enabled: controlledEnabled,
+    onToggle,
+    reloadAmountCents: controlledReload,
+    thresholdCents: controlledThreshold,
+  });
+  const currencyDisplay = currencySymbol ?? getCurrencySymbol(locale, currency);
+  const handleSave = useCallback(() => {
+    onSave?.({
+      reloadAmountCents: controller.reloadAmount,
+      thresholdCents: controller.threshold,
+    });
+  }, [controller.reloadAmount, controller.threshold, onSave]);
+  return {
+    controller,
+    currencyDisplay,
+    handleSave,
+    reloadAmountId,
+    resolvedLabels,
+    thresholdId,
+    toggleId,
+  };
+}
+
+export const AutoReload = forwardRef<HTMLDivElement, AutoReloadProps>(
+  (props, ref) => {
+    const {
+      className,
+      disabled = false,
+      disabledMessage,
+      isSaving = false,
+      maxAmountCents,
+      minAmountCents = 100,
+      stepCents = DEFAULT_STEP_CENTS,
+    } = props;
+    const internals = useAutoReloadInternals(props);
+    if (disabled) {
+      return (
+        <DisabledBanner
+          className={className}
+          message={disabledMessage ?? internals.resolvedLabels.disabledFallback}
+          ref={ref}
+        />
+      );
+    }
+    return (
+      <ActivePanel
+        className={className}
+        controller={internals.controller}
+        currencyDisplay={internals.currencyDisplay}
+        isSaving={isSaving}
+        labels={internals.resolvedLabels}
+        maxAmountCents={maxAmountCents}
+        minAmountCents={minAmountCents}
+        onSave={internals.handleSave}
+        ref={ref}
+        reloadAmountId={internals.reloadAmountId}
+        stepCents={stepCents}
+        thresholdId={internals.thresholdId}
+        toggleId={internals.toggleId}
+      />
+    );
+  },
+);
+AutoReload.displayName = "AutoReload";

--- a/apps/registry/registry/default/avatar-group/avatar-group.tsx
+++ b/apps/registry/registry/default/avatar-group/avatar-group.tsx
@@ -1,1 +1,99 @@
-export * from '@vllnt/ui'
+import * as React from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+import { Avatar, AvatarFallback, AvatarImage } from "@vllnt/ui";
+
+const avatarGroupVariants = cva("flex items-center", {
+  defaultVariants: {
+    size: "md",
+  },
+  variants: {
+    size: {
+      lg: "-space-x-4",
+      md: "-space-x-3",
+      sm: "-space-x-2.5",
+    },
+  },
+});
+
+const avatarItemVariants = cva(
+  "ring-2 ring-background border border-border bg-muted text-muted-foreground",
+  {
+    defaultVariants: {
+      size: "md",
+    },
+    variants: {
+      size: {
+        lg: "h-12 w-12 text-sm",
+        md: "h-10 w-10 text-xs",
+        sm: "h-8 w-8 text-[11px]",
+      },
+    },
+  },
+);
+
+const overflowBadgeVariants = cva(
+  "inline-flex shrink-0 items-center justify-center rounded-full border border-border bg-muted font-medium text-muted-foreground ring-2 ring-background",
+  {
+    defaultVariants: {
+      size: "md",
+    },
+    variants: {
+      size: {
+        lg: "h-12 min-w-12 px-3 text-sm",
+        md: "h-10 min-w-10 px-2.5 text-xs",
+        sm: "h-8 min-w-8 px-2 text-[11px]",
+      },
+    },
+  },
+);
+
+export type AvatarGroupItem = {
+  alt: string;
+  fallback: string;
+  src?: string;
+};
+
+export type AvatarGroupProps = React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof avatarGroupVariants> & {
+    items: AvatarGroupItem[];
+    max?: number;
+    overflowLabel?: (hiddenCount: number) => string;
+  };
+
+const AvatarGroup = React.forwardRef<HTMLDivElement, AvatarGroupProps>(
+  ({ className, items, max, overflowLabel, size, ...props }, reference) => {
+    const visibleItems = max === undefined ? items : items.slice(0, max);
+    const hiddenCount = max === undefined ? 0 : Math.max(items.length - max, 0);
+
+    return (
+      <div
+        className={cn(avatarGroupVariants({ size }), className)}
+        ref={reference}
+        {...props}
+      >
+        {visibleItems.map((item, index) => (
+          <Avatar
+            className={avatarItemVariants({ size })}
+            key={`${item.alt}-${index}`}
+            style={{ zIndex: visibleItems.length - index }}
+          >
+            {item.src ? <AvatarImage alt={item.alt} src={item.src} /> : null}
+            <AvatarFallback>{item.fallback}</AvatarFallback>
+          </Avatar>
+        ))}
+        {hiddenCount > 0 ? (
+          <span className={overflowBadgeVariants({ size })}>
+            {overflowLabel ? overflowLabel(hiddenCount) : `+${hiddenCount}`}
+          </span>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+AvatarGroup.displayName = "AvatarGroup";
+
+export { AvatarGroup, avatarGroupVariants, avatarItemVariants };

--- a/apps/registry/registry/default/avatar/avatar.tsx
+++ b/apps/registry/registry/default/avatar/avatar.tsx
@@ -1,1 +1,51 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+
+import { cn } from "@vllnt/ui";
+
+const Avatar = forwardRef<
+  React.ComponentRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+Avatar.displayName = AvatarPrimitive.Root.displayName;
+
+const AvatarImage = forwardRef<
+  React.ComponentRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    className={cn("aspect-square h-full w-full", className)}
+    ref={ref}
+    {...props}
+  />
+));
+AvatarImage.displayName = AvatarPrimitive.Image.displayName;
+
+const AvatarFallback = forwardRef<
+  React.ComponentRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
+
+export { Avatar, AvatarFallback, AvatarImage };

--- a/apps/registry/registry/default/badge/badge.tsx
+++ b/apps/registry/registry/default/badge/badge.tsx
@@ -1,2 +1,34 @@
-// Re-export from @vllnt/ui package
-export { Badge, badgeVariants } from '@vllnt/ui'
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    defaultVariants: {
+      variant: "default",
+    },
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+      },
+    },
+  },
+);
+
+export type BadgeProps = {} & React.HTMLAttributes<HTMLSpanElement> &
+  VariantProps<typeof badgeVariants>;
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <span className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/apps/registry/registry/default/banner/banner.tsx
+++ b/apps/registry/registry/default/banner/banner.tsx
@@ -1,2 +1,252 @@
-// Re-export from @vllnt/ui package
-export { Banner, BannerAction, bannerVariants } from '@vllnt/ui'
+"use client";
+
+import {
+  type ButtonHTMLAttributes,
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+const bannerVariants = cva(
+  "flex w-full items-start gap-3 border-b px-4 py-3 text-sm transition-all motion-safe:animate-in motion-safe:slide-in-from-top-1",
+  {
+    defaultVariants: {
+      variant: "info",
+    },
+    variants: {
+      variant: {
+        destructive:
+          "border-destructive/50 bg-destructive/10 text-destructive dark:border-destructive [&_svg]:text-destructive",
+        info: "border-border bg-muted text-foreground [&_svg]:text-muted-foreground",
+        success:
+          "border-emerald-500/40 bg-emerald-500/10 text-emerald-900 dark:text-emerald-200 [&_svg]:text-emerald-600 dark:[&_svg]:text-emerald-300",
+        warning:
+          "border-amber-500/40 bg-amber-500/10 text-amber-900 dark:text-amber-200 [&_svg]:text-amber-600 dark:[&_svg]:text-amber-300",
+      },
+    },
+  },
+);
+
+/**
+ * Visual variant for {@link Banner}. Drives both color treatment and the ARIA
+ * role: `warning` and `destructive` render as `role="alert"`, others as
+ * `role="status"`.
+ *
+ * @public
+ */
+export type BannerVariant = "destructive" | "info" | "success" | "warning";
+
+const URGENT_VARIANTS: ReadonlySet<BannerVariant> = new Set([
+  "destructive",
+  "warning",
+]);
+
+const STORAGE_PREFIX = "vllnt-ui:banner-dismissed:";
+
+function safeStorageGet(key: string): null | string {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeStorageSet(key: string, value: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    return;
+  }
+}
+
+function subscribeToStorage(callback: () => void): () => void {
+  if (typeof window === "undefined") {
+    return () => {
+      return;
+    };
+  }
+  window.addEventListener("storage", callback);
+  return () => {
+    window.removeEventListener("storage", callback);
+  };
+}
+
+function usePersistedDismissed(storageKey: string | undefined): boolean {
+  const getClientSnapshot = useCallback(() => {
+    if (!storageKey) return false;
+    return safeStorageGet(storageKey) === "1";
+  }, [storageKey]);
+  const getServerSnapshot = useCallback(() => false, []);
+  return useSyncExternalStore(
+    subscribeToStorage,
+    getClientSnapshot,
+    getServerSnapshot,
+  );
+}
+
+/**
+ * Props for {@link Banner}.
+ *
+ * @public
+ */
+export type BannerProps = {
+  /** When true, renders a dismiss control. */
+  dismissible?: boolean;
+  /** Accessible label for the dismiss control. Defaults to `"Dismiss"`. */
+  dismissLabel?: string;
+  /** Optional icon rendered to the left of the message. */
+  icon?: ReactNode;
+  /**
+   * Stable identifier used as the localStorage key when persisting dismissal.
+   * Pair with `persistDismissal` to remember a user's choice.
+   */
+  id?: string;
+  /** Fires after the user clicks the dismiss control. */
+  onDismiss?: () => void;
+  /**
+   * When true alongside `id`, persists dismissal in localStorage so the
+   * banner remains hidden across reloads.
+   */
+  persistDismissal?: boolean;
+} & ComponentPropsWithoutRef<"div"> &
+  VariantProps<typeof bannerVariants>;
+
+/**
+ * Full-width announcement bar.
+ *
+ * Renders a horizontal bar with variant-driven color treatment, an optional
+ * icon slot, and an optional dismiss control. Pair `id` with
+ * `persistDismissal` to remember dismissal across sessions in localStorage.
+ *
+ * @example
+ * ```tsx
+ * <Banner variant="warning" dismissible icon={<AlertTriangle />}>
+ *   Scheduled maintenance tonight at 11pm UTC.
+ *   <BannerAction onClick={openStatus}>View status</BannerAction>
+ * </Banner>
+ * ```
+ *
+ * @public
+ */
+export const Banner = forwardRef<HTMLDivElement, BannerProps>(
+  (
+    {
+      children,
+      className,
+      dismissible = false,
+      dismissLabel = "Dismiss",
+      icon,
+      id,
+      onDismiss,
+      persistDismissal = false,
+      role: roleOverride,
+      variant,
+      ...rest
+    },
+    ref,
+  ) => {
+    const storageKey =
+      persistDismissal && id ? `${STORAGE_PREFIX}${id}` : undefined;
+    const persistedDismissed = usePersistedDismissed(storageKey);
+    const [locallyDismissed, setLocallyDismissed] = useState(false);
+
+    const handleDismiss = useCallback(() => {
+      setLocallyDismissed(true);
+      if (storageKey) safeStorageSet(storageKey, "1");
+      onDismiss?.();
+    }, [onDismiss, storageKey]);
+
+    if (locallyDismissed || persistedDismissed) return null;
+
+    const resolvedVariant: BannerVariant = variant ?? "info";
+    const role =
+      roleOverride ??
+      (URGENT_VARIANTS.has(resolvedVariant) ? "alert" : "status");
+
+    return (
+      <div
+        className={cn(bannerVariants({ variant }), className)}
+        id={id}
+        ref={ref}
+        role={role}
+        {...rest}
+      >
+        {icon ? (
+          <span
+            aria-hidden="true"
+            className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center [&>svg]:h-4 [&>svg]:w-4"
+          >
+            {icon}
+          </span>
+        ) : null}
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1">
+          {children}
+        </div>
+        {dismissible ? (
+          <button
+            aria-label={dismissLabel}
+            className="ml-auto inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md opacity-70 transition-colors hover:bg-foreground/10 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            onClick={handleDismiss}
+            type="button"
+          >
+            <X aria-hidden="true" className="h-4 w-4" />
+          </button>
+        ) : null}
+      </div>
+    );
+  },
+);
+Banner.displayName = "Banner";
+
+/**
+ * Props for {@link BannerAction}.
+ *
+ * @public
+ */
+export type BannerActionProps = {
+  /** Render the wrapped child element instead of a `<button>`. */
+  asChild?: boolean;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+/**
+ * Action slot used inside a {@link Banner} body. Renders a styled button by
+ * default, or composes onto a passed child element when `asChild` is true
+ * (e.g. wrap an `<a>` for link actions).
+ *
+ * @public
+ */
+export const BannerAction = forwardRef<HTMLButtonElement, BannerActionProps>(
+  ({ asChild = false, children, className, type, ...rest }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    const buttonProps: ButtonHTMLAttributes<HTMLButtonElement> = asChild
+      ? rest
+      : { type: type ?? "button", ...rest };
+
+    return (
+      <Comp
+        className={cn(
+          "inline-flex h-7 items-center justify-center rounded-md border border-foreground/20 bg-transparent px-3 text-xs font-medium underline-offset-4 transition-colors hover:bg-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          className,
+        )}
+        ref={ref}
+        {...buttonProps}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+BannerAction.displayName = "BannerAction";
+
+export { bannerVariants };

--- a/apps/registry/registry/default/blog-card/blog-card.tsx
+++ b/apps/registry/registry/default/blog-card/blog-card.tsx
@@ -1,2 +1,94 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+import Link from "next/link";
+
+import { Badge } from "@vllnt/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@vllnt/ui";
+
+type ContentCardPost = {
+  date?: string;
+  description: string;
+  slug: string;
+  tags?: string[];
+  title: string;
+  updatedDate?: string;
+};
+
+type ContentCardProps = {
+  formatDate?: (date: string, lang: string) => string;
+  getDictValue?: (dict: Record<string, unknown>, path: string) => string;
+  href: string;
+  lang?: string;
+  post: ContentCardPost;
+  readMoreLabel?: string;
+  showBadge?: boolean;
+  showDate?: boolean;
+  showReadMore?: boolean;
+  updatedLabel?: string;
+};
+
+export function ContentCard({
+  formatDate,
+  href,
+  lang,
+  post,
+  readMoreLabel,
+  showBadge = true,
+  showDate = true,
+  showReadMore = true,
+  updatedLabel,
+}: ContentCardProps) {
+  const shouldShowBadge = showBadge && post.tags && post.tags.length > 0;
+  const shouldShowDate = showDate && post.date && formatDate && lang;
+  const shouldShowUpdatedDate =
+    showDate && post.updatedDate && formatDate && lang;
+  const shouldShowHeaderMeta =
+    shouldShowBadge || shouldShowDate || shouldShowUpdatedDate;
+
+  return (
+    <Link className="block h-full" href={href}>
+      <Card className="h-full flex flex-col hover:shadow-lg transition-shadow cursor-pointer">
+        <CardHeader>
+          {shouldShowHeaderMeta ? (
+            <div className="flex items-center gap-2 mb-2">
+              {shouldShowBadge ? (
+                <Badge className="text-xs" variant="secondary">
+                  {post.tags?.[0]}
+                </Badge>
+              ) : null}
+              {shouldShowDate && post.date && lang ? (
+                <span className="text-xs text-muted-foreground">
+                  {formatDate(post.date, lang)}
+                </span>
+              ) : null}
+              {shouldShowUpdatedDate && post.updatedDate && lang ? (
+                <span className="text-xs text-muted-foreground">
+                  {updatedLabel ? `${updatedLabel} ` : ""}
+                  {formatDate(post.updatedDate, lang)}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
+          <CardTitle className="text-lg line-clamp-2">{post.title}</CardTitle>
+          <CardDescription className="line-clamp-3">
+            {post.description}
+          </CardDescription>
+        </CardHeader>
+        {showReadMore && readMoreLabel ? (
+          <CardContent className="mt-auto">
+            <span className="inline-flex items-center gap-1 text-sm text-muted-foreground">
+              {readMoreLabel} <span className="text-sm">→</span>
+            </span>
+          </CardContent>
+        ) : null}
+      </Card>
+    </Link>
+  );
+}
+
+// Keep BlogCard as an alias for backward compatibility
+export const BlogCard = ContentCard;

--- a/apps/registry/registry/default/border-beam/border-beam.tsx
+++ b/apps/registry/registry/default/border-beam/border-beam.tsx
@@ -1,2 +1,63 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type BorderBeamProps = React.ComponentPropsWithoutRef<"span"> & {
+  borderWidth?: number;
+  colorFrom?: string;
+  colorTo?: string;
+  delay?: number;
+  duration?: number;
+  reverse?: boolean;
+};
+
+export const BorderBeam = React.forwardRef<HTMLSpanElement, BorderBeamProps>(
+  (
+    {
+      borderWidth = 1,
+      className,
+      colorFrom = "hsl(var(--primary) / 0.85)",
+      colorTo = "hsl(var(--ring) / 0.25)",
+      delay = 0,
+      duration = 6,
+      reverse = false,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const beamStyle: React.CSSProperties = {
+      animationDelay: `${delay}s`,
+      animationDirection: reverse ? "reverse" : "normal",
+      animationDuration: `${duration}s`,
+      animationIterationCount: "infinite",
+      animationName: "vllnt-border-beam-angle",
+      animationTimingFunction: "linear",
+      background: `conic-gradient(from var(--vllnt-border-beam-angle, 90deg), transparent 0deg, transparent 220deg, ${colorFrom} 280deg, ${colorTo} 335deg, transparent 360deg)`,
+      borderRadius: "inherit",
+      boxSizing: "border-box",
+      mask: "linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)",
+      maskComposite: "exclude",
+      padding: `${borderWidth}px`,
+      WebkitMask:
+        "linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)",
+      WebkitMaskComposite: "xor",
+      ...style,
+    };
+
+    return (
+      <span
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute inset-0 rounded-[inherit]",
+          className,
+        )}
+        ref={ref}
+        style={beamStyle}
+        {...props}
+      />
+    );
+  },
+);
+
+BorderBeam.displayName = "BorderBeam";

--- a/apps/registry/registry/default/bottom-activity-strip/bottom-activity-strip.tsx
+++ b/apps/registry/registry/default/bottom-activity-strip/bottom-activity-strip.tsx
@@ -1,7 +1,188 @@
-export {
-  type ActivityEvent,
-  type ActivityStripTone,
-  BottomActivityStrip,
-  type BottomActivityStripLabels,
-  type BottomActivityStripProps,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Tone of an event — drives the leading dot color.
+ *
+ * @public
+ */
+export type ActivityStripTone =
+  | "danger"
+  | "info"
+  | "neutral"
+  | "success"
+  | "warn";
+
+const TONE_DOT: Record<ActivityStripTone, string> = {
+  danger: "bg-red-500",
+  info: "bg-blue-500",
+  neutral: "bg-muted-foreground",
+  success: "bg-emerald-500",
+  warn: "bg-amber-500",
+};
+
+/**
+ * One event in the strip.
+ *
+ * @public
+ */
+export type ActivityEvent = {
+  /** Stable identifier — used as the React key + analytics hook. */
+  id: string;
+  /** Short label (e.g. `"deploy completed"`). */
+  label: ReactNode;
+  /** Optional click handler — when provided, the chip becomes a button. */
+  onActivate?: () => void;
+  /** Optional tone for the leading dot. Defaults to `"neutral"`. */
+  tone?: ActivityStripTone;
+  /** Pre-formatted timestamp (host owns formatting). */
+  ts: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type BottomActivityStripLabels = {
+  /** Empty-state copy. Defaults to `"No recent activity"`. */
+  empty?: string;
+  /** Aria-label for the strip. Defaults to `"Recent activity"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No recent activity",
+  region: "Recent activity",
+} as const satisfies Required<BottomActivityStripLabels>;
+
+/**
+ * Props for {@link BottomActivityStrip}.
+ *
+ * @public
+ */
+export type BottomActivityStripProps = {
+  /** Event entries — newest first. */
+  events: ActivityEvent[];
+  /** Localizable strings. */
+  labels?: BottomActivityStripLabels;
+  /** Cap the rendered events. The component drops the tail without warning. */
+  maxEvents?: number;
+} & ComponentPropsWithoutRef<"section">;
+
+const ChipBody = (props: { event: ActivityEvent }): React.ReactElement => {
+  const { event } = props;
+  const tone = event.tone ?? "neutral";
+  return (
+    <span className="flex items-center gap-1.5 whitespace-nowrap">
+      <span
+        aria-hidden="true"
+        className={cn("h-1.5 w-1.5 rounded-full", TONE_DOT[tone])}
+      />
+      <span className="text-foreground">{event.label}</span>
+      <span className="text-[10px] text-muted-foreground" data-strip-event-ts>
+        {event.ts}
+      </span>
+    </span>
+  );
+};
+
+const Chip = (props: { event: ActivityEvent }): React.ReactElement => {
+  const { event } = props;
+  const tone = event.tone ?? "neutral";
+  if (event.onActivate) {
+    const handleClick = (): void => {
+      event.onActivate?.();
+    };
+    return (
+      <button
+        className="flex items-center rounded-full border border-border bg-background px-2 py-1 text-[11px] transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        data-strip-event={event.id}
+        data-strip-event-tone={tone}
+        onClick={handleClick}
+        type="button"
+      >
+        <ChipBody event={event} />
+      </button>
+    );
+  }
+  return (
+    <span
+      className="flex items-center rounded-full border border-border bg-background px-2 py-1 text-[11px]"
+      data-strip-event={event.id}
+      data-strip-event-tone={tone}
+    >
+      <ChipBody event={event} />
+    </span>
+  );
+};
+
+/**
+ * Slim bottom strip showing a horizontally-scrolling row of recent
+ * canvas events. The lowest-noise live execution surface — keep
+ * `ObjectCard`, panels, and overlays for high-value surfaces; let the
+ * strip carry the steady drip of activity.
+ *
+ * Pure presentation; the host computes the event list (newest first)
+ * and supplies an optional `onActivate` per event to jump to the
+ * related object.
+ *
+ * Distinct from `ActivityLog` (vertical, persistent) and `LiveFeed`
+ * (full-height feed): this primitive is a single horizontal row that
+ * lives at the bottom of the canvas.
+ *
+ * @example
+ * ```tsx
+ * <BottomActivityStrip
+ *   events={[
+ *     { id: "1", label: "deploy ok", ts: "12s", tone: "success" },
+ *     { id: "2", label: "queue spike", ts: "1m", tone: "warn" },
+ *   ]}
+ *   maxEvents={20}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const BottomActivityStrip = forwardRef<
+  HTMLElement,
+  BottomActivityStripProps
+>((props, ref) => {
+  const { className, events, labels, maxEvents, ...rest } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const visible =
+    maxEvents === undefined || maxEvents >= events.length
+      ? events
+      : events.slice(0, maxEvents);
+  return (
+    <section
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "flex w-full items-center gap-2 overflow-x-auto rounded-md border border-border bg-background/90 px-2 py-1 text-foreground",
+        className,
+      )}
+      data-bottom-activity-strip
+      ref={ref}
+      {...rest}
+    >
+      {visible.length === 0 ? (
+        <span
+          className="px-2 text-[11px] text-muted-foreground"
+          data-strip-state="empty"
+        >
+          {resolvedLabels.empty}
+        </span>
+      ) : (
+        visible.map((event) => <Chip event={event} key={event.id} />)
+      )}
+    </section>
+  );
+});
+BottomActivityStrip.displayName = "BottomActivityStrip";

--- a/apps/registry/registry/default/breadcrumb/breadcrumb.tsx
+++ b/apps/registry/registry/default/breadcrumb/breadcrumb.tsx
@@ -1,2 +1,89 @@
-// Re-export from @vllnt/ui package
-export { Breadcrumb, type BreadcrumbItem } from '@vllnt/ui'
+import Link from "next/link";
+import type * as React from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type BreadcrumbItem = {
+  href?: string;
+  icon?: React.ReactNode;
+  label: React.ReactNode;
+};
+
+type BreadcrumbProps = {
+  className?: string;
+  items: BreadcrumbItem[];
+  separator?: "arrow" | "chevron" | "slash";
+  showHomeIcon?: boolean;
+  variant?: "default" | "minimal";
+};
+
+const SEPARATOR_CHARS: Record<string, string> = {
+  arrow: "→",
+  chevron: "›",
+  slash: "/",
+};
+
+function SeparatorIcon({ type }: { type: string }) {
+  return (
+    <span aria-hidden="true" className="text-muted-foreground">
+      {SEPARATOR_CHARS[type] ?? "›"}
+    </span>
+  );
+}
+
+export function Breadcrumb({
+  className,
+  items,
+  separator = "chevron",
+  variant = "default",
+}: BreadcrumbProps) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={cn("flex items-center space-x-1 text-sm", className)}
+    >
+      {items.map((item, index) => (
+        <div className="flex items-center" key={index}>
+          {index > 0 && (
+            <span className="mx-2">
+              <SeparatorIcon type={separator} />
+            </span>
+          )}
+
+          {item.href ? (
+            <Link
+              className="flex items-center gap-1 hover:text-foreground transition-colors"
+              href={item.href}
+            >
+              {item.icon ? (
+                <span className="flex-shrink-0">{item.icon}</span>
+              ) : null}
+              <span
+                className={cn(
+                  // Truncate plain string labels; custom React elements handle their own overflow
+                  typeof item.label === "string" && "truncate",
+                  variant === "minimal"
+                    ? "text-muted-foreground"
+                    : "text-foreground",
+                )}
+              >
+                {item.label}
+              </span>
+            </Link>
+          ) : (
+            <span className="flex items-center gap-1 text-muted-foreground">
+              {item.icon ? (
+                <span className="flex-shrink-0">{item.icon}</span>
+              ) : null}
+              <span
+                className={cn(typeof item.label === "string" && "truncate")}
+              >
+                {item.label}
+              </span>
+            </span>
+          )}
+        </div>
+      ))}
+    </nav>
+  );
+}

--- a/apps/registry/registry/default/button/button.tsx
+++ b/apps/registry/registry/default/button/button.tsx
@@ -1,2 +1,56 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    defaultVariants: {
+      size: "default",
+      variant: "default",
+    },
+    variants: {
+      size: {
+        default: "h-10 px-4 py-2",
+        icon: "h-10 w-10",
+        lg: "h-11 rounded-md px-8",
+        sm: "h-9 rounded-md px-3",
+      },
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+      },
+    },
+  },
+);
+
+export type ButtonProps = {
+  asChild?: boolean;
+} & React.ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof buttonVariants>;
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ asChild = false, className, size, variant, ...props }, reference) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ className, size, variant }))}
+        ref={reference}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/apps/registry/registry/default/calendar/calendar.tsx
+++ b/apps/registry/registry/default/calendar/calendar.tsx
@@ -1,1 +1,82 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { DayPicker } from "react-day-picker";
+
+import { cn } from "@vllnt/ui";
+import { buttonVariants } from "@vllnt/ui";
+
+export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+
+function IconLeft() {
+  return <ChevronLeft className="h-4 w-4" />;
+}
+
+function IconRight() {
+  return <ChevronRight className="h-4 w-4" />;
+}
+
+function ChevronComponent({
+  orientation = "right",
+}: {
+  orientation?: "down" | "left" | "right" | "up";
+}) {
+  return orientation === "left" ? <IconLeft /> : <IconRight />;
+}
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: CalendarProps) {
+  return (
+    <DayPicker
+      className={cn("p-3", className)}
+      classNames={{
+        button_next: cn(
+          buttonVariants({ variant: "outline" }),
+          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute right-1",
+        ),
+        button_previous: cn(
+          buttonVariants({ variant: "outline" }),
+          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute left-1",
+        ),
+        caption_label: "text-sm font-medium",
+        day: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+        day_button: cn(
+          buttonVariants({ variant: "ghost" }),
+          "h-9 w-9 p-0 font-normal aria-selected:opacity-100",
+        ),
+        disabled: "text-muted-foreground opacity-50",
+        hidden: "invisible",
+        month: "space-y-4",
+        month_caption: "flex justify-center pt-1 relative items-center",
+        month_grid: "w-full border-collapse space-y-1",
+        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
+        nav: "space-x-1 flex items-center",
+        outside:
+          "day-outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",
+        range_end: "day-range-end",
+        range_middle:
+          "aria-selected:bg-accent aria-selected:text-accent-foreground",
+        selected:
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+        today: "bg-accent text-accent-foreground",
+        week: "flex w-full mt-2",
+        weekday:
+          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
+        weekdays: "flex",
+        ...classNames,
+      }}
+      components={{
+        Chevron: ChevronComponent,
+      }}
+      showOutsideDays={showOutsideDays}
+      {...props}
+    />
+  );
+}
+Calendar.displayName = "Calendar";
+
+export { Calendar };

--- a/apps/registry/registry/default/callout/callout.tsx
+++ b/apps/registry/registry/default/callout/callout.tsx
@@ -1,66 +1,90 @@
-import type { ReactNode } from 'react'
+import type { ReactNode } from "react";
 
-import { cn } from '../../../lib/utils'
+import { cn } from "@vllnt/ui";
 
-export type CalloutVariant = 'danger' | 'info' | 'note' | 'success' | 'tip' | 'warning'
+export type CalloutVariant =
+  | "danger"
+  | "info"
+  | "note"
+  | "success"
+  | "tip"
+  | "warning";
 
 export type CalloutProps = {
-  children: ReactNode
-  className?: string
-  icon?: ReactNode
-  title?: string
-  variant?: CalloutVariant
-}
+  children: ReactNode;
+  className?: string;
+  icon?: ReactNode;
+  title?: string;
+  variant?: CalloutVariant;
+};
 
-const variantStyles: Record<CalloutVariant, { className: string; defaultTitle: string }> = {
+const variantStyles: Record<
+  CalloutVariant,
+  { className: string; defaultTitle: string }
+> = {
   danger: {
-    className: 'border-red-500/50 bg-red-500/10 text-red-700 dark:text-red-300',
-    defaultTitle: 'Danger',
+    className: "border-red-500/50 bg-red-500/10 text-red-700 dark:text-red-300",
+    defaultTitle: "Danger",
   },
   info: {
-    className: 'border-blue-500/50 bg-blue-500/10 text-blue-700 dark:text-blue-300',
-    defaultTitle: 'Info',
+    className:
+      "border-blue-500/50 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+    defaultTitle: "Info",
   },
   note: {
-    className: 'border-gray-500/50 bg-gray-500/10 text-gray-700 dark:text-gray-300',
-    defaultTitle: 'Note',
+    className:
+      "border-gray-500/50 bg-gray-500/10 text-gray-700 dark:text-gray-300",
+    defaultTitle: "Note",
   },
   success: {
-    className: 'border-green-500/50 bg-green-500/10 text-green-700 dark:text-green-300',
-    defaultTitle: 'Success',
+    className:
+      "border-green-500/50 bg-green-500/10 text-green-700 dark:text-green-300",
+    defaultTitle: "Success",
   },
   tip: {
-    className: 'border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-300',
-    defaultTitle: 'Tip',
+    className:
+      "border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+    defaultTitle: "Tip",
   },
   warning: {
-    className: 'border-orange-500/50 bg-orange-500/10 text-orange-700 dark:text-orange-300',
-    defaultTitle: 'Warning',
+    className:
+      "border-orange-500/50 bg-orange-500/10 text-orange-700 dark:text-orange-300",
+    defaultTitle: "Warning",
   },
-}
+};
 
 export function Callout({
   children,
   className,
   icon,
   title,
-  variant = 'info',
+  variant = "info",
 }: CalloutProps): React.ReactNode {
-  const config = variantStyles[variant]
-  const displayTitle = title ?? config.defaultTitle
+  const config = variantStyles[variant];
+  const displayTitle = title ?? config.defaultTitle;
 
   return (
     <div
-      className={cn('my-6 rounded-lg border-l-4 p-4', config.className, className)}
+      className={cn(
+        "my-6 rounded-lg border-l-4 p-4",
+        config.className,
+        className,
+      )}
       role="alert"
     >
       <div className="flex items-start gap-3">
-        {icon ? <span className="h-5 w-5 flex-shrink-0 mt-0.5">{icon}</span> : null}
+        {icon ? (
+          <span className="h-5 w-5 flex-shrink-0 mt-0.5">{icon}</span>
+        ) : null}
         <div className="flex-1 min-w-0">
-          {displayTitle ? <p className="font-semibold mb-1">{displayTitle}</p> : null}
-          <div className="text-sm [&>p]:mb-0 [&>p:last-child]:mb-0">{children}</div>
+          {displayTitle ? (
+            <p className="font-semibold mb-1">{displayTitle}</p>
+          ) : null}
+          <div className="text-sm [&>p]:mb-0 [&>p:last-child]:mb-0">
+            {children}
+          </div>
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/apps/registry/registry/default/candlestick-chart/candlestick-chart.tsx
+++ b/apps/registry/registry/default/candlestick-chart/candlestick-chart.tsx
@@ -1,1 +1,266 @@
-export { CandlestickChart } from "@vllnt/ui";
+import * as React from "react";
+
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+export type CandlestickDatum = {
+  close: number;
+  high: number;
+  label: string;
+  low: number;
+  open: number;
+};
+
+export type CandlestickChartProps = {
+  data: CandlestickDatum[];
+  height?: number;
+  showGrid?: boolean;
+  width?: number;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+type ChartMetrics = {
+  bodyWidth: number;
+  bottomPadding: number;
+  chartHeight: number;
+  columnWidth: number;
+  maxPrice: number;
+  minPrice: number;
+  range: number;
+  topPadding: number;
+};
+
+const DEFAULT_WIDTH = 760;
+const DEFAULT_HEIGHT = 260;
+
+function formatValue(value: number) {
+  return value.toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  });
+}
+
+function buildMetrics(
+  data: CandlestickDatum[],
+  height: number,
+  width: number,
+): ChartMetrics {
+  const allValues = data.flatMap((candle) => [
+    candle.high,
+    candle.low,
+    candle.open,
+    candle.close,
+  ]);
+  const minPrice = Math.min(...allValues);
+  const maxPrice = Math.max(...allValues);
+  const range = maxPrice - minPrice || 1;
+  const topPadding = 20;
+  const bottomPadding = 30;
+  const chartHeight = height - topPadding - bottomPadding;
+  const columnWidth = width / data.length;
+  const bodyWidth = Math.max(columnWidth * 0.56, 8);
+
+  return {
+    bodyWidth,
+    bottomPadding,
+    chartHeight,
+    columnWidth,
+    maxPrice,
+    minPrice,
+    range,
+    topPadding,
+  };
+}
+
+function getYForPrice(price: number, metrics: ChartMetrics) {
+  const ratio = (price - metrics.minPrice) / metrics.range;
+  return metrics.topPadding + metrics.chartHeight - ratio * metrics.chartHeight;
+}
+
+function PriceGrid({
+  metrics,
+  showGrid,
+  width,
+}: {
+  metrics: ChartMetrics;
+  showGrid: boolean;
+  width: number;
+}) {
+  if (!showGrid) {
+    return null;
+  }
+
+  const ticks = Array.from({ length: 4 }, (_, index) => {
+    const ratio = index / 3;
+    return {
+      value: metrics.maxPrice - ratio * metrics.range,
+      y: metrics.topPadding + ratio * metrics.chartHeight,
+    };
+  });
+
+  return ticks.map((tick) => (
+    <g key={tick.value}>
+      <line
+        stroke="hsl(var(--border))"
+        strokeDasharray="4 6"
+        strokeOpacity="0.8"
+        x1="0"
+        x2={width}
+        y1={tick.y}
+        y2={tick.y}
+      />
+      <text
+        fill="hsl(var(--muted-foreground))"
+        fontSize="11"
+        textAnchor="end"
+        x={width - 6}
+        y={tick.y - 4}
+      >
+        {formatValue(tick.value)}
+      </text>
+    </g>
+  ));
+}
+
+function CandleMarks({
+  data,
+  height,
+  metrics,
+}: {
+  data: CandlestickDatum[];
+  height: number;
+  metrics: ChartMetrics;
+}) {
+  return data.map((candle, index) => {
+    const centerX = metrics.columnWidth * index + metrics.columnWidth / 2;
+    const wickTop = getYForPrice(candle.high, metrics);
+    const wickBottom = getYForPrice(candle.low, metrics);
+    const openY = getYForPrice(candle.open, metrics);
+    const closeY = getYForPrice(candle.close, metrics);
+    const bodyY = Math.min(openY, closeY);
+    const bodyHeight = Math.max(Math.abs(openY - closeY), 3);
+    const isBullish = candle.close >= candle.open;
+    const fill = isBullish ? "hsl(142 71% 45%)" : "hsl(348 83% 47%)";
+
+    return (
+      <g key={candle.label}>
+        <line
+          stroke={fill}
+          strokeLinecap="round"
+          strokeWidth={2}
+          x1={centerX}
+          x2={centerX}
+          y1={wickTop}
+          y2={wickBottom}
+        />
+        <rect
+          fill={fill}
+          fillOpacity={isBullish ? 0.25 : 0.18}
+          height={bodyHeight}
+          rx={4}
+          stroke={fill}
+          strokeWidth={1.5}
+          width={metrics.bodyWidth}
+          x={centerX - metrics.bodyWidth / 2}
+          y={bodyY}
+        >
+          <title>
+            {`${candle.label}: O ${formatValue(candle.open)} H ${formatValue(candle.high)} L ${formatValue(candle.low)} C ${formatValue(candle.close)}`}
+          </title>
+        </rect>
+        <text
+          fill="hsl(var(--muted-foreground))"
+          fontSize="11"
+          textAnchor="middle"
+          x={centerX}
+          y={height - 8}
+        >
+          {candle.label}
+        </text>
+      </g>
+    );
+  });
+}
+
+function SessionPill({ sessionChange }: { sessionChange: number }) {
+  const isPositive = sessionChange >= 0;
+  const TrendIcon = isPositive ? ArrowUpRight : ArrowDownRight;
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm font-medium",
+        isPositive
+          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+          : "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400",
+      )}
+    >
+      <TrendIcon className="h-4 w-4" />
+      {sessionChange >= 0 ? "+" : ""}
+      {formatValue(sessionChange)}
+    </div>
+  );
+}
+
+export const CandlestickChart = React.forwardRef<
+  HTMLDivElement,
+  CandlestickChartProps
+>(
+  (
+    {
+      className,
+      data,
+      height = DEFAULT_HEIGHT,
+      showGrid = true,
+      width = DEFAULT_WIDTH,
+      ...props
+    },
+    reference,
+  ) => {
+    const firstCandle = data[0];
+    const finalCandle = data.at(-1);
+
+    if (!firstCandle || !finalCandle) {
+      return null;
+    }
+
+    const metrics = buildMetrics(data, height, width);
+    const sessionChange = finalCandle.close - firstCandle.open;
+
+    return (
+      <div
+        className={cn(
+          "rounded-2xl border border-border bg-card/80 p-4 shadow-sm",
+          className,
+        )}
+        ref={reference}
+        {...props}
+      >
+        <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-[0.28em] text-muted-foreground">
+              OHLC session
+            </p>
+            <h3 className="text-lg font-semibold text-foreground">
+              Candlestick chart
+            </h3>
+          </div>
+          <SessionPill sessionChange={sessionChange} />
+        </div>
+        <svg
+          aria-label="Candlestick chart"
+          className="h-full w-full"
+          height={height}
+          role="img"
+          viewBox={`0 0 ${width} ${height}`}
+          width={width}
+        >
+          <PriceGrid metrics={metrics} showGrid={showGrid} width={width} />
+          <CandleMarks data={data} height={height} metrics={metrics} />
+        </svg>
+      </div>
+    );
+  },
+);
+
+CandlestickChart.displayName = "CandlestickChart";

--- a/apps/registry/registry/default/canvas-shell/canvas-shell.tsx
+++ b/apps/registry/registry/default/canvas-shell/canvas-shell.tsx
@@ -1,1 +1,349 @@
-export { CanvasShell, type CanvasShellProps } from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import type { CSSProperties, ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+
+import type { CanvasShellInsets } from "./canvas-shell-route-config";
+
+export type CanvasShellProps = React.ComponentPropsWithoutRef<"section"> & {
+  bottomBar?: ReactNode;
+  bottomSlot?: ReactNode;
+  children?: ReactNode;
+  chromeInset?: number | string;
+  contentPadding?: CanvasShellInsets;
+  leftBar?: ReactNode;
+  leftRail?: ReactNode;
+  rightBar?: ReactNode;
+  rightDock?: ReactNode;
+  topBar?: ReactNode;
+};
+
+type CanvasShellChromeProps = {
+  bottomBar?: ReactNode;
+  inset: string;
+  leftBar?: ReactNode;
+  rightBar?: ReactNode;
+  topBar?: ReactNode;
+};
+
+type CanvasShellSafeAreaStyle = CSSProperties & {
+  "--canvas-shell-safe-bottom": string;
+  "--canvas-shell-safe-left": string;
+  "--canvas-shell-safe-right": string;
+  "--canvas-shell-safe-top": string;
+};
+
+function toInsetValue(value: number | string | undefined) {
+  if (typeof value === "number") {
+    return `${value}px`;
+  }
+
+  return value;
+}
+
+const FLOATING_BOTTOM_BAR_FOOTPRINT = "3.5rem";
+const FLOATING_LEFT_BAR_FOOTPRINT = "4.5rem";
+const FLOATING_RIGHT_BAR_FOOTPRINT = "18rem";
+const FLOATING_TOP_BAR_FOOTPRINT = "3.5rem";
+
+function getReservedInset(
+  inset: string,
+  footprint: string,
+  override: number | string | undefined,
+) {
+  return toInsetValue(override) ?? `calc(${inset} + ${footprint})`;
+}
+
+function getSafeAreaInsets({
+  chromeInset,
+  contentPadding,
+  hasBottomBar,
+  hasLeftBar,
+  hasRightBar,
+  hasTopBar,
+}: {
+  chromeInset: number | string;
+  contentPadding?: CanvasShellInsets;
+  hasBottomBar: boolean;
+  hasLeftBar: boolean;
+  hasRightBar: boolean;
+  hasTopBar: boolean;
+}) {
+  const inset = toInsetValue(chromeInset) ?? "16px";
+
+  return {
+    bottom: hasBottomBar
+      ? getReservedInset(
+          inset,
+          FLOATING_BOTTOM_BAR_FOOTPRINT,
+          contentPadding?.bottom,
+        )
+      : (toInsetValue(contentPadding?.bottom) ?? inset),
+    left: hasLeftBar
+      ? getReservedInset(
+          inset,
+          FLOATING_LEFT_BAR_FOOTPRINT,
+          contentPadding?.left,
+        )
+      : (toInsetValue(contentPadding?.left) ?? inset),
+    right: hasRightBar
+      ? getReservedInset(
+          inset,
+          FLOATING_RIGHT_BAR_FOOTPRINT,
+          contentPadding?.right,
+        )
+      : (toInsetValue(contentPadding?.right) ?? inset),
+    top: hasTopBar
+      ? getReservedInset(inset, FLOATING_TOP_BAR_FOOTPRINT, contentPadding?.top)
+      : (toInsetValue(contentPadding?.top) ?? inset),
+  };
+}
+
+function getSafeAreaStyle(
+  insets: ReturnType<typeof getSafeAreaInsets>,
+): CanvasShellSafeAreaStyle {
+  return {
+    "--canvas-shell-safe-bottom": insets.bottom,
+    "--canvas-shell-safe-left": insets.left,
+    "--canvas-shell-safe-right": insets.right,
+    "--canvas-shell-safe-top": insets.top,
+  } satisfies CanvasShellSafeAreaStyle;
+}
+
+const hasChromeContent = Boolean;
+
+type CanvasShellChromeAfterProps = Pick<
+  CanvasShellChromeProps,
+  "bottomBar" | "inset" | "rightBar"
+>;
+
+function CanvasShellChromeBefore({
+  inset,
+  leftBar,
+  topBar,
+}: Pick<CanvasShellChromeProps, "inset" | "leftBar" | "topBar">) {
+  return (
+    <>
+      {hasChromeContent(topBar) ? (
+        <div
+          className="pointer-events-none absolute inset-x-0 z-30"
+          style={{ top: inset }}
+        >
+          <div
+            className="pointer-events-auto mx-auto w-full max-w-[960px]"
+            style={{ paddingLeft: inset, paddingRight: inset }}
+          >
+            {topBar}
+          </div>
+        </div>
+      ) : null}
+      {hasChromeContent(leftBar) ? (
+        <div
+          className="pointer-events-none absolute left-0 z-30 flex"
+          style={{
+            bottom: "var(--canvas-shell-safe-bottom)",
+            left: inset,
+            top: "var(--canvas-shell-safe-top)",
+          }}
+        >
+          <div className="pointer-events-auto flex">{leftBar}</div>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function CanvasShellChromeAfter({
+  bottomBar,
+  inset,
+  rightBar,
+}: CanvasShellChromeAfterProps) {
+  return (
+    <>
+      {hasChromeContent(rightBar) ? (
+        <div
+          className="pointer-events-none absolute right-0 z-30 flex"
+          style={{
+            bottom: "var(--canvas-shell-safe-bottom)",
+            right: inset,
+            top: "var(--canvas-shell-safe-top)",
+          }}
+        >
+          <div className="pointer-events-auto flex">{rightBar}</div>
+        </div>
+      ) : null}
+      {hasChromeContent(bottomBar) ? (
+        <div
+          className="pointer-events-none absolute inset-x-0 z-30"
+          style={{ bottom: inset }}
+        >
+          <div
+            className="pointer-events-auto mx-auto w-full max-w-[960px]"
+            style={{ paddingLeft: inset, paddingRight: inset }}
+          >
+            {bottomBar}
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function renderLegacyCanvasShell(
+  {
+    bottomBar: _bottomBar,
+    bottomSlot,
+    children,
+    chromeInset: _chromeInset = 16,
+    className,
+    contentPadding: _contentPadding,
+    leftBar: _leftBar,
+    leftRail,
+    rightBar: _rightBar,
+    rightDock,
+    style,
+    topBar,
+    ...props
+  }: CanvasShellProps,
+  ref: React.ForwardedRef<HTMLElement>,
+) {
+  return (
+    <section
+      className={cn(
+        "flex min-h-[720px] w-full flex-col overflow-hidden rounded-md border border-border bg-background",
+        className,
+      )}
+      ref={ref}
+      style={style}
+      {...props}
+    >
+      {topBar}
+      <div className="grid min-h-0 flex-1 grid-cols-[auto_minmax(0,1fr)_auto] overflow-hidden bg-background">
+        {leftRail ?? <div />}
+        <div className="relative min-h-0 min-w-0 overflow-hidden">
+          {children}
+        </div>
+        {rightDock ?? <div />}
+      </div>
+      {bottomSlot ? (
+        <div className="border-t border-border bg-background px-4 py-2">
+          {bottomSlot}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function renderFloatingContent(
+  children: ReactNode,
+  contentStyle: CSSProperties,
+) {
+  return (
+    <div
+      className="relative z-0 h-full w-full min-h-0 min-w-0"
+      data-slot="canvas-shell-content"
+      style={contentStyle}
+    >
+      <div className="h-full w-full min-h-0 min-w-0 overflow-hidden">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function renderFloatingCanvasShell(
+  {
+    bottomBar,
+    bottomSlot,
+    children,
+    chromeInset = 16,
+    className,
+    contentPadding,
+    leftBar,
+    leftRail,
+    rightBar,
+    rightDock,
+    style,
+    topBar,
+    ...props
+  }: CanvasShellProps,
+  ref: React.ForwardedRef<HTMLElement>,
+) {
+  const inset = toInsetValue(chromeInset) ?? "16px";
+  const resolvedBottomBar = bottomBar ?? bottomSlot;
+  const resolvedLeftBar = leftBar ?? leftRail;
+  const resolvedRightBar = rightBar ?? rightDock;
+
+  const hasTopBar = hasChromeContent(topBar);
+  const hasLeftBar = hasChromeContent(resolvedLeftBar);
+  const hasRightBar = hasChromeContent(resolvedRightBar);
+  const hasBottomBar = hasChromeContent(resolvedBottomBar);
+  const safeAreaInsets = getSafeAreaInsets({
+    chromeInset,
+    contentPadding,
+    hasBottomBar,
+    hasLeftBar,
+    hasRightBar,
+    hasTopBar,
+  });
+  const mergedStyle = {
+    ...getSafeAreaStyle(safeAreaInsets),
+    ...style,
+  } satisfies CSSProperties;
+  const contentStyle = {
+    paddingBottom: "var(--canvas-shell-safe-bottom)",
+    paddingLeft: "var(--canvas-shell-safe-left)",
+    paddingRight: "var(--canvas-shell-safe-right)",
+    paddingTop: "var(--canvas-shell-safe-top)",
+  } satisfies CSSProperties;
+
+  return (
+    <section
+      className={cn(
+        "relative isolate flex min-h-[720px] w-full overflow-hidden bg-[radial-gradient(circle_at_top,hsl(var(--background)/0.94),hsl(var(--muted)/0.6))]",
+        className,
+      )}
+      ref={ref}
+      style={mergedStyle}
+      {...props}
+    >
+      <div className="absolute inset-0 bg-[linear-gradient(180deg,hsl(var(--background)/0.94),hsl(var(--background)/0.8))]" />
+      <CanvasShellChromeBefore
+        inset={inset}
+        leftBar={hasLeftBar ? resolvedLeftBar : undefined}
+        topBar={hasTopBar ? topBar : undefined}
+      />
+      {renderFloatingContent(children, contentStyle)}
+      <CanvasShellChromeAfter
+        bottomBar={hasBottomBar ? resolvedBottomBar : undefined}
+        inset={inset}
+        rightBar={hasRightBar ? resolvedRightBar : undefined}
+      />
+    </section>
+  );
+}
+
+const CanvasShell = forwardRef<HTMLElement, CanvasShellProps>((props, ref) => {
+  const { bottomBar, chromeInset, contentPadding, leftBar, rightBar } = props;
+  const hasExplicitChromeInset = Object.prototype.hasOwnProperty.call(
+    props,
+    "chromeInset",
+  );
+  const usesFloatingChrome =
+    hasChromeContent(bottomBar) ||
+    hasChromeContent(leftBar) ||
+    hasChromeContent(rightBar) ||
+    contentPadding !== undefined ||
+    (hasExplicitChromeInset && chromeInset !== undefined);
+
+  if (!usesFloatingChrome) {
+    return renderLegacyCanvasShell(props, ref);
+  }
+
+  return renderFloatingCanvasShell(props, ref);
+});
+
+CanvasShell.displayName = "CanvasShell";
+
+export { CanvasShell };

--- a/apps/registry/registry/default/canvas-view/canvas-view.tsx
+++ b/apps/registry/registry/default/canvas-view/canvas-view.tsx
@@ -1,1 +1,652 @@
-export { CanvasView, type CanvasViewProps } from '@vllnt/ui'
+"use client";
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+  WheelEvent as ReactWheelEvent,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type CanvasViewport = {
+  x: number;
+  y: number;
+  zoom: number;
+};
+
+export type CanvasViewHandle = {
+  resetViewport: () => void;
+  setViewport: (viewport: CanvasViewport) => void;
+};
+
+export type CanvasViewProps = Omit<
+  React.ComponentPropsWithoutRef<"div">,
+  "onScroll"
+> & {
+  defaultViewport?: CanvasViewport;
+  maxZoom?: number;
+  minZoom?: number;
+  onViewportChange?: (viewport: CanvasViewport) => void;
+  overlay?: React.ReactNode;
+  zoomStep?: number;
+};
+
+type DragOrigin = {
+  pointerX: number;
+  pointerY: number;
+  viewport: CanvasViewport;
+};
+
+type ViewportReference = {
+  current: CanvasViewport;
+};
+
+const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
+
+const INTERACTIVE_ELEMENT_SELECTOR = [
+  "a[href]",
+  "button",
+  'input:not([type="hidden"])',
+  "select",
+  "textarea",
+  "summary",
+  '[contenteditable=""]',
+  '[contenteditable="true"]',
+  '[role="button"]',
+  '[role="checkbox"]',
+  '[role="link"]',
+  '[role="menuitem"]',
+  '[role="option"]',
+  '[role="radio"]',
+  '[role="slider"]',
+  '[role="spinbutton"]',
+  '[role="switch"]',
+  '[role="tab"]',
+  '[role="textbox"]',
+].join(", ");
+
+function clampZoom(value: number, minZoom: number, maxZoom: number) {
+  return Math.min(maxZoom, Math.max(minZoom, Number(value.toFixed(2))));
+}
+
+function isHtmlElement(target: EventTarget | null): target is HTMLElement {
+  return target instanceof HTMLElement;
+}
+
+function isInteractiveDescendant(
+  element: HTMLElement,
+  container: HTMLDivElement,
+) {
+  const interactiveAncestor = element.closest(INTERACTIVE_ELEMENT_SELECTOR);
+
+  return (
+    interactiveAncestor !== null && container.contains(interactiveAncestor)
+  );
+}
+
+function supportsScrollableOverflow(value: string) {
+  return value === "auto" || value === "overlay" || value === "scroll";
+}
+
+function hasScrollableAxis(element: HTMLElement, axis: "x" | "y") {
+  const style = window.getComputedStyle(element);
+
+  if (axis === "x") {
+    return (
+      supportsScrollableOverflow(style.overflowX) &&
+      element.scrollWidth > element.clientWidth
+    );
+  }
+
+  return (
+    supportsScrollableOverflow(style.overflowY) &&
+    element.scrollHeight > element.clientHeight
+  );
+}
+
+function hasScrollableAncestor(
+  element: HTMLElement,
+  container: HTMLDivElement,
+  delta: { x: number; y: number },
+): boolean {
+  if (!container.contains(element) || element === container) {
+    return false;
+  }
+
+  if (
+    (delta.x !== 0 && hasScrollableAxis(element, "x")) ||
+    (delta.y !== 0 && hasScrollableAxis(element, "y"))
+  ) {
+    return true;
+  }
+
+  return element.parentElement === null
+    ? false
+    : hasScrollableAncestor(element.parentElement, container, delta);
+}
+
+function shouldHandleCanvasKeyboardEvent(
+  event: ReactKeyboardEvent<HTMLDivElement>,
+) {
+  if (
+    isHtmlElement(event.target) &&
+    event.target !== event.currentTarget &&
+    isInteractiveDescendant(event.target, event.currentTarget)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function shouldHandleCanvasWheelEvent(event: ReactWheelEvent<HTMLDivElement>) {
+  if (
+    isHtmlElement(event.target) &&
+    hasScrollableAncestor(event.target, event.currentTarget, {
+      x: event.deltaX,
+      y: event.deltaY,
+    })
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function isPanGesture(
+  event: ReactPointerEvent<HTMLDivElement>,
+  isSpacePressed: boolean,
+) {
+  return event.button === 1 || (event.button === 0 && isSpacePressed);
+}
+
+function createViewportKeyHandler({
+  nudgeViewport,
+  resetViewport,
+  setViewport,
+  viewportRef,
+  zoomStep,
+}: {
+  nudgeViewport: (deltaX: number, deltaY: number) => void;
+  resetViewport: () => void;
+  setViewport: (viewport: CanvasViewport) => void;
+  viewportRef: ViewportReference;
+  zoomStep: number;
+}) {
+  return (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "+" || event.key === "=") {
+      event.preventDefault();
+      setViewport({
+        ...viewportRef.current,
+        zoom: viewportRef.current.zoom + zoomStep,
+      });
+      return;
+    }
+
+    if (event.key === "-") {
+      event.preventDefault();
+      setViewport({
+        ...viewportRef.current,
+        zoom: viewportRef.current.zoom - zoomStep,
+      });
+      return;
+    }
+
+    if (event.key === "0") {
+      event.preventDefault();
+      resetViewport();
+      return;
+    }
+
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      nudgeViewport(40, 0);
+      return;
+    }
+
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      nudgeViewport(-40, 0);
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      nudgeViewport(0, 40);
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      nudgeViewport(0, -40);
+    }
+  };
+}
+
+function useViewportState({
+  defaultViewport,
+  maxZoom,
+  minZoom,
+  onViewportChange,
+}: {
+  defaultViewport: CanvasViewport;
+  maxZoom: number;
+  minZoom: number;
+  onViewportChange?: (viewport: CanvasViewport) => void;
+}) {
+  const defaultViewportRef = useRef(defaultViewport);
+  const viewportRef = useRef(defaultViewport);
+  const [viewport, setViewport] = useState(defaultViewport);
+
+  useEffect(() => {
+    defaultViewportRef.current = defaultViewport;
+  }, [defaultViewport]);
+
+  const applyViewport = useCallback(
+    (nextViewport: CanvasViewport) => {
+      const resolvedViewport = {
+        x: Math.round(nextViewport.x),
+        y: Math.round(nextViewport.y),
+        zoom: clampZoom(nextViewport.zoom, minZoom, maxZoom),
+      };
+
+      viewportRef.current = resolvedViewport;
+      setViewport(resolvedViewport);
+      onViewportChange?.(resolvedViewport);
+    },
+    [maxZoom, minZoom, onViewportChange],
+  );
+
+  const resetViewport = useCallback(() => {
+    applyViewport(defaultViewportRef.current);
+  }, [applyViewport]);
+
+  const nudgeViewport = useCallback(
+    (deltaX: number, deltaY: number) => {
+      const currentViewport = viewportRef.current;
+      applyViewport({
+        x: currentViewport.x + deltaX,
+        y: currentViewport.y + deltaY,
+        zoom: currentViewport.zoom,
+      });
+    },
+    [applyViewport],
+  );
+
+  return {
+    nudgeViewport,
+    resetViewport,
+    setViewport: applyViewport,
+    viewport,
+    viewportRef,
+  };
+}
+
+function useCanvasKeyboardInteractions({
+  nudgeViewport,
+  resetViewport,
+  setViewport,
+  viewportRef,
+  zoomStep,
+}: {
+  nudgeViewport: (deltaX: number, deltaY: number) => void;
+  resetViewport: () => void;
+  setViewport: (viewport: CanvasViewport) => void;
+  viewportRef: ViewportReference;
+  zoomStep: number;
+}) {
+  const [isSpacePressed, setIsSpacePressed] = useState(false);
+
+  const handleWheel = useCallback(
+    (event: ReactWheelEvent<HTMLDivElement>) => {
+      if (event.ctrlKey || event.metaKey) {
+        event.preventDefault();
+        setViewport({
+          ...viewportRef.current,
+          zoom:
+            viewportRef.current.zoom +
+            (event.deltaY > 0 ? -zoomStep : zoomStep),
+        });
+        return;
+      }
+
+      if (!shouldHandleCanvasWheelEvent(event)) {
+        return;
+      }
+
+      event.preventDefault();
+      nudgeViewport(-event.deltaX, -event.deltaY);
+    },
+    [nudgeViewport, setViewport, viewportRef, zoomStep],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (!shouldHandleCanvasKeyboardEvent(event)) {
+        return;
+      }
+
+      if (event.key === " ") {
+        event.preventDefault();
+        setIsSpacePressed(true);
+        return;
+      }
+
+      createViewportKeyHandler({
+        nudgeViewport,
+        resetViewport,
+        setViewport,
+        viewportRef,
+        zoomStep,
+      })(event);
+    },
+    [nudgeViewport, resetViewport, setViewport, viewportRef, zoomStep],
+  );
+
+  const handleKeyUp = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (!shouldHandleCanvasKeyboardEvent(event)) {
+        return;
+      }
+
+      if (event.key === " ") {
+        setIsSpacePressed(false);
+      }
+    },
+    [],
+  );
+
+  return { handleKeyDown, handleKeyUp, handleWheel, isSpacePressed };
+}
+
+function endCanvasDrag(
+  event: ReactPointerEvent<HTMLDivElement>,
+  dragOriginRef: React.RefObject<DragOrigin | null>,
+  setIsDragging: React.Dispatch<React.SetStateAction<boolean>>,
+) {
+  dragOriginRef.current = null;
+  setIsDragging(false);
+  if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+    event.currentTarget.releasePointerCapture(event.pointerId);
+  }
+}
+
+function useCanvasPointerInteractions({
+  isSpacePressed,
+  setViewport,
+  viewportRef,
+}: {
+  isSpacePressed: boolean;
+  setViewport: (viewport: CanvasViewport) => void;
+  viewportRef: ViewportReference;
+}) {
+  const dragOriginRef = useRef<DragOrigin | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!isPanGesture(event, isSpacePressed)) {
+        return;
+      }
+
+      if (event.button === 1) {
+        event.preventDefault();
+      }
+
+      dragOriginRef.current = {
+        pointerX: event.clientX,
+        pointerY: event.clientY,
+        viewport: viewportRef.current,
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+      setIsDragging(true);
+    },
+    [isSpacePressed, viewportRef],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const dragOrigin = dragOriginRef.current;
+      if (!dragOrigin) {
+        return;
+      }
+
+      setViewport({
+        x: dragOrigin.viewport.x + (event.clientX - dragOrigin.pointerX),
+        y: dragOrigin.viewport.y + (event.clientY - dragOrigin.pointerY),
+        zoom: dragOrigin.viewport.zoom,
+      });
+    },
+    [setViewport],
+  );
+
+  const handlePointerCancel = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      endCanvasDrag(event, dragOriginRef, setIsDragging);
+    },
+    [],
+  );
+
+  const handlePointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      endCanvasDrag(event, dragOriginRef, setIsDragging);
+    },
+    [],
+  );
+
+  return {
+    handlePointerCancel,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    isDragging,
+  };
+}
+
+function usePreventBodySelection(disabled: boolean) {
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const { body } = document;
+    const previousUserSelect = body.style.userSelect;
+
+    if (disabled) {
+      body.style.userSelect = "none";
+    }
+
+    return () => {
+      body.style.userSelect = previousUserSelect;
+    };
+  }, [disabled]);
+}
+
+function useCanvasViewHandle(
+  ref: React.ForwardedRef<CanvasViewHandle>,
+  viewportState: {
+    resetViewport: () => void;
+    setViewport: (viewport: CanvasViewport) => void;
+  },
+) {
+  useImperativeHandle(
+    ref,
+    () => ({
+      resetViewport: viewportState.resetViewport,
+      setViewport: viewportState.setViewport,
+    }),
+    [viewportState.resetViewport, viewportState.setViewport],
+  );
+}
+
+type CanvasInteractionLayerProps = {
+  children: React.ReactNode;
+  instructionsId: string;
+  isDragging: boolean;
+  isSpacePressed: boolean;
+  onKeyDown: (event: ReactKeyboardEvent<HTMLDivElement>) => void;
+  onKeyUp: (event: ReactKeyboardEvent<HTMLDivElement>) => void;
+  onPointerCancel: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerUp: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onWheel: (event: ReactWheelEvent<HTMLDivElement>) => void;
+  viewport: CanvasViewport;
+};
+
+function CanvasInteractionLayer({
+  children,
+  instructionsId,
+  isDragging,
+  isSpacePressed,
+  onKeyDown,
+  onKeyUp,
+  onPointerCancel,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+  onWheel,
+  viewport,
+}: CanvasInteractionLayerProps) {
+  return (
+    <div
+      aria-describedby={instructionsId}
+      aria-label="Canvas workspace"
+      aria-roledescription="canvas"
+      className={cn(
+        "relative h-full w-full select-none touch-none outline-none",
+        isDragging || isSpacePressed
+          ? "cursor-grab active:cursor-grabbing"
+          : "cursor-default",
+      )}
+      data-viewport={JSON.stringify(viewport)}
+      onKeyDown={onKeyDown}
+      onKeyUp={onKeyUp}
+      onPointerCancel={onPointerCancel}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onWheel={onWheel}
+      role="button"
+      tabIndex={0}
+    >
+      <div className="sr-only" id={instructionsId}>
+        Hold space and drag or use the middle mouse button to pan. Use plus,
+        minus, or control wheel to zoom. Press zero to reset the viewport.
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function CanvasContentLayer({
+  children,
+  overlay,
+  viewport,
+}: {
+  children: React.ReactNode;
+  overlay?: React.ReactNode;
+  viewport: CanvasViewport;
+}) {
+  return (
+    <>
+      <div
+        className="absolute inset-0 origin-top-left transition-transform duration-150 ease-out"
+        style={{
+          transform: `translate3d(${viewport.x}px, ${viewport.y}px, 0) scale(${viewport.zoom})`,
+        }}
+      >
+        {children}
+      </div>
+      {overlay ? (
+        <div className="pointer-events-none absolute inset-0 z-20">
+          {overlay}
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+const CanvasView = forwardRef<CanvasViewHandle, CanvasViewProps>(
+  (
+    {
+      children,
+      className,
+      defaultViewport = DEFAULT_VIEWPORT,
+      maxZoom = 2,
+      minZoom = 0.5,
+      onViewportChange,
+      overlay,
+      zoomStep = 0.1,
+      ...props
+    },
+    ref,
+  ) => {
+    const instructionsId = useId();
+    const viewportState = useViewportState({
+      defaultViewport,
+      maxZoom,
+      minZoom,
+      onViewportChange,
+    });
+    const keyboard = useCanvasKeyboardInteractions({
+      nudgeViewport: viewportState.nudgeViewport,
+      resetViewport: viewportState.resetViewport,
+      setViewport: viewportState.setViewport,
+      viewportRef: viewportState.viewportRef,
+      zoomStep,
+    });
+    const pointer = useCanvasPointerInteractions({
+      isSpacePressed: keyboard.isSpacePressed,
+      setViewport: viewportState.setViewport,
+      viewportRef: viewportState.viewportRef,
+    });
+    usePreventBodySelection(pointer.isDragging);
+    useCanvasViewHandle(ref, viewportState);
+
+    return (
+      <div
+        className={cn(
+          "relative h-full min-h-[32rem] overflow-hidden rounded-sm border border-border bg-background",
+          className,
+        )}
+        {...props}
+      >
+        <CanvasInteractionLayer
+          instructionsId={instructionsId}
+          isDragging={pointer.isDragging}
+          isSpacePressed={keyboard.isSpacePressed}
+          onKeyDown={keyboard.handleKeyDown}
+          onKeyUp={keyboard.handleKeyUp}
+          onPointerCancel={pointer.handlePointerCancel}
+          onPointerDown={pointer.handlePointerDown}
+          onPointerMove={pointer.handlePointerMove}
+          onPointerUp={pointer.handlePointerUp}
+          onWheel={keyboard.handleWheel}
+          viewport={viewportState.viewport}
+        >
+          <CanvasContentLayer
+            overlay={overlay}
+            viewport={viewportState.viewport}
+          >
+            {children}
+          </CanvasContentLayer>
+        </CanvasInteractionLayer>
+      </div>
+    );
+  },
+);
+
+CanvasView.displayName = "CanvasView";
+
+export { CanvasView };

--- a/apps/registry/registry/default/card/card.tsx
+++ b/apps/registry/registry/default/card/card.tsx
@@ -1,2 +1,86 @@
-// Re-export from @vllnt/ui package
-export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@vllnt/ui'
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, reference) => (
+  <div
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className,
+    )}
+    ref={reference}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, reference) => (
+  <div
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    ref={reference}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, reference) => (
+  <div
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className,
+    )}
+    ref={reference}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, reference) => (
+  <div
+    className={cn("text-sm text-muted-foreground", className)}
+    ref={reference}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, reference) => (
+  <div className={cn("p-6 pt-0", className)} ref={reference} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, reference) => (
+  <div
+    className={cn("flex items-center p-6 pt-0", className)}
+    ref={reference}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+};

--- a/apps/registry/registry/default/carousel/carousel.tsx
+++ b/apps/registry/registry/default/carousel/carousel.tsx
@@ -1,1 +1,322 @@
-export * from '@vllnt/ui'
+"use client";
+
+import {
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
+
+type CarouselProps = {
+  opts?: CarouselOptions;
+  orientation?: "horizontal" | "vertical";
+  plugins?: CarouselPlugin;
+  setApi?: (api: CarouselApi) => void;
+};
+
+type CarouselContextProps = {
+  api: ReturnType<typeof useEmblaCarousel>[1];
+  canScrollNext: boolean;
+  canScrollPrev: boolean;
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+  scrollNext: () => void;
+  scrollPrev: () => void;
+} & CarouselProps;
+
+const CarouselContext = createContext<CarouselContextProps | null>(null);
+
+function useCarousel() {
+  const context = useContext(CarouselContext);
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />");
+  }
+
+  return context;
+}
+
+type UseCarouselLogicOptions = {
+  options: CarouselOptions;
+  orientation: "horizontal" | "vertical";
+  plugins: CarouselPlugin;
+  setApi?: (api: CarouselApi) => void;
+};
+
+function useCarouselLogic({
+  options,
+  orientation,
+  plugins,
+  setApi,
+}: UseCarouselLogicOptions) {
+  const [carouselRef, api] = useEmblaCarousel(
+    {
+      ...options,
+      axis: orientation === "horizontal" ? "x" : "y",
+    },
+    plugins,
+  );
+  const [canScrollPrevious, setCanScrollPrevious] = useState(false);
+  const [canScrollNext, setCanScrollNext] = useState(false);
+
+  const onSelect = useCallback((api: CarouselApi) => {
+    if (!api) {
+      return;
+    }
+
+    setCanScrollPrevious(api.canScrollPrev());
+    setCanScrollNext(api.canScrollNext());
+  }, []);
+
+  const scrollPrevious = useCallback(() => {
+    api?.scrollPrev();
+  }, [api]);
+
+  const scrollNext = useCallback(() => {
+    api?.scrollNext();
+  }, [api]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        scrollPrevious();
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        scrollNext();
+      }
+    },
+    [scrollPrevious, scrollNext],
+  );
+
+  useEffect(() => {
+    if (!api || !setApi) {
+      return;
+    }
+
+    setApi(api);
+  }, [api, setApi]);
+
+  useEffect(() => {
+    if (!api) {
+      return;
+    }
+
+    api.on("reInit", onSelect);
+    api.on("select", onSelect);
+
+    const rafId = requestAnimationFrame(() => {
+      onSelect(api);
+    });
+
+    return () => {
+      api?.off("select", onSelect);
+      api?.off("reInit", onSelect);
+      cancelAnimationFrame(rafId);
+    };
+  }, [api, onSelect]);
+
+  return {
+    api,
+    canScrollNext,
+    canScrollPrevious,
+    carouselRef,
+    handleKeyDown,
+    scrollNext,
+    scrollPrevious,
+  };
+}
+
+const Carousel = forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+>(
+  (
+    {
+      children,
+      className,
+      opts,
+      orientation = "horizontal",
+      plugins,
+      setApi,
+      ...props
+    },
+    ref,
+  ) => {
+    const {
+      api,
+      canScrollNext,
+      canScrollPrevious,
+      carouselRef,
+      handleKeyDown,
+      scrollNext,
+      scrollPrevious,
+    } = useCarouselLogic({ options: opts, orientation, plugins, setApi });
+
+    const contextValue = useMemo(
+      () => ({
+        api,
+        canScrollNext,
+        canScrollPrev: canScrollPrevious,
+        carouselRef,
+        opts,
+        orientation:
+          orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+        scrollNext,
+        scrollPrev: scrollPrevious,
+      }),
+      [
+        api,
+        canScrollNext,
+        canScrollPrevious,
+        carouselRef,
+        opts,
+        orientation,
+        scrollNext,
+        scrollPrevious,
+      ],
+    );
+
+    return (
+      <CarouselContext.Provider value={contextValue}>
+        <div
+          aria-roledescription="carousel"
+          className={cn("relative", className)}
+          onKeyDownCapture={handleKeyDown}
+          ref={ref}
+          role="region"
+          {...props}
+        >
+          {children}
+        </div>
+      </CarouselContext.Provider>
+    );
+  },
+);
+Carousel.displayName = "Carousel";
+
+const CarouselContent = forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { carouselRef, orientation } = useCarousel();
+
+  return (
+    <div className="overflow-hidden" ref={carouselRef}>
+      <div
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    </div>
+  );
+});
+CarouselContent.displayName = "CarouselContent";
+
+const CarouselItem = forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { orientation } = useCarousel();
+
+  return (
+    <div
+      aria-roledescription="slide"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className,
+      )}
+      ref={ref}
+      role="group"
+      {...props}
+    />
+  );
+});
+CarouselItem.displayName = "CarouselItem";
+
+const CarouselPrevious = forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, size = "icon", variant = "outline", ...props }, ref) => {
+  const { canScrollPrev, orientation, scrollPrev } = useCarousel();
+
+  return (
+    <Button
+      className={cn(
+        "absolute h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-left-12 top-1/2 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className,
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      ref={ref}
+      size={size}
+      variant={variant}
+      {...props}
+    >
+      <ArrowLeft className="h-4 w-4" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  );
+});
+CarouselPrevious.displayName = "CarouselPrevious";
+
+const CarouselNext = forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, size = "icon", variant = "outline", ...props }, ref) => {
+  const { canScrollNext, orientation, scrollNext } = useCarousel();
+
+  return (
+    <Button
+      className={cn(
+        "absolute h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-right-12 top-1/2 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className,
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      ref={ref}
+      size={size}
+      variant={variant}
+      {...props}
+    >
+      <ArrowRight className="h-4 w-4" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  );
+});
+CarouselNext.displayName = "CarouselNext";
+
+export {
+  Carousel,
+  type CarouselApi,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+};

--- a/apps/registry/registry/default/category-filter/category-filter.tsx
+++ b/apps/registry/registry/default/category-filter/category-filter.tsx
@@ -1,2 +1,64 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { Badge } from "@vllnt/ui";
+
+type CategoryFilterProps = {
+  categories: string[];
+  lang: string;
+};
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize("NFD")
+    .replaceAll(/[\u0300-\u036F]/g, "") // Remove diacritics
+    .replaceAll(/[^\s\w-]/g, "") // Remove special characters except spaces and hyphens
+    .trim()
+    .replaceAll(/\s+/g, "-") // Replace spaces with hyphens
+    .replaceAll(/-+/g, "-") // Collapse consecutive hyphens
+    .replaceAll(/^-+|-+$/g, ""); // Remove leading/trailing hyphens
+}
+
+export function CategoryFilter({ categories, lang }: CategoryFilterProps) {
+  const pathname = usePathname();
+
+  // Get all unique categories and sort them
+  // eslint-disable-next-line unicorn/prefer-spread
+  const allCategories: string[] = Array.from(new Set(categories)).sort();
+
+  if (allCategories.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {allCategories.map((category) => {
+        const categorySlug = slugify(category);
+        const isSelected = pathname.includes(`/${categorySlug}`);
+        const href = `/${lang}/${categorySlug}`;
+
+        if (isSelected) {
+          return (
+            <Badge className="cursor-default" key={category} variant="default">
+              {category.charAt(0).toUpperCase() + category.slice(1)}
+            </Badge>
+          );
+        }
+
+        return (
+          <Link href={href} key={category}>
+            <Badge
+              className="cursor-pointer hover:bg-primary hover:text-primary-foreground transition-colors"
+              variant="secondary"
+            >
+              {category.charAt(0).toUpperCase() + category.slice(1)}
+            </Badge>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/registry/registry/default/checkbox/checkbox.tsx
+++ b/apps/registry/registry/default/checkbox/checkbox.tsx
@@ -1,2 +1,31 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import * as React from "react";
+
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+const Checkbox = React.forwardRef<
+  React.ComponentRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, reference) => (
+  <CheckboxPrimitive.Root
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded border border-input bg-background ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary",
+      className,
+    )}
+    ref={reference}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/apps/registry/registry/default/checklist/checklist.tsx
+++ b/apps/registry/registry/default/checklist/checklist.tsx
@@ -1,28 +1,34 @@
-'use client'
+"use client";
 
-import { useState } from 'react'
+import { useState } from "react";
 
-import { cn } from '../../../lib/utils'
+import { cn } from "@vllnt/ui";
+
+export const CHECKLIST_PROGRESS_EVENT = "vllnt:checklist-progress-change";
 
 export type ChecklistItem = {
-  description?: string
-  id: string
-  label: string
-}
+  description?: string;
+  id: string;
+  label: string;
+};
 
 type ChecklistItemRowProps = {
-  isChecked: boolean
-  item: ChecklistItem
-  onToggle: () => void
-}
+  isChecked: boolean;
+  item: ChecklistItem;
+  onToggle: () => void;
+};
 
-function ChecklistItemRow({ isChecked, item, onToggle }: ChecklistItemRowProps): React.ReactNode {
+function ChecklistItemRow({
+  isChecked,
+  item,
+  onToggle,
+}: ChecklistItemRowProps): React.ReactNode {
   return (
     <li>
       <button
         className={cn(
-          'w-full flex items-start gap-3 p-2 rounded-md text-left transition-colors hover:bg-muted/50',
-          isChecked && 'opacity-60',
+          "w-full flex items-start gap-3 p-2 rounded-md text-left transition-colors hover:bg-muted/50",
+          isChecked && "opacity-60",
         )}
         onClick={onToggle}
         type="button"
@@ -48,33 +54,56 @@ function ChecklistItemRow({ isChecked, item, onToggle }: ChecklistItemRowProps):
             stroke="currentColor"
             viewBox="0 0 24 24"
           >
-            <rect height="18" rx="2" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} width="18" x="3" y="3" />
+            <rect
+              height="18"
+              rx="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              width="18"
+              x="3"
+              y="3"
+            />
           </svg>
         )}
         <div className="flex-1 min-w-0">
-          <span className={cn('text-sm', isChecked && 'line-through')}>{item.label}</span>
+          <span className={cn("text-sm", isChecked && "line-through")}>
+            {item.label}
+          </span>
           {item.description ? (
-            <p className="text-xs text-muted-foreground mt-0.5">{item.description}</p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {item.description}
+            </p>
           ) : null}
         </div>
       </button>
     </li>
-  )
+  );
 }
 
 type ChecklistHeaderProps = {
-  checked: number
-  progress: number
-  title?: string
-  total: number
-}
+  checked: number;
+  progress: number;
+  title?: string;
+  total: number;
+};
 
-function ChecklistHeader({ checked, progress, title, total }: ChecklistHeaderProps): React.ReactNode {
-  if (!title) return null
+function ChecklistHeader({
+  checked,
+  progress,
+  title,
+  total,
+}: ChecklistHeaderProps): React.ReactNode {
+  if (!title) return null;
   return (
     <div className="flex items-center justify-between mb-3">
       <h4 className="font-semibold flex items-center gap-2">
-        <svg className="h-5 w-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg
+          className="h-5 w-5 text-primary"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
           <path
             d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
             strokeLinecap="round"
@@ -88,17 +117,18 @@ function ChecklistHeader({ checked, progress, title, total }: ChecklistHeaderPro
         {checked}/{total} ({progress}%)
       </span>
     </div>
-  )
+  );
 }
 
 export type ChecklistProps = {
-  className?: string
-  items: ChecklistItem[]
-  onComplete?: () => void
-  persistKey?: string
-  title?: string
-}
+  className?: string;
+  items: ChecklistItem[];
+  onComplete?: () => void;
+  persistKey?: string;
+  title?: string;
+};
 
+// eslint-disable-next-line max-lines-per-function -- Complex interactive component with state and localStorage
 export function Checklist({
   className,
   items,
@@ -107,48 +137,61 @@ export function Checklist({
   title,
 }: ChecklistProps): React.ReactNode {
   const [checked, setChecked] = useState<Set<string>>(() => {
-    if (typeof window !== 'undefined' && persistKey) {
-      const saved = localStorage.getItem(`checklist:${persistKey}`)
+    if (typeof window !== "undefined" && persistKey) {
+      const saved = localStorage.getItem(`checklist:${persistKey}`);
       if (saved) {
         try {
-          return new Set(JSON.parse(saved) as string[])
+          return new Set(JSON.parse(saved) as string[]);
         } catch {
           /* skip */
         }
       }
     }
-    return new Set()
-  })
+    return new Set();
+  });
 
   const toggleItem = (id: string): void => {
-    const newChecked = new Set(checked)
-    if (newChecked.has(id)) newChecked.delete(id)
-    else newChecked.add(id)
-    setChecked(newChecked)
+    const newChecked = new Set(checked);
+    if (newChecked.has(id)) newChecked.delete(id);
+    else newChecked.add(id);
+    setChecked(newChecked);
     if (persistKey) {
       try {
-        // eslint-disable-next-line unicorn/prefer-spread -- Set iteration requires Array.from with current tsconfig
-        localStorage.setItem(`checklist:${persistKey}`, JSON.stringify(Array.from(newChecked)))
+        localStorage.setItem(
+          `checklist:${persistKey}`,
+          JSON.stringify([...newChecked]),
+        );
+        window.dispatchEvent(
+          new CustomEvent(CHECKLIST_PROGRESS_EVENT, {
+            detail: { persistKey },
+          }),
+        );
       } catch {
         /* skip */
       }
     }
     if (newChecked.size === items.length) {
-      onComplete?.()
+      onComplete?.();
     }
-  }
+  };
 
-  const allChecked = checked.size === items.length
-  const progress = items.length > 0 ? Math.round((checked.size / items.length) * 100) : 0
+  const allChecked = checked.size === items.length;
+  const progress =
+    items.length > 0 ? Math.round((checked.size / items.length) * 100) : 0;
 
   return (
-    <div className={cn('my-6 rounded-lg border bg-card p-4', className)}>
-      <ChecklistHeader checked={checked.size} progress={progress} title={title} total={items.length} />
+    <div className={cn("my-6 rounded-lg border bg-card p-4", className)}>
+      <ChecklistHeader
+        checked={checked.size}
+        progress={progress}
+        title={title}
+        total={items.length}
+      />
       <div className="h-1 bg-muted rounded-full mb-4 overflow-hidden">
         <div
           className={cn(
-            'h-full transition-all duration-300',
-            allChecked ? 'bg-green-500' : 'bg-primary',
+            "h-full transition-all duration-300",
+            allChecked ? "bg-green-500" : "bg-primary",
           )}
           style={{ width: `${progress}%` }}
         />
@@ -160,7 +203,7 @@ export function Checklist({
             item={item}
             key={item.id}
             onToggle={() => {
-              toggleItem(item.id)
+              toggleItem(item.id);
             }}
           />
         ))}
@@ -171,5 +214,5 @@ export function Checklist({
         </div>
       ) : null}
     </div>
-  )
+  );
 }

--- a/apps/registry/registry/default/choropleth-map/choropleth-map.tsx
+++ b/apps/registry/registry/default/choropleth-map/choropleth-map.tsx
@@ -1,11 +1,581 @@
-export {
-  type ChoroplethColorScale,
-  ChoroplethLegend,
-  type ChoroplethLegendProps,
-  ChoroplethMap,
-  type ChoroplethMapLabels,
-  type ChoroplethMapProps,
-  type ChoroplethRegion,
-  ChoroplethTooltip,
-  type ChoroplethTooltipProps,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+const VIEWBOX_WIDTH = 1000;
+const VIEWBOX_HEIGHT = 500;
+
+/**
+ * Geographic coordinate `[longitude, latitude]`.
+ *
+ * @public
+ */
+export type GeoPosition = [number, number];
+
+/**
+ * A region polygon. Outer ring closes by repeating the first point;
+ * holes are out of scope for the MVP.
+ *
+ * @public
+ */
+export type ChoroplethRegion = {
+  /** Outer ring as `[lng, lat]` positions. */
+  coordinates: GeoPosition[];
+  /** Stable identifier — matches keys in the `data` map. */
+  id: string;
+  /** Human-readable region name shown in the default tooltip. */
+  name: string;
+};
+
+/**
+ * Two-stop color scale `[low, high]` for sequential data, or three stops
+ * `[low, mid, high]` for diverging data. Linear interpolation between stops.
+ *
+ * @public
+ */
+export type ChoroplethColorScale = [string, string, string] | [string, string];
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type ChoroplethMapLabels = {
+  /** Aria-label for the SVG canvas. Defaults to `"Choropleth map"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Choropleth map",
+} as const satisfies Required<ChoroplethMapLabels>;
+
+const DEFAULT_SCALE: ChoroplethColorScale = ["#f1f5f9", "#1d4ed8"];
+const DEFAULT_MISSING = "#e5e7eb";
+
+type Hover = { id: string; value?: number };
+
+type ChoroplethCtx = {
+  colorFor: (value?: number) => string;
+  hover?: Hover;
+  legend?: { domain: [number, number]; scale: ChoroplethColorScale };
+  regionByid: Map<string, ChoroplethRegion>;
+  setHover: (next?: Hover) => void;
+  valueFor: (id: string) => null | number;
+};
+
+const ChoroplethContext = createContext<ChoroplethCtx | null>(null);
+
+function useChoroplethContext(): ChoroplethCtx {
+  const ctx = useContext(ChoroplethContext);
+  if (!ctx) {
+    throw new Error("ChoroplethMap subcomponent used outside its root.");
+  }
+  return ctx;
+}
+
+function projectEquirectangular(
+  position: GeoPosition,
+  width: number,
+  height: number,
+): { x: number; y: number } {
+  const [lng, lat] = position;
+  const x = ((lng + 180) / 360) * width;
+  const y = ((90 - lat) / 180) * height;
+  return { x, y };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function parseHex(color: string): [number, number, number] | undefined {
+  const match = /^#([\da-f]{6})$/i.exec(color.trim());
+  if (!match) return undefined;
+  const hex = match[1] ?? "";
+  return [
+    Number.parseInt(hex.slice(0, 2), 16),
+    Number.parseInt(hex.slice(2, 4), 16),
+    Number.parseInt(hex.slice(4, 6), 16),
+  ];
+}
+
+function toHex(channel: number): string {
+  return clamp(Math.round(channel), 0, 255).toString(16).padStart(2, "0");
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function interpolateColor(stops: string[], t: number): string {
+  if (stops.length === 0) return "#000000";
+  if (stops.length === 1) return stops[0] ?? "#000000";
+  const segments = stops.length - 1;
+  const scaledT = clamp(t, 0, 1) * segments;
+  const segmentIndex = Math.min(Math.floor(scaledT), segments - 1);
+  const localT = scaledT - segmentIndex;
+  const lower = stops[segmentIndex];
+  const upper = stops[segmentIndex + 1];
+  if (!lower || !upper) return stops[0] ?? "#000000";
+  const lowerRgb = parseHex(lower);
+  const upperRgb = parseHex(upper);
+  if (!lowerRgb || !upperRgb) return lower;
+  const [lr, lg, lb] = lowerRgb;
+  const [ur, ug, ub] = upperRgb;
+  const r = lerp(lr, ur, localT);
+  const g = lerp(lg, ug, localT);
+  const b = lerp(lb, ub, localT);
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function computeDomain(values: number[]): [number, number] {
+  const first = values[0];
+  if (first === undefined) return [0, 1];
+  const min = values.reduce(
+    (accumulator, value) => Math.min(accumulator, value),
+    first,
+  );
+  const max = values.reduce(
+    (accumulator, value) => Math.max(accumulator, value),
+    first,
+  );
+  if (min === max) return [min, max + 1];
+  return [min, max];
+}
+
+/**
+ * Props for {@link ChoroplethMap}.
+ *
+ * @public
+ */
+export type ChoroplethMapProps = {
+  /** Color stops. Two stops = sequential; three stops = diverging. Defaults to a blue ramp. */
+  colorScale?: ChoroplethColorScale;
+  /** Map of region id → numeric value. */
+  data: Record<string, number>;
+  /** Optional explicit `[min, max]` value domain. Defaults to the data extent. */
+  domain?: [number, number];
+  /** Localizable strings. */
+  labels?: ChoroplethMapLabels;
+  /** Color used when a region has no data. Defaults to a neutral gray. */
+  missingColor?: string;
+  /** Fires after a region click. */
+  onSelectRegion?: (region: ChoroplethRegion) => void;
+  /** Region polygons. */
+  regions: ChoroplethRegion[];
+} & ComponentPropsWithoutRef<"section">;
+
+type RegionPathProps = {
+  active: boolean;
+  onSelect: (region: ChoroplethRegion) => void;
+  region: ChoroplethRegion;
+  selectedId?: string;
+  setHoverFn: (next?: Hover) => void;
+};
+
+function regionPath(region: ChoroplethRegion): string {
+  return region.coordinates
+    .map((coord, index) => {
+      const projected = projectEquirectangular(
+        coord,
+        VIEWBOX_WIDTH,
+        VIEWBOX_HEIGHT,
+      );
+      return `${index === 0 ? "M" : "L"}${projected.x.toString()},${projected.y.toString()}`;
+    })
+    .join(" ");
+}
+
+function RegionPath({
+  active,
+  onSelect,
+  region,
+  selectedId,
+  setHoverFn,
+}: RegionPathProps): ReactNode {
+  const { colorFor, valueFor } = useChoroplethContext();
+  const value = valueFor(region.id) ?? undefined;
+  const fill = colorFor(value);
+  const handleEnter = (): void => {
+    setHoverFn({ id: region.id, value });
+  };
+  const handleLeave = (): void => {
+    setHoverFn();
+  };
+  const handleSelect = (): void => {
+    onSelect(region);
+  };
+  return (
+    <path
+      aria-label={`${region.name}${value === undefined ? " no data" : ` ${value.toString()}`}`}
+      className={cn(
+        "cursor-pointer outline-none transition-[opacity,filter]",
+        active ? "opacity-100" : "opacity-90 hover:opacity-100",
+        selectedId === region.id ? "stroke-foreground" : "stroke-background",
+      )}
+      d={regionPath(region) + " Z"}
+      data-region-id={region.id}
+      data-selected={selectedId === region.id ? "true" : undefined}
+      data-value={value}
+      fill={fill}
+      onBlur={handleLeave}
+      onClick={handleSelect}
+      onFocus={handleEnter}
+      onMouseEnter={handleEnter}
+      onMouseLeave={handleLeave}
+      strokeWidth={selectedId === region.id ? 2 : 0.75}
+      tabIndex={0}
+    />
+  );
+}
+
+type ChoroplethTooltipRender = (arguments_: {
+  region: ChoroplethRegion;
+  value?: number;
+}) => ReactNode;
+
+/**
+ * Tooltip slot. Pass a render-prop function via `children` for full
+ * control, or omit it to use the default `Region Name · value` layout.
+ *
+ * @public
+ */
+export type ChoroplethTooltipProps = {
+  /** Render-prop receiving the hovered region + value. */
+  children?: ChoroplethTooltipRender;
+} & Omit<ComponentPropsWithoutRef<"div">, "children">;
+
+export const ChoroplethTooltip = forwardRef<
+  HTMLDivElement,
+  ChoroplethTooltipProps
+>(({ children, className, ...rest }, ref) => {
+  const { hover, regionByid } = useChoroplethContext();
+  if (!hover) return null;
+  const region = regionByid.get(hover.id);
+  if (!region) return null;
+  return (
+    <div
+      className={cn(
+        "pointer-events-none absolute left-3 top-3 z-10 max-w-xs rounded-md border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md",
+        className,
+      )}
+      data-tooltip-region-id={region.id}
+      ref={ref}
+      role="status"
+      {...rest}
+    >
+      {children ? (
+        children({ region, value: hover.value })
+      ) : (
+        <span>
+          <span className="font-medium">{region.name}</span>
+          {hover.value === undefined ? (
+            <span className="text-muted-foreground"> · no data</span>
+          ) : (
+            <span> · {hover.value.toLocaleString()}</span>
+          )}
+        </span>
+      )}
+    </div>
+  );
+});
+ChoroplethTooltip.displayName = "ChoroplethTooltip";
+
+/**
+ * Legend slot. Renders a horizontal color ramp with min / max labels.
+ *
+ * @public
+ */
+export type ChoroplethLegendProps = {
+  /** Optional title rendered above the ramp. */
+  title?: ReactNode;
+} & Omit<ComponentPropsWithoutRef<"div">, "children">;
+
+export const ChoroplethLegend = forwardRef<
+  HTMLDivElement,
+  ChoroplethLegendProps
+>(({ className, title, ...rest }, ref) => {
+  const { legend } = useChoroplethContext();
+  if (!legend) return null;
+  const stops = legend.scale.join(", ");
+  return (
+    <div
+      className={cn(
+        "absolute bottom-3 right-3 z-10 flex flex-col gap-1 rounded-md border bg-background/95 px-2 py-1 text-[11px] text-foreground shadow-sm backdrop-blur",
+        className,
+      )}
+      data-legend
+      ref={ref}
+      {...rest}
+    >
+      {title ? (
+        <span className="font-medium uppercase tracking-wide text-muted-foreground">
+          {title}
+        </span>
+      ) : null}
+      <div
+        aria-hidden="true"
+        className="h-2 w-32 rounded-full"
+        style={{ background: `linear-gradient(to right, ${stops})` }}
+      />
+      <div className="flex justify-between text-muted-foreground">
+        <span>{legend.domain[0].toLocaleString()}</span>
+        <span>{legend.domain[1].toLocaleString()}</span>
+      </div>
+    </div>
+  );
+});
+ChoroplethLegend.displayName = "ChoroplethLegend";
+
+type DataSummaryProps = {
+  data: Record<string, number>;
+  regions: ChoroplethRegion[];
+  titleId: string;
+};
+
+function DataSummary({ data, regions, titleId }: DataSummaryProps): ReactNode {
+  return (
+    <div aria-labelledby={titleId} className="sr-only" role="region">
+      <h3 id={titleId}>Choropleth data summary</h3>
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Region</th>
+            <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {regions.map((region) => {
+            const value = data[region.id];
+            return (
+              <tr key={region.id}>
+                <td>{region.name}</td>
+                <td>
+                  {value === undefined ? "no data" : value.toLocaleString()}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+type ChildBuckets = {
+  legend: ReactNode;
+  tooltip: ReactNode;
+};
+
+function bucketChildren(children: ReactNode): ChildBuckets {
+  const list: ReactNode[] = Array.isArray(children) ? children : [children];
+  return list.reduce<ChildBuckets>(
+    (accumulator, child) => {
+      const name = displayName(child);
+      if (name === ChoroplethLegend.displayName) accumulator.legend = child;
+      else if (name === ChoroplethTooltip.displayName)
+        accumulator.tooltip = child;
+      return accumulator;
+    },
+    { legend: null, tooltip: null },
+  );
+}
+
+function displayName(child: ReactNode): string | undefined {
+  if (typeof child !== "object" || child === null) return undefined;
+  if (!("type" in child)) return undefined;
+  const type = (child as { type: unknown }).type;
+  if (typeof type !== "object" && typeof type !== "function") return undefined;
+  const name = (type as { displayName?: unknown }).displayName;
+  return typeof name === "string" ? name : undefined;
+}
+
+function useChoroplethState(arguments_: {
+  colorScale: ChoroplethColorScale;
+  data: Record<string, number>;
+  domain: [number, number];
+  missingColor: string;
+  regions: ChoroplethRegion[];
+}): ChoroplethCtx {
+  const { colorScale, data, domain, missingColor, regions } = arguments_;
+  const regionByid = useMemo(
+    () =>
+      new Map<string, ChoroplethRegion>(
+        regions.map((region) => [region.id, region]),
+      ),
+    [regions],
+  );
+
+  const valueFor = useCallback(
+    (id: string): null | number => data[id] ?? null,
+    [data],
+  );
+
+  const colorFor = useCallback(
+    (value?: number): string => {
+      if (value === undefined) return missingColor;
+      const [min, max] = domain;
+      const span = max - min;
+      const t = span === 0 ? 0.5 : (value - min) / span;
+      return interpolateColor(colorScale, t);
+    },
+    [colorScale, domain, missingColor],
+  );
+
+  const [hover, setHover] = useState<Hover | undefined>();
+
+  return useMemo<ChoroplethCtx>(
+    () => ({
+      colorFor,
+      hover,
+      legend: { domain, scale: colorScale },
+      regionByid,
+      setHover,
+      valueFor,
+    }),
+    [colorFor, colorScale, domain, hover, regionByid, valueFor],
+  );
+}
+
+type RegionsLayerProps = {
+  onSelect: (region: ChoroplethRegion) => void;
+  regions: ChoroplethRegion[];
+  selectedId?: string;
+  setHoverFn: (next?: Hover) => void;
+};
+
+function RegionsLayer({
+  onSelect,
+  regions,
+  selectedId,
+  setHoverFn,
+}: RegionsLayerProps): ReactNode {
+  return (
+    <g>
+      {regions.map((region) => (
+        <RegionPath
+          active={selectedId === region.id}
+          key={region.id}
+          onSelect={onSelect}
+          region={region}
+          selectedId={selectedId}
+          setHoverFn={setHoverFn}
+        />
+      ))}
+    </g>
+  );
+}
+
+/**
+ * Region-colored data map (choropleth). Standalone SVG primitive — no
+ * external map library or tile provider required. Pass an array of
+ * {@link ChoroplethRegion} polygons, a `data` map (region id → numeric
+ * value), and an optional `colorScale`. Hover any region to surface the
+ * tooltip; click to fire `onSelectRegion`.
+ *
+ * Compose with {@link ChoroplethLegend} (color ramp + min / max labels)
+ * and {@link ChoroplethTooltip} (custom render-prop).
+ *
+ * @example
+ * ```tsx
+ * <ChoroplethMap
+ *   regions={countries}
+ *   data={{ FR: 2937, DE: 4082, IT: 2107 }}
+ *   colorScale={["#f1f5f9", "#1d4ed8"]}
+ * >
+ *   <ChoroplethTooltip />
+ *   <ChoroplethLegend title="GDP (B USD)" />
+ * </ChoroplethMap>
+ * ```
+ *
+ * @public
+ */
+export const ChoroplethMap = forwardRef<HTMLElement, ChoroplethMapProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      colorScale = DEFAULT_SCALE,
+      data,
+      domain: domainProperty,
+      labels,
+      missingColor = DEFAULT_MISSING,
+      onSelectRegion,
+      regions,
+      ...rest
+    } = props;
+    const titleId = useId();
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+
+    const domain = useMemo(
+      () => domainProperty ?? computeDomain(Object.values(data)),
+      [data, domainProperty],
+    );
+
+    const ctx = useChoroplethState({
+      colorScale,
+      data,
+      domain,
+      missingColor,
+      regions,
+    });
+    const buckets = useMemo(() => bucketChildren(children), [children]);
+
+    const [selectedId, setSelectedId] = useState<string | undefined>();
+
+    const handleSelect = useCallback(
+      (region: ChoroplethRegion) => {
+        setSelectedId(region.id);
+        onSelectRegion?.(region);
+      },
+      [onSelectRegion],
+    );
+
+    return (
+      <ChoroplethContext.Provider value={ctx}>
+        <section
+          aria-label={resolvedLabels.region}
+          className={cn(
+            "relative aspect-[2/1] w-full overflow-hidden rounded-2xl border bg-background text-foreground",
+            className,
+          )}
+          ref={ref}
+          {...rest}
+        >
+          <svg
+            aria-hidden="true"
+            className="block h-full w-full"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox={`0 0 ${VIEWBOX_WIDTH.toString()} ${VIEWBOX_HEIGHT.toString()}`}
+          >
+            <RegionsLayer
+              onSelect={handleSelect}
+              regions={regions}
+              selectedId={selectedId}
+              setHoverFn={ctx.setHover}
+            />
+          </svg>
+          {buckets.tooltip}
+          {buckets.legend}
+          <DataSummary data={data} regions={regions} titleId={titleId} />
+        </section>
+      </ChoroplethContext.Provider>
+    );
+  },
+);
+ChoroplethMap.displayName = "ChoroplethMap";

--- a/apps/registry/registry/default/chronological-timeline/chronological-timeline.tsx
+++ b/apps/registry/registry/default/chronological-timeline/chronological-timeline.tsx
@@ -1,7 +1,544 @@
-export {
-  type ChronoEventProps,
-  ChronoEvent,
-  type ChronoMedia,
-  type ChronologicalTimelineProps,
-  ChronologicalTimeline,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Media payload for a {@link ChronoEvent}.
+ *
+ * @public
+ */
+export type ChronoMedia =
+  | {
+      alt: string;
+      caption?: ReactNode;
+      credit?: ReactNode;
+      src: string;
+      type: "image";
+    }
+  | {
+      alt?: string;
+      caption?: ReactNode;
+      credit?: ReactNode;
+      src: string;
+      type: "audio";
+    }
+  | {
+      caption?: ReactNode;
+      credit?: ReactNode;
+      src: string;
+      title?: string;
+      type: "video";
+    };
+
+type ChronoCtx = {
+  registerEvent: (id: string, node: HTMLElement | null) => void;
+  setActiveId: (id: string) => void;
+  titleId: string;
+};
+
+const ChronoContext = createContext<ChronoCtx | null>(null);
+
+function useChronoContext(): ChronoCtx {
+  const ctx = useContext(ChronoContext);
+  if (!ctx) {
+    throw new Error("ChronoEvent used outside ChronologicalTimeline.");
+  }
+  return ctx;
+}
+
+/**
+ * Props for {@link ChronologicalTimeline}.
+ *
+ * @public
+ */
+export type ChronologicalTimelineProps = {
+  /** Aria-label for the timeline progress strip. Defaults to `"Timeline progress"`. */
+  progressLabel?: string;
+  /** Headline rendered at the top of the timeline. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+/**
+ * Props for {@link ChronoEvent}.
+ *
+ * @public
+ */
+export type ChronoEventProps = {
+  /** Display date (free-form string — pass `"1957"`, `"October 4, 1957"`, etc.). */
+  date: ReactNode;
+  /** When `true`, the card renders larger to emphasise pivotal events. */
+  featured?: boolean;
+  /** Stable id. Defaults to a generated id; pass one for deep links. */
+  id?: string;
+  /** Optional media payload — image / video / audio. */
+  media?: ChronoMedia;
+  /** Optional subtitle. */
+  subtitle?: ReactNode;
+  /** Card title. */
+  title: ReactNode;
+} & Omit<ComponentPropsWithoutRef<"article">, "id" | "title">;
+
+type ImageMediaProps = {
+  media: Extract<ChronoMedia, { type: "image" }>;
+};
+
+function ImageMedia({ media }: ImageMediaProps): ReactNode {
+  return (
+    <figure className="overflow-hidden rounded-xl border bg-muted">
+      <img
+        alt={media.alt}
+        className="aspect-video w-full object-cover"
+        loading="lazy"
+        src={media.src}
+      />
+      {media.caption || media.credit ? (
+        <figcaption className="border-t bg-background px-3 py-2 text-xs text-muted-foreground">
+          {media.caption ? (
+            <span className="block">{media.caption}</span>
+          ) : null}
+          {media.credit ? (
+            <span className="block italic">{media.credit}</span>
+          ) : null}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}
+
+type VideoMediaProps = {
+  media: Extract<ChronoMedia, { type: "video" }>;
+};
+
+function VideoMedia({ media }: VideoMediaProps): ReactNode {
+  return (
+    <figure className="overflow-hidden rounded-xl border bg-muted">
+      <div className="aspect-video w-full">
+        <iframe
+          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          className="h-full w-full"
+          src={media.src}
+          title={media.title ?? "Embedded video"}
+        />
+      </div>
+      {media.caption || media.credit ? (
+        <figcaption className="border-t bg-background px-3 py-2 text-xs text-muted-foreground">
+          {media.caption ? (
+            <span className="block">{media.caption}</span>
+          ) : null}
+          {media.credit ? (
+            <span className="block italic">{media.credit}</span>
+          ) : null}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}
+
+type AudioMediaProps = {
+  media: Extract<ChronoMedia, { type: "audio" }>;
+};
+
+function AudioMedia({ media }: AudioMediaProps): ReactNode {
+  return (
+    <figure className="overflow-hidden rounded-xl border bg-muted px-3 py-3">
+      <audio
+        aria-label={media.alt}
+        className="w-full"
+        controls
+        preload="metadata"
+        src={media.src}
+      >
+        <track kind="captions" />
+      </audio>
+      {media.caption || media.credit ? (
+        <figcaption className="pt-2 text-xs text-muted-foreground">
+          {media.caption ? (
+            <span className="block">{media.caption}</span>
+          ) : null}
+          {media.credit ? (
+            <span className="block italic">{media.credit}</span>
+          ) : null}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}
+
+type MediaProps = {
+  media: ChronoMedia;
+};
+
+function Media({ media }: MediaProps): ReactNode {
+  if (media.type === "image") return <ImageMedia media={media} />;
+  if (media.type === "video") return <VideoMedia media={media} />;
+  return <AudioMedia media={media} />;
+}
+
+type DateColumnProps = {
+  date: ReactNode;
+};
+
+function DateColumn({ date }: DateColumnProps): ReactNode {
+  return (
+    <div className="hidden items-start justify-end pr-4 text-right text-xs font-semibold uppercase tracking-wide text-muted-foreground md:flex md:group-[[data-side='right']]:order-3 md:group-[[data-side='right']]:justify-start md:group-[[data-side='right']]:pl-4 md:group-[[data-side='right']]:text-left">
+      <time className="pt-2">{date}</time>
+    </div>
+  );
+}
+
+type RailColumnProps = {
+  featured: boolean;
+};
+
+function RailColumn({ featured }: RailColumnProps): ReactNode {
+  return (
+    <div
+      aria-hidden="true"
+      className="relative hidden md:flex md:w-6 md:items-start md:justify-center"
+    >
+      <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border" />
+      <span
+        className={cn(
+          "relative z-10 mt-3 block h-3 w-3 rounded-full border-2 border-background bg-primary",
+          featured ? "h-4 w-4" : "",
+        )}
+      />
+    </div>
+  );
+}
+
+type EventCardProps = {
+  children?: ReactNode;
+  date: ReactNode;
+  eventId: string;
+  featured: boolean;
+  media?: ChronoMedia;
+  subtitle?: ReactNode;
+  title: ReactNode;
+};
+
+function EventCard({
+  children,
+  date,
+  eventId,
+  featured,
+  media,
+  subtitle,
+  title,
+}: EventCardProps): ReactNode {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border bg-background p-5 shadow-sm md:group-[[data-side='right']]:order-1",
+        featured ? "ring-1 ring-primary/30" : "",
+      )}
+    >
+      <header className="mb-3 flex flex-col gap-1">
+        <time className="text-xs font-semibold uppercase tracking-wide text-muted-foreground md:hidden">
+          {date}
+        </time>
+        <h3
+          className={cn(
+            "font-semibold text-foreground",
+            featured ? "text-xl" : "text-lg",
+          )}
+          id={`${eventId}-title`}
+        >
+          {title}
+        </h3>
+        {subtitle ? (
+          <p className="text-sm text-muted-foreground">{subtitle}</p>
+        ) : null}
+      </header>
+      {media ? (
+        <div className="mb-3">
+          <Media media={media} />
+        </div>
+      ) : null}
+      {children ? (
+        <div className="space-y-2 text-sm leading-relaxed text-foreground [&_blockquote]:my-3 [&_blockquote]:border-l-2 [&_blockquote]:border-primary [&_blockquote]:pl-3 [&_blockquote]:italic [&_blockquote]:text-muted-foreground">
+          {children}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * A single event card inside {@link ChronologicalTimeline}. Place
+ * narrative paragraphs, blockquotes, and lists as children.
+ *
+ * @public
+ */
+export const ChronoEvent = forwardRef<HTMLElement, ChronoEventProps>(
+  (props, forwardedRef) => {
+    const {
+      children,
+      className,
+      date,
+      featured = false,
+      id,
+      media,
+      subtitle,
+      title,
+      ...rest
+    } = props;
+    const generatedId = useId();
+    const eventId = id ?? generatedId;
+    const ref = useRef<HTMLElement | null>(null);
+    const { registerEvent, setActiveId } = useChronoContext();
+
+    const refCallback = useCallback(
+      (node: HTMLElement | null) => {
+        ref.current = node;
+        registerEvent(eventId, node);
+        if (typeof forwardedRef === "function") forwardedRef(node);
+        else if (forwardedRef) forwardedRef.current = node;
+      },
+      [eventId, forwardedRef, registerEvent],
+    );
+
+    const handleFocus = useCallback(() => {
+      setActiveId(eventId);
+    }, [eventId, setActiveId]);
+
+    return (
+      <article
+        aria-labelledby={`${eventId}-title`}
+        className={cn(
+          "group relative grid gap-4 py-6 md:grid-cols-[1fr_auto_1fr] md:gap-8",
+          className,
+        )}
+        data-event-id={eventId}
+        data-featured={featured ? "true" : undefined}
+        id={eventId}
+        onFocus={handleFocus}
+        ref={refCallback}
+        {...rest}
+      >
+        <DateColumn date={date} />
+        <RailColumn featured={featured} />
+        <EventCard
+          date={date}
+          eventId={eventId}
+          featured={featured}
+          media={media}
+          subtitle={subtitle}
+          title={title}
+        >
+          {children}
+        </EventCard>
+      </article>
+    );
+  },
+);
+ChronoEvent.displayName = "ChronoEvent";
+
+type ProgressStripProps = {
+  activeId?: string;
+  ids: string[];
+  label: string;
+};
+
+function ProgressStrip({
+  activeId,
+  ids,
+  label,
+}: ProgressStripProps): ReactNode {
+  if (ids.length === 0) return null;
+  const activeIndex = activeId ? ids.indexOf(activeId) : -1;
+  const ratio = activeIndex < 0 ? 0 : (activeIndex + 1) / ids.length;
+  return (
+    <div
+      aria-label={label}
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={Math.round(ratio * 100)}
+      className="sticky top-0 z-10 h-1 w-full bg-border"
+      role="progressbar"
+    >
+      <span
+        className="block h-full bg-primary transition-[width] duration-200"
+        style={{ width: `${(ratio * 100).toString()}%` }}
+      />
+    </div>
+  );
+}
+
+function useChronoActiveTracker(): {
+  activeId?: string;
+  ids: string[];
+  registerEvent: (id: string, node: HTMLElement | null) => void;
+  setActiveId: (id: string) => void;
+} {
+  const eventsRef = useRef<Map<string, HTMLElement>>(new Map());
+  const [ids, setIds] = useState<string[]>([]);
+  const [activeId, setActiveId] = useState<string | undefined>();
+
+  const registerEvent = useCallback((id: string, node: HTMLElement | null) => {
+    const map = eventsRef.current;
+    if (node) map.set(id, node);
+    else map.delete(id);
+    setIds([...map.keys()]);
+  }, []);
+
+  useEffect(() => {
+    if (typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        const first = visible[0];
+        if (first) {
+          const target = first.target;
+          if (target instanceof HTMLElement) {
+            const eventId = target.dataset.eventId;
+            if (eventId) setActiveId(eventId);
+          }
+        }
+      },
+      { rootMargin: "-30% 0px -50% 0px", threshold: 0.1 },
+    );
+    [...eventsRef.current.values()].forEach((node) => {
+      observer.observe(node);
+    });
+    return () => {
+      observer.disconnect();
+    };
+  }, [ids]);
+
+  return { activeId, ids, registerEvent, setActiveId };
+}
+
+type EventListProps = {
+  activeId?: string;
+  children: ReactNode;
+};
+
+function EventList({ activeId, children }: EventListProps): ReactNode {
+  if (!Array.isArray(children)) {
+    return (
+      <ol className="relative flex flex-col px-4 pb-6 md:px-6">{children}</ol>
+    );
+  }
+  return (
+    <ol className="relative flex flex-col px-4 pb-6 md:px-6">
+      {children.map((child, index) => (
+        <li
+          className="block list-none"
+          data-active={
+            isReactElementWithEventId(child, activeId) ? "true" : undefined
+          }
+          data-side={index % 2 === 0 ? "left" : "right"}
+          key={getChildKey(child, index)}
+        >
+          {child}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+/**
+ * Media-rich, scroll-driven chronological timeline. Cards alternate
+ * sides on desktop and stack on mobile. Each {@link ChronoEvent} can
+ * include an image, video, or audio payload plus narrative children
+ * (paragraphs, blockquotes, lists). An `IntersectionObserver` follows
+ * the reader and drives the progress strip + the active card flag.
+ *
+ * @example
+ * ```tsx
+ * <ChronologicalTimeline title="The Space Race">
+ *   <ChronoEvent date="October 4, 1957" title="Sputnik 1" subtitle="First artificial satellite">
+ *     <p>The Soviet Union launched Sputnik 1...</p>
+ *   </ChronoEvent>
+ *   <ChronoEvent date="July 20, 1969" title="Apollo 11" featured>
+ *     <p>Neil Armstrong and Buzz Aldrin walked on the Moon...</p>
+ *   </ChronoEvent>
+ * </ChronologicalTimeline>
+ * ```
+ *
+ * @public
+ */
+export const ChronologicalTimeline = forwardRef<
+  HTMLElement,
+  ChronologicalTimelineProps
+>((props, ref) => {
+  const {
+    children,
+    className,
+    progressLabel = "Timeline progress",
+    title,
+    ...rest
+  } = props;
+  const titleId = useId();
+  const { activeId, ids, registerEvent, setActiveId } =
+    useChronoActiveTracker();
+
+  const ctx = useMemo<ChronoCtx>(
+    () => ({ registerEvent, setActiveId, titleId }),
+    [registerEvent, setActiveId, titleId],
+  );
+
+  return (
+    <ChronoContext.Provider value={ctx}>
+      <section
+        aria-labelledby={title ? titleId : undefined}
+        className={cn(
+          "relative mx-auto flex w-full max-w-4xl flex-col overflow-hidden rounded-2xl border bg-background text-foreground",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <ProgressStrip activeId={activeId} ids={ids} label={progressLabel} />
+        {title ? (
+          <header className="px-6 py-6">
+            <h2 className="text-2xl font-semibold tracking-tight" id={titleId}>
+              {title}
+            </h2>
+          </header>
+        ) : null}
+        <EventList activeId={activeId}>{children}</EventList>
+      </section>
+    </ChronoContext.Provider>
+  );
+});
+ChronologicalTimeline.displayName = "ChronologicalTimeline";
+
+function isReactElementWithEventId(
+  child: unknown,
+  activeId: string | undefined,
+): boolean {
+  if (!activeId) return false;
+  if (typeof child !== "object" || child === null) return false;
+  if (!("props" in child)) return false;
+  const props = (child as { props: unknown }).props;
+  if (typeof props !== "object" || props === null) return false;
+  const id = (props as { id?: unknown }).id;
+  return typeof id === "string" && id === activeId;
+}
+
+function getChildKey(child: unknown, fallback: number): number | string {
+  if (typeof child !== "object" || child === null) return fallback;
+  if (!("key" in child)) return fallback;
+  const key = (child as { key: unknown }).key;
+  if (typeof key === "string" || typeof key === "number") return key;
+  return fallback;
+}

--- a/apps/registry/registry/default/civilization-card/civilization-card.tsx
+++ b/apps/registry/registry/default/civilization-card/civilization-card.tsx
@@ -1,2 +1,460 @@
-// Re-export from @vllnt/ui package
-export { CivilizationCard, CivilizationComparison } from '@vllnt/ui'
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { Globe } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+
+const CIVILIZATION_COLOR_VARIANTS: Record<
+  CivilizationCardColor,
+  { gradient: string; ring: string }
+> = {
+  amber: {
+    gradient: "from-amber-500/20 to-amber-700/40",
+    ring: "ring-amber-500/30",
+  },
+  blue: {
+    gradient: "from-blue-500/20 to-blue-700/40",
+    ring: "ring-blue-500/30",
+  },
+  emerald: {
+    gradient: "from-emerald-500/20 to-emerald-700/40",
+    ring: "ring-emerald-500/30",
+  },
+  neutral: {
+    gradient: "from-muted to-muted-foreground/10",
+    ring: "ring-border",
+  },
+  purple: {
+    gradient: "from-purple-500/20 to-purple-700/40",
+    ring: "ring-purple-500/30",
+  },
+  red: {
+    gradient: "from-red-500/20 to-red-700/40",
+    ring: "ring-red-500/30",
+  },
+};
+
+/**
+ * Color theme for the {@link CivilizationCard} hero band.
+ *
+ * @public
+ */
+export type CivilizationCardColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "neutral"
+  | "purple"
+  | "red";
+
+/**
+ * Era span (start / end years) for {@link CivilizationCardProps}.
+ *
+ * Use positive integers for CE / negative integers for BCE. `end` may be
+ * omitted when the civilization is extant.
+ *
+ * @public
+ */
+export type CivilizationCardEra = {
+  /** End year. Negative for BCE; omit when extant. */
+  end?: number;
+  /** Start year. Negative for BCE. */
+  start: number;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type CivilizationCardLabels = {
+  /** Heading above the achievements list. Defaults to `"Achievements"`. */
+  achievements?: string;
+  /** Caption for the capital row. Defaults to `"Capital"`. */
+  capital?: string;
+  /** Caption for the duration stat. Defaults to `"Duration"`. */
+  duration?: string;
+  /** Heading above the leaders list. Defaults to `"Notable leaders"`. */
+  leaders?: string;
+  /** Caption for the peak population stat. Defaults to `"Peak population"`. */
+  peakPopulation?: string;
+  /** Aria-label on the era timeline bar. Defaults to `"Era timeline"`. */
+  timeline?: string;
+};
+
+/**
+ * Props for {@link CivilizationCard}.
+ *
+ * @public
+ */
+export type CivilizationCardProps = {
+  /** Notable achievements / cultural contributions. */
+  achievements?: ReactNode[];
+  /** Optional primary CTA href. Renders the card as a link card when set. */
+  actionHref?: string;
+  /** Optional capital city. */
+  capital?: ReactNode;
+  /** Color theme for the hero band. Defaults to `"neutral"`. */
+  color?: CivilizationCardColor;
+  /** Era span. */
+  era?: CivilizationCardEra;
+  /** Optional hero image src. Falls back to a globe icon. */
+  image?: string;
+  /** Localizable captions. */
+  labels?: CivilizationCardLabels;
+  /** Notable leaders. */
+  leaders?: ReactNode[];
+  /** Display name. */
+  name: ReactNode;
+  /** Optional peak population stat (string). */
+  peakPopulation?: ReactNode;
+  /** Optional geographic region. */
+  region?: ReactNode;
+} & ComponentPropsWithoutRef<"article">;
+
+const DEFAULT_LABELS = {
+  achievements: "Achievements",
+  capital: "Capital",
+  duration: "Duration",
+  leaders: "Notable leaders",
+  peakPopulation: "Peak population",
+  timeline: "Era timeline",
+} as const satisfies Required<CivilizationCardLabels>;
+
+function formatEraYear(year: number): string {
+  if (year < 0) return `${Math.abs(year).toString()} BCE`;
+  return `${year.toString()} CE`;
+}
+
+function formatEra(era: CivilizationCardEra): string {
+  const start = formatEraYear(era.start);
+  if (era.end === undefined) return `${start} – present`;
+  return `${start} – ${formatEraYear(era.end)}`;
+}
+
+function getDuration(era: CivilizationCardEra | undefined): string | undefined {
+  if (!era) return undefined;
+  const end = era.end ?? new Date().getFullYear();
+  const years = end - era.start;
+  if (years <= 0) return undefined;
+  return `${years.toString()} years`;
+}
+
+type HeroProps = {
+  color: CivilizationCardColor;
+  image?: string;
+  imageAlt?: string;
+};
+
+function CivilizationHero({ color, image, imageAlt }: HeroProps): ReactNode {
+  const palette = CIVILIZATION_COLOR_VARIANTS[color];
+  return (
+    <div
+      className={cn(
+        "relative h-32 w-full overflow-hidden rounded-t-2xl bg-gradient-to-br",
+        palette.gradient,
+      )}
+    >
+      {image ? (
+        <img
+          alt={imageAlt ?? ""}
+          className="h-full w-full object-cover mix-blend-multiply"
+          src={image}
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center text-muted-foreground/50">
+          <Globe aria-hidden="true" className="h-12 w-12" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+type EraTimelineProps = {
+  era: CivilizationCardEra;
+  label: string;
+};
+
+function EraTimeline({ era, label }: EraTimelineProps): ReactNode {
+  const eraLabel = formatEra(era);
+  return (
+    <div
+      aria-label={`${label}: ${eraLabel}`}
+      className="flex flex-col gap-1"
+      role="img"
+    >
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {eraLabel}
+      </span>
+      <div className="h-1.5 w-full rounded-full bg-muted">
+        <span className="block h-full w-2/3 rounded-full bg-primary" />
+      </div>
+    </div>
+  );
+}
+
+type StatsProps = {
+  capital?: ReactNode;
+  capitalCaption: string;
+  durationCaption: string;
+  durationValue?: string;
+  peakCaption: string;
+  peakPopulation?: ReactNode;
+};
+
+function CivilizationStats({
+  capital,
+  capitalCaption,
+  durationCaption,
+  durationValue,
+  peakCaption,
+  peakPopulation,
+}: StatsProps): ReactNode {
+  const items: { caption: string; value: ReactNode }[] = [];
+  if (capital) items.push({ caption: capitalCaption, value: capital });
+  if (peakPopulation) {
+    items.push({ caption: peakCaption, value: peakPopulation });
+  }
+  if (durationValue) {
+    items.push({ caption: durationCaption, value: durationValue });
+  }
+  if (items.length === 0) return null;
+  return (
+    <dl className="grid grid-cols-2 gap-x-3 gap-y-2 text-sm">
+      {items.map((item) => (
+        <div className="flex flex-col" key={item.caption}>
+          <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {item.caption}
+          </dt>
+          <dd className="font-medium text-foreground">{item.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+type ListBlockProps = {
+  emptyHidden?: boolean;
+  heading: string;
+  items: ReactNode[];
+  variant: "badge" | "list";
+};
+
+function CivilizationListBlock({
+  heading,
+  items,
+  variant,
+}: ListBlockProps): ReactNode {
+  if (items.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2">
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {heading}
+      </h4>
+      {variant === "badge" ? (
+        <div className="flex flex-wrap gap-1.5">
+          {items.map((item, index) => (
+            <Badge key={`${heading}-${index.toString()}`} variant="secondary">
+              {item}
+            </Badge>
+          ))}
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-1 text-sm text-foreground">
+          {items.map((item, index) => (
+            <li
+              className="leading-tight"
+              key={`${heading}-${index.toString()}`}
+            >
+              {item}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Overview card for historical civilizations: hero band with optional image
+ * + color theme, era timeline (BCE / CE / present), key stats, achievement
+ * chips, notable leaders, and an optional follow-up link.
+ *
+ * @example
+ * ```tsx
+ * <CivilizationCard
+ *   name="Roman Empire"
+ *   era={{ start: -27, end: 476 }}
+ *   region="Mediterranean"
+ *   capital="Rome"
+ *   peakPopulation="70 million"
+ *   color="red"
+ *   achievements={["Aqueducts", "Roads", "Law", "Architecture"]}
+ *   leaders={["Augustus", "Trajan", "Marcus Aurelius"]}
+ *   actionHref="/civilizations/rome"
+ * />
+ * ```
+ *
+ * @public
+ */
+type CivilizationBodyProps = {
+  achievements?: ReactNode[];
+  actionHref?: string;
+  capital?: ReactNode;
+  era?: CivilizationCardEra;
+  labels: Required<CivilizationCardLabels>;
+  leaders?: ReactNode[];
+  name: ReactNode;
+  peakPopulation?: ReactNode;
+  region?: ReactNode;
+};
+
+function CivilizationBody({
+  achievements,
+  actionHref,
+  capital,
+  era,
+  labels,
+  leaders,
+  name,
+  peakPopulation,
+  region,
+}: CivilizationBodyProps): ReactNode {
+  const durationValue = getDuration(era);
+  return (
+    <div className="flex flex-col gap-4 p-5">
+      <header className="flex flex-col gap-1">
+        <h3 className="text-lg font-semibold leading-tight tracking-tight">
+          {name}
+        </h3>
+        {region ? (
+          <p className="text-sm text-muted-foreground">{region}</p>
+        ) : null}
+      </header>
+
+      {era ? <EraTimeline era={era} label={labels.timeline} /> : null}
+
+      <CivilizationStats
+        capital={capital}
+        capitalCaption={labels.capital}
+        durationCaption={labels.duration}
+        durationValue={durationValue}
+        peakCaption={labels.peakPopulation}
+        peakPopulation={peakPopulation}
+      />
+
+      {achievements && achievements.length > 0 ? (
+        <CivilizationListBlock
+          heading={labels.achievements}
+          items={achievements}
+          variant="badge"
+        />
+      ) : null}
+
+      {leaders && leaders.length > 0 ? (
+        <CivilizationListBlock
+          heading={labels.leaders}
+          items={leaders}
+          variant="list"
+        />
+      ) : null}
+
+      {actionHref ? (
+        <a
+          className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+          href={actionHref}
+        >
+          Explore →
+        </a>
+      ) : null}
+    </div>
+  );
+}
+
+export const CivilizationCard = forwardRef<HTMLElement, CivilizationCardProps>(
+  (props, ref) => {
+    const {
+      achievements,
+      actionHref,
+      capital,
+      className,
+      color = "neutral",
+      era,
+      image,
+      labels,
+      leaders,
+      name,
+      peakPopulation,
+      region,
+      ...rest
+    } = props;
+
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const palette = CIVILIZATION_COLOR_VARIANTS[color];
+    const altName = typeof name === "string" ? name : undefined;
+
+    return (
+      <article
+        className={cn(
+          "flex flex-col overflow-hidden rounded-2xl border bg-background text-foreground shadow-sm ring-1",
+          palette.ring,
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <CivilizationHero color={color} image={image} imageAlt={altName} />
+        <CivilizationBody
+          achievements={achievements}
+          actionHref={actionHref}
+          capital={capital}
+          era={era}
+          labels={resolvedLabels}
+          leaders={leaders}
+          name={name}
+          peakPopulation={peakPopulation}
+          region={region}
+        />
+      </article>
+    );
+  },
+);
+CivilizationCard.displayName = "CivilizationCard";
+
+/**
+ * Props for {@link CivilizationComparison}.
+ *
+ * @public
+ */
+export type CivilizationComparisonProps = ComponentPropsWithoutRef<"div">;
+
+/**
+ * Side-by-side comparison container for {@link CivilizationCard}s. Renders
+ * children in a responsive grid (single column on mobile, two columns on
+ * `md`, three on `lg`).
+ *
+ * @public
+ */
+export const CivilizationComparison = forwardRef<
+  HTMLDivElement,
+  CivilizationComparisonProps
+>(({ children, className, ...rest }, ref) => {
+  return (
+    <div
+      className={cn(
+        "grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+});
+CivilizationComparison.displayName = "CivilizationComparison";

--- a/apps/registry/registry/default/code-block/code-block.tsx
+++ b/apps/registry/registry/default/code-block/code-block.tsx
@@ -1,2 +1,151 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { type ReactNode, useEffect, useRef, useState } from "react";
+
+import { Check, Copy } from "lucide-react";
+import { useTheme } from "next-themes";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import {
+  oneDark,
+  oneLight,
+} from "react-syntax-highlighter/dist/esm/styles/prism";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+
+type CodeBlockProps = {
+  children: ReactNode;
+  className?: string;
+  language?: string;
+  showLanguage?: boolean;
+};
+
+function extractTextFromChildren(children: ReactNode): string {
+  if (typeof children === "string") {
+    return children;
+  }
+  if (typeof children === "number") {
+    return String(children);
+  }
+  if (Array.isArray(children)) {
+    return children.map(extractTextFromChildren).join("");
+  }
+  if (
+    children &&
+    typeof children === "object" &&
+    "props" in children &&
+    children.props &&
+    typeof children.props === "object" &&
+    "children" in children.props
+  ) {
+    return extractTextFromChildren(children.props.children as ReactNode);
+  }
+  return String(children ?? "");
+}
+
+function findScrollableParent(
+  element: HTMLElement | null,
+): HTMLElement | undefined {
+  if (!element) return undefined;
+  if (element.scrollHeight > element.clientHeight) return element;
+  return findScrollableParent(element.parentElement);
+}
+
+export function CodeBlock({
+  children,
+  className,
+  language = "typescript",
+  showLanguage = false,
+}: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+  const { systemTheme, theme } = useTheme();
+
+  const resolvedTheme = theme === "system" ? systemTheme : theme;
+  const isDark = resolvedTheme !== "light";
+  const codeStyle = isDark ? oneDark : oneLight;
+  const code = extractTextFromChildren(children);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+
+    const onWheel = (event: WheelEvent) => {
+      if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
+      const scrollable = findScrollableParent(element);
+      if (scrollable) {
+        scrollable.scrollTop += event.deltaY;
+        event.preventDefault();
+      }
+    };
+
+    element.addEventListener("wheel", onWheel, { passive: false });
+    return () => {
+      element.removeEventListener("wheel", onWheel);
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+
+  return (
+    <div
+      className={cn(
+        "relative w-full overflow-hidden rounded-md border bg-background",
+        className,
+      )}
+    >
+      <div
+        className="relative overflow-x-auto overflow-y-hidden touch-pan-y"
+        ref={scrollRef}
+      >
+        <SyntaxHighlighter
+          codeTagProps={{
+            className: "font-mono text-sm",
+            style: {
+              background: "transparent",
+              display: "block",
+            },
+          }}
+          customStyle={{
+            background: "hsl(var(--background))",
+            fontSize: "0.875rem",
+            margin: 0,
+            minWidth: "fit-content",
+            overflowY: "hidden",
+            padding: "1rem",
+          }}
+          language={language}
+          style={codeStyle}
+        >
+          {code}
+        </SyntaxHighlighter>
+        <div className="absolute right-2 top-2 flex items-center gap-2">
+          {showLanguage ? (
+            <span className="text-xs font-mono text-muted-foreground uppercase tracking-wider">
+              {language}
+            </span>
+          ) : null}
+          <Button
+            className="h-8 w-8"
+            onClick={handleCopy}
+            size="icon"
+            variant="ghost"
+          >
+            {copied ? (
+              <Check className="h-3 w-3" />
+            ) : (
+              <Copy className="h-3 w-3" />
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/registry/registry/default/code-playground/code-playground.tsx
+++ b/apps/registry/registry/default/code-playground/code-playground.tsx
@@ -1,2 +1,144 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { useState } from "react";
+
+import { Check, Code, Copy, FileCode } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+
+type CodeLineProps = {
+  highlightLines: number[];
+  line: string;
+  lineNumber: number;
+};
+
+function CodeLine({ highlightLines, line, lineNumber }: CodeLineProps) {
+  const isHighlighted = highlightLines.includes(lineNumber);
+  return (
+    <div className={cn("flex", isHighlighted && "bg-primary/10 -mx-4 px-4")}>
+      <span className="select-none w-8 text-right pr-4 text-muted-foreground/50">
+        {lineNumber}
+      </span>
+      <span>{line}</span>
+    </div>
+  );
+}
+
+export type CodePlaygroundProps = {
+  children: ReactNode;
+  description?: string;
+  filename?: string;
+  highlightLines?: number[];
+  language?: string;
+  showLineNumbers?: boolean;
+  title: string;
+};
+
+export function CodePlayground({
+  children,
+  description,
+  filename,
+  highlightLines = [],
+  language = "typescript",
+  showLineNumbers = false,
+  title,
+}: CodePlaygroundProps) {
+  const [copied, setCopied] = useState(false);
+  const code = typeof children === "string" ? children : "";
+  const lines = code.split("\n");
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+
+  return (
+    <div className="my-6 rounded-lg border bg-card overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/30">
+        <div className="flex items-center gap-3">
+          <div className="flex h-8 w-8 items-center justify-center rounded bg-primary/10">
+            <Code className="h-4 w-4 text-primary" />
+          </div>
+          <div>
+            <h4 className="font-semibold text-sm">{title}</h4>
+            {description ? (
+              <p className="text-xs text-muted-foreground">{description}</p>
+            ) : null}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {filename ? (
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <FileCode className="h-3 w-3" />
+              <span className="font-mono">{filename}</span>
+            </div>
+          ) : null}
+          <Button
+            className="h-8 w-8"
+            onClick={handleCopy}
+            size="icon"
+            variant="ghost"
+          >
+            {copied ? (
+              <Check className="h-3 w-3" />
+            ) : (
+              <Copy className="h-3 w-3" />
+            )}
+          </Button>
+        </div>
+      </div>
+      <div className="relative overflow-x-auto">
+        <pre className="p-4 text-sm font-mono">
+          {showLineNumbers ? (
+            <code>
+              {lines.map((line, index) => (
+                <CodeLine
+                  highlightLines={highlightLines}
+                  key={index}
+                  line={line}
+                  lineNumber={index + 1}
+                />
+              ))}
+            </code>
+          ) : (
+            <code>{code}</code>
+          )}
+        </pre>
+      </div>
+      <div className="px-4 py-2 border-t bg-muted/30">
+        <span className="text-xs font-mono text-muted-foreground uppercase tracking-wider">
+          {language}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export type FileTreeProps = {
+  children: ReactNode;
+  title?: string;
+};
+
+export function FileTree({
+  children,
+  title = "File Structure",
+}: FileTreeProps) {
+  return (
+    <div className="my-6 rounded-lg border bg-card overflow-hidden">
+      <div className="px-4 py-2 border-b bg-muted/30">
+        <h4 className="font-semibold text-sm flex items-center gap-2">
+          <FileCode className="h-4 w-4" />
+          {title}
+        </h4>
+      </div>
+      <div className="p-4 font-mono text-sm [&>ul]:m-0 [&>ul]:list-none [&_ul]:ml-4 [&_ul]:list-none [&_li]:text-muted-foreground">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/registry/registry/default/collapsible/collapsible.tsx
+++ b/apps/registry/registry/default/collapsible/collapsible.tsx
@@ -1,1 +1,11 @@
-export * from '@vllnt/ui'
+"use client";
+
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+
+const Collapsible = CollapsiblePrimitive.Root;
+
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
+
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
+
+export { Collapsible, CollapsibleContent, CollapsibleTrigger };

--- a/apps/registry/registry/default/combobox/combobox.tsx
+++ b/apps/registry/registry/default/combobox/combobox.tsx
@@ -1,1 +1,167 @@
-export { Combobox } from '@vllnt/ui'
+"use client";
+
+import * as React from "react";
+
+import { Check, ChevronsUpDown } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@vllnt/ui";
+import { Popover, PopoverContent, PopoverTrigger } from "@vllnt/ui";
+
+export type ComboboxOption = {
+  disabled?: boolean;
+  keywords?: string[];
+  label: string;
+  value: string;
+};
+
+export type ComboboxProps = {
+  className?: string;
+  commandClassName?: string;
+  emptyText?: string;
+  onValueChange?: (value: string) => void;
+  options: ComboboxOption[];
+  placeholder?: string;
+  searchPlaceholder?: string;
+  triggerClassName?: string;
+  value?: string;
+};
+
+function useComboboxValue(
+  value: string | undefined,
+  onValueChange?: (value: string) => void,
+) {
+  const [internalValue, setInternalValue] = React.useState(value ?? "");
+
+  React.useEffect(() => {
+    if (value !== undefined) {
+      setInternalValue(value);
+    }
+  }, [value]);
+
+  const resolvedValue = value ?? internalValue;
+
+  const setResolvedValue = (nextValue: string) => {
+    if (value === undefined) {
+      setInternalValue(nextValue);
+    }
+
+    onValueChange?.(nextValue);
+  };
+
+  return { resolvedValue, setResolvedValue };
+}
+
+function ComboboxOptionItem({
+  onSelect,
+  option,
+  selectedValue,
+}: {
+  onSelect: (value: string) => void;
+  option: ComboboxOption;
+  selectedValue: string;
+}) {
+  const keywords = option.keywords?.join(" ") ?? "";
+
+  return (
+    <CommandItem
+      disabled={option.disabled}
+      onSelect={() => {
+        onSelect(option.value);
+      }}
+      value={`${option.label} ${option.value} ${keywords}`}
+    >
+      <Check
+        className={cn(
+          "mr-2 h-4 w-4",
+          selectedValue === option.value ? "opacity-100" : "opacity-0",
+        )}
+      />
+      <span className="truncate">{option.label}</span>
+    </CommandItem>
+  );
+}
+
+const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
+  (
+    {
+      className,
+      commandClassName,
+      emptyText = "No option found.",
+      onValueChange,
+      options,
+      placeholder = "Select an option",
+      searchPlaceholder = "Search options...",
+      triggerClassName,
+      value,
+    },
+    reference,
+  ) => {
+    const [open, setOpen] = React.useState(false);
+    const { resolvedValue, setResolvedValue } = useComboboxValue(
+      value,
+      onValueChange,
+    );
+    const selectedOption = options.find(
+      (option) => option.value === resolvedValue,
+    );
+
+    const handleSelect = (nextValue: string) => {
+      setResolvedValue(nextValue === resolvedValue ? "" : nextValue);
+      setOpen(false);
+    };
+
+    return (
+      <Popover onOpenChange={setOpen} open={open}>
+        <PopoverTrigger asChild>
+          <Button
+            aria-expanded={open}
+            className={cn("w-full justify-between", triggerClassName)}
+            ref={reference}
+            role="combobox"
+            variant="outline"
+          >
+            <span className="truncate">
+              {selectedOption ? selectedOption.label : placeholder}
+            </span>
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className={cn(
+            "w-[var(--radix-popover-trigger-width)] p-0",
+            className,
+          )}
+        >
+          <Command className={commandClassName}>
+            <CommandInput placeholder={searchPlaceholder} />
+            <CommandList>
+              <CommandEmpty>{emptyText}</CommandEmpty>
+              <CommandGroup>
+                {options.map((option) => (
+                  <ComboboxOptionItem
+                    key={option.value}
+                    onSelect={handleSelect}
+                    option={option}
+                    selectedValue={resolvedValue}
+                  />
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    );
+  },
+);
+Combobox.displayName = "Combobox";
+
+export { Combobox };

--- a/apps/registry/registry/default/command/command.tsx
+++ b/apps/registry/registry/default/command/command.tsx
@@ -1,4 +1,149 @@
-// Re-export from @vllnt/ui package
+"use client";
+
+import * as React from "react";
+
+import type * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Command as CommandPrimitive } from "cmdk";
+import { Search } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Dialog, DialogContent, DialogTitle } from "@vllnt/ui";
+
+const Command = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, reference) => (
+  <CommandPrimitive
+    className={cn(
+      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      className,
+    )}
+    ref={reference}
+    {...props}
+  />
+));
+Command.displayName = CommandPrimitive.displayName;
+
+type CommandDialogProps = {} & React.ComponentPropsWithoutRef<
+  typeof DialogPrimitive.Root
+>;
+
+const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+  return (
+    <Dialog {...props}>
+      <DialogContent className="overflow-hidden p-0 shadow-lg">
+        <DialogTitle className="sr-only">Command Menu</DialogTitle>
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const CommandInput = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, reference) => (
+  // eslint-disable-next-line react/no-unknown-property
+  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <CommandPrimitive.Input
+      className={cn(
+        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      ref={reference}
+      {...props}
+    />
+  </div>
+));
+CommandInput.displayName = CommandPrimitive.Input.displayName;
+
+const CommandList = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, reference) => (
+  <CommandPrimitive.List
+    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+    ref={reference}
+    {...props}
+  />
+));
+CommandList.displayName = CommandPrimitive.List.displayName;
+
+const CommandEmpty = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>((props, reference) => (
+  <CommandPrimitive.Empty
+    className="py-6 text-center text-sm"
+    ref={reference}
+    {...props}
+  />
+));
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
+
+const CommandGroup = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, reference) => (
+  <CommandPrimitive.Group
+    className={cn(
+      "overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      className,
+    )}
+    ref={reference}
+    {...props}
+  />
+));
+CommandGroup.displayName = CommandPrimitive.Group.displayName;
+
+const CommandSeparator = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
+>(({ className, ...props }, reference) => (
+  <CommandPrimitive.Separator
+    className={cn("-mx-1 h-px bg-border", className)}
+    ref={reference}
+    {...props}
+  />
+));
+CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
+
+const CommandItem = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, disabled, ...props }, reference) => (
+  <CommandPrimitive.Item
+    className={cn(
+      "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:opacity-50",
+      disabled && "pointer-events-none",
+      className,
+    )}
+    disabled={disabled}
+    ref={reference}
+    {...props}
+  />
+));
+CommandItem.displayName = CommandPrimitive.Item.displayName;
+
+const CommandShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+CommandShortcut.displayName = "CommandShortcut";
+
 export {
   Command,
   CommandDialog,
@@ -9,4 +154,4 @@ export {
   CommandList,
   CommandSeparator,
   CommandShortcut,
-} from '@vllnt/ui'
+};

--- a/apps/registry/registry/default/comment-pin/comment-pin.tsx
+++ b/apps/registry/registry/default/comment-pin/comment-pin.tsx
@@ -1,6 +1,188 @@
-export {
-  CommentPin,
-  type CommentPinLabels,
-  type CommentPinProps,
-  type CommentPinState,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Resolution state of a pinned comment.
+ *
+ * @public
+ */
+export type CommentPinState = "open" | "resolved";
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type CommentPinLabels = {
+  /** Aria-label override. Defaults to `"Comment"`. */
+  region?: string;
+  /** Suffix appended after the unread count for screen readers. */
+  unreadSuffix?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Comment",
+  unreadSuffix: "unread",
+} as const satisfies Required<CommentPinLabels>;
+
+/**
+ * Props for {@link CommentPin}.
+ *
+ * @public
+ */
+export type CommentPinProps = {
+  /** Optional author initial / glyph rendered inside the pin. */
+  authorInitial?: ReactNode;
+  /** Optional accent color for the pin. Defaults to the foreground. */
+  color?: string;
+  /** Localizable strings. */
+  labels?: CommentPinLabels;
+  /** Click handler — when provided, the pin becomes a button. */
+  onActivate?: () => void;
+  /** State of the underlying thread. Defaults to `"open"`. */
+  state?: CommentPinState;
+  /** Optional unread reply count. Renders as a small numeric badge. */
+  unread?: number;
+  /** Anchor X in canvas pixels. */
+  x: number;
+  /** Anchor Y in canvas pixels. */
+  y: number;
+} & ComponentPropsWithoutRef<"div">;
+
+const STATE_FILL: Record<CommentPinState, string> = {
+  open: "bg-foreground text-background",
+  resolved: "bg-muted text-muted-foreground",
+};
+
+type PinBodyInput = {
+  accent?: string;
+  authorInitial?: ReactNode;
+  state: CommentPinState;
+  unread?: number;
+};
+
+const PinBody = (props: PinBodyInput): React.ReactElement => {
+  const showBadge = typeof props.unread === "number" && props.unread > 0;
+  const useAccent = props.accent && props.state === "open";
+  return (
+    <>
+      <span
+        aria-hidden="true"
+        className={cn(
+          "flex h-7 w-7 items-center justify-center rounded-full border border-background text-[11px] font-semibold shadow-sm",
+          STATE_FILL[props.state],
+        )}
+        data-comment-pin-body
+        style={
+          useAccent
+            ? { backgroundColor: props.accent, color: "white" }
+            : undefined
+        }
+      >
+        {props.authorInitial ?? "•"}
+      </span>
+      {showBadge ? (
+        <span
+          aria-hidden="true"
+          className="absolute -right-1 -top-1 inline-flex min-h-[14px] min-w-[14px] items-center justify-center rounded-full bg-red-500 px-1 text-[9px] font-medium text-white"
+          data-comment-pin-unread
+        >
+          {props.unread}
+        </span>
+      ) : null}
+    </>
+  );
+};
+
+/**
+ * Anchored discussion pin rendered at canvas coordinates. Use to mark
+ * an object-anchored comment thread; click to expand into a
+ * {@link "../thread-bubble/thread-bubble".ThreadBubble} (or whatever the host wires up).
+ *
+ * Pure presentation; the host owns the thread store + supplies the
+ * unread count and resolution state.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <CommentPin
+ *     x={420} y={180}
+ *     authorInitial="B"
+ *     unread={3}
+ *     onActivate={() => openThread("c-1")}
+ *   />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const CommentPin = forwardRef<HTMLDivElement, CommentPinProps>(
+  (props, ref) => {
+    const {
+      authorInitial,
+      className,
+      color,
+      labels,
+      onActivate,
+      state = "open",
+      unread,
+      x,
+      y,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const showBadge = typeof unread === "number" && unread > 0;
+    const ariaLabel = showBadge
+      ? `${resolvedLabels.region}, ${unread} ${resolvedLabels.unreadSuffix}`
+      : resolvedLabels.region;
+    const handleClick = (): void => {
+      onActivate?.();
+    };
+    const body = (
+      <PinBody
+        accent={color}
+        authorInitial={authorInitial}
+        state={state}
+        unread={unread}
+      />
+    );
+    return (
+      <div
+        aria-label={ariaLabel}
+        className={cn(
+          "absolute z-30 inline-flex -translate-x-1/2 -translate-y-1/2",
+          className,
+        )}
+        data-comment-pin
+        data-comment-pin-state={state}
+        ref={ref}
+        role="img"
+        style={{ left: x, top: y }}
+        {...rest}
+      >
+        {onActivate ? (
+          <button
+            aria-label={ariaLabel}
+            className="relative inline-flex rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            data-comment-pin-trigger
+            onClick={handleClick}
+            type="button"
+          >
+            {body}
+          </button>
+        ) : (
+          <span className="relative inline-flex">{body}</span>
+        )}
+      </div>
+    );
+  },
+);
+CommentPin.displayName = "CommentPin";

--- a/apps/registry/registry/default/comparison/comparison.tsx
+++ b/apps/registry/registry/default/comparison/comparison.tsx
@@ -1,2 +1,148 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { ArrowRight, Check, Minus, X } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+
+type ComparisonSide = {
+  items: string[];
+  title: string;
+  variant?: "bad" | "good" | "neutral";
+};
+
+export type ComparisonProps = {
+  after: ComparisonSide;
+  before: ComparisonSide;
+  title?: string;
+};
+
+const variantConfig = {
+  bad: {
+    className: "border-red-500/30 bg-red-500/5",
+    headerClass: "bg-red-500/10 text-red-700 dark:text-red-300",
+    icon: X,
+    iconClass: "text-red-500",
+  },
+  good: {
+    className: "border-green-500/30 bg-green-500/5",
+    headerClass: "bg-green-500/10 text-green-700 dark:text-green-300",
+    icon: Check,
+    iconClass: "text-green-500",
+  },
+  neutral: {
+    className: "border-border bg-muted/30",
+    headerClass: "bg-muted text-muted-foreground",
+    icon: Minus,
+    iconClass: "text-muted-foreground",
+  },
+};
+
+export function Comparison({
+  after,
+  before,
+  title,
+  ...rest
+}: ComparisonProps & Record<string, unknown>) {
+  if (!before || !after) {
+    const hint =
+      "left" in rest || "right" in rest
+        ? ' Did you mean "before" / "after" instead of "left" / "right"?'
+        : "";
+    console.error(
+      `[Comparison] Missing required props "before" and "after".${hint}`,
+    );
+    return null;
+  }
+  const beforeConfig = variantConfig[before.variant || "bad"];
+  const afterConfig = variantConfig[after.variant || "good"];
+  const BeforeIcon = beforeConfig.icon;
+  const AfterIcon = afterConfig.icon;
+
+  return (
+    <div className="my-6">
+      {title ? <h4 className="font-semibold mb-3">{title}</h4> : null}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className={cn("rounded-lg border", beforeConfig.className)}>
+          <div
+            className={cn(
+              "px-4 py-2 rounded-t-lg font-medium text-sm",
+              beforeConfig.headerClass,
+            )}
+          >
+            {before.title}
+          </div>
+          <ul className="p-4 space-y-2">
+            {before.items.map((item, index) => (
+              <li className="flex items-start gap-2 text-sm" key={index}>
+                <BeforeIcon
+                  className={cn(
+                    "h-4 w-4 mt-0.5 flex-shrink-0",
+                    beforeConfig.iconClass,
+                  )}
+                />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className={cn("rounded-lg border", afterConfig.className)}>
+          <div
+            className={cn(
+              "px-4 py-2 rounded-t-lg font-medium text-sm",
+              afterConfig.headerClass,
+            )}
+          >
+            {after.title}
+          </div>
+          <ul className="p-4 space-y-2">
+            {after.items.map((item, index) => (
+              <li className="flex items-start gap-2 text-sm" key={index}>
+                <AfterIcon
+                  className={cn(
+                    "h-4 w-4 mt-0.5 flex-shrink-0",
+                    afterConfig.iconClass,
+                  )}
+                />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export type BeforeAfterProps = {
+  after: ReactNode;
+  before: ReactNode;
+  title?: string;
+};
+
+export function BeforeAfter({ after, before, title }: BeforeAfterProps) {
+  return (
+    <div className="my-6">
+      {title ? <h4 className="font-semibold mb-3">{title}</h4> : null}
+      <div className="grid grid-cols-1 md:grid-cols-[1fr_auto_1fr] gap-4 items-start">
+        <div className="rounded-lg border border-red-500/30 bg-red-500/5 overflow-hidden">
+          <div className="px-4 py-2 bg-red-500/10 text-red-700 dark:text-red-300 font-medium text-sm flex items-center gap-2">
+            <X className="h-4 w-4" />
+            Before
+          </div>
+          <div className="p-4 text-sm [&>pre]:my-0">{before}</div>
+        </div>
+        <div className="hidden md:flex items-center justify-center h-full">
+          <ArrowRight className="h-6 w-6 text-muted-foreground" />
+        </div>
+        <div className="rounded-lg border border-green-500/30 bg-green-500/5 overflow-hidden">
+          <div className="px-4 py-2 bg-green-500/10 text-green-700 dark:text-green-300 font-medium text-sm flex items-center gap-2">
+            <Check className="h-4 w-4" />
+            After
+          </div>
+          <div className="p-4 text-sm [&>pre]:my-0">{after}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/registry/registry/default/completion-dialog/completion-dialog.tsx
+++ b/apps/registry/registry/default/completion-dialog/completion-dialog.tsx
@@ -1,2 +1,198 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { memo, useCallback, useEffect, useRef } from "react";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+
+export type CompletionDialogProps = {
+  cancelLabel?: string;
+  cancelShortcut?: string;
+  className?: string;
+  closeIcon?: ReactNode;
+  confirmLabel?: string;
+  confirmShortcut?: string;
+  description?: ReactNode;
+  isOpen: boolean;
+  onCancel: () => void;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+};
+
+type DialogContentProps = Omit<CompletionDialogProps, "isOpen">;
+
+// eslint-disable-next-line max-lines-per-function -- Dialog content with keyboard handling
+function DialogContent({
+  cancelLabel = "Skip",
+  cancelShortcut = "S",
+  className,
+  closeIcon,
+  confirmLabel = "Done",
+  confirmShortcut = "D",
+  description,
+  onCancel,
+  onClose,
+  onConfirm,
+  title,
+}: DialogContentProps): React.ReactNode {
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    confirmButtonRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      className={cn(
+        "relative z-10 w-full max-w-md mx-4 p-6 bg-background border border-border rounded-lg shadow-lg",
+        "animate-in fade-in-0 zoom-in-95 duration-200",
+        className,
+      )}
+    >
+      <button
+        aria-label="Close"
+        className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100 transition-opacity"
+        onClick={onClose}
+        type="button"
+      >
+        {closeIcon ?? (
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 18L18 6M6 6l12 12"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+            />
+          </svg>
+        )}
+      </button>
+      <div className="mb-4">
+        <h2 className="text-lg font-semibold" id="completion-dialog-title">
+          {title}
+        </h2>
+        {description ? (
+          <div className="text-sm text-muted-foreground mt-1.5">
+            {description}
+          </div>
+        ) : null}
+      </div>
+      <div className="flex flex-row gap-2">
+        <Button className="flex-1 gap-2" onClick={onCancel} variant="outline">
+          <span>{cancelLabel}</span>
+          {cancelShortcut ? (
+            <kbd className="hidden md:inline-flex px-1.5 py-0.5 text-[10px] font-mono bg-muted rounded">
+              {cancelShortcut}
+            </kbd>
+          ) : null}
+        </Button>
+        <Button
+          className="flex-1 gap-2"
+          onClick={onConfirm}
+          ref={confirmButtonRef}
+        >
+          <span>{confirmLabel}</span>
+          {confirmShortcut ? (
+            <kbd className="hidden md:inline-flex px-1.5 py-0.5 text-[10px] font-mono bg-primary-foreground/20 rounded">
+              {confirmShortcut}
+            </kbd>
+          ) : null}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// eslint-disable-next-line max-lines-per-function -- Modal with keyboard handling
+function CompletionDialogImpl({
+  cancelLabel,
+  cancelShortcut = "S",
+  className,
+  closeIcon,
+  confirmLabel,
+  confirmShortcut = "D",
+  description,
+  isOpen,
+  onCancel,
+  onClose,
+  onConfirm,
+  title,
+}: CompletionDialogProps): React.ReactNode {
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (!isOpen) return;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+      if (
+        event.key === "Enter" ||
+        event.key.toLowerCase() === confirmShortcut.toLowerCase()
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        onConfirm();
+        return;
+      }
+      if (event.key.toLowerCase() === cancelShortcut.toLowerCase()) {
+        event.preventDefault();
+        event.stopPropagation();
+        onCancel();
+      }
+    },
+    [isOpen, onClose, onConfirm, onCancel, confirmShortcut, cancelShortcut],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [isOpen, handleKeyDown]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      aria-labelledby="completion-dialog-title"
+      aria-modal="true"
+      className="absolute inset-0 z-[100] flex items-center justify-center"
+      role="dialog"
+    >
+      <div
+        aria-hidden="true"
+        className={cn(
+          "absolute inset-0 bg-background/80 backdrop-blur-sm",
+          "animate-in fade-in-0 duration-200",
+        )}
+        onClick={onClose}
+      />
+      <DialogContent
+        cancelLabel={cancelLabel}
+        cancelShortcut={cancelShortcut}
+        className={className}
+        closeIcon={closeIcon}
+        confirmLabel={confirmLabel}
+        confirmShortcut={confirmShortcut}
+        description={description}
+        onCancel={onCancel}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        title={title}
+      />
+    </div>
+  );
+}
+
+export const CompletionDialog = memo(CompletionDialogImpl);
+CompletionDialog.displayName = "CompletionDialog";

--- a/apps/registry/registry/default/connector-edge/connector-edge.tsx
+++ b/apps/registry/registry/default/connector-edge/connector-edge.tsx
@@ -1,1 +1,80 @@
-export { ConnectorEdge, type ConnectorEdgeProps } from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import type { CSSProperties } from "react";
+
+import { cn } from "@vllnt/ui";
+import { EdgeLabel } from "@vllnt/ui";
+
+export type ConnectorEdgePoint = {
+  x: number;
+  y: number;
+};
+
+export type ConnectorEdgeProps = React.ComponentPropsWithoutRef<"div"> & {
+  end: ConnectorEdgePoint;
+  label?: string;
+  start: ConnectorEdgePoint;
+  state?: "active" | "blocked" | "idle";
+};
+
+const strokeClasses: Record<
+  NonNullable<ConnectorEdgeProps["state"]>,
+  string
+> = {
+  active: "stroke-sky-500",
+  blocked: "stroke-amber-500",
+  idle: "stroke-muted-foreground/60",
+};
+
+const ConnectorEdge = forwardRef<HTMLDivElement, ConnectorEdgeProps>(
+  ({ className, end, label, start, state = "idle", ...props }, ref) => {
+    const width = Math.max(Math.abs(end.x - start.x), 32);
+    const height = Math.max(Math.abs(end.y - start.y), 32);
+    const midX = width / 2;
+    const startX = start.x <= end.x ? 4 : width - 4;
+    const endX = start.x <= end.x ? width - 4 : 4;
+    const startY = start.y <= end.y ? 4 : height - 4;
+    const endY = start.y <= end.y ? height - 4 : 4;
+    const path = `M ${startX} ${startY} C ${midX} ${startY}, ${midX} ${endY}, ${endX} ${endY}`;
+
+    const style = {
+      height,
+      width,
+    } satisfies CSSProperties;
+
+    return (
+      <div
+        className={cn("relative inline-flex", className)}
+        ref={ref}
+        style={style}
+        {...props}
+      >
+        <svg
+          className="overflow-visible"
+          height={height}
+          viewBox={`0 0 ${width} ${height}`}
+          width={width}
+        >
+          <path
+            className={cn("fill-none stroke-[2.5]", strokeClasses[state])}
+            d={path}
+            strokeDasharray={state === "blocked" ? "4 4" : undefined}
+            strokeLinecap="round"
+          />
+        </svg>
+        {label ? (
+          <EdgeLabel
+            className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+            emphasis={state === "active" ? "active" : "subtle"}
+          >
+            {label}
+          </EdgeLabel>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+ConnectorEdge.displayName = "ConnectorEdge";
+
+export { ConnectorEdge };

--- a/apps/registry/registry/default/content-intro/content-intro.tsx
+++ b/apps/registry/registry/default/content-intro/content-intro.tsx
@@ -1,2 +1,203 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { memo, useCallback, useEffect } from "react";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+
+export type ContentIntroSection = {
+  id: string;
+  title: string;
+};
+
+export type ContentIntroLabels = {
+  continueLabel?: string;
+  startLabel?: string;
+  tableOfContentsLabel?: string;
+};
+
+export type ContentIntroProps = {
+  /** Extra content sections (share, profile, etc.) */
+  additionalContent?: ReactNode;
+  /** Completed section IDs */
+  completedSections: Set<string>;
+  /** Estimated time to complete */
+  estimatedTime: string;
+  /** Is loading progress */
+  isLoading?: boolean;
+  /** Labels for i18n */
+  labels?: ContentIntroLabels;
+  /** Callback when navigating to section */
+  onGoToSection: (index: number) => void;
+  /** Callback when starting */
+  onStart: () => void;
+  /** Render function for intro content */
+  renderIntroContent: () => ReactNode;
+  /** Sections for TOC */
+  sections: ContentIntroSection[];
+  /** Intro section title */
+  title: string;
+};
+
+const DEFAULT_LABELS: Required<ContentIntroLabels> = {
+  continueLabel: "Continue Tutorial",
+  startLabel: "Start Tutorial",
+  tableOfContentsLabel: "Table of Contents",
+};
+
+// eslint-disable-next-line max-lines-per-function -- Complex intro with TOC and sticky button
+function ContentIntroImpl({
+  additionalContent,
+  completedSections,
+  estimatedTime,
+  isLoading = false,
+  labels = {},
+  onGoToSection,
+  onStart,
+  renderIntroContent,
+  sections,
+  title,
+}: ContentIntroProps): React.ReactNode {
+  const mergedLabels = { ...DEFAULT_LABELS, ...labels };
+  const hasProgress = completedSections.size > 0;
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        onStart();
+      }
+    },
+    [onStart],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleKeyDown]);
+
+  return (
+    <>
+      <div className="animate-in fade-in-0 duration-500 pb-24">
+        {/* Introduction Content */}
+        <section className="py-6">
+          <h2 className="text-2xl md:text-3xl font-bold mb-6">{title}</h2>
+          <div className={cn("max-w-none", "[&_h2:first-of-type]:hidden")}>
+            {renderIntroContent()}
+          </div>
+        </section>
+
+        {/* Table of Contents */}
+        <section className="mt-8 py-6 border-t border-border">
+          <h3 className="text-lg font-semibold mb-4">
+            {mergedLabels.tableOfContentsLabel}
+          </h3>
+          <ol className="space-y-2">
+            {sections.map((section, index) => {
+              const isCompleted =
+                !isLoading && completedSections.has(section.id);
+              return (
+                <li key={`${section.id}-${index}`}>
+                  <button
+                    className="w-full flex items-center gap-3 p-2 -m-2 rounded-lg hover:bg-muted/50 transition-colors text-left"
+                    onClick={() => {
+                      onGoToSection(index);
+                    }}
+                    type="button"
+                  >
+                    <span
+                      className={cn(
+                        "flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-medium tabular-nums transition-colors",
+                        isLoading && "animate-pulse bg-muted",
+                        !isLoading &&
+                          isCompleted &&
+                          "bg-foreground text-background",
+                        !isLoading && !isCompleted && "bg-muted",
+                      )}
+                    >
+                      {isCompleted ? (
+                        <svg
+                          className="h-3 w-3"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M5 13l4 4L19 7"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                          />
+                        </svg>
+                      ) : (
+                        index + 1
+                      )}
+                    </span>
+                    <span
+                      className={cn(
+                        "text-sm",
+                        isCompleted && "line-through text-muted-foreground",
+                      )}
+                    >
+                      {section.title}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ol>
+        </section>
+
+        {/* Extra Content (Share, Profile, etc.) */}
+        {additionalContent}
+      </div>
+
+      {/* Sticky Start/Continue Button */}
+      <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-background/80 backdrop-blur-sm safe-bottom">
+        <div className="mx-auto max-w-3xl px-4 py-4">
+          <div className="flex items-center justify-between gap-4">
+            <p className="text-sm text-muted-foreground hidden sm:block">
+              {hasProgress
+                ? `${completedSections.size}/${sections.length} completed`
+                : `${sections.length} sections · ${estimatedTime}`}
+            </p>
+            <Button
+              className="flex-1 sm:flex-none px-8 py-6 text-lg font-medium gap-2"
+              onClick={onStart}
+              size="lg"
+            >
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M5 3l14 9-14 9V3z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                />
+              </svg>
+              <span>
+                {hasProgress
+                  ? mergedLabels.continueLabel
+                  : mergedLabels.startLabel}
+              </span>
+              <kbd className="hidden md:inline-flex ml-1 px-1.5 py-0.5 text-xs font-mono bg-primary-foreground/20 rounded">
+                ↵
+              </kbd>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export const ContentIntro = memo(ContentIntroImpl);
+ContentIntro.displayName = "ContentIntro";

--- a/apps/registry/registry/default/context-lens/context-lens.tsx
+++ b/apps/registry/registry/default/context-lens/context-lens.tsx
@@ -1,6 +1,146 @@
-export {
-  ContextLens,
-  type ContextLensFocus,
-  type ContextLensLabels,
-  type ContextLensProps,
-} from '@vllnt/ui'
+"use client";
+
+import { type ComponentPropsWithoutRef, forwardRef, useId } from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Focus point — pixel coordinates relative to the canvas viewport.
+ *
+ * @public
+ */
+export type ContextLensFocus = {
+  /** Center X of the lens. */
+  cx: number;
+  /** Center Y of the lens. */
+  cy: number;
+  /** Inner radius — fully transparent inside this circle. */
+  inner: number;
+  /** Outer radius — full dim beyond this circle. */
+  outer: number;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type ContextLensLabels = {
+  /** Aria-label for the lens layer. Defaults to `"Context lens"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Context lens",
+} as const satisfies Required<ContextLensLabels>;
+
+/**
+ * Props for {@link ContextLens}.
+ *
+ * @public
+ */
+export type ContextLensProps = {
+  /** Lens geometry. When `null`, no lens renders (full surface unobscured). */
+  focus: ContextLensFocus | null;
+  /** Localizable strings. */
+  labels?: ContextLensLabels;
+  /** Dim opacity outside the outer ring (0..1). Defaults to `0.55`. */
+  opacity?: number;
+} & ComponentPropsWithoutRef<"svg">;
+
+const clamp01 = (value: number): number => {
+  if (value < 0) {
+    return 0;
+  }
+  if (value > 1) {
+    return 1;
+  }
+  return value;
+};
+
+const safeRadius = (value: number): number => (value < 0 ? 0 : value);
+
+/**
+ * Vignette overlay that dims the canvas outside a circular focus
+ * region. Use to draw the eye to a selection, an active run, or any
+ * single object the user must attend to. Pure presentation; the host
+ * computes the focus center + radii from the active selection's
+ * bounding box.
+ *
+ * The lens is `pointer-events: none` — host gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <ContextLens focus={{ cx: 480, cy: 320, inner: 90, outer: 180 }} />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const ContextLens = forwardRef<SVGSVGElement, ContextLensProps>(
+  (props, ref) => {
+    const { className, focus, labels, opacity = 0.55, ...rest } = props;
+    const maskId = useId();
+    if (!focus) {
+      return null;
+    }
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const inner = safeRadius(focus.inner);
+    const outer = safeRadius(Math.max(focus.outer, inner));
+    const fillOpacity = clamp01(opacity);
+    return (
+      <svg
+        aria-hidden="true"
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "pointer-events-none absolute inset-0 z-20 h-full w-full",
+          className,
+        )}
+        data-context-lens
+        ref={ref}
+        {...rest}
+      >
+        <defs>
+          <radialGradient
+            cx={focus.cx}
+            cy={focus.cy}
+            data-context-lens-gradient
+            gradientUnits="userSpaceOnUse"
+            id={maskId}
+            r={outer === 0 ? 1 : outer}
+          >
+            <stop offset="0%" stopColor="black" stopOpacity={0} />
+            <stop
+              offset={outer === 0 ? "100%" : `${(inner / outer) * 100}%`}
+              stopColor="black"
+              stopOpacity={0}
+            />
+            <stop offset="100%" stopColor="black" stopOpacity={1} />
+          </radialGradient>
+        </defs>
+        <rect
+          data-context-lens-dim
+          fill="black"
+          fillOpacity={fillOpacity}
+          height="100%"
+          mask={`url(#${maskId}-mask)`}
+          width="100%"
+          x={0}
+          y={0}
+        />
+        <mask id={`${maskId}-mask`}>
+          <rect fill="white" height="100%" width="100%" x={0} y={0} />
+          <circle
+            cx={focus.cx}
+            cy={focus.cy}
+            fill={`url(#${maskId})`}
+            r={outer}
+          />
+        </mask>
+      </svg>
+    );
+  },
+);
+ContextLens.displayName = "ContextLens";

--- a/apps/registry/registry/default/context-menu/context-menu.tsx
+++ b/apps/registry/registry/default/context-menu/context-menu.tsx
@@ -1,1 +1,201 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+const ContextMenu = ContextMenuPrimitive.Root;
+
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
+
+const ContextMenuGroup = ContextMenuPrimitive.Group;
+
+const ContextMenuPortal = ContextMenuPrimitive.Portal;
+
+const ContextMenuSub = ContextMenuPrimitive.Sub;
+
+const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
+
+const ContextMenuSubTrigger = forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ children, className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.SubTrigger
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      inset && "pl-8",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </ContextMenuPrimitive.SubTrigger>
+));
+ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
+
+const ContextMenuSubContent = forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.SubContent
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
+
+const ContextMenuContent = forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Content
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+));
+ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
+
+const ContextMenuItem = forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Item
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
+
+const ContextMenuCheckboxItem = forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
+>(({ checked, children, className, ...props }, ref) => (
+  <ContextMenuPrimitive.CheckboxItem
+    checked={checked}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.CheckboxItem>
+));
+ContextMenuCheckboxItem.displayName =
+  ContextMenuPrimitive.CheckboxItem.displayName;
+
+const ContextMenuRadioItem = forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
+>(({ children, className, ...props }, ref) => (
+  <ContextMenuPrimitive.RadioItem
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.RadioItem>
+));
+ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName;
+
+const ContextMenuLabel = forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Label
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold text-foreground",
+      inset && "pl-8",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName;
+
+const ContextMenuSeparator = forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Separator
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    ref={ref}
+    {...props}
+  />
+));
+ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
+
+const ContextMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+ContextMenuShortcut.displayName = "ContextMenuShortcut";
+
+export {
+  ContextMenu,
+  ContextMenuCheckboxItem,
+  ContextMenuContent,
+  ContextMenuGroup,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuPortal,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+};

--- a/apps/registry/registry/default/copy-button/copy-button.tsx
+++ b/apps/registry/registry/default/copy-button/copy-button.tsx
@@ -1,2 +1,325 @@
-// Re-export from @vllnt/ui package
-export { CopyButton, useCopyToClipboard } from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type MouseEvent as ReactMouseEvent,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import { Check, Copy } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vllnt/ui";
+
+const FALLBACK_TIMEOUT_MS = 2000;
+
+/**
+ * Options for {@link useCopyToClipboard}.
+ *
+ * @public
+ */
+export type UseCopyToClipboardOptions = {
+  /** Milliseconds the `copied` flag stays true after a successful copy. */
+  timeout?: number;
+};
+
+/**
+ * Return shape for {@link useCopyToClipboard}.
+ *
+ * @public
+ */
+export type UseCopyToClipboardResult = {
+  /** True for `timeout` ms after the most recent successful copy. */
+  copied: boolean;
+  /** Writes `value` to the clipboard. Resolves to `true` on success. */
+  copy: (value: string) => Promise<boolean>;
+  /** Clears the `copied` flag and pending timer. */
+  reset: () => void;
+};
+
+/**
+ * React hook that copies arbitrary strings to the clipboard with a transient
+ * `copied` flag suitable for visual feedback.
+ *
+ * @example
+ * ```tsx
+ * const { copied, copy } = useCopyToClipboard()
+ * <button onClick={() => copy(apiKey)}>{copied ? "Copied!" : "Copy"}</button>
+ * ```
+ *
+ * @public
+ */
+export function useCopyToClipboard(
+  options: UseCopyToClipboardOptions = {},
+): UseCopyToClipboardResult {
+  const { timeout = FALLBACK_TIMEOUT_MS } = options;
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== undefined) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const reset = useCallback(() => {
+    if (timerRef.current !== undefined) clearTimeout(timerRef.current);
+    setCopied(false);
+  }, []);
+
+  const copy = useCallback(
+    async (value: string): Promise<boolean> => {
+      try {
+        if (
+          typeof navigator === "undefined" ||
+          typeof navigator.clipboard?.writeText !== "function"
+        ) {
+          return false;
+        }
+        await navigator.clipboard.writeText(value);
+        if (timerRef.current !== undefined) clearTimeout(timerRef.current);
+        setCopied(true);
+        timerRef.current = setTimeout(() => {
+          setCopied(false);
+        }, timeout);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [timeout],
+  );
+
+  return { copied, copy, reset };
+}
+
+/**
+ * Visual variant for {@link CopyButton}.
+ *
+ * - `icon`   — compact icon-style button (default), suitable for toolbars.
+ * - `inline` — small button sized to sit next to short inline text.
+ * - `button` — full button with text label, suitable for primary CTAs.
+ *
+ * @public
+ */
+export type CopyButtonVariant = "button" | "icon" | "inline";
+
+type ButtonElementProps = ComponentPropsWithoutRef<"button">;
+
+/**
+ * Props for {@link CopyButton}.
+ *
+ * @public
+ */
+export type CopyButtonProps = {
+  /** Tooltip + announcement text after a successful copy. Defaults to `"Copied!"`. */
+  copiedLabel?: string;
+  /** Class name forwarded to the rendered icon. */
+  iconClassName?: string;
+  /** Tooltip + accessible label before copy. Defaults to `"Copy"`. */
+  label?: string;
+  /** Set to `false` to suppress the tooltip. */
+  showTooltip?: boolean;
+  /** Milliseconds the success state persists. Defaults to 2000. */
+  timeout?: number;
+  /** String to write to the clipboard when clicked. */
+  value: string;
+  /** Visual variant. */
+  variant?: CopyButtonVariant;
+} & Omit<ButtonElementProps, "value">;
+
+function CopyIcon({
+  className,
+  copied,
+  size,
+}: {
+  className?: string;
+  copied: boolean;
+  size: "sm" | "xs";
+}): ReactNode {
+  const Icon = copied ? Check : Copy;
+  const sizeClass = size === "xs" ? "h-3 w-3" : "h-4 w-4";
+  return <Icon aria-hidden="true" className={cn(sizeClass, className)} />;
+}
+
+type TriggerProps = Omit<
+  CopyButtonProps,
+  "copiedLabel" | "showTooltip" | "timeout"
+> & {
+  accessibleLabel: string;
+  copied: boolean;
+  copiedText: string;
+  onClickHandler: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+};
+
+const ButtonTrigger = forwardRef<HTMLButtonElement, TriggerProps>(
+  (
+    {
+      accessibleLabel,
+      className,
+      copied,
+      copiedText,
+      iconClassName,
+      label = "Copy",
+      onClick: _onClick,
+      onClickHandler,
+      value: _value,
+      variant = "icon",
+      ...rest
+    },
+    ref,
+  ) => {
+    if (variant === "button") {
+      return (
+        <Button
+          aria-label={accessibleLabel}
+          className={cn(className)}
+          onClick={onClickHandler}
+          ref={ref}
+          size="sm"
+          type="button"
+          variant="outline"
+          {...rest}
+        >
+          <CopyIcon className={iconClassName} copied={copied} size="sm" />
+          <span>{copied ? copiedText : label}</span>
+        </Button>
+      );
+    }
+
+    if (variant === "inline") {
+      return (
+        <Button
+          aria-label={accessibleLabel}
+          className={cn(
+            "h-6 w-6 align-middle text-muted-foreground hover:text-foreground",
+            className,
+          )}
+          onClick={onClickHandler}
+          ref={ref}
+          size="icon"
+          type="button"
+          variant="ghost"
+          {...rest}
+        >
+          <CopyIcon className={iconClassName} copied={copied} size="xs" />
+        </Button>
+      );
+    }
+
+    return (
+      <Button
+        aria-label={accessibleLabel}
+        className={cn("h-8 w-8", className)}
+        onClick={onClickHandler}
+        ref={ref}
+        size="icon"
+        type="button"
+        variant="ghost"
+        {...rest}
+      >
+        <CopyIcon className={iconClassName} copied={copied} size="sm" />
+      </Button>
+    );
+  },
+);
+ButtonTrigger.displayName = "CopyButton.Trigger";
+
+/**
+ * Click-to-copy button with confirmation feedback.
+ *
+ * Composes {@link Button} and {@link Tooltip}. Copies `value` to the clipboard
+ * via the async Clipboard API and announces success to assistive tech via a
+ * visually hidden status region.
+ *
+ * @example
+ * ```tsx
+ * <CopyButton value={apiKey} />
+ * <CopyButton value={url} variant="button" label="Copy link" />
+ * <span>ID: usr_42 <CopyButton value="usr_42" variant="inline" /></span>
+ * ```
+ *
+ * @public
+ */
+export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
+  (
+    {
+      "aria-label": ariaLabelOverride,
+      copiedLabel = "Copied!",
+      label = "Copy",
+      onClick,
+      showTooltip = true,
+      timeout = FALLBACK_TIMEOUT_MS,
+      value,
+      ...rest
+    },
+    ref,
+  ) => {
+    const { copied, copy } = useCopyToClipboard({ timeout });
+
+    const handleClick = useCallback(
+      (event: ReactMouseEvent<HTMLButtonElement>) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        void copy(value);
+      },
+      [copy, onClick, value],
+    );
+
+    const accessibleLabel = ariaLabelOverride ?? (copied ? copiedLabel : label);
+    const tooltipText = copied ? copiedLabel : label;
+
+    const trigger: ReactElement = (
+      <ButtonTrigger
+        {...rest}
+        accessibleLabel={accessibleLabel}
+        copied={copied}
+        copiedText={copiedLabel}
+        label={label}
+        onClickHandler={handleClick}
+        ref={ref}
+        value={value}
+      />
+    );
+
+    const liveRegion = (
+      <span aria-live="polite" className="sr-only" role="status">
+        {copied ? copiedLabel : ""}
+      </span>
+    );
+
+    if (!showTooltip) {
+      return (
+        <>
+          {trigger}
+          {liveRegion}
+        </>
+      );
+    }
+
+    return (
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+          <TooltipContent>{tooltipText}</TooltipContent>
+        </Tooltip>
+        {liveRegion}
+      </TooltipProvider>
+    );
+  },
+);
+CopyButton.displayName = "CopyButton";

--- a/apps/registry/registry/default/countdown-timer/countdown-timer.tsx
+++ b/apps/registry/registry/default/countdown-timer/countdown-timer.tsx
@@ -1,1 +1,253 @@
-export * from "@vllnt/ui";
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@vllnt/ui";
+
+export type CountdownTimerProps = React.ComponentPropsWithoutRef<"div"> & {
+  deadline: Date | number | string;
+  description?: string;
+  now?: Date | number | string;
+  startedAt?: Date | number | string;
+  tickMs?: number;
+  title?: string;
+  warningThresholdMs?: number;
+};
+
+type TimerSegment = {
+  label: string;
+  value: string;
+};
+
+function normalizeDate(input: Date | number | string): Date {
+  if (input instanceof Date) {
+    return new Date(input.getTime());
+  }
+
+  return new Date(input);
+}
+
+function useLiveDate(now: CountdownTimerProps["now"], tickMs: number) {
+  const fixedNow = React.useMemo(
+    () => (now ? normalizeDate(now) : undefined),
+    [now],
+  );
+  const [liveNow, setLiveNow] = React.useState<Date>(fixedNow ?? new Date());
+
+  React.useEffect(() => {
+    if (fixedNow) {
+      setLiveNow(fixedNow);
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      setLiveNow(new Date());
+    }, tickMs);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [fixedNow, tickMs]);
+
+  return liveNow;
+}
+
+function getRemainingMs(deadline: Date, now: Date): number {
+  return deadline.getTime() - now.getTime();
+}
+
+function getStatus(
+  remainingMs: number,
+  warningThresholdMs: number,
+): {
+  badgeVariant: "default" | "destructive" | "secondary";
+  label: string;
+  toneClassName: string;
+} {
+  if (remainingMs <= 0) {
+    return {
+      badgeVariant: "destructive",
+      label: "Breached",
+      toneClassName: "bg-destructive",
+    };
+  }
+
+  if (remainingMs <= warningThresholdMs) {
+    return {
+      badgeVariant: "secondary",
+      label: "At risk",
+      toneClassName: "bg-amber-500",
+    };
+  }
+
+  return {
+    badgeVariant: "default",
+    label: "On track",
+    toneClassName: "bg-emerald-500",
+  };
+}
+
+function formatSegments(milliseconds: number): TimerSegment[] {
+  const totalSeconds = Math.max(0, Math.floor(milliseconds / 1000));
+  const days = Math.floor(totalSeconds / 86_400);
+  const hours = Math.floor((totalSeconds % 86_400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  return [
+    { label: "Days", value: String(days).padStart(2, "0") },
+    { label: "Hours", value: String(hours).padStart(2, "0") },
+    { label: "Minutes", value: String(minutes).padStart(2, "0") },
+    { label: "Seconds", value: String(seconds).padStart(2, "0") },
+  ];
+}
+
+function formatDeadline(date: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    month: "short",
+    timeZoneName: "short",
+  }).format(date);
+}
+
+function getProgress(deadline: Date, now: Date, startedAt?: Date): number {
+  if (!startedAt) {
+    return 0;
+  }
+
+  const total = deadline.getTime() - startedAt.getTime();
+
+  if (total <= 0) {
+    return 100;
+  }
+
+  const elapsed = now.getTime() - startedAt.getTime();
+
+  return Math.min(100, Math.max(0, (elapsed / total) * 100));
+}
+
+function TimerSegments({ segments }: { segments: TimerSegment[] }) {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      {segments.map((segment) => (
+        <div
+          className="rounded-lg border bg-background/80 px-3 py-4 text-center"
+          key={segment.label}
+        >
+          <div className="text-2xl font-semibold tracking-tight">
+            {segment.value}
+          </div>
+          <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+            {segment.label}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TimerProgress({
+  progress,
+  remainingMs,
+  segments,
+  startedAt,
+  toneClassName,
+}: {
+  progress: number;
+  remainingMs: number;
+  segments: TimerSegment[];
+  startedAt?: Date;
+  toneClassName: string;
+}) {
+  const progressWidth = startedAt ? progress : remainingMs <= 0 ? 100 : 0;
+  const statusText = startedAt
+    ? `${Math.round(progress)}% used`
+    : segments.map((segment) => segment.value).join(":");
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>{startedAt ? "SLA elapsed" : "Time remaining"}</span>
+        <span>{statusText}</span>
+      </div>
+      <div className="h-2 overflow-hidden rounded-full bg-muted">
+        <div
+          className={cn("h-full transition-all", toneClassName)}
+          style={{ width: `${progressWidth}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export const CountdownTimer = React.forwardRef<
+  HTMLDivElement,
+  CountdownTimerProps
+>(
+  (
+    {
+      className,
+      deadline,
+      description,
+      now,
+      startedAt,
+      tickMs = 1000,
+      title = "Countdown timer",
+      warningThresholdMs = 15 * 60 * 1000,
+      ...props
+    },
+    ref,
+  ) => {
+    const deadlineDate = React.useMemo(
+      () => normalizeDate(deadline),
+      [deadline],
+    );
+    const startedAtDate = React.useMemo(
+      () => (startedAt ? normalizeDate(startedAt) : undefined),
+      [startedAt],
+    );
+    const liveNow = useLiveDate(now, tickMs);
+    const remainingMs = getRemainingMs(deadlineDate, liveNow);
+    const status = getStatus(remainingMs, warningThresholdMs);
+    const segments = formatSegments(Math.abs(remainingMs));
+    const progress = getProgress(deadlineDate, liveNow, startedAtDate);
+
+    return (
+      <Card className={cn("shadow-sm", className)} ref={ref} {...props}>
+        <CardHeader className="space-y-2 pb-3">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <CardTitle className="text-base">{title}</CardTitle>
+              <CardDescription>
+                {description ?? `Deadline ${formatDeadline(deadlineDate)}`}
+              </CardDescription>
+            </div>
+            <Badge variant={status.badgeVariant}>{status.label}</Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <TimerSegments segments={segments} />
+          <TimerProgress
+            progress={progress}
+            remainingMs={remainingMs}
+            segments={segments}
+            startedAt={startedAtDate}
+            toneClassName={status.toneClassName}
+          />
+        </CardContent>
+      </Card>
+    );
+  },
+);
+
+CountdownTimer.displayName = "CountdownTimer";

--- a/apps/registry/registry/default/credit-badge/credit-badge.tsx
+++ b/apps/registry/registry/default/credit-badge/credit-badge.tsx
@@ -1,2 +1,70 @@
-// Re-export from @vllnt/ui package
-export { CreditBadge } from '@vllnt/ui'
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+import { badgeVariants } from "@vllnt/ui";
+
+export type CreditBadgeStatus = "depleted" | "healthy" | "low" | "overdue";
+
+export type CreditBadgeProps = Omit<
+  React.ComponentPropsWithoutRef<"span">,
+  "children"
+> & {
+  amount?: string;
+  label?: string;
+  status: CreditBadgeStatus;
+};
+
+function getStatusLabel(status: CreditBadgeStatus): string {
+  switch (status) {
+    case "depleted":
+      return "No credits left";
+    case "healthy":
+      return "Credits available";
+    case "low":
+      return "Credits running low";
+    case "overdue":
+      return "Balance overdue";
+  }
+}
+
+function getStatusClasses(status: CreditBadgeStatus): string {
+  switch (status) {
+    case "depleted":
+      return "border-slate-500/30 bg-slate-500/10 text-slate-700 dark:text-slate-300";
+    case "healthy":
+      return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+    case "low":
+      return "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300";
+    case "overdue":
+      return "border-destructive/30 bg-destructive/10 text-destructive";
+  }
+}
+
+export const CreditBadge = React.forwardRef<HTMLSpanElement, CreditBadgeProps>(
+  ({ amount, className, label, status, ...props }, reference) => {
+    return (
+      <span
+        className={cn(
+          badgeVariants({ variant: "outline" }),
+          "gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium shadow-none",
+          getStatusClasses(status),
+          className,
+        )}
+        ref={reference}
+        {...props}
+      >
+        <span
+          aria-hidden="true"
+          className="h-1.5 w-1.5 rounded-full bg-current"
+        />
+        <span>
+          {amount
+            ? `${amount} • ${label ?? getStatusLabel(status)}`
+            : (label ?? getStatusLabel(status))}
+        </span>
+      </span>
+    );
+  },
+);
+
+CreditBadge.displayName = "CreditBadge";

--- a/apps/registry/registry/default/data-list/data-list.tsx
+++ b/apps/registry/registry/default/data-list/data-list.tsx
@@ -1,1 +1,130 @@
-export * from '@vllnt/ui'
+"use client";
+
+import * as React from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+
+const dataListVariants = cva(
+  "grid rounded-xl border bg-card text-card-foreground",
+  {
+    defaultVariants: {
+      density: "default",
+    },
+    variants: {
+      density: {
+        compact: "divide-y",
+        default: "divide-y",
+      },
+    },
+  },
+);
+
+const dataListItemVariants = cva(
+  "grid gap-1 px-4 py-4 sm:grid-cols-[minmax(0,12rem)_1fr] sm:gap-4 sm:px-5",
+  {
+    defaultVariants: {
+      density: "default",
+    },
+    variants: {
+      density: {
+        compact: "py-3",
+        default: "py-4",
+      },
+    },
+  },
+);
+
+type DataListContextValue = {
+  density: NonNullable<VariantProps<typeof dataListVariants>["density"]>;
+};
+
+const DataListContext = React.createContext<DataListContextValue>({
+  density: "default",
+});
+
+export type DataListProps = React.HTMLAttributes<HTMLDListElement> &
+  VariantProps<typeof dataListVariants>;
+
+const DataList = React.forwardRef<HTMLDListElement, DataListProps>(
+  ({ className, density, ...props }, reference) => {
+    const resolvedDensity = density ?? "default";
+    const contextValue = React.useMemo<DataListContextValue>(
+      () => ({ density: resolvedDensity }),
+      [resolvedDensity],
+    );
+
+    return (
+      <DataListContext.Provider value={contextValue}>
+        <dl
+          className={cn(
+            dataListVariants({ density: resolvedDensity }),
+            className,
+          )}
+          ref={reference}
+          {...props}
+        />
+      </DataListContext.Provider>
+    );
+  },
+);
+
+DataList.displayName = "DataList";
+
+export type DataListItemProps = React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof dataListItemVariants>;
+
+const DataListItem = React.forwardRef<HTMLDivElement, DataListItemProps>(
+  ({ className, density, ...props }, reference) => {
+    const context = React.useContext(DataListContext);
+
+    return (
+      <div
+        className={cn(
+          dataListItemVariants({ density: density ?? context.density }),
+          className,
+        )}
+        ref={reference}
+        {...props}
+      />
+    );
+  },
+);
+
+DataListItem.displayName = "DataListItem";
+
+const DataListLabel = React.forwardRef<
+  HTMLElement,
+  React.HTMLAttributes<HTMLElement>
+>(({ className, ...props }, reference) => (
+  <dt
+    className={cn("text-sm font-medium text-muted-foreground", className)}
+    ref={reference}
+    {...props}
+  />
+));
+
+DataListLabel.displayName = "DataListLabel";
+
+const DataListValue = React.forwardRef<
+  HTMLElement,
+  React.HTMLAttributes<HTMLElement>
+>(({ className, ...props }, reference) => (
+  <dd
+    className={cn("m-0 text-sm leading-6 text-foreground", className)}
+    ref={reference}
+    {...props}
+  />
+));
+
+DataListValue.displayName = "DataListValue";
+
+export {
+  DataList,
+  DataListItem,
+  dataListItemVariants,
+  DataListLabel,
+  DataListValue,
+  dataListVariants,
+};

--- a/apps/registry/registry/default/data-table/data-table.tsx
+++ b/apps/registry/registry/default/data-table/data-table.tsx
@@ -1,1 +1,322 @@
-export * from '@vllnt/ui'
+"use client";
+
+import * as React from "react";
+
+import {
+  type ColumnDef,
+  type ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  type Row,
+  type RowData,
+  type RowSelectionState,
+  type SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import { Checkbox } from "@vllnt/ui";
+import { Input } from "@vllnt/ui";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vllnt/ui";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@vllnt/ui";
+
+export type DataTableFilterOption = {
+  label: string;
+  value: string;
+};
+
+export type DataTableFilter = {
+  columnId: string;
+  label: string;
+  options: DataTableFilterOption[];
+};
+
+export type DataTableProps<TData extends RowData> =
+  React.HTMLAttributes<HTMLDivElement> & {
+    caption?: string;
+    columns: ColumnDef<TData>[];
+    data: TData[];
+    emptyMessage?: string;
+    enableFiltering?: boolean;
+    enablePagination?: boolean;
+    enableSelection?: boolean;
+    filterableColumns?: DataTableFilter[];
+    getRowId?: (
+      originalRow: TData,
+      index: number,
+      parent?: Row<TData>,
+    ) => string;
+    pageSize?: number;
+    searchPlaceholder?: string;
+  };
+
+function SortIcon({ direction }: { direction: "asc" | "desc" | false }) {
+  if (direction === "asc") {
+    return <ArrowUp className="h-4 w-4" />;
+  }
+
+  if (direction === "desc") {
+    return <ArrowDown className="h-4 w-4" />;
+  }
+
+  return <ArrowUpDown className="h-4 w-4" />;
+}
+
+function DataTableComponent<TData extends RowData>({
+  caption,
+  className,
+  columns,
+  data,
+  emptyMessage = "No results found.",
+  enableFiltering = true,
+  enablePagination = true,
+  enableSelection = false,
+  filterableColumns = [],
+  getRowId,
+  pageSize = 10,
+  searchPlaceholder = "Search rows...",
+  ...props
+}: DataTableProps<TData>) {
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [globalFilter, setGlobalFilter] = React.useState("");
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
+    [],
+  );
+  const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({});
+
+  const selectionColumn = React.useMemo<ColumnDef<TData>>(
+    () => ({
+      cell: ({ row }) => (
+        <Checkbox
+          aria-label={`Select row ${row.index + 1}`}
+          checked={row.getIsSelected()}
+          onCheckedChange={(checked) => {
+            row.toggleSelected(Boolean(checked));
+          }}
+        />
+      ),
+      enableHiding: false,
+      enableSorting: false,
+      header: ({ table }) => (
+        <Checkbox
+          aria-label="Select all rows"
+          checked={
+            table.getIsAllPageRowsSelected()
+              ? true
+              : table.getIsSomePageRowsSelected()
+                ? "indeterminate"
+                : false
+          }
+          onCheckedChange={(checked) => {
+            table.toggleAllPageRowsSelected(Boolean(checked));
+          }}
+        />
+      ),
+      id: "select",
+      size: 40,
+    }),
+    [],
+  );
+
+  const resolvedColumns = React.useMemo(
+    () => (enableSelection ? [selectionColumn, ...columns] : columns),
+    [columns, enableSelection, selectionColumn],
+  );
+
+  const table = useReactTable({
+    columns: resolvedColumns,
+    data,
+    enableRowSelection: enableSelection,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getRowId,
+    getSortedRowModel: getSortedRowModel(),
+    initialState: {
+      pagination: {
+        pageIndex: 0,
+        pageSize,
+      },
+    },
+    onColumnFiltersChange: setColumnFilters,
+    onGlobalFilterChange: setGlobalFilter,
+    onRowSelectionChange: setRowSelection,
+    onSortingChange: setSorting,
+    state: {
+      columnFilters,
+      globalFilter,
+      rowSelection,
+      sorting,
+    },
+  });
+
+  return (
+    <div className={cn("space-y-4", className)} {...props}>
+      {enableFiltering ? (
+        <div className="flex flex-col gap-3 rounded-xl border bg-card p-4 sm:flex-row sm:items-center sm:justify-between">
+          <Input
+            className="w-full sm:max-w-sm"
+            onChange={(event) => {
+              setGlobalFilter(event.target.value);
+            }}
+            placeholder={searchPlaceholder}
+            value={globalFilter}
+          />
+          {filterableColumns.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {filterableColumns.map((filter) => {
+                const column = table.getColumn(filter.columnId);
+                const value = column?.getFilterValue();
+                const selectValue =
+                  typeof value === "string" && value ? value : "all";
+
+                return column ? (
+                  <Select
+                    key={filter.columnId}
+                    onValueChange={(nextValue) => {
+                      column.setFilterValue(
+                        nextValue === "all" ? undefined : nextValue,
+                      );
+                    }}
+                    value={selectValue}
+                  >
+                    <SelectTrigger className="w-[180px]">
+                      <SelectValue placeholder={filter.label} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All {filter.label}</SelectItem>
+                      {filter.options.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : null;
+              })}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="rounded-xl border bg-card">
+        <Table>
+          {caption ? <caption className="sr-only">{caption}</caption> : null}
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder ? null : header.column.getCanSort() ? (
+                      <Button
+                        className="-ml-3 h-8 px-3 text-xs font-medium"
+                        onClick={header.column.getToggleSortingHandler()}
+                        type="button"
+                        variant="ghost"
+                      >
+                        {flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                        <SortIcon direction={header.column.getIsSorted()} />
+                      </Button>
+                    ) : (
+                      flexRender(
+                        header.column.columnDef.header,
+                        header.getContext(),
+                      )
+                    )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length > 0 ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  data-state={row.getIsSelected() ? "selected" : undefined}
+                  key={row.id}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  className="h-24 text-center text-muted-foreground"
+                  colSpan={resolvedColumns.length}
+                >
+                  {emptyMessage}
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="flex flex-col gap-3 rounded-xl border bg-card p-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          {enableSelection
+            ? `${table.getSelectedRowModel().rows.length} selected`
+            : `${table.getFilteredRowModel().rows.length} rows`}
+        </div>
+        {enablePagination ? (
+          <div className="flex items-center gap-2 self-end sm:self-auto">
+            <Button
+              disabled={!table.getCanPreviousPage()}
+              onClick={() => {
+                table.previousPage();
+              }}
+              type="button"
+              variant="outline"
+            >
+              Previous
+            </Button>
+            <span className="min-w-24 text-center text-xs uppercase tracking-wide text-muted-foreground">
+              Page {table.getState().pagination.pageIndex + 1} of{" "}
+              {table.getPageCount()}
+            </span>
+            <Button
+              disabled={!table.getCanNextPage()}
+              onClick={() => {
+                table.nextPage();
+              }}
+              type="button"
+              variant="outline"
+            >
+              Next
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export { DataTableComponent as DataTable };

--- a/apps/registry/registry/default/date-picker/date-picker.tsx
+++ b/apps/registry/registry/default/date-picker/date-picker.tsx
@@ -1,1 +1,95 @@
-export { DatePicker } from '@vllnt/ui'
+"use client";
+
+import * as React from "react";
+
+import { CalendarIcon } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import { Calendar, type CalendarProps } from "@vllnt/ui";
+import { Popover, PopoverContent, PopoverTrigger } from "@vllnt/ui";
+
+const defaultDateFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+});
+
+export type DatePickerProps = {
+  buttonClassName?: string;
+  calendarProps?: Omit<CalendarProps, "mode" | "onSelect" | "selected">;
+  className?: string;
+  onValueChange?: (date?: Date) => void;
+  placeholder?: string;
+  value?: Date;
+};
+
+const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
+  (
+    {
+      buttonClassName,
+      calendarProps,
+      className,
+      onValueChange,
+      placeholder = "Pick a date",
+      value,
+    },
+    reference,
+  ) => {
+    const [open, setOpen] = React.useState(false);
+    const [internalValue, setInternalValue] = React.useState<Date | undefined>(
+      value,
+    );
+    const selectedDate = value ?? internalValue;
+
+    React.useEffect(() => {
+      if (value !== undefined) {
+        setInternalValue(value);
+      }
+    }, [value]);
+
+    const handleSelect = (nextDate: Date | undefined) => {
+      if (value === undefined) {
+        setInternalValue(nextDate);
+      }
+
+      onValueChange?.(nextDate);
+
+      if (nextDate) {
+        setOpen(false);
+      }
+    };
+
+    return (
+      <Popover onOpenChange={setOpen} open={open}>
+        <PopoverTrigger asChild>
+          <Button
+            className={cn(
+              "w-full justify-start text-left font-normal",
+              !selectedDate && "text-muted-foreground",
+              buttonClassName,
+            )}
+            ref={reference}
+            variant="outline"
+          >
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            {selectedDate
+              ? defaultDateFormatter.format(selectedDate)
+              : placeholder}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className={cn("w-auto p-0", className)}>
+          <Calendar
+            mode="single"
+            onSelect={handleSelect}
+            selected={selectedDate}
+            {...calendarProps}
+          />
+        </PopoverContent>
+      </Popover>
+    );
+  },
+);
+DatePicker.displayName = "DatePicker";
+
+export { DatePicker };

--- a/apps/registry/registry/default/dialog/dialog.tsx
+++ b/apps/registry/registry/default/dialog/dialog.tsx
@@ -1,4 +1,114 @@
-// Re-export from @vllnt/ui package
+"use client";
+
+import * as React from "react";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, reference) => (
+  <DialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    ref={reference}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ children, className, ...props }, reference) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+      )}
+      ref={reference}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, reference) => (
+  <DialogPrimitive.Title
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
+    ref={reference}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, reference) => (
+  <DialogPrimitive.Description
+    className={cn("text-sm text-muted-foreground", className)}
+    ref={reference}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
 export {
   Dialog,
   DialogClose,
@@ -10,4 +120,4 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-} from '@vllnt/ui'
+};

--- a/apps/registry/registry/default/document-sibling-nav/document-sibling-nav.tsx
+++ b/apps/registry/registry/default/document-sibling-nav/document-sibling-nav.tsx
@@ -1,2 +1,217 @@
-// Re-export from @vllnt/ui package
-export { DocumentSiblingNav, documentSiblingNavVariants } from '@vllnt/ui'
+import {
+  type AnchorHTMLAttributes,
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+
+const navVariants = cva("grid w-full gap-3 text-sm sm:grid-cols-2", {
+  defaultVariants: {
+    variant: "with-title",
+  },
+  variants: {
+    variant: {
+      compact: "",
+      "with-meta": "",
+      "with-title": "",
+    },
+  },
+});
+
+const itemVariants = cva(
+  "group flex flex-col gap-1 rounded-lg border border-border bg-background p-4 text-foreground transition-colors hover:border-foreground/30 hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+  {
+    defaultVariants: {
+      side: "previous",
+    },
+    variants: {
+      side: {
+        next: "items-end text-right sm:col-start-2",
+        previous: "items-start text-left",
+      },
+    },
+  },
+);
+
+/**
+ * Visual variant for {@link DocumentSiblingNav}.
+ *
+ * - `compact` — single-line caption and arrow, no title.
+ * - `with-title` — caption plus the sibling document title (default).
+ * - `with-meta` — caption, title, and an optional `meta` line (date, author, etc.).
+ *
+ * @public
+ */
+export type DocumentSiblingNavVariant = "compact" | "with-meta" | "with-title";
+
+type AnchorPassthroughProps = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  "href" | "title"
+>;
+
+/**
+ * Per-side description for {@link DocumentSiblingNav}.
+ *
+ * @public
+ */
+export type DocumentSiblingNavLink = {
+  /** Optional anchor props (rel, target, etc.) forwarded to the rendered `<a>`. */
+  anchorProps?: AnchorPassthroughProps;
+  /** Destination URL. */
+  href: string;
+  /** Optional secondary line shown when `variant="with-meta"`. */
+  meta?: ReactNode;
+  /** Title of the sibling document. */
+  title: ReactNode;
+};
+
+type LabelDictionary = {
+  /** Aria label for the wrapping `<nav>`. */
+  navigation?: string;
+  /** Caption above the next link. */
+  next?: string;
+  /** Caption above the previous link. */
+  previous?: string;
+};
+
+/**
+ * Props for {@link DocumentSiblingNav}.
+ *
+ * @public
+ */
+export type DocumentSiblingNavProps = {
+  /** Localizable captions. */
+  labels?: LabelDictionary;
+  /** The next sibling, or `undefined` at the end of the series. */
+  next?: DocumentSiblingNavLink;
+  /** The previous sibling, or `undefined` at the start of the series. */
+  previous?: DocumentSiblingNavLink;
+} & Omit<ComponentPropsWithoutRef<"nav">, "title"> &
+  VariantProps<typeof navVariants>;
+
+const DEFAULT_LABELS = {
+  navigation: "Document navigation",
+  next: "Newer",
+  previous: "Older",
+} as const satisfies Required<LabelDictionary>;
+
+type ItemProps = {
+  ariaLabel: string;
+  caption: string;
+  link: DocumentSiblingNavLink;
+  side: "next" | "previous";
+  variant: DocumentSiblingNavVariant;
+};
+
+function SiblingItem({
+  ariaLabel,
+  caption,
+  link,
+  side,
+  variant,
+}: ItemProps): ReactNode {
+  const { anchorProps, href, meta, title } = link;
+  return (
+    <a
+      aria-label={ariaLabel}
+      className={cn(itemVariants({ side }))}
+      href={href}
+      {...anchorProps}
+    >
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {caption}
+      </span>
+      {variant === "compact" ? null : (
+        <span className="line-clamp-2 text-sm font-semibold text-foreground group-hover:underline">
+          {title}
+        </span>
+      )}
+      {variant === "with-meta" && meta ? (
+        <span className="text-xs text-muted-foreground">{meta}</span>
+      ) : null}
+    </a>
+  );
+}
+
+function buildAriaLabel(
+  caption: string,
+  link: DocumentSiblingNavLink,
+  variant: DocumentSiblingNavVariant,
+): string {
+  if (variant === "compact" || typeof link.title !== "string") {
+    return caption;
+  }
+  return `${caption}: ${link.title}`;
+}
+
+/**
+ * Sibling-document navigator. Renders previous / next links to the surrounding
+ * items in an ordered series (e.g. newer/older blog post, prev/next doc page).
+ * Pass `previous`, `next`, or both — the component returns `null` when both
+ * are absent.
+ *
+ * Server-renderable — no client hooks required.
+ *
+ * @example
+ * ```tsx
+ * <DocumentSiblingNav
+ *   previous={{ href: '/posts/foo', title: 'Foo post' }}
+ *   next={{ href: '/posts/bar', title: 'Bar post' }}
+ *   labels={{ previous: 'Older', next: 'Newer' }}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const DocumentSiblingNav = forwardRef<
+  HTMLElement,
+  DocumentSiblingNavProps
+>(({ className, labels, next, previous, variant, ...rest }, ref) => {
+  if (!previous && !next) return null;
+
+  const resolvedVariant: DocumentSiblingNavVariant = variant ?? "with-title";
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+
+  return (
+    <nav
+      aria-label={resolvedLabels.navigation}
+      className={cn(navVariants({ variant: resolvedVariant }), className)}
+      ref={ref}
+      {...rest}
+    >
+      {previous ? (
+        <SiblingItem
+          ariaLabel={buildAriaLabel(
+            resolvedLabels.previous,
+            previous,
+            resolvedVariant,
+          )}
+          caption={resolvedLabels.previous}
+          link={previous}
+          side="previous"
+          variant={resolvedVariant}
+        />
+      ) : (
+        <span aria-hidden="true" />
+      )}
+      {next ? (
+        <SiblingItem
+          ariaLabel={buildAriaLabel(resolvedLabels.next, next, resolvedVariant)}
+          caption={resolvedLabels.next}
+          link={next}
+          side="next"
+          variant={resolvedVariant}
+        />
+      ) : (
+        <span aria-hidden="true" />
+      )}
+    </nav>
+  );
+});
+DocumentSiblingNav.displayName = "DocumentSiblingNav";
+
+export { navVariants as documentSiblingNavVariants };

--- a/apps/registry/registry/default/drawer/drawer.tsx
+++ b/apps/registry/registry/default/drawer/drawer.tsx
@@ -1,1 +1,119 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import { Drawer as DrawerPrimitive } from "vaul";
+
+import { cn } from "@vllnt/ui";
+
+const Drawer = ({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root
+    shouldScaleBackground={shouldScaleBackground}
+    {...props}
+  />
+);
+Drawer.displayName = "Drawer";
+
+const DrawerTrigger = DrawerPrimitive.Trigger;
+
+const DrawerPortal = DrawerPrimitive.Portal;
+
+const DrawerClose = DrawerPrimitive.Close;
+
+const DrawerOverlay = forwardRef<
+  React.ComponentRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    ref={ref}
+    {...props}
+  />
+));
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
+
+const DrawerContent = forwardRef<
+  React.ComponentRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ children, className, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    >
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+));
+DrawerContent.displayName = "DrawerContent";
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
+    {...props}
+  />
+);
+DrawerHeader.displayName = "DrawerHeader";
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+    {...props}
+  />
+);
+DrawerFooter.displayName = "DrawerFooter";
+
+const DrawerTitle = forwardRef<
+  React.ComponentRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
+
+const DrawerDescription = forwardRef<
+  React.ComponentRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    className={cn("text-sm text-muted-foreground", className)}
+    ref={ref}
+    {...props}
+  />
+));
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
+
+export {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+};

--- a/apps/registry/registry/default/dropdown-menu/dropdown-menu.tsx
+++ b/apps/registry/registry/default/dropdown-menu/dropdown-menu.tsx
@@ -1,4 +1,186 @@
-// Re-export from @vllnt/ui package
+"use client";
+
+import * as React from "react";
+
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+
+import { cn } from "@vllnt/ui";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ children, className, inset, ...props }, reference) => (
+  <DropdownMenuPrimitive.SubTrigger
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
+      inset && "pl-8",
+      className,
+    )}
+    ref={reference}
+    {...props}
+  >
+    {children}
+    <span className="ml-auto text-xs">›</span>
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, reference) => (
+  <DropdownMenuPrimitive.SubContent
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    ref={reference}
+    {...props}
+  />
+));
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, reference) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      ref={reference}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, reference) => (
+  <DropdownMenuPrimitive.Item
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className,
+    )}
+    ref={reference}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ checked, children, className, ...props }, reference) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    checked={checked}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    ref={reference}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <span className="text-xs">✓</span>
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName;
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ children, className, ...props }, reference) => (
+  <DropdownMenuPrimitive.RadioItem
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    ref={reference}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <span className="text-xs">○</span>
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, reference) => (
+  <DropdownMenuPrimitive.Label
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold",
+      inset && "pl-8",
+      className,
+    )}
+    ref={reference}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, reference) => (
+  <DropdownMenuPrimitive.Separator
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    ref={reference}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      {...props}
+    />
+  );
+};
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
+
 export {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -15,4 +197,4 @@ export {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-} from '@vllnt/ui'
+};

--- a/apps/registry/registry/default/edge-label/edge-label.tsx
+++ b/apps/registry/registry/default/edge-label/edge-label.tsx
@@ -1,1 +1,34 @@
-export { EdgeLabel, type EdgeLabelProps } from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type EdgeLabelProps = React.ComponentPropsWithoutRef<"span"> & {
+  emphasis?: "active" | "subtle";
+};
+
+const emphasisClasses: Record<
+  NonNullable<EdgeLabelProps["emphasis"]>,
+  string
+> = {
+  active: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  subtle: "border-border/60 bg-background/90 text-muted-foreground",
+};
+
+const EdgeLabel = forwardRef<HTMLSpanElement, EdgeLabelProps>(
+  ({ className, emphasis = "subtle", ...props }, ref) => (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.18em] shadow-sm",
+        emphasisClasses[emphasis],
+        className,
+      )}
+      data-emphasis={emphasis}
+      ref={ref}
+      {...props}
+    />
+  ),
+);
+
+EdgeLabel.displayName = "EdgeLabel";
+
+export { EdgeLabel };

--- a/apps/registry/registry/default/empty-state/empty-state.tsx
+++ b/apps/registry/registry/default/empty-state/empty-state.tsx
@@ -1,2 +1,162 @@
-// Re-export from @vllnt/ui package
-export { EmptyState, emptyStateVariants } from '@vllnt/ui'
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+
+const emptyStateVariants = cva(
+  "flex flex-col items-center justify-center gap-3 text-center text-foreground",
+  {
+    defaultVariants: {
+      size: "md",
+    },
+    variants: {
+      size: {
+        lg: "px-6 py-16",
+        md: "px-4 py-10",
+        sm: "px-3 py-6",
+      },
+    },
+  },
+);
+
+const titleVariants = cva("font-semibold tracking-tight", {
+  defaultVariants: {
+    size: "md",
+  },
+  variants: {
+    size: {
+      lg: "text-xl",
+      md: "text-lg",
+      sm: "text-base",
+    },
+  },
+});
+
+const descriptionVariants = cva("max-w-prose text-muted-foreground", {
+  defaultVariants: {
+    size: "md",
+  },
+  variants: {
+    size: {
+      lg: "text-base",
+      md: "text-sm",
+      sm: "text-xs",
+    },
+  },
+});
+
+const iconVariants = cva(
+  "mb-1 flex items-center justify-center rounded-full bg-muted text-muted-foreground [&_svg]:h-1/2 [&_svg]:w-1/2",
+  {
+    defaultVariants: {
+      size: "md",
+    },
+    variants: {
+      size: {
+        lg: "h-16 w-16",
+        md: "h-12 w-12",
+        sm: "h-8 w-8",
+      },
+    },
+  },
+);
+
+/**
+ * Visual size for {@link EmptyState}.
+ *
+ * - `sm` — inline, suitable for compact lists or cards
+ * - `md` — section-level (default)
+ * - `lg` — full-page placeholder
+ *
+ * @public
+ */
+export type EmptyStateSize = "lg" | "md" | "sm";
+
+/**
+ * Props for {@link EmptyState}.
+ *
+ * @public
+ */
+export type EmptyStateProps = {
+  /**
+   * Action slot rendered below the description. Compose with `Button` or any
+   * interactive element.
+   */
+  children?: ReactNode;
+  /** Optional secondary text describing the empty condition. */
+  description?: ReactNode;
+  /** Optional icon or illustration shown above the title. */
+  icon?: ReactNode;
+  /** Headline rendered as a heading element. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"div"> &
+  VariantProps<typeof emptyStateVariants>;
+
+/**
+ * Placeholder for empty lists, tables, and search results. Composes a
+ * centered icon, title, description, and an action slot. Announces itself
+ * via `role="status"` so assistive tech can pick up state changes
+ * (e.g. when filters clear results).
+ *
+ * @example
+ * ```tsx
+ * <EmptyState
+ *   icon={<Inbox />}
+ *   title="No results found"
+ *   description="Try adjusting your search or filters."
+ * >
+ *   <Button variant="outline" onClick={clearFilters}>Clear filters</Button>
+ * </EmptyState>
+ * ```
+ *
+ * @public
+ */
+export const EmptyState = forwardRef<HTMLDivElement, EmptyStateProps>(
+  (
+    {
+      children,
+      className,
+      description,
+      icon,
+      role: roleOverride,
+      size,
+      title,
+      ...rest
+    },
+    ref,
+  ) => {
+    return (
+      <div
+        className={cn(emptyStateVariants({ size }), className)}
+        ref={ref}
+        role={roleOverride ?? "status"}
+        {...rest}
+      >
+        {icon ? (
+          <span aria-hidden="true" className={cn(iconVariants({ size }))}>
+            {icon}
+          </span>
+        ) : null}
+        {title ? (
+          <h3 className={cn(titleVariants({ size }))}>{title}</h3>
+        ) : null}
+        {description ? (
+          <p className={cn(descriptionVariants({ size }))}>{description}</p>
+        ) : null}
+        {children ? (
+          <div className="mt-2 flex flex-wrap items-center justify-center gap-2">
+            {children}
+          </div>
+        ) : null}
+      </div>
+    );
+  },
+);
+EmptyState.displayName = "EmptyState";
+
+export { emptyStateVariants };

--- a/apps/registry/registry/default/era-comparison/era-comparison.tsx
+++ b/apps/registry/registry/default/era-comparison/era-comparison.tsx
@@ -1,9 +1,347 @@
-// Re-export from @vllnt/ui package
-export {
-  EraColumn,
-  EraComparison,
-  EraDomain,
-  EraFigure,
-  EraHighlight,
-  useEraColumnColor,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type AnchorHTMLAttributes,
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useContext,
+  useMemo,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Color theme for an {@link EraColumn} accent strip.
+ *
+ * @public
+ */
+export type EraColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "neutral"
+  | "purple"
+  | "red"
+  | "rose";
+
+const ERA_PALETTE: Record<EraColor, { accent: string; chip: string }> = {
+  amber: {
+    accent: "bg-amber-500",
+    chip: "bg-amber-500/15 text-amber-700 dark:text-amber-300",
+  },
+  blue: {
+    accent: "bg-blue-500",
+    chip: "bg-blue-500/15 text-blue-700 dark:text-blue-300",
+  },
+  emerald: {
+    accent: "bg-emerald-500",
+    chip: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+  },
+  neutral: {
+    accent: "bg-muted-foreground/40",
+    chip: "bg-muted text-muted-foreground",
+  },
+  purple: {
+    accent: "bg-purple-500",
+    chip: "bg-purple-500/15 text-purple-700 dark:text-purple-300",
+  },
+  red: {
+    accent: "bg-red-500",
+    chip: "bg-red-500/15 text-red-700 dark:text-red-300",
+  },
+  rose: {
+    accent: "bg-rose-500",
+    chip: "bg-rose-500/15 text-rose-700 dark:text-rose-300",
+  },
+};
+
+type EraColumnContextValue = {
+  color: EraColor;
+};
+
+const EraColumnContext = createContext<EraColumnContextValue>({
+  color: "neutral",
+});
+
+/**
+ * Hook for reading the surrounding {@link EraColumn}'s color theme. Useful
+ * for custom children that want to match the column accent.
+ *
+ * @public
+ */
+export function useEraColumnColor(): EraColor {
+  return useContext(EraColumnContext).color;
+}
+
+/**
+ * Props for {@link EraComparison}.
+ *
+ * @public
+ */
+export type EraComparisonProps = ComponentPropsWithoutRef<"section">;
+
+/**
+ * Side-by-side comparison of historical eras. Lays out {@link EraColumn}
+ * children in a responsive grid (1 col on mobile → 2 col on `md` → 3 col
+ * on `xl`). Composes {@link Badge}.
+ *
+ * @example
+ * ```tsx
+ * <EraComparison>
+ *   <EraColumn name="Renaissance" period="1400–1600" color="amber">
+ *     <EraDomain name="Art">
+ *       <EraHighlight>Perspective painting, humanism</EraHighlight>
+ *       <EraFigure name="Leonardo da Vinci" />
+ *     </EraDomain>
+ *   </EraColumn>
+ *   <EraColumn name="Islamic Golden Age" period="800–1400" color="emerald">
+ *     <EraDomain name="Science">
+ *       <EraHighlight>Algebra, optics, astronomy</EraHighlight>
+ *       <EraFigure name="Al-Khwarizmi" />
+ *     </EraDomain>
+ *   </EraColumn>
+ * </EraComparison>
+ * ```
+ *
+ * @public
+ */
+export const EraComparison = forwardRef<HTMLElement, EraComparisonProps>(
+  ({ children, className, ...rest }, ref) => (
+    <section
+      className={cn(
+        "grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      {children}
+    </section>
+  ),
+);
+EraComparison.displayName = "EraComparison";
+
+/**
+ * Props for {@link EraColumn}.
+ *
+ * @public
+ */
+export type EraColumnProps = {
+  /** Color theme. Drives the top accent strip + chip. Defaults to `"neutral"`. */
+  color?: EraColor;
+  /** Era display name. */
+  name: ReactNode;
+  /** Period label (e.g. `"1400–1600"`). */
+  period?: ReactNode;
+  /** Optional region label (e.g. `"Europe"`). */
+  region?: ReactNode;
+} & ComponentPropsWithoutRef<"article">;
+
+type ColumnHeaderProps = {
+  color: EraColor;
+  name: ReactNode;
+  period?: ReactNode;
+  region?: ReactNode;
+};
+
+function ColumnHeader({
+  color,
+  name,
+  period,
+  region,
+}: ColumnHeaderProps): ReactNode {
+  const palette = ERA_PALETTE[color];
+  return (
+    <header className="flex flex-col gap-2">
+      <span
+        aria-hidden="true"
+        className={cn("h-1 w-12 rounded-full", palette.accent)}
+      />
+      <div className="flex items-baseline justify-between gap-2">
+        <h3 className="text-base font-semibold tracking-tight text-foreground">
+          {name}
+        </h3>
+        {period ? (
+          <span
+            className={cn(
+              "rounded-full px-2 py-0.5 text-xs font-mono",
+              palette.chip,
+            )}
+          >
+            {period}
+          </span>
+        ) : null}
+      </div>
+      {region ? (
+        <p className="text-xs text-muted-foreground">{region}</p>
+      ) : null}
+    </header>
+  );
+}
+
+/**
+ * Single era column inside an {@link EraComparison}. Wraps a header (name,
+ * period, region) and the column body — typically a series of
+ * {@link EraDomain} sections.
+ *
+ * @public
+ */
+export const EraColumn = forwardRef<HTMLElement, EraColumnProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      color = "neutral",
+      name,
+      period,
+      region,
+      ...rest
+    } = props;
+    const contextValue = useMemo<EraColumnContextValue>(
+      () => ({ color }),
+      [color],
+    );
+    return (
+      <EraColumnContext.Provider value={contextValue}>
+        <article
+          className={cn(
+            "flex flex-col gap-3 rounded-2xl border border-border bg-background p-4 shadow-sm",
+            className,
+          )}
+          data-color={color}
+          ref={ref}
+          {...rest}
+        >
+          <ColumnHeader
+            color={color}
+            name={name}
+            period={period}
+            region={region}
+          />
+          <div className="flex flex-col gap-3">{children}</div>
+        </article>
+      </EraColumnContext.Provider>
+    );
+  },
+);
+EraColumn.displayName = "EraColumn";
+
+/**
+ * Props for {@link EraDomain}.
+ *
+ * @public
+ */
+export type EraDomainProps = {
+  /** Domain display name (e.g. `"Art"`, `"Science"`). */
+  name: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+/**
+ * Domain row inside an {@link EraColumn}. Aligns across columns by
+ * convention — pass the same `name` in each column for parallel rows.
+ *
+ * @public
+ */
+export const EraDomain = forwardRef<HTMLElement, EraDomainProps>(
+  ({ children, className, name, ...rest }, ref) => (
+    <section
+      className={cn("flex flex-col gap-2", className)}
+      data-domain={typeof name === "string" ? name : undefined}
+      ref={ref}
+      {...rest}
+    >
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {name}
+      </h4>
+      {children}
+    </section>
+  ),
+);
+EraDomain.displayName = "EraDomain";
+
+/**
+ * Props for {@link EraHighlight}.
+ *
+ * @public
+ */
+export type EraHighlightProps = ComponentPropsWithoutRef<"p">;
+
+/**
+ * Single-line achievement note inside an {@link EraDomain}. Picks up the
+ * surrounding column's color theme automatically.
+ *
+ * @public
+ */
+export const EraHighlight = forwardRef<HTMLParagraphElement, EraHighlightProps>(
+  ({ children, className, ...rest }, ref) => {
+    const color = useEraColumnColor();
+    const palette = ERA_PALETTE[color];
+    return (
+      <p
+        className={cn("rounded-md px-2 py-1 text-sm", palette.chip, className)}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+      </p>
+    );
+  },
+);
+EraHighlight.displayName = "EraHighlight";
+
+type AnchorPassthroughProps = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  "children"
+>;
+
+/**
+ * Props for {@link EraFigure}.
+ *
+ * @public
+ */
+export type EraFigureProps = {
+  /** Anchor passthrough (e.g. `target`, `rel`). Forwarded with `href`. */
+  anchorProps?: AnchorPassthroughProps;
+  /** Optional anchor href. With this prop the chip renders as an `<a>`. */
+  href?: string;
+  /** Display name for the figure. */
+  name: ReactNode;
+} & Omit<ComponentPropsWithoutRef<"span">, "children">;
+
+/**
+ * Pill-shaped reference to a notable figure. With an `href`, the chip
+ * renders as a link.
+ *
+ * @public
+ */
+export const EraFigure = forwardRef<HTMLSpanElement, EraFigureProps>(
+  (props, ref) => {
+    const { anchorProps, className, href, name, ...rest } = props;
+    const color = useEraColumnColor();
+    const palette = ERA_PALETTE[color];
+    const baseClass = cn(
+      "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+      palette.chip,
+      className,
+    );
+    if (href) {
+      return (
+        <a
+          className={cn(baseClass, "underline-offset-4 hover:underline")}
+          href={href}
+          {...anchorProps}
+        >
+          {name}
+        </a>
+      );
+    }
+    return (
+      <span className={baseClass} ref={ref} {...rest}>
+        {name}
+      </span>
+    );
+  },
+);
+EraFigure.displayName = "EraFigure";

--- a/apps/registry/registry/default/exercise/exercise.tsx
+++ b/apps/registry/registry/default/exercise/exercise.tsx
@@ -1,2 +1,168 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { useState } from "react";
+
+import { Check, Dumbbell, Eye, EyeOff } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+
+const difficultyConfig = {
+  easy: { className: "text-green-600 dark:text-green-400", label: "Easy" },
+  hard: { className: "text-red-600 dark:text-red-400", label: "Hard" },
+  medium: { className: "text-amber-600 dark:text-amber-400", label: "Medium" },
+};
+
+type HeaderProps = {
+  completed: boolean;
+  config: { className: string; label: string };
+  onToggle: () => void;
+  title: string;
+};
+
+function ExerciseHeader({ completed, config, onToggle, title }: HeaderProps) {
+  return (
+    <div className="flex items-start justify-between gap-4 mb-4">
+      <div className="flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+          <Dumbbell className="h-5 w-5 text-primary" />
+        </div>
+        <div>
+          <h4 className="font-semibold text-foreground">{title}</h4>
+          <span className={cn("text-xs font-medium", config.className)}>
+            {config.label}
+          </span>
+        </div>
+      </div>
+      <Button
+        className={cn(completed && "bg-green-500 hover:bg-green-600")}
+        onClick={onToggle}
+        size="sm"
+        variant={completed ? "default" : "outline"}
+      >
+        {completed ? (
+          <>
+            <Check className="h-4 w-4 mr-1" />
+            Done
+          </>
+        ) : (
+          "Mark Complete"
+        )}
+      </Button>
+    </div>
+  );
+}
+
+type HintProps = { hint: string; onShow: () => void; showHint: boolean };
+
+function ExerciseHint({ hint, onShow, showHint }: HintProps) {
+  return (
+    <div className="mb-4">
+      {showHint ? (
+        <div className="p-3 rounded bg-muted/50 text-sm">
+          <p className="font-medium text-xs uppercase tracking-wider text-muted-foreground mb-1">
+            Hint
+          </p>
+          <p className="text-muted-foreground italic">{hint}</p>
+        </div>
+      ) : (
+        <button
+          className="text-sm text-primary hover:underline"
+          onClick={onShow}
+          type="button"
+        >
+          Need a hint?
+        </button>
+      )}
+    </div>
+  );
+}
+
+type SolutionProps = {
+  onToggle: () => void;
+  showSolution: boolean;
+  solution: ReactNode;
+};
+
+function ExerciseSolution({ onToggle, showSolution, solution }: SolutionProps) {
+  return (
+    <div>
+      <Button className="mb-3" onClick={onToggle} size="sm" variant="outline">
+        {showSolution ? (
+          <>
+            <EyeOff className="h-4 w-4 mr-1" />
+            Hide Solution
+          </>
+        ) : (
+          <>
+            <Eye className="h-4 w-4 mr-1" />
+            Show Solution
+          </>
+        )}
+      </Button>
+      {showSolution ? (
+        <div className="p-4 rounded-lg bg-card border text-sm [&>pre]:my-0">
+          <p className="font-medium text-xs uppercase tracking-wider text-muted-foreground mb-2">
+            Solution
+          </p>
+          {solution}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export type ExerciseProps = {
+  children: ReactNode;
+  difficulty?: "easy" | "hard" | "medium";
+  hint?: string;
+  solution?: ReactNode;
+  title: string;
+};
+
+export function Exercise({
+  children,
+  difficulty = "medium",
+  hint,
+  solution,
+  title,
+}: ExerciseProps) {
+  const [showSolution, setShowSolution] = useState(false);
+  const [showHint, setShowHint] = useState(false);
+  const [completed, setCompleted] = useState(false);
+
+  return (
+    <div className="my-6 rounded-lg border-2 border-dashed border-primary/30 bg-primary/5 p-6">
+      <ExerciseHeader
+        completed={completed}
+        config={difficultyConfig[difficulty]}
+        onToggle={() => {
+          setCompleted(!completed);
+        }}
+        title={title}
+      />
+      <div className="text-sm text-muted-foreground mb-4 [&>p]:mb-2 [&>ul]:mb-2">
+        {children}
+      </div>
+      {hint ? (
+        <ExerciseHint
+          hint={hint}
+          onShow={() => {
+            setShowHint(true);
+          }}
+          showHint={showHint}
+        />
+      ) : null}
+      {solution ? (
+        <ExerciseSolution
+          onToggle={() => {
+            setShowSolution(!showSolution);
+          }}
+          showSolution={showSolution}
+          solution={solution}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/registry/registry/default/faq/faq.tsx
+++ b/apps/registry/registry/default/faq/faq.tsx
@@ -1,2 +1,69 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { useState } from "react";
+
+import { ChevronDown, HelpCircle } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type FAQItemProps = {
+  children: ReactNode;
+  defaultOpen?: boolean;
+  question: string;
+};
+
+function FAQItem({ children, defaultOpen = false, question }: FAQItemProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <div className="border-b border-border last:border-b-0">
+      <button
+        className="w-full flex items-center justify-between py-4 text-left hover:text-primary transition-colors"
+        onClick={() => {
+          setIsOpen(!isOpen);
+        }}
+        type="button"
+      >
+        <span className="font-medium text-sm pr-4">{question}</span>
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 flex-shrink-0 transition-transform duration-200",
+            isOpen && "rotate-180",
+          )}
+        />
+      </button>
+      <div
+        className={cn(
+          "overflow-hidden transition-all duration-200",
+          isOpen ? "max-h-96 pb-4" : "max-h-0",
+        )}
+      >
+        <div className="text-sm text-muted-foreground [&>p]:mb-2 [&>p:last-child]:mb-0">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export type FAQProps = {
+  children: ReactNode;
+  title?: string;
+};
+
+function FAQ({ children, title = "Frequently Asked Questions" }: FAQProps) {
+  return (
+    <div className="my-6 rounded-lg border bg-card">
+      <div className="flex items-center gap-2 p-4 border-b border-border">
+        <HelpCircle className="h-5 w-5 text-primary" />
+        <h4 className="font-semibold">{title}</h4>
+      </div>
+      <div className="px-4">{children}</div>
+    </div>
+  );
+}
+
+FAQ.Item = FAQItem;
+
+export { FAQ, FAQItem };

--- a/apps/registry/registry/default/file-upload/file-upload.tsx
+++ b/apps/registry/registry/default/file-upload/file-upload.tsx
@@ -1,1 +1,286 @@
-export { FileUpload } from '@vllnt/ui'
+"use client";
+
+import * as React from "react";
+
+import { FileUp, UploadCloud, X } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+
+export type FileUploadProps = Omit<
+  React.ComponentPropsWithoutRef<"input">,
+  "onChange" | "type" | "value"
+> & {
+  browseLabel?: string;
+  dropzoneText?: string;
+  files?: File[];
+  helperText?: string;
+  onFilesChange?: (files: File[]) => void;
+};
+
+function useFileUploadState(
+  controlledFiles: File[] | undefined,
+  multiple: boolean,
+  onFilesChange?: (files: File[]) => void,
+) {
+  const [internalFiles, setInternalFiles] = React.useState<File[]>(
+    controlledFiles ?? [],
+  );
+
+  React.useEffect(() => {
+    if (controlledFiles !== undefined) {
+      setInternalFiles(controlledFiles);
+    }
+  }, [controlledFiles]);
+
+  const resolvedFiles = controlledFiles ?? internalFiles;
+
+  const updateFiles = React.useCallback(
+    (nextFiles: File[]) => {
+      if (controlledFiles === undefined) {
+        setInternalFiles(nextFiles);
+      }
+
+      onFilesChange?.(nextFiles);
+    },
+    [controlledFiles, onFilesChange],
+  );
+
+  const addFiles = React.useCallback(
+    (incomingFiles: File[] | FileList) => {
+      const nextFiles = [...incomingFiles];
+      updateFiles(
+        multiple ? [...resolvedFiles, ...nextFiles] : nextFiles.slice(0, 1),
+      );
+    },
+    [multiple, resolvedFiles, updateFiles],
+  );
+
+  const removeFile = React.useCallback(
+    (fileToRemove: File) => {
+      updateFiles(
+        resolvedFiles.filter(
+          (file) =>
+            !(
+              file.name === fileToRemove.name &&
+              file.size === fileToRemove.size &&
+              file.lastModified === fileToRemove.lastModified
+            ),
+        ),
+      );
+    },
+    [resolvedFiles, updateFiles],
+  );
+
+  return { addFiles, removeFile, resolvedFiles };
+}
+
+function assignInputReference(
+  reference: React.ForwardedRef<HTMLInputElement>,
+  node: HTMLInputElement | null,
+) {
+  if (typeof reference === "function") {
+    reference(node);
+    return;
+  }
+
+  if (reference) {
+    reference.current = node;
+  }
+}
+
+function FileListItem({
+  file,
+  onRemove,
+}: {
+  file: File;
+  onRemove: () => void;
+}) {
+  return (
+    <li className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-2 text-sm">
+      <div className="min-w-0">
+        <p className="truncate font-medium">{file.name}</p>
+        <p className="text-xs text-muted-foreground">
+          {(file.size / 1024).toFixed(1)} KB
+        </p>
+      </div>
+      <Button
+        aria-label={`Remove ${file.name}`}
+        onClick={onRemove}
+        size="icon"
+        type="button"
+        variant="ghost"
+      >
+        <X className="h-4 w-4" />
+      </Button>
+    </li>
+  );
+}
+
+type FileUploadDropzoneProps = {
+  browseLabel: string;
+  children: React.ReactNode;
+  disabled?: boolean;
+  dropzoneText: string;
+  helperText: string;
+  isDragging: boolean;
+  onActivate: () => void;
+  onDragStateChange: (dragging: boolean) => void;
+  onFilesDrop: (files: FileList) => void;
+};
+
+function FileUploadDropzone({
+  browseLabel,
+  children,
+  disabled,
+  dropzoneText,
+  helperText,
+  isDragging,
+  onActivate,
+  onDragStateChange,
+  onFilesDrop,
+}: FileUploadDropzoneProps) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-40 cursor-pointer flex-col items-center justify-center rounded-lg border border-dashed border-input bg-background px-6 py-8 text-center transition-colors",
+        isDragging && "border-primary bg-accent/40",
+        disabled && "cursor-not-allowed opacity-50",
+      )}
+      onClick={onActivate}
+      onDragEnter={(event) => {
+        event.preventDefault();
+        if (!disabled) {
+          onDragStateChange(true);
+        }
+      }}
+      onDragLeave={(event) => {
+        event.preventDefault();
+        onDragStateChange(false);
+      }}
+      onDragOver={(event) => {
+        event.preventDefault();
+      }}
+      onDrop={(event) => {
+        event.preventDefault();
+        onDragStateChange(false);
+        if (!disabled && event.dataTransfer.files.length > 0) {
+          onFilesDrop(event.dataTransfer.files);
+        }
+      }}
+      onKeyDown={(event) => {
+        if ((event.key === "Enter" || event.key === " ") && !disabled) {
+          event.preventDefault();
+          onActivate();
+        }
+      }}
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+    >
+      <UploadCloud className="mb-3 h-10 w-10 text-muted-foreground" />
+      <div className="space-y-1">
+        <p className="font-medium">{dropzoneText}</p>
+        <p className="text-sm text-muted-foreground">{helperText}</p>
+      </div>
+      <span className="mt-4 inline-flex h-10 items-center justify-center rounded-md border border-input bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground shadow-sm">
+        <FileUp className="mr-2 h-4 w-4" />
+        {browseLabel}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+function FileUploadList({
+  files,
+  onRemove,
+}: {
+  files: File[];
+  onRemove: (file: File) => void;
+}) {
+  if (files.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="space-y-2">
+      {files.map((file) => (
+        <FileListItem
+          file={file}
+          key={`${file.name}-${file.lastModified}-${file.size}`}
+          onRemove={() => {
+            onRemove(file);
+          }}
+        />
+      ))}
+    </ul>
+  );
+}
+
+function FileUploadComponent(
+  {
+    accept,
+    browseLabel = "Choose files",
+    className,
+    disabled,
+    dropzoneText = "Drag and drop files here, or click to browse.",
+    files,
+    helperText = "Supports one or more files.",
+    multiple = true,
+    onFilesChange,
+    ...props
+  }: FileUploadProps,
+  reference: React.ForwardedRef<HTMLInputElement>,
+) {
+  const inputReference = React.useRef<HTMLInputElement | null>(null);
+  const [isDragging, setIsDragging] = React.useState(false);
+  const { addFiles, removeFile, resolvedFiles } = useFileUploadState(
+    files,
+    multiple,
+    onFilesChange,
+  );
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      <FileUploadDropzone
+        browseLabel={browseLabel}
+        disabled={disabled}
+        dropzoneText={dropzoneText}
+        helperText={helperText}
+        isDragging={isDragging}
+        onActivate={() => {
+          if (!disabled) {
+            inputReference.current?.click();
+          }
+        }}
+        onDragStateChange={setIsDragging}
+        onFilesDrop={addFiles}
+      >
+        <input
+          {...props}
+          accept={accept}
+          aria-label={browseLabel}
+          className="sr-only"
+          disabled={disabled}
+          multiple={multiple}
+          onChange={(event) => {
+            if (event.target.files) {
+              addFiles(event.target.files);
+            }
+          }}
+          ref={(node) => {
+            inputReference.current = node;
+            assignInputReference(reference, node);
+          }}
+          type="file"
+        />
+      </FileUploadDropzone>
+      <FileUploadList files={resolvedFiles} onRemove={removeFile} />
+    </div>
+  );
+}
+
+const FileUpload = React.forwardRef(FileUploadComponent);
+FileUpload.displayName = "FileUpload";
+
+export { FileUpload };

--- a/apps/registry/registry/default/filter-bar/filter-bar.tsx
+++ b/apps/registry/registry/default/filter-bar/filter-bar.tsx
@@ -1,2 +1,342 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { memo, useCallback, useState } from "react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+
+export type FilterOption = {
+  label: string;
+  value: string;
+};
+
+export type FilterBarLabels = {
+  activeFilters?: string;
+  clearAll?: string;
+  clearTags?: string;
+  difficultyLabel?: string;
+  searchLabel?: string;
+  searchPlaceholder?: string;
+  tagsLabel?: string;
+};
+
+export type FilterBarProps = {
+  className?: string;
+  /** Current active difficulty filter */
+  currentDifficulty: string;
+  /** Current active tags */
+  currentTags: string[];
+  /** Difficulty filter options */
+  difficultyOptions: readonly FilterOption[];
+  /** Labels for i18n */
+  labels?: FilterBarLabels;
+  /** Callback when filters change */
+  onFiltersChange: (filters: {
+    difficulty?: string;
+    search?: string;
+    tags?: string[];
+  }) => void;
+  /** Search query */
+  searchQuery: string;
+  /** Available tags */
+  tags: string[];
+};
+
+// Search input sub-component
+function SearchInput({
+  disabled,
+  label,
+  onChange,
+  placeholder,
+  value,
+}: {
+  disabled: boolean;
+  label: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  value: string;
+}): React.ReactNode {
+  return (
+    <div>
+      <label className="sr-only" htmlFor="filter-search">
+        {label}
+      </label>
+      <input
+        className={cn(
+          "w-full px-4 py-2 border border-border rounded-lg",
+          "bg-background text-foreground placeholder:text-muted-foreground",
+          "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+        )}
+        defaultValue={value}
+        disabled={disabled}
+        id="filter-search"
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
+        placeholder={placeholder}
+        type="text"
+      />
+    </div>
+  );
+}
+
+// Difficulty filter sub-component
+function DifficultyFilter({
+  activeDifficulty,
+  disabled,
+  label,
+  onChange,
+  options,
+}: {
+  activeDifficulty: string;
+  disabled: boolean;
+  label: string;
+  onChange: (value: string) => void;
+  options: readonly FilterOption[];
+}): React.ReactNode {
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-sm font-medium">{label}</span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {options.map((option) => {
+          const isActive = option.value === activeDifficulty;
+          return (
+            <button
+              className={cn(
+                "px-3 py-1 text-sm rounded-lg border transition-colors",
+                isActive
+                  ? "bg-primary text-primary-foreground border-transparent"
+                  : "bg-background text-foreground border-border hover:bg-muted",
+              )}
+              disabled={disabled}
+              key={option.value}
+              onClick={() => {
+                onChange(option.value);
+              }}
+              type="button"
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// Tag filter sub-component
+function TagFilter({
+  clearLabel,
+  currentTags,
+  label,
+  onClearTags,
+  onTagToggle,
+  tags,
+}: {
+  clearLabel: string;
+  currentTags: string[];
+  label: string;
+  onClearTags: () => void;
+  onTagToggle: (tag: string) => void;
+  tags: string[];
+}): React.ReactNode {
+  if (tags.length === 0) return null;
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-sm font-medium">{label}</span>
+        {currentTags.length > 0 ? (
+          <button
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            onClick={onClearTags}
+            type="button"
+          >
+            {clearLabel}
+          </button>
+        ) : null}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {tags.map((tag) => {
+          const isActive = currentTags.includes(tag);
+          return (
+            <Badge
+              className={cn(
+                "cursor-pointer transition-all",
+                isActive
+                  ? "bg-primary text-primary-foreground border-transparent"
+                  : "hover:bg-muted",
+              )}
+              key={tag}
+              onClick={() => {
+                onTagToggle(tag);
+              }}
+              variant={isActive ? "default" : "outline"}
+            >
+              {tag}
+            </Badge>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// Active filters summary sub-component
+function ActiveFiltersSummary({
+  clearAllLabel,
+  currentDifficulty,
+  currentTags,
+  difficultyOptions,
+  label,
+  onClearAll,
+  searchLabel,
+  searchQuery,
+}: {
+  clearAllLabel: string;
+  currentDifficulty: string;
+  currentTags: string[];
+  difficultyOptions: readonly FilterOption[];
+  label: string;
+  onClearAll: () => void;
+  searchLabel: string;
+  searchQuery: string;
+}): React.ReactNode {
+  if (!currentDifficulty && currentTags.length === 0 && !searchQuery)
+    return null;
+
+  const difficultyLabel = difficultyOptions.find(
+    (o) => o.value === currentDifficulty,
+  )?.label;
+
+  return (
+    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+      <span>{label}</span>
+      {difficultyLabel ? (
+        <Badge className="capitalize" variant="secondary">
+          {difficultyLabel}
+        </Badge>
+      ) : null}
+      {currentTags.map((tag) => (
+        <Badge key={tag} variant="secondary">
+          {tag}
+        </Badge>
+      ))}
+      {searchQuery ? (
+        <Badge variant="secondary">
+          {searchLabel} &quot;{searchQuery}&quot;
+        </Badge>
+      ) : null}
+      <button
+        className="text-xs hover:underline"
+        onClick={onClearAll}
+        type="button"
+      >
+        {clearAllLabel}
+      </button>
+    </div>
+  );
+}
+
+const DEFAULT_LABELS: Required<FilterBarLabels> = {
+  activeFilters: "Active filters:",
+  clearAll: "Clear all",
+  clearTags: "Clear",
+  difficultyLabel: "Difficulty:",
+  searchLabel: "Search",
+  searchPlaceholder: "Search...",
+  tagsLabel: "Tags:",
+};
+
+// eslint-disable-next-line max-lines-per-function -- Complex filter component with sub-components
+function FilterBarImpl({
+  className,
+  currentDifficulty,
+  currentTags,
+  difficultyOptions,
+  labels = {},
+  onFiltersChange,
+  searchQuery,
+  tags,
+}: FilterBarProps): React.ReactNode {
+  const [isPending, setIsPending] = useState(false);
+  const mergedLabels = { ...DEFAULT_LABELS, ...labels };
+
+  const handleDifficultyChange = useCallback(
+    (difficulty: string): void => {
+      setIsPending(true);
+      onFiltersChange({ difficulty });
+      setIsPending(false);
+    },
+    [onFiltersChange],
+  );
+
+  const handleSearchChange = useCallback(
+    (search: string): void => {
+      onFiltersChange({ search });
+    },
+    [onFiltersChange],
+  );
+
+  const handleTagToggle = useCallback(
+    (tag: string): void => {
+      const newTags = currentTags.includes(tag)
+        ? currentTags.filter((t) => t !== tag)
+        : [...currentTags, tag];
+      onFiltersChange({ tags: newTags });
+    },
+    [currentTags, onFiltersChange],
+  );
+
+  const handleClearAll = useCallback((): void => {
+    onFiltersChange({ difficulty: "all", search: "", tags: [] });
+    const input = document.querySelector<HTMLInputElement>("#filter-search");
+    if (input) input.value = "";
+  }, [onFiltersChange]);
+
+  const activeDifficulty = currentDifficulty || "all";
+
+  return (
+    <div className={cn("space-y-4 mb-8", className)}>
+      <SearchInput
+        disabled={isPending}
+        label={mergedLabels.searchLabel}
+        onChange={handleSearchChange}
+        placeholder={mergedLabels.searchPlaceholder}
+        value={searchQuery}
+      />
+      <DifficultyFilter
+        activeDifficulty={activeDifficulty}
+        disabled={isPending}
+        label={mergedLabels.difficultyLabel}
+        onChange={handleDifficultyChange}
+        options={difficultyOptions}
+      />
+      <TagFilter
+        clearLabel={mergedLabels.clearTags}
+        currentTags={currentTags}
+        label={mergedLabels.tagsLabel}
+        onClearTags={() => {
+          onFiltersChange({ tags: [] });
+        }}
+        onTagToggle={handleTagToggle}
+        tags={tags}
+      />
+      <ActiveFiltersSummary
+        clearAllLabel={mergedLabels.clearAll}
+        currentDifficulty={currentDifficulty}
+        currentTags={currentTags}
+        difficultyOptions={difficultyOptions}
+        label={mergedLabels.activeFilters}
+        onClearAll={handleClearAll}
+        searchLabel={mergedLabels.searchLabel}
+        searchQuery={searchQuery}
+      />
+    </div>
+  );
+}
+
+export const FilterBar = memo(FilterBarImpl);
+FilterBar.displayName = "FilterBar";

--- a/apps/registry/registry/default/flashcard/flashcard.tsx
+++ b/apps/registry/registry/default/flashcard/flashcard.tsx
@@ -1,2 +1,87 @@
-// Re-export from @vllnt/ui package
-export { Flashcard } from '@vllnt/ui'
+"use client";
+
+import { useState } from "react";
+
+import { RefreshCcw } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@vllnt/ui";
+
+export type FlashcardProps = {
+  answer: ReactNode;
+  category?: string;
+  className?: string;
+  defaultFlipped?: boolean;
+  hint?: string;
+  onFlipChange?: (flipped: boolean) => void;
+  question: ReactNode;
+  title?: string;
+};
+
+export function Flashcard({
+  answer,
+  category,
+  className,
+  defaultFlipped = false,
+  hint,
+  onFlipChange,
+  question,
+  title = "Flashcard",
+}: FlashcardProps): ReactNode {
+  const [flipped, setFlipped] = useState(defaultFlipped);
+
+  const toggleFlipped = (): void => {
+    const nextValue = !flipped;
+    setFlipped(nextValue);
+    onFlipChange?.(nextValue);
+  };
+
+  return (
+    <Card
+      className={cn(
+        "my-6 overflow-hidden border-primary/20 bg-gradient-to-br from-card to-primary/5",
+        className,
+      )}
+    >
+      <CardHeader className="flex flex-row items-center justify-between gap-3 border-b bg-background/80">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <Badge variant="secondary">Study</Badge>
+            {category ? <Badge variant="outline">{category}</Badge> : null}
+          </div>
+          <CardTitle>{title}</CardTitle>
+        </div>
+        <Button onClick={toggleFlipped} size="sm" variant="outline">
+          <RefreshCcw className="mr-2 h-4 w-4" />
+          Flip
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4 p-6">
+        <div className="min-h-40 rounded-xl border bg-background p-6 shadow-sm">
+          <p className="mb-2 text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+            {flipped ? "Answer" : "Prompt"}
+          </p>
+          <div className="text-base text-foreground [&>p]:mb-3">
+            {flipped ? answer : question}
+          </div>
+        </div>
+        {hint ? (
+          <p className="text-sm text-muted-foreground">Hint: {hint}</p>
+        ) : null}
+      </CardContent>
+      <CardFooter className="justify-between border-t bg-background/80 px-6 py-4">
+        <span className="text-sm text-muted-foreground">
+          {flipped
+            ? "Use this side to check your recall."
+            : "Try answering before flipping the card."}
+        </span>
+        <Button onClick={toggleFlipped} variant="ghost">
+          {flipped ? "Show prompt" : "Reveal answer"}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/registry/registry/default/floating-action-button/floating-action-button.tsx
+++ b/apps/registry/registry/default/floating-action-button/floating-action-button.tsx
@@ -1,2 +1,45 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { memo } from "react";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type FloatingActionButtonProps = {
+  "aria-label": string;
+  children: ReactNode;
+  className?: string;
+  onClick: () => void;
+  position?: "bottom-left" | "bottom-right";
+};
+
+function FloatingActionButtonImpl({
+  "aria-label": ariaLabel,
+  children,
+  className,
+  onClick,
+  position = "bottom-right",
+}: FloatingActionButtonProps): React.ReactNode {
+  return (
+    <button
+      aria-label={ariaLabel}
+      className={cn(
+        "fixed z-40 flex h-12 w-12 items-center justify-center rounded-full",
+        "bg-primary text-primary-foreground shadow-lg",
+        "transition-transform hover:scale-110",
+        "focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2",
+        position === "bottom-right" && "bottom-20 right-4 sm:bottom-4",
+        position === "bottom-left" && "bottom-20 left-4 sm:bottom-4",
+        className,
+      )}
+      onClick={onClick}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+}
+
+export const FloatingActionButton = memo(FloatingActionButtonImpl);
+FloatingActionButton.displayName = "FloatingActionButton";

--- a/apps/registry/registry/default/floating-toolbar/floating-toolbar.tsx
+++ b/apps/registry/registry/default/floating-toolbar/floating-toolbar.tsx
@@ -1,6 +1,144 @@
-export {
-  type FloatingToolbarAction,
-  FloatingToolbar,
-  type FloatingToolbarLabels,
-  type FloatingToolbarProps,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * One toolbar action.
+ *
+ * @public
+ */
+export type FloatingToolbarAction = {
+  /** Optional aria-label override (defaults to the visible label). */
+  ariaLabel?: string;
+  /** When `true`, renders dimmed and ignores clicks. */
+  disabled?: boolean;
+  /** Optional leading glyph. */
+  glyph?: ReactNode;
+  /** Stable identifier. */
+  id: string;
+  /** Visible label. */
+  label: ReactNode;
+  /** Click handler. */
+  onActivate: () => void;
+  /** Optional emphasis level. Defaults to `"ghost"`. */
+  variant?: "destructive" | "ghost" | "primary";
+};
+
+const VARIANT_CLASSES: Record<
+  NonNullable<FloatingToolbarAction["variant"]>,
+  string
+> = {
+  destructive:
+    "border-red-300 bg-red-500/10 text-red-700 hover:bg-red-500/20 dark:text-red-300",
+  ghost: "border-border bg-background text-foreground hover:bg-accent",
+  primary:
+    "border-primary bg-primary text-primary-foreground hover:bg-primary/90",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type FloatingToolbarLabels = {
+  /** Aria-label for the toolbar. Defaults to `"Selection actions"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Selection actions",
+} as const satisfies Required<FloatingToolbarLabels>;
+
+/**
+ * Props for {@link FloatingToolbar}.
+ *
+ * @public
+ */
+export type FloatingToolbarProps = {
+  /** Toolbar actions in render order. */
+  actions: FloatingToolbarAction[];
+  /** Localizable strings. */
+  labels?: FloatingToolbarLabels;
+  /** X coordinate in container px (left edge of the toolbar). */
+  x: number;
+  /** Y coordinate in container px (bottom edge of the toolbar — the bar floats above this point). */
+  y: number;
+} & Omit<ComponentPropsWithoutRef<"div">, "style">;
+
+/**
+ * Compact action bar that floats above a selection. Pair with
+ * {@link SelectionHalo} — surface the toolbar at the halo's top edge so
+ * the user sees the available actions for the current selection.
+ *
+ * @example
+ * ```tsx
+ * <FloatingToolbar
+ *   x={120}
+ *   y={80}
+ *   actions={[
+ *     { id: "rename", label: "Rename", onActivate: rename, variant: "primary" },
+ *     { id: "duplicate", label: "Duplicate", onActivate: duplicate },
+ *     { id: "delete", label: "Delete", onActivate: remove, variant: "destructive" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const FloatingToolbar = forwardRef<HTMLDivElement, FloatingToolbarProps>(
+  (props, ref) => {
+    const { actions, className, labels, x, y, ...rest } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "absolute z-30 flex -translate-y-full items-center gap-1 rounded-md border border-border bg-background/95 p-1 shadow-md backdrop-blur",
+          className,
+        )}
+        data-floating-toolbar
+        ref={ref}
+        role="toolbar"
+        style={{ left: `${x.toString()}px`, top: `${y.toString()}px` }}
+        {...rest}
+      >
+        {actions.map((action) => {
+          const variant = action.variant ?? "ghost";
+          const handleClick = (): void => {
+            action.onActivate();
+          };
+          return (
+            <button
+              aria-label={action.ariaLabel ?? undefined}
+              className={cn(
+                "inline-flex h-7 items-center gap-1 rounded-md border px-2 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                VARIANT_CLASSES[variant],
+                action.disabled ? "cursor-not-allowed opacity-50" : "",
+              )}
+              data-action-id={action.id}
+              data-variant={variant}
+              disabled={action.disabled}
+              key={action.id}
+              onClick={handleClick}
+              type="button"
+            >
+              {action.glyph ? (
+                <span aria-hidden="true" className="inline-flex h-3 w-3">
+                  {action.glyph}
+                </span>
+              ) : null}
+              <span>{action.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    );
+  },
+);
+FloatingToolbar.displayName = "FloatingToolbar";

--- a/apps/registry/registry/default/flow-diagram/flow-diagram.tsx
+++ b/apps/registry/registry/default/flow-diagram/flow-diagram.tsx
@@ -1,13 +1,166 @@
-export {
-  FlowControls,
-  FlowDiagram,
-  FlowFullscreen,
-  useFlowDiagram,
-  type FlowControlsProps,
-  type FlowDiagramEdge,
-  type FlowDiagramNode,
-  type FlowDiagramProps,
-  type FlowFullscreenProps,
-  type UseFlowDiagramOptions,
-  type UseFlowDiagramReturn,
-} from '@vllnt/ui'
+"use client";
+
+import "@xyflow/react/dist/style.css";
+
+import { memo, useCallback, useEffect } from "react";
+
+import {
+  type Node,
+  type NodeMouseHandler,
+  ReactFlowProvider,
+} from "@xyflow/react";
+
+import { cn } from "@vllnt/ui";
+
+import { FlowCanvas } from "./flow-canvas";
+import { FlowErrorBoundary } from "./flow-error-boundary";
+import { FlowFullscreen } from "./flow-fullscreen";
+import type {
+  FlowDiagramEdge,
+  FlowDiagramNode,
+  FlowDiagramProps,
+} from "./types";
+import { useFlowDiagram } from "./use-flow-diagram";
+
+/**
+ * Validates nodes and edges, logging warnings for common issues.
+ */
+function validateFlowData(
+  nodes: FlowDiagramNode[],
+  edges: FlowDiagramEdge[],
+): void {
+  if (nodes.length === 0 && edges.length > 0) {
+    console.warn(
+      "[FlowDiagram] Edges provided without nodes - edges will not render",
+    );
+  }
+
+  const nodeIds = new Set(nodes.map((n) => n.id));
+  const invalidEdges = edges.filter(
+    (e) => !nodeIds.has(e.source) || !nodeIds.has(e.target),
+  );
+
+  if (invalidEdges.length > 0) {
+    console.warn(
+      `[FlowDiagram] ${invalidEdges.length} edge(s) reference non-existent nodes:`,
+      invalidEdges.map((e) => `${e.id}: ${e.source} -> ${e.target}`),
+    );
+  }
+
+  const nodesWithoutPosition = nodes.filter((n) => n.position === undefined);
+  if (nodesWithoutPosition.length > 0) {
+    console.warn(
+      `[FlowDiagram] ${nodesWithoutPosition.length} node(s) missing position:`,
+      nodesWithoutPosition.map((n) => n.id),
+    );
+  }
+}
+
+const FlowDiagramInner = memo(function FlowDiagramInner({
+  allowCopy = false,
+  allowFullscreen = true,
+  className,
+  edges,
+  fitView = true,
+  fitViewOptions,
+  height = 400,
+  nodes,
+  onNodeClick,
+  showControls = true,
+  title,
+}: FlowDiagramProps) {
+  // Check input on mount and when data changes
+  useEffect(() => {
+    validateFlowData(nodes, edges);
+  }, [nodes, edges]);
+
+  const {
+    closeFullscreen,
+    copyStatus,
+    copyToClipboard,
+    fitView: handleFitView,
+    isFullscreen,
+    toggleFullscreen,
+    zoomIn,
+    zoomOut,
+  } = useFlowDiagram({ allowCopy, allowFullscreen });
+
+  // Memoize node click handler to prevent unnecessary re-renders
+  const handleNodeClick: NodeMouseHandler | undefined = useCallback(
+    (_event: React.MouseEvent, node: Node) => {
+      onNodeClick?.(node as FlowDiagramNode);
+    },
+    [onNodeClick],
+  );
+
+  const handleCopy = useCallback(() => {
+    void copyToClipboard();
+  }, [copyToClipboard]);
+
+  const canvasProps = {
+    allowCopy,
+    allowFullscreen,
+    className,
+    copyStatus,
+    edges,
+    fitView,
+    fitViewOptions,
+    height,
+    isFullscreen,
+    nodes,
+    onCopy: allowCopy ? handleCopy : undefined,
+    onFitView: handleFitView,
+    onFullscreen: allowFullscreen ? toggleFullscreen : undefined,
+    onNodeClick: onNodeClick ? handleNodeClick : undefined,
+    onZoomIn: zoomIn,
+    onZoomOut: zoomOut,
+    showControls,
+    title,
+  };
+
+  if (isFullscreen) {
+    return (
+      <>
+        <div
+          className={cn(
+            "rounded-lg border border-border bg-muted/50",
+            className,
+          )}
+          style={{ height }}
+        />
+        <FlowFullscreen isOpen={isFullscreen} onClose={closeFullscreen}>
+          <FlowCanvas {...canvasProps} />
+        </FlowFullscreen>
+      </>
+    );
+  }
+
+  return <FlowCanvas {...canvasProps} />;
+});
+
+/**
+ * FlowDiagram component for rendering interactive flow diagrams.
+ * Uses @xyflow/react under the hood with error boundary protection.
+ *
+ * @example
+ * ```tsx
+ * <FlowDiagram
+ *   nodes={[
+ *     { id: '1', data: { label: 'Start' }, position: { x: 0, y: 0 } },
+ *     { id: '2', data: { label: 'End' }, position: { x: 200, y: 100 } }
+ *   ]}
+ *   edges={[{ id: 'e1-2', source: '1', target: '2' }]}
+ *   showControls
+ *   allowFullscreen
+ * />
+ * ```
+ */
+export const FlowDiagram = memo(function FlowDiagram(props: FlowDiagramProps) {
+  return (
+    <FlowErrorBoundary height={props.height}>
+      <ReactFlowProvider>
+        <FlowDiagramInner {...props} />
+      </ReactFlowProvider>
+    </FlowErrorBoundary>
+  );
+});

--- a/apps/registry/registry/default/follow-mode/follow-mode.tsx
+++ b/apps/registry/registry/default/follow-mode/follow-mode.tsx
@@ -1,6 +1,135 @@
-export {
-  FollowMode,
-  type FollowModeColor,
-  type FollowModeLabels,
-  type FollowModeProps,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Color theme for the follow ring + chip.
+ *
+ * @public
+ */
+export type FollowModeColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "purple"
+  | "red"
+  | "rose";
+
+const PALETTE: Record<FollowModeColor, { chip: string; ring: string }> = {
+  amber: { chip: "bg-amber-500 text-white", ring: "ring-amber-500" },
+  blue: { chip: "bg-blue-500 text-white", ring: "ring-blue-500" },
+  emerald: { chip: "bg-emerald-500 text-white", ring: "ring-emerald-500" },
+  purple: { chip: "bg-purple-500 text-white", ring: "ring-purple-500" },
+  red: { chip: "bg-red-500 text-white", ring: "ring-red-500" },
+  rose: { chip: "bg-rose-500 text-white", ring: "ring-rose-500" },
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type FollowModeLabels = {
+  /** Aria-label for the follow chrome. Defaults to `"Follow mode"`. */
+  region?: string;
+  /** Stop-following button copy. Defaults to `"Stop"`. */
+  stop?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Follow mode",
+  stop: "Stop",
+} as const satisfies Required<FollowModeLabels>;
+
+/**
+ * Props for {@link FollowMode}.
+ *
+ * @public
+ */
+export type FollowModeProps = {
+  /** Color theme. Defaults to `"blue"`. */
+  color?: FollowModeColor;
+  /** Localizable strings. */
+  labels?: FollowModeLabels;
+  /** Display name of the followed participant. */
+  name: ReactNode;
+  /** Fires when the user picks the stop-following button. */
+  onStop?: () => void;
+} & Omit<ComponentPropsWithoutRef<"div">, "color">;
+
+/**
+ * Follow-mode chrome. Wrap any region (typically the whole canvas) to
+ * outline it with the followed participant's color and surface a
+ * pinned chip + stop-following button. Pure presentation — the host
+ * drives viewport sync and toggles the wrapper on / off.
+ *
+ * @example
+ * ```tsx
+ * <FollowMode color="emerald" name="Sam" onStop={stop}>
+ *   <CanvasView … />
+ * </FollowMode>
+ * ```
+ *
+ * @public
+ */
+export const FollowMode = forwardRef<HTMLDivElement, FollowModeProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      color = "blue",
+      labels,
+      name,
+      onStop,
+      ...rest
+    } = props;
+    const palette = PALETTE[color];
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "relative h-full w-full rounded-2xl ring-2 ring-inset",
+          palette.ring,
+          className,
+        )}
+        data-follow-color={color}
+        ref={ref}
+        {...rest}
+      >
+        <div
+          className="pointer-events-auto absolute left-1/2 top-2 z-30 flex -translate-x-1/2 items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold shadow-sm"
+          data-follow-chip
+        >
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full px-1.5 py-0.5",
+              palette.chip,
+            )}
+          >
+            <span aria-hidden="true">▸</span>
+            <span>Following {name}</span>
+          </span>
+          {onStop ? (
+            <button
+              aria-label={resolvedLabels.stop}
+              className="inline-flex h-5 items-center rounded-full border border-border bg-background px-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              onClick={onStop}
+              type="button"
+            >
+              {resolvedLabels.stop}
+            </button>
+          ) : null}
+        </div>
+        {children}
+      </div>
+    );
+  },
+);
+FollowMode.displayName = "FollowMode";

--- a/apps/registry/registry/default/form/form.tsx
+++ b/apps/registry/registry/default/form/form.tsx
@@ -1,9 +1,710 @@
-// Re-export from @vllnt/ui package
+"use client";
+
+import * as React from "react";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Slot } from "@radix-ui/react-slot";
+import {
+  Controller,
+  type ControllerProps,
+  type DefaultValues,
+  type FieldPath,
+  type FieldValues,
+  FormProvider,
+  type Resolver,
+  type SubmitErrorHandler,
+  useForm,
+  useFormContext,
+  type UseFormReturn,
+} from "react-hook-form";
+
+import { cn } from "@vllnt/ui";
+import { Label } from "@vllnt/ui";
+
+type FormInstance<TFieldValues extends FieldValues> = UseFormReturn<
+  TFieldValues,
+  unknown,
+  TFieldValues
+>;
+
+type FormRenderChildren<TFieldValues extends FieldValues> =
+  | ((form: FormInstance<TFieldValues>) => React.ReactNode)
+  | React.ReactNode;
+
+type FormSubmitHandler<TFieldValues extends FieldValues> = (
+  values: TFieldValues,
+  form: FormInstance<TFieldValues>,
+) => Promise<void> | void;
+
+type FormErrorHandler<TFieldValues extends FieldValues> = (
+  errors: Parameters<SubmitErrorHandler<TFieldValues>>[0],
+  form: FormInstance<TFieldValues>,
+) => Promise<void> | void;
+
+type BaseFormProps<TFieldValues extends FieldValues> = Omit<
+  React.ComponentPropsWithoutRef<"form">,
+  "children"
+> & {
+  children?: FormRenderChildren<TFieldValues>;
+  controlId?: string;
+  descriptionId?: string;
+  disabled?: boolean;
+  invalid?: boolean;
+  messageId?: string;
+  onError?: FormErrorHandler<TFieldValues>;
+  onValidSubmit?: FormSubmitHandler<TFieldValues>;
+  required?: boolean;
+};
+
+type ManagedFormProps<TFieldValues extends FieldValues> = {
+  defaultValues?: DefaultValues<TFieldValues>;
+  form?: undefined;
+  resolver?: Resolver<TFieldValues>;
+  schema?: Parameters<typeof zodResolver>[0];
+  values?: TFieldValues;
+};
+
+type ProvidedFormProps<TFieldValues extends FieldValues> = {
+  defaultValues?: never;
+  form: FormInstance<TFieldValues>;
+  resolver?: never;
+  schema?: never;
+  values?: never;
+};
+
+export type FormProps<TFieldValues extends FieldValues = FieldValues> =
+  BaseFormProps<TFieldValues> &
+    (ManagedFormProps<TFieldValues> | ProvidedFormProps<TFieldValues>);
+
+type FormNativeSubmitHandler =
+  React.ComponentPropsWithoutRef<"form">["onSubmit"];
+
+type FormRootContextValue = {
+  controlId?: string;
+  descriptionId?: string;
+  disabled: boolean;
+  invalid: boolean;
+  messageId?: string;
+  required: boolean;
+};
+
+type FormFieldContextValue = {
+  name: string;
+};
+
+type FormItemContextValue = {
+  controlId: string;
+  descriptionId: string;
+  disabled: boolean;
+  hasDescription: boolean;
+  hasMessage: boolean;
+  hasMessageSlot: boolean;
+  id: string;
+  invalid: boolean;
+  messageId: string;
+  required: boolean;
+};
+
+const FormRootContext = React.createContext<FormRootContextValue | undefined>(
+  undefined,
+);
+
+const FormFieldContext = React.createContext<FormFieldContextValue | undefined>(
+  undefined,
+);
+
+const FormItemContext = React.createContext<FormItemContextValue | undefined>(
+  undefined,
+);
+
+function useFormRootContext(componentName: string) {
+  const context = React.useContext(FormRootContext);
+
+  if (context === undefined) {
+    throw new Error(`${componentName} must be used within Form.`);
+  }
+
+  return context;
+}
+
+function useFormItemContext(componentName: string) {
+  const context = React.useContext(FormItemContext);
+
+  if (context === undefined) {
+    throw new Error(`${componentName} must be used within FormItem.`);
+  }
+
+  return context;
+}
+
+function composeIds(...ids: (string | undefined)[]) {
+  const value = ids.filter((id) => id !== undefined && id.length > 0).join(" ");
+
+  return value.length > 0 ? value : undefined;
+}
+
+function resolveItemId(
+  baseId: string | undefined,
+  generatedId: string,
+  suffix: string,
+) {
+  if (baseId === undefined) {
+    return `${generatedId}-${suffix}`;
+  }
+
+  return baseId.endsWith(`-${suffix}`)
+    ? `${baseId}-${generatedId}`
+    : `${baseId}-${suffix}-${generatedId}`;
+}
+
+function isNamedFormChild(
+  child: React.ReactNode,
+  name: "FormDescription" | "FormMessage",
+): child is React.ReactElement<{ children?: React.ReactNode }> {
+  if (!React.isValidElement<{ children?: React.ReactNode }>(child)) {
+    return false;
+  }
+
+  const { type } = child;
+  if (typeof type === "string" || typeof type === "symbol") {
+    return false;
+  }
+
+  return "displayName" in type && type.displayName === name;
+}
+
+function hasVisibleContent(children: React.ReactNode): boolean {
+  return React.Children.toArray(children).some((child) => {
+    if (child === null || child === undefined || typeof child === "boolean") {
+      return false;
+    }
+
+    if (typeof child === "string") {
+      return child.length > 0;
+    }
+
+    if (typeof child === "number") {
+      return true;
+    }
+
+    if (React.isValidElement<{ children?: React.ReactNode }>(child)) {
+      const nestedChildren = child.props.children;
+
+      return nestedChildren === undefined
+        ? true
+        : hasVisibleContent(nestedChildren);
+    }
+
+    return true;
+  });
+}
+
+function hasFormChild(
+  children: React.ReactNode,
+  name: "FormDescription" | "FormMessage",
+): boolean {
+  return React.Children.toArray(children).some((child) => {
+    if (isNamedFormChild(child, name)) {
+      return true;
+    }
+
+    if (React.isValidElement<{ children?: React.ReactNode }>(child)) {
+      return hasFormChild(child.props.children, name);
+    }
+
+    return false;
+  });
+}
+
+function hasRenderedFormChild(
+  children: React.ReactNode,
+  name: "FormDescription" | "FormMessage",
+): boolean {
+  return React.Children.toArray(children).some((child) => {
+    if (isNamedFormChild(child, name)) {
+      return name === "FormMessage"
+        ? hasVisibleContent(child.props.children)
+        : true;
+    }
+
+    if (React.isValidElement<{ children?: React.ReactNode }>(child)) {
+      return hasRenderedFormChild(child.props.children, name);
+    }
+
+    return false;
+  });
+}
+
+function createManagedSubmitHandler<TFieldValues extends FieldValues>(
+  form: FormInstance<TFieldValues>,
+  options: {
+    onError?: FormErrorHandler<TFieldValues>;
+    onValidSubmit?: FormSubmitHandler<TFieldValues>;
+    shouldValidate: boolean;
+  },
+): ReturnType<FormInstance<TFieldValues>["handleSubmit"]> | undefined {
+  const { onError, onValidSubmit, shouldValidate } = options;
+
+  if (!shouldValidate) {
+    return undefined;
+  }
+
+  return form.handleSubmit(
+    async (submittedValues) => {
+      if (onValidSubmit !== undefined) {
+        await onValidSubmit(submittedValues, form);
+      }
+    },
+    async (errors) => {
+      if (onError !== undefined) {
+        await onError(errors, form);
+      }
+    },
+  );
+}
+
+function createSubmitHandler(
+  nativeSubmit: FormNativeSubmitHandler,
+  handleValidatedSubmit:
+    | ((event?: React.BaseSyntheticEvent) => Promise<void>)
+    | undefined,
+): FormNativeSubmitHandler {
+  return async (event) => {
+    nativeSubmit?.(event);
+
+    if (handleValidatedSubmit && !event.defaultPrevented) {
+      await handleValidatedSubmit(event);
+    }
+  };
+}
+
+function useFormRootContextValue(
+  value: FormRootContextValue,
+): FormRootContextValue {
+  const { controlId, descriptionId, disabled, invalid, messageId, required } =
+    value;
+
+  return React.useMemo(
+    () => ({
+      controlId,
+      descriptionId,
+      disabled,
+      invalid,
+      messageId,
+      required,
+    }),
+    [controlId, descriptionId, disabled, invalid, messageId, required],
+  );
+}
+
+type FormMarkupProps<TFieldValues extends FieldValues> = {
+  children: FormProps<TFieldValues>["children"];
+  className?: string;
+  disabled: boolean;
+  form: FormInstance<TFieldValues>;
+  formProps: Omit<
+    React.ComponentPropsWithoutRef<"form">,
+    "children" | "className" | "onSubmit"
+  >;
+  formRef: React.ForwardedRef<HTMLFormElement>;
+  handleValidatedSubmit?: ReturnType<
+    FormInstance<TFieldValues>["handleSubmit"]
+  >;
+  invalid: boolean;
+  onSubmit: FormNativeSubmitHandler;
+  rootContextValue: FormRootContextValue;
+};
+
+function FormMarkup<TFieldValues extends FieldValues>({
+  children,
+  className,
+  disabled,
+  form,
+  formProps,
+  formRef,
+  handleValidatedSubmit,
+  invalid,
+  onSubmit,
+  rootContextValue,
+}: FormMarkupProps<TFieldValues>) {
+  return (
+    <FormRootContext.Provider value={rootContextValue}>
+      <FormProvider {...form}>
+        <form
+          className={cn("space-y-2", className)}
+          data-disabled={
+            disabled || form.formState.isSubmitting ? "true" : undefined
+          }
+          data-invalid={invalid ? "true" : undefined}
+          data-submitting={form.formState.isSubmitting ? "true" : undefined}
+          onSubmit={
+            onSubmit === undefined && handleValidatedSubmit === undefined
+              ? undefined
+              : createSubmitHandler(onSubmit, handleValidatedSubmit)
+          }
+          ref={formRef}
+          {...formProps}
+        >
+          {typeof children === "function" ? children(form) : children}
+        </form>
+      </FormProvider>
+    </FormRootContext.Provider>
+  );
+}
+
+function FormInner<TFieldValues extends FieldValues = FieldValues>(
+  {
+    children,
+    className,
+    controlId,
+    defaultValues,
+    descriptionId,
+    disabled = false,
+    form: providedForm,
+    invalid = false,
+    messageId,
+    onError,
+    onSubmit,
+    onValidSubmit,
+    required = false,
+    resolver,
+    schema,
+    values,
+    ...props
+  }: FormProps<TFieldValues>,
+  ref: React.ForwardedRef<HTMLFormElement>,
+) {
+  const internalForm = useForm<TFieldValues>({
+    defaultValues,
+    resolver:
+      schema === undefined
+        ? resolver
+        : (zodResolver(schema) as Resolver<TFieldValues>),
+    values,
+  });
+  const form: FormInstance<TFieldValues> = providedForm ?? internalForm;
+  const isManagedForm =
+    providedForm !== undefined ||
+    resolver !== undefined ||
+    schema !== undefined;
+  const rootContextValue = useFormRootContextValue({
+    controlId,
+    descriptionId,
+    disabled,
+    invalid,
+    messageId,
+    required,
+  });
+  const handleValidatedSubmit = createManagedSubmitHandler(form, {
+    onError,
+    onValidSubmit,
+    shouldValidate:
+      isManagedForm || onValidSubmit !== undefined || onError !== undefined,
+  });
+
+  return (
+    <FormMarkup
+      className={className}
+      disabled={disabled}
+      form={form}
+      formProps={props}
+      formRef={ref}
+      handleValidatedSubmit={handleValidatedSubmit}
+      invalid={invalid}
+      onSubmit={onSubmit}
+      rootContextValue={rootContextValue}
+    >
+      {children}
+    </FormMarkup>
+  );
+}
+
+const FormBase = React.forwardRef(FormInner);
+FormBase.displayName = "Form";
+
+const Form = FormBase as <TFieldValues extends FieldValues = FieldValues>(
+  props: FormProps<TFieldValues> & React.RefAttributes<HTMLFormElement>,
+) => React.ReactElement;
+
+function FormField<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({ ...props }: ControllerProps<TFieldValues, TName>) {
+  const fieldContextValue = React.useMemo(
+    () => ({ name: props.name }),
+    [props.name],
+  );
+
+  return (
+    <FormFieldContext.Provider value={fieldContextValue}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+}
+
+function useFormField() {
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = useFormItemContext("useFormField");
+  const { formState, getFieldState } = useFormContext();
+
+  if (fieldContext === undefined) {
+    return {
+      disabled: itemContext.disabled,
+      error: undefined,
+      formDescriptionId: itemContext.descriptionId,
+      formItemId: itemContext.controlId,
+      formMessageId: itemContext.messageId,
+      hasDescription: itemContext.hasDescription,
+      hasMessage: itemContext.hasMessage,
+      hasMessageSlot: itemContext.hasMessageSlot,
+      id: itemContext.id,
+      invalid: itemContext.invalid,
+      isDirty: false,
+      isTouched: false,
+      isValidating: false,
+      name: "",
+      required: itemContext.required,
+    };
+  }
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  return {
+    disabled: itemContext.disabled,
+    error: fieldState.error,
+    formDescriptionId: itemContext.descriptionId,
+    formItemId: itemContext.controlId,
+    formMessageId: itemContext.messageId,
+    hasDescription: itemContext.hasDescription,
+    hasMessage: itemContext.hasMessage,
+    hasMessageSlot: itemContext.hasMessageSlot,
+    id: itemContext.id,
+    invalid: itemContext.invalid || fieldState.invalid,
+    isDirty: fieldState.isDirty,
+    isTouched: fieldState.isTouched,
+    isValidating: fieldState.isValidating,
+    name: fieldContext.name,
+    required: itemContext.required,
+  };
+}
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"div"> & {
+    disabled?: boolean;
+    invalid?: boolean;
+    required?: boolean;
+  }
+>(
+  (
+    {
+      children,
+      className,
+      disabled: itemDisabled,
+      invalid: itemInvalid,
+      required: itemRequired,
+      ...props
+    },
+    ref,
+  ) => {
+    const {
+      controlId: controlIdBase,
+      descriptionId: descriptionIdBase,
+      disabled,
+      invalid,
+      messageId: messageIdBase,
+      required,
+    } = useFormRootContext("FormItem");
+    const generatedId = React.useId();
+    const hasDescription = hasRenderedFormChild(children, "FormDescription");
+    const hasMessage = hasRenderedFormChild(children, "FormMessage");
+    const hasMessageSlot = hasFormChild(children, "FormMessage");
+
+    const effectiveDisabled = itemDisabled ?? disabled;
+    const effectiveInvalid = itemInvalid ?? invalid;
+    const effectiveRequired = itemRequired ?? required;
+
+    const value = React.useMemo<FormItemContextValue>(
+      () => ({
+        controlId: resolveItemId(controlIdBase, generatedId, "control"),
+        descriptionId: resolveItemId(
+          descriptionIdBase,
+          generatedId,
+          "description",
+        ),
+        disabled: effectiveDisabled,
+        hasDescription,
+        hasMessage,
+        hasMessageSlot,
+        id: generatedId,
+        invalid: effectiveInvalid,
+        messageId: resolveItemId(messageIdBase, generatedId, "message"),
+        required: effectiveRequired,
+      }),
+      [
+        controlIdBase,
+        descriptionIdBase,
+        effectiveDisabled,
+        effectiveInvalid,
+        effectiveRequired,
+        generatedId,
+        hasDescription,
+        hasMessage,
+        hasMessageSlot,
+        messageIdBase,
+      ],
+    );
+
+    return (
+      <FormItemContext.Provider value={value}>
+        <div className={cn("space-y-2", className)} ref={ref} {...props}>
+          {children}
+        </div>
+      </FormItemContext.Provider>
+    );
+  },
+);
+FormItem.displayName = "FormItem";
+
+const FormLabel = React.forwardRef<
+  React.ComponentRef<typeof Label>,
+  React.ComponentPropsWithoutRef<typeof Label>
+>(({ className, htmlFor, ...props }, ref) => {
+  const { formItemId, invalid } = useFormField();
+
+  return (
+    <Label
+      className={cn(invalid && "text-destructive", className)}
+      data-invalid={invalid ? "true" : undefined}
+      htmlFor={htmlFor ?? formItemId}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+FormLabel.displayName = "FormLabel";
+
+type FormControlProps = React.ComponentPropsWithoutRef<typeof Slot> & {
+  disabled?: boolean;
+  required?: boolean;
+};
+
+const FormControl = React.forwardRef<HTMLElement, FormControlProps>(
+  (
+    { disabled: controlDisabled, id: _id, required: controlRequired, ...props },
+    ref,
+  ) => {
+    const {
+      disabled,
+      error,
+      formDescriptionId,
+      formItemId,
+      formMessageId,
+      hasDescription,
+      hasMessage,
+      hasMessageSlot,
+      invalid,
+      required,
+    } = useFormField();
+    const { formState } = useFormContext();
+    const hasErrorMessage = hasVisibleContent(error?.message);
+    const describedBy = composeIds(
+      props["aria-describedby"],
+      hasDescription ? formDescriptionId : undefined,
+      error === undefined
+        ? hasMessage && invalid
+          ? formMessageId
+          : undefined
+        : hasMessageSlot && hasErrorMessage
+          ? formMessageId
+          : undefined,
+    );
+    const effectiveDisabled =
+      controlDisabled ?? (disabled || formState.isSubmitting);
+    const effectiveRequired = controlRequired ?? required;
+    const nativeConstraintProps: {
+      disabled?: boolean;
+      required?: boolean;
+    } = {
+      disabled: effectiveDisabled || undefined,
+      required: effectiveRequired || undefined,
+    };
+
+    return (
+      <Slot
+        {...props}
+        {...nativeConstraintProps}
+        aria-describedby={describedBy}
+        aria-disabled={
+          props["aria-disabled"] ?? (effectiveDisabled || undefined)
+        }
+        aria-invalid={props["aria-invalid"] ?? (invalid || undefined)}
+        aria-required={
+          props["aria-required"] ?? (effectiveRequired || undefined)
+        }
+        data-disabled={effectiveDisabled ? "true" : undefined}
+        data-invalid={invalid ? "true" : undefined}
+        id={formItemId}
+        ref={ref}
+      />
+    );
+  },
+);
+FormControl.displayName = "FormControl";
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.ComponentPropsWithoutRef<"p">
+>(({ className, id: _id, ...props }, ref) => {
+  const { formDescriptionId } = useFormField();
+
+  return (
+    <p
+      {...props}
+      className={cn("text-sm text-muted-foreground", className)}
+      id={formDescriptionId}
+      ref={ref}
+    />
+  );
+});
+FormDescription.displayName = "FormDescription";
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.ComponentPropsWithoutRef<"p">
+>(({ children, className, id: _id, ...props }, ref) => {
+  const { error, formMessageId, invalid } = useFormField();
+  const body = error?.message ?? children;
+
+  if (!hasVisibleContent(body)) {
+    return null;
+  }
+
+  return (
+    <p
+      {...props}
+      className={cn(
+        "text-sm font-medium",
+        invalid || error !== undefined ? "text-destructive" : "text-foreground",
+        className,
+      )}
+      id={formMessageId}
+      ref={ref}
+      role={invalid || error !== undefined ? "alert" : undefined}
+    >
+      {body}
+    </p>
+  );
+});
+FormMessage.displayName = "FormMessage";
+
 export {
   Form,
   FormControl,
   FormDescription,
+  FormField,
   FormItem,
   FormLabel,
   FormMessage,
-} from '@vllnt/ui'
+  useFormField,
+};

--- a/apps/registry/registry/default/gantt-chart/gantt-chart.tsx
+++ b/apps/registry/registry/default/gantt-chart/gantt-chart.tsx
@@ -1,2 +1,567 @@
-// Re-export from @vllnt/ui package
-export { GanttChart } from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useMemo,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const DEFAULT_LOCALE = "en-US";
+
+/**
+ * Color theme for a {@link GanttTask}'s bar.
+ *
+ * @public
+ */
+export type GanttColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "neutral"
+  | "purple"
+  | "red"
+  | "rose";
+
+const COLOR_CLASSES: Record<GanttColor, { bar: string; progress: string }> = {
+  amber: {
+    bar: "bg-amber-500/30",
+    progress: "bg-amber-600 dark:bg-amber-500",
+  },
+  blue: {
+    bar: "bg-blue-500/30",
+    progress: "bg-blue-600 dark:bg-blue-500",
+  },
+  emerald: {
+    bar: "bg-emerald-500/30",
+    progress: "bg-emerald-600 dark:bg-emerald-500",
+  },
+  neutral: {
+    bar: "bg-muted",
+    progress: "bg-muted-foreground",
+  },
+  purple: {
+    bar: "bg-purple-500/30",
+    progress: "bg-purple-600 dark:bg-purple-500",
+  },
+  red: {
+    bar: "bg-red-500/30",
+    progress: "bg-red-600 dark:bg-red-500",
+  },
+  rose: {
+    bar: "bg-rose-500/30",
+    progress: "bg-rose-600 dark:bg-rose-500",
+  },
+};
+
+/**
+ * Time-axis scale.
+ *
+ * @public
+ */
+export type GanttScale = "day" | "month" | "quarter" | "week";
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type GanttChartLabels = {
+  /** Aria-label prefix for milestone diamonds. Defaults to `"Milestone"`. */
+  milestone?: string;
+  /** Caption for the today line. Defaults to `"Today"`. */
+  today?: string;
+};
+
+const DEFAULT_LABELS = {
+  milestone: "Milestone",
+  today: "Today",
+} as const satisfies Required<GanttChartLabels>;
+
+/**
+ * One task bar inside a {@link GanttGroup}.
+ *
+ * @public
+ */
+export type GanttTask = {
+  /** Optional assignee label rendered next to the task title. */
+  assignee?: ReactNode;
+  /** Optional color theme. Defaults to `"blue"`. */
+  color?: GanttColor;
+  /** End date (inclusive). ISO string or `Date`. */
+  end: Date | string;
+  /** Stable identifier. */
+  id: string;
+  /** Optional progress percentage 0–100. */
+  progress?: number;
+  /** Start date (inclusive). ISO string or `Date`. */
+  start: Date | string;
+  /** Task title. */
+  title: ReactNode;
+};
+
+/**
+ * Group of related {@link GanttTask}s.
+ *
+ * @public
+ */
+export type GanttGroup = {
+  /** Stable identifier. */
+  id: string;
+  /** Group display name. */
+  name: ReactNode;
+  /** Tasks rendered in this group. */
+  tasks: GanttTask[];
+};
+
+/**
+ * Vertical milestone marker rendered on the timeline.
+ *
+ * @public
+ */
+export type GanttMilestone = {
+  /** Date the milestone falls on. */
+  date: Date | string;
+  /** Stable identifier. */
+  id: string;
+  /** Milestone title. */
+  title: ReactNode;
+};
+
+/**
+ * Props for {@link GanttChart}.
+ *
+ * @public
+ */
+export type GanttChartProps = {
+  /** End of the visible time window. */
+  endDate: Date | string;
+  /** Task groups, rendered in order. */
+  groups: GanttGroup[];
+  /** Localizable strings. */
+  labels?: GanttChartLabels;
+  /** BCP-47 locale tag. Defaults to `"en-US"`. */
+  locale?: string;
+  /** Optional milestone markers. */
+  milestones?: GanttMilestone[];
+  /** Optional override for the "today" date. Defaults to the current date. */
+  now?: Date | string;
+  /** Time-axis scale. Drives the tick interval and label format. Defaults to `"month"`. */
+  scale?: GanttScale;
+  /** Start of the visible time window. */
+  startDate: Date | string;
+  /** Width allocated to the task name column (left side). Defaults to `200`. */
+  taskColumnWidth?: number;
+} & ComponentPropsWithoutRef<"div">;
+
+function toDate(value: Date | string): Date {
+  return value instanceof Date ? new Date(value.getTime()) : new Date(value);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function diffInDays(later: Date, earlier: Date): number {
+  return (later.getTime() - earlier.getTime()) / MS_PER_DAY;
+}
+
+function buildTickFormatter(
+  scale: GanttScale,
+  locale: string,
+): (date: Date) => string {
+  switch (scale) {
+    case "day":
+      return new Intl.DateTimeFormat(locale, {
+        day: "2-digit",
+        month: "short",
+      }).format;
+    case "week":
+      return new Intl.DateTimeFormat(locale, {
+        day: "2-digit",
+        month: "short",
+      }).format;
+    case "month":
+      return new Intl.DateTimeFormat(locale, {
+        month: "short",
+        year: "numeric",
+      }).format;
+    case "quarter":
+      return (date: Date) => {
+        const quarter = Math.floor(date.getMonth() / 3) + 1;
+        return `Q${quarter.toString()} ${date.getFullYear().toString()}`;
+      };
+  }
+}
+
+function getTickStep(scale: GanttScale): number {
+  switch (scale) {
+    case "day":
+      return 1;
+    case "week":
+      return 7;
+    case "month":
+      return 30;
+    case "quarter":
+      return 91;
+  }
+}
+
+type ChartGeometry = {
+  end: Date;
+  pxPerDay: number;
+  start: Date;
+  ticks: { label: string; offset: number }[];
+  totalDays: number;
+};
+
+type TicksInput = {
+  end: Date;
+  locale: string;
+  scale: GanttScale;
+  start: Date;
+  totalDays: number;
+};
+
+function buildTicks(input: TicksInput): { label: string; offset: number }[] {
+  const { end, locale, scale, start, totalDays } = input;
+  const formatter = buildTickFormatter(scale, locale);
+  const stepDays = getTickStep(scale);
+  const tickCount = Math.floor(totalDays / stepDays);
+  return Array.from({ length: tickCount + 1 })
+    .map((_, index) => {
+      const day = index * stepDays;
+      return {
+        date: new Date(start.getTime() + day * MS_PER_DAY),
+        offset: day,
+      };
+    })
+    .filter((tick) => tick.date.getTime() <= end.getTime())
+    .map((tick) => ({ label: formatter(tick.date), offset: tick.offset }));
+}
+
+type GeometryOptions = {
+  endDate: Date | string;
+  locale: string;
+  scale: GanttScale;
+  startDate: Date | string;
+};
+
+function useChartGeometry(options: GeometryOptions): ChartGeometry {
+  const { endDate, locale, scale, startDate } = options;
+  return useMemo<ChartGeometry>(() => {
+    const start = toDate(startDate);
+    const end = toDate(endDate);
+    const totalDays = Math.max(1, diffInDays(end, start));
+    const ticks = buildTicks({ end, locale, scale, start, totalDays });
+    return {
+      end,
+      pxPerDay: 1 / totalDays,
+      start,
+      ticks,
+      totalDays,
+    };
+  }, [endDate, locale, scale, startDate]);
+}
+
+type TaskBarProps = {
+  geometry: ChartGeometry;
+  task: GanttTask;
+};
+
+function TaskBar({ geometry, task }: TaskBarProps): ReactNode {
+  const start = toDate(task.start);
+  const end = toDate(task.end);
+  const offsetDays = diffInDays(start, geometry.start);
+  const durationDays = Math.max(0.5, diffInDays(end, start));
+  const leftRatio = clamp(offsetDays / geometry.totalDays, 0, 1);
+  const widthRatio = clamp(durationDays / geometry.totalDays, 0, 1 - leftRatio);
+  const palette = COLOR_CLASSES[task.color ?? "blue"];
+  const progress = clamp(task.progress ?? 0, 0, 100);
+  const ariaLabel =
+    typeof task.title === "string"
+      ? `${task.title} from ${start.toISOString().slice(0, 10)} to ${end.toISOString().slice(0, 10)}, ${progress.toString()} percent complete`
+      : undefined;
+  return (
+    <div
+      aria-label={ariaLabel}
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={progress}
+      className={cn(
+        "absolute top-1.5 flex h-5 items-center overflow-hidden rounded-md ring-1 ring-border",
+        palette.bar,
+      )}
+      data-task-id={task.id}
+      role="progressbar"
+      style={{
+        left: `${(leftRatio * 100).toString()}%`,
+        width: `${(widthRatio * 100).toString()}%`,
+      }}
+    >
+      <span
+        aria-hidden="true"
+        className={cn("h-full rounded-md", palette.progress)}
+        style={{ width: `${progress.toString()}%` }}
+      />
+    </div>
+  );
+}
+
+type MilestoneMarkerProps = {
+  geometry: ChartGeometry;
+  label: string;
+  milestone: GanttMilestone;
+};
+
+function MilestoneMarker({
+  geometry,
+  label,
+  milestone,
+}: MilestoneMarkerProps): ReactNode {
+  const date = toDate(milestone.date);
+  const offsetDays = diffInDays(date, geometry.start);
+  if (offsetDays < 0 || offsetDays > geometry.totalDays) return null;
+  const leftRatio = offsetDays / geometry.totalDays;
+  const titleText = typeof milestone.title === "string" ? milestone.title : "";
+  return (
+    <div
+      aria-label={`${label}: ${titleText}`}
+      className="absolute top-0 z-10 -ml-1.5 flex flex-col items-center"
+      data-milestone-id={milestone.id}
+      style={{ left: `${(leftRatio * 100).toString()}%` }}
+    >
+      <div
+        aria-hidden="true"
+        className="h-3 w-3 rotate-45 bg-amber-500 ring-2 ring-background"
+      />
+      {titleText ? (
+        <span className="mt-0.5 whitespace-nowrap rounded bg-amber-500/20 px-1 text-[10px] font-medium text-amber-900 dark:text-amber-200">
+          {titleText}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+type TodayLineProps = {
+  geometry: ChartGeometry;
+  label: string;
+  now: Date;
+};
+
+function TodayLine({ geometry, label, now }: TodayLineProps): ReactNode {
+  const offsetDays = diffInDays(now, geometry.start);
+  if (offsetDays < 0 || offsetDays > geometry.totalDays) return null;
+  const leftRatio = offsetDays / geometry.totalDays;
+  return (
+    <div
+      aria-label={label}
+      className="pointer-events-none absolute inset-y-0 z-10"
+      style={{ left: `${(leftRatio * 100).toString()}%` }}
+    >
+      <div
+        aria-hidden="true"
+        className="absolute inset-y-0 w-0.5 -translate-x-1/2 bg-destructive"
+      />
+      <span className="absolute -top-5 -translate-x-1/2 whitespace-nowrap rounded bg-destructive/15 px-1 text-[10px] font-semibold uppercase tracking-wide text-destructive">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+type AxisProps = {
+  geometry: ChartGeometry;
+};
+
+function Axis({ geometry }: AxisProps): ReactNode {
+  return (
+    <div className="relative flex h-7 items-end border-b border-border text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+      {geometry.ticks.map((tick) => (
+        <span
+          className="absolute -translate-x-1/2 px-1"
+          key={tick.offset}
+          style={{
+            left: `${((tick.offset / geometry.totalDays) * 100).toString()}%`,
+          }}
+        >
+          {tick.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+type TaskRowProps = {
+  geometry: ChartGeometry;
+  task: GanttTask;
+};
+
+function TaskRow({ geometry, task }: TaskRowProps): ReactNode {
+  return (
+    <div className="relative flex h-8 items-center border-b border-border/40">
+      <TaskBar geometry={geometry} task={task} />
+    </div>
+  );
+}
+
+type LeftColumnProps = {
+  groups: GanttGroup[];
+  taskColumnWidth: number;
+};
+
+function LeftColumn({ groups, taskColumnWidth }: LeftColumnProps): ReactNode {
+  return (
+    <div
+      className="flex flex-col border-r border-border bg-background"
+      style={{
+        minWidth: `${taskColumnWidth.toString()}px`,
+        width: `${taskColumnWidth.toString()}px`,
+      }}
+    >
+      <div className="h-7 border-b border-border" />
+      {groups.map((group) => (
+        <div className="flex flex-col" key={group.id}>
+          <div className="flex h-7 items-center border-b border-border/60 px-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {group.name}
+          </div>
+          {group.tasks.map((task) => (
+            <div
+              className="flex h-8 items-center justify-between gap-2 border-b border-border/40 px-3 text-sm text-foreground"
+              key={task.id}
+            >
+              <span className="truncate">{task.title}</span>
+              {task.assignee ? (
+                <span className="text-xs text-muted-foreground">
+                  {task.assignee}
+                </span>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+type TimelineColumnProps = {
+  geometry: ChartGeometry;
+  groups: GanttGroup[];
+  labels: Required<GanttChartLabels>;
+  milestones: GanttMilestone[];
+  now: Date;
+};
+
+function TimelineColumn({
+  geometry,
+  groups,
+  labels,
+  milestones,
+  now,
+}: TimelineColumnProps): ReactNode {
+  return (
+    <div className="relative min-w-0 flex-1">
+      <Axis geometry={geometry} />
+      <div className="relative">
+        {groups.map((group) => (
+          <div className="flex flex-col" key={group.id}>
+            <div className="h-7 border-b border-border/60 bg-muted/20" />
+            {group.tasks.map((task) => (
+              <TaskRow geometry={geometry} key={task.id} task={task} />
+            ))}
+          </div>
+        ))}
+        {milestones.map((milestone) => (
+          <MilestoneMarker
+            geometry={geometry}
+            key={milestone.id}
+            label={labels.milestone}
+            milestone={milestone}
+          />
+        ))}
+        <TodayLine geometry={geometry} label={labels.today} now={now} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Pure-SVG-free Gantt chart for project planning. Renders task bars with
+ * progress overlays, milestone diamonds, and a today indicator across a
+ * configurable time scale (day / week / month / quarter). The left column
+ * shows group headers and task names; the right column is the timeline.
+ *
+ * Drag-to-edit, dependency arrows, critical-path highlighting, and
+ * virtualization for large datasets are intentionally **out of scope** —
+ * the consumer drives those externally and feeds data through `groups`.
+ *
+ * @example
+ * ```tsx
+ * <GanttChart
+ *   startDate="2026-01-01"
+ *   endDate="2026-12-31"
+ *   scale="month"
+ *   groups={[
+ *     {
+ *       id: "phase-1",
+ *       name: "Phase 1",
+ *       tasks: [
+ *         { id: "design", title: "Design system", start: "2026-01-15", end: "2026-02-28", progress: 100, color: "blue" },
+ *         { id: "core", title: "Core components", start: "2026-02-01", end: "2026-04-15", progress: 65, color: "emerald" },
+ *       ],
+ *     },
+ *   ]}
+ *   milestones={[{ id: "v1", date: "2026-04-15", title: "v1.0" }]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
+  (props, ref) => {
+    const {
+      className,
+      endDate,
+      groups,
+      labels,
+      locale = DEFAULT_LOCALE,
+      milestones = [],
+      now,
+      scale = "month",
+      startDate,
+      taskColumnWidth = 200,
+      ...rest
+    } = props;
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const geometry = useChartGeometry({ endDate, locale, scale, startDate });
+    const nowDate = useMemo(() => (now ? toDate(now) : new Date()), [now]);
+
+    return (
+      <div
+        className={cn(
+          "flex w-full overflow-x-auto rounded-2xl border bg-background text-foreground",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <LeftColumn groups={groups} taskColumnWidth={taskColumnWidth} />
+        <TimelineColumn
+          geometry={geometry}
+          groups={groups}
+          labels={resolvedLabels}
+          milestones={milestones}
+          now={nowDate}
+        />
+      </div>
+    );
+  },
+);
+GanttChart.displayName = "GanttChart";

--- a/apps/registry/registry/default/geography-quiz-map/geography-quiz-map.tsx
+++ b/apps/registry/registry/default/geography-quiz-map/geography-quiz-map.tsx
@@ -1,11 +1,552 @@
-export {
-  GeographyQuizMap,
-  type GeographyQuizMapLabels,
-  GeographyQuizMapPrompt,
-  type GeographyQuizMapProps,
-  GeographyQuizMapResults,
-  GeographyQuizMapScore,
-  type QuizAnswer,
-  type QuizQuestion,
-  type QuizRegion,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+const VIEWBOX_WIDTH = 1000;
+const VIEWBOX_HEIGHT = 500;
+const FEEDBACK_DURATION_MS = 800;
+
+/**
+ * Geographic coordinate `[longitude, latitude]`.
+ *
+ * @public
+ */
+export type GeoPosition = [number, number];
+
+/**
+ * A region polygon — outer ring of `[lng, lat]` positions; close the
+ * ring by repeating the first point.
+ *
+ * @public
+ */
+export type QuizRegion = {
+  /** Outer ring positions. */
+  coordinates: GeoPosition[];
+  /** Stable identifier — referenced by `QuizQuestion.answerRegionId`. */
+  id: string;
+  /** Human-readable name (used in the prompt and results panel). */
+  name: string;
+};
+
+/**
+ * Identify-mode question. The user clicks the region matching `answerRegionId`.
+ *
+ * @public
+ */
+export type QuizQuestion = {
+  /** Region id of the correct answer. */
+  answerRegionId: string;
+  /** Stable identifier. */
+  id: string;
+  /** Human-readable prompt rendered above the map. */
+  prompt: ReactNode;
+};
+
+/**
+ * Outcome for a single answered question.
+ *
+ * @public
+ */
+export type QuizAnswer = {
+  /** `true` when the selected region matches the answer. */
+  correct: boolean;
+  /** The original question. */
+  question: QuizQuestion;
+  /** Region id the user clicked. */
+  selectedRegionId: string;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type GeographyQuizMapLabels = {
+  /** Aria-label for the quiz region. Defaults to `"Geography quiz map"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Geography quiz map",
+} as const satisfies Required<GeographyQuizMapLabels>;
+
+type Phase = "complete" | "playing";
+type Feedback = "correct" | "incorrect";
+
+type QuizCtx = {
+  answers: QuizAnswer[];
+  current?: QuizQuestion;
+  feedback?: Feedback;
+  phase: Phase;
+  questionIndex: number;
+  totalQuestions: number;
+};
+
+const QuizContext = createContext<null | QuizCtx>(null);
+
+function useQuizContext(): QuizCtx {
+  const ctx = useContext(QuizContext);
+  if (!ctx) {
+    throw new Error("GeographyQuizMap subcomponent used outside its root.");
+  }
+  return ctx;
+}
+
+function projectEquirectangular(position: GeoPosition): {
+  x: number;
+  y: number;
+} {
+  const [lng, lat] = position;
+  const x = ((lng + 180) / 360) * VIEWBOX_WIDTH;
+  const y = ((90 - lat) / 180) * VIEWBOX_HEIGHT;
+  return { x, y };
+}
+
+function regionPath(region: QuizRegion): string {
+  const points = region.coordinates
+    .map((coord, index) => {
+      const projected = projectEquirectangular(coord);
+      return `${index === 0 ? "M" : "L"}${projected.x.toString()},${projected.y.toString()}`;
+    })
+    .join(" ");
+  return `${points} Z`;
+}
+
+/**
+ * Props for {@link GeographyQuizMap}.
+ *
+ * @public
+ */
+export type GeographyQuizMapProps = {
+  /** Optional backdrop image URL. */
+  backdrop?: string;
+  /** Aria-label for the backdrop image. */
+  backdropAlt?: string;
+  /** Localizable strings. */
+  labels?: GeographyQuizMapLabels;
+  /** Fires once the user finishes every question. */
+  onComplete?: (answers: QuizAnswer[]) => void;
+  /** Quiz questions in order. */
+  questions: QuizQuestion[];
+  /** Region polygons. */
+  regions: QuizRegion[];
+} & ComponentPropsWithoutRef<"section">;
+
+type RegionPathProps = {
+  disabled: boolean;
+  feedback?: Feedback;
+  isAnswerForCurrent: boolean;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+  region: QuizRegion;
+  showAnswerFlash: boolean;
+};
+
+function RegionShape({
+  disabled,
+  feedback,
+  isAnswerForCurrent,
+  isSelected,
+  onSelect,
+  region,
+  showAnswerFlash,
+}: RegionPathProps): ReactNode {
+  let fill = "rgb(226, 232, 240)";
+  if (isSelected && feedback === "correct") fill = "rgb(34, 197, 94)";
+  else if (isSelected && feedback === "incorrect") fill = "rgb(239, 68, 68)";
+  else if (showAnswerFlash && isAnswerForCurrent && !isSelected)
+    fill = "rgba(34, 197, 94, 0.4)";
+  return (
+    <path
+      aria-label={region.name}
+      className={cn(
+        "stroke-background outline-none transition-colors",
+        disabled
+          ? "cursor-not-allowed"
+          : "cursor-pointer hover:opacity-90 focus-visible:opacity-90",
+      )}
+      d={regionPath(region)}
+      data-region-id={region.id}
+      data-state={
+        isSelected
+          ? feedback === "correct"
+            ? "correct"
+            : "incorrect"
+          : showAnswerFlash && isAnswerForCurrent
+            ? "answer"
+            : undefined
+      }
+      fill={fill}
+      onClick={() => {
+        if (!disabled) onSelect(region.id);
+      }}
+      onKeyDown={(event) => {
+        if (disabled) return;
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        onSelect(region.id);
+      }}
+      role="button"
+      strokeWidth={1}
+      tabIndex={disabled ? -1 : 0}
+    />
+  );
+}
+
+type StageProps = {
+  backdrop?: string;
+  backdropAlt?: string;
+  current?: QuizQuestion;
+  disabled: boolean;
+  feedback?: Feedback;
+  onSelect: (id: string) => void;
+  regions: QuizRegion[];
+  selectedRegionId?: string;
+};
+
+function Stage({
+  backdrop,
+  backdropAlt,
+  current,
+  disabled,
+  feedback,
+  onSelect,
+  regions,
+  selectedRegionId,
+}: StageProps): ReactNode {
+  return (
+    <svg
+      className="block h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      viewBox={`0 0 ${VIEWBOX_WIDTH.toString()} ${VIEWBOX_HEIGHT.toString()}`}
+    >
+      <rect
+        className="fill-muted"
+        height={VIEWBOX_HEIGHT}
+        width={VIEWBOX_WIDTH}
+        x="0"
+        y="0"
+      />
+      {backdrop ? (
+        <image
+          aria-label={backdropAlt}
+          height={VIEWBOX_HEIGHT}
+          href={backdrop}
+          preserveAspectRatio="xMidYMid slice"
+          width={VIEWBOX_WIDTH}
+          x="0"
+          y="0"
+        />
+      ) : null}
+      {regions.map((region) => (
+        <RegionShape
+          disabled={disabled}
+          feedback={feedback}
+          isAnswerForCurrent={current?.answerRegionId === region.id}
+          isSelected={selectedRegionId === region.id}
+          key={region.id}
+          onSelect={onSelect}
+          region={region}
+          showAnswerFlash={feedback === "incorrect"}
+        />
+      ))}
+    </svg>
+  );
+}
+
+/**
+ * Prompt slot. Renders the current question text on top of the map.
+ *
+ * @public
+ */
+export const GeographyQuizMapPrompt = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ className, ...rest }, ref) => {
+  const { current, phase } = useQuizContext();
+  if (phase !== "playing" || !current) return null;
+  return (
+    <div
+      className={cn(
+        "absolute inset-x-3 top-3 z-10 rounded-md border bg-background/95 px-3 py-2 text-center text-sm font-medium text-foreground shadow-sm backdrop-blur",
+        className,
+      )}
+      data-quiz-prompt
+      ref={ref}
+      {...rest}
+    >
+      {current.prompt}
+    </div>
+  );
+});
+GeographyQuizMapPrompt.displayName = "GeographyQuizMapPrompt";
+
+/**
+ * Score slot. Renders `correct / total · streak%`.
+ *
+ * @public
+ */
+export const GeographyQuizMapScore = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ className, ...rest }, ref) => {
+  const { answers, totalQuestions } = useQuizContext();
+  const correct = answers.filter((entry) => entry.correct).length;
+  const accuracy =
+    answers.length === 0 ? 0 : Math.round((correct / answers.length) * 100);
+  return (
+    <div
+      className={cn(
+        "absolute right-3 top-3 z-10 rounded-md border bg-background/95 px-2 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur",
+        className,
+      )}
+      data-quiz-score
+      ref={ref}
+      {...rest}
+    >
+      {`${correct.toString()} / ${totalQuestions.toString()} · ${accuracy.toString()}%`}
+    </div>
+  );
+});
+GeographyQuizMapScore.displayName = "GeographyQuizMapScore";
+
+/**
+ * Results slot. Renders the per-question outcome list once the
+ * user finishes every question.
+ *
+ * @public
+ */
+export const GeographyQuizMapResults = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ className, ...rest }, ref) => {
+  const { answers, phase, totalQuestions } = useQuizContext();
+  if (phase !== "complete") return null;
+  const correct = answers.filter((entry) => entry.correct).length;
+  return (
+    <div
+      className={cn(
+        "absolute inset-3 z-20 flex flex-col gap-3 overflow-auto rounded-md border bg-background/95 p-4 text-sm text-foreground shadow-md backdrop-blur",
+        className,
+      )}
+      data-quiz-results
+      ref={ref}
+      {...rest}
+    >
+      <h3 className="text-base font-semibold">
+        {`Results · ${correct.toString()} / ${totalQuestions.toString()}`}
+      </h3>
+      <ol className="space-y-1">
+        {answers.map((entry) => (
+          <li
+            className={cn(
+              "flex items-center gap-2 rounded-md border px-2 py-1",
+              entry.correct
+                ? "border-emerald-300 bg-emerald-500/10"
+                : "border-red-300 bg-red-500/10",
+            )}
+            data-answer-correct={entry.correct ? "true" : "false"}
+            data-answer-id={entry.question.id}
+            key={entry.question.id}
+          >
+            <span aria-hidden="true">{entry.correct ? "✓" : "✗"}</span>
+            <span className="flex-1">{entry.question.prompt}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+});
+GeographyQuizMapResults.displayName = "GeographyQuizMapResults";
+
+type QuizState = {
+  answers: QuizAnswer[];
+  feedback?: Feedback;
+  questionIndex: number;
+  selectedRegionId?: string;
+};
+
+function useQuizState(arguments_: {
+  onComplete?: (answers: QuizAnswer[]) => void;
+  questions: QuizQuestion[];
+}): {
+  handleSelect: (regionId: string) => void;
+  state: QuizState;
+} {
+  const { onComplete, questions } = arguments_;
+  const [state, setState] = useState<QuizState>({
+    answers: [],
+    feedback: undefined,
+    questionIndex: 0,
+    selectedRegionId: undefined,
+  });
+
+  const handleSelect = useCallback(
+    (regionId: string) => {
+      setState((current) => {
+        if (current.feedback) return current;
+        const question = questions[current.questionIndex];
+        if (!question) return current;
+        const correct = question.answerRegionId === regionId;
+        const next: QuizState = {
+          ...current,
+          answers: [
+            ...current.answers,
+            { correct, question, selectedRegionId: regionId },
+          ],
+          feedback: correct ? "correct" : "incorrect",
+          selectedRegionId: regionId,
+        };
+        scheduleAdvance(setState, onComplete, questions);
+        return next;
+      });
+    },
+    [onComplete, questions],
+  );
+
+  return { handleSelect, state };
+}
+
+function scheduleAdvance(
+  setState: React.Dispatch<React.SetStateAction<QuizState>>,
+  onComplete: ((answers: QuizAnswer[]) => void) | undefined,
+  questions: QuizQuestion[],
+): void {
+  if (typeof window === "undefined") return;
+  window.setTimeout(() => {
+    setState((current) => {
+      const nextIndex = current.questionIndex + 1;
+      if (nextIndex >= questions.length) {
+        onComplete?.(current.answers);
+        return {
+          ...current,
+          feedback: undefined,
+          questionIndex: questions.length,
+          selectedRegionId: undefined,
+        };
+      }
+      return {
+        ...current,
+        feedback: undefined,
+        questionIndex: nextIndex,
+        selectedRegionId: undefined,
+      };
+    });
+  }, FEEDBACK_DURATION_MS);
+}
+
+/**
+ * Interactive map quiz. Identify-mode: each question asks the user to
+ * click the region matching the prompt. Correct clicks flash green,
+ * incorrect clicks flash red and reveal the correct region. After the
+ * final question the {@link GeographyQuizMapResults} slot renders the
+ * per-question outcome list and `onComplete` fires.
+ *
+ * Compose with {@link GeographyQuizMapPrompt}, {@link GeographyQuizMapScore},
+ * and {@link GeographyQuizMapResults} as children.
+ *
+ * @example
+ * ```tsx
+ * <GeographyQuizMap
+ *   regions={countries}
+ *   questions={[
+ *     { id: "q1", prompt: "Click on France", answerRegionId: "FR" },
+ *     { id: "q2", prompt: "Click on Germany", answerRegionId: "DE" },
+ *   ]}
+ *   onComplete={(answers) => console.info(answers)}
+ * >
+ *   <GeographyQuizMapPrompt />
+ *   <GeographyQuizMapScore />
+ *   <GeographyQuizMapResults />
+ * </GeographyQuizMap>
+ * ```
+ *
+ * @public
+ */
+export const GeographyQuizMap = forwardRef<HTMLElement, GeographyQuizMapProps>(
+  (props, ref) => {
+    const {
+      backdrop,
+      backdropAlt,
+      children,
+      className,
+      labels,
+      onComplete,
+      questions,
+      regions,
+      ...rest
+    } = props;
+    const titleId = useId();
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const { handleSelect, state } = useQuizState({ onComplete, questions });
+
+    const phase: Phase =
+      state.questionIndex >= questions.length ? "complete" : "playing";
+    const current = questions[state.questionIndex];
+
+    const ctx = useMemo<QuizCtx>(
+      () => ({
+        answers: state.answers,
+        current,
+        feedback: state.feedback,
+        phase,
+        questionIndex: state.questionIndex,
+        totalQuestions: questions.length,
+      }),
+      [
+        current,
+        phase,
+        questions.length,
+        state.answers,
+        state.feedback,
+        state.questionIndex,
+      ],
+    );
+
+    return (
+      <QuizContext.Provider value={ctx}>
+        <section
+          aria-labelledby={titleId}
+          className={cn(
+            "relative aspect-[2/1] w-full overflow-hidden rounded-2xl border bg-background text-foreground",
+            className,
+          )}
+          ref={ref}
+          {...rest}
+        >
+          <span className="sr-only" id={titleId}>
+            {resolvedLabels.region}
+          </span>
+          <Stage
+            backdrop={backdrop}
+            backdropAlt={backdropAlt}
+            current={current}
+            disabled={phase === "complete" || Boolean(state.feedback)}
+            feedback={state.feedback}
+            onSelect={handleSelect}
+            regions={regions}
+            selectedRegionId={state.selectedRegionId}
+          />
+          {children}
+        </section>
+      </QuizContext.Provider>
+    );
+  },
+);
+GeographyQuizMap.displayName = "GeographyQuizMap";

--- a/apps/registry/registry/default/globe-3d/globe-3d.tsx
+++ b/apps/registry/registry/default/globe-3d/globe-3d.tsx
@@ -1,11 +1,642 @@
-export {
-  Globe3D,
-  type Globe3DLabels,
-  type Globe3DProps,
-  GlobeArc,
-  type GlobeArcProps,
-  type GlobeColor,
-  type GlobeCoord,
-  GlobeMarker,
-  type GlobeMarkerProps,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  Children,
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  isValidElement,
+  type PointerEvent as ReactPointerEvent,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+const VIEWBOX = 400;
+const SPHERE_RADIUS = 180;
+const CENTER = VIEWBOX / 2;
+
+/**
+ * Geographic coordinate as `{ lat, lng }`.
+ *
+ * @public
+ */
+export type GlobeCoord = { lat: number; lng: number };
+
+/**
+ * Color theme for markers and arcs.
+ *
+ * @public
+ */
+export type GlobeColor =
+  | "amber"
+  | "blue"
+  | "cyan"
+  | "emerald"
+  | "purple"
+  | "red"
+  | "rose";
+
+const PALETTE: Record<GlobeColor, { fill: string; stroke: string }> = {
+  amber: { fill: "fill-amber-500", stroke: "stroke-amber-500" },
+  blue: { fill: "fill-blue-500", stroke: "stroke-blue-500" },
+  cyan: { fill: "fill-cyan-500", stroke: "stroke-cyan-500" },
+  emerald: { fill: "fill-emerald-500", stroke: "stroke-emerald-500" },
+  purple: { fill: "fill-purple-500", stroke: "stroke-purple-500" },
+  red: { fill: "fill-red-500", stroke: "stroke-red-500" },
+  rose: { fill: "fill-rose-500", stroke: "stroke-rose-500" },
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type Globe3DLabels = {
+  /** Aria-label for the globe region. Defaults to `"Globe"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Globe",
+} as const satisfies Required<Globe3DLabels>;
+
+type Vec3 = { x: number; y: number; z: number };
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function rotate(vector: Vec3, lngOffset: number, latOffset: number): Vec3 {
+  const yawRad = toRadians(lngOffset);
+  const pitchRad = toRadians(latOffset);
+  const cosY = Math.cos(yawRad);
+  const sinY = Math.sin(yawRad);
+  const xy = vector.x * cosY + vector.z * sinY;
+  const zy = -vector.x * sinY + vector.z * cosY;
+  const cosP = Math.cos(pitchRad);
+  const sinP = Math.sin(pitchRad);
+  const yp = vector.y * cosP - zy * sinP;
+  const zp = vector.y * sinP + zy * cosP;
+  return { x: xy, y: yp, z: zp };
+}
+
+function latLngToVector({ lat, lng }: GlobeCoord): Vec3 {
+  const phi = toRadians(90 - lat);
+  const theta = toRadians(lng);
+  return {
+    x: Math.sin(phi) * Math.sin(theta),
+    y: Math.cos(phi),
+    z: Math.sin(phi) * Math.cos(theta),
+  };
+}
+
+function project(
+  coord: GlobeCoord,
+  rotationLng: number,
+  rotationLat: number,
+): { visible: boolean; x: number; y: number; z: number } {
+  const baseVector = latLngToVector(coord);
+  const rotated = rotate(baseVector, rotationLng, rotationLat);
+  return {
+    visible: rotated.z >= 0,
+    x: CENTER + rotated.x * SPHERE_RADIUS,
+    y: CENTER - rotated.y * SPHERE_RADIUS,
+    z: rotated.z,
+  };
+}
+
+type Ctx = {
+  rotationLat: number;
+  rotationLng: number;
+};
+
+const GlobeContext = createContext<Ctx | null>(null);
+
+function useGlobeContext(): Ctx {
+  const ctx = useContext(GlobeContext);
+  if (!ctx) {
+    throw new Error("Globe3D subcomponent used outside its root.");
+  }
+  return ctx;
+}
+
+/**
+ * Props for {@link GlobeMarker}.
+ *
+ * @public
+ */
+export type GlobeMarkerProps = {
+  /** Color theme. Defaults to `"red"`. */
+  color?: GlobeColor;
+  /** Stable id used for analytics + React keys. */
+  id?: string;
+  /** Optional label rendered next to the marker. */
+  label?: ReactNode;
+  /** Latitude. Positive = north. */
+  lat: number;
+  /** Longitude. Positive = east. */
+  lng: number;
+} & Omit<ComponentPropsWithoutRef<"g">, "id">;
+
+/**
+ * Point marker pinned to a `[lat, lng]`. Hidden when the point falls on
+ * the far side of the globe.
+ *
+ * @public
+ */
+export const GlobeMarker = forwardRef<SVGGElement, GlobeMarkerProps>(
+  (props, ref) => {
+    const { color = "red", id, label, lat, lng, ...rest } = props;
+    const { rotationLat, rotationLng } = useGlobeContext();
+    const projected = project({ lat, lng }, rotationLng, rotationLat);
+    if (!projected.visible) return null;
+    const palette = PALETTE[color];
+    return (
+      <g
+        data-marker-id={id}
+        data-marker-visible="true"
+        ref={ref}
+        transform={`translate(${projected.x.toString()}, ${projected.y.toString()})`}
+        {...rest}
+      >
+        <circle
+          className={cn("stroke-background", palette.fill)}
+          r="5"
+          strokeWidth="1.5"
+        />
+        {label ? (
+          <text
+            className="select-none fill-foreground text-[10px] font-semibold"
+            dominantBaseline="middle"
+            textAnchor="middle"
+            y="-10"
+          >
+            {label}
+          </text>
+        ) : null}
+      </g>
+    );
+  },
+);
+GlobeMarker.displayName = "GlobeMarker";
+
+/**
+ * Props for {@link GlobeArc}.
+ *
+ * @public
+ */
+export type GlobeArcProps = {
+  /** Color theme. Defaults to `"cyan"`. */
+  color?: GlobeColor;
+  /** Origin coordinate. */
+  from: GlobeCoord;
+  /** Stable id used for analytics + React keys. */
+  id?: string;
+  /** Stroke width in viewBox units. Defaults to `2`. */
+  strokeWidth?: number;
+  /** Destination coordinate. */
+  to: GlobeCoord;
+} & Omit<ComponentPropsWithoutRef<"path">, "d" | "id" | "stroke">;
+
+function buildArc(arguments_: {
+  from: GlobeCoord;
+  rotationLat: number;
+  rotationLng: number;
+  to: GlobeCoord;
+}): string {
+  const { from, rotationLat, rotationLng, to } = arguments_;
+  const samples = 36;
+  return Array.from({ length: samples + 1 })
+    .map((_, index) => {
+      const t = index / samples;
+      const lat = from.lat + (to.lat - from.lat) * t;
+      const lng = from.lng + (to.lng - from.lng) * t;
+      return project({ lat, lng }, rotationLng, rotationLat);
+    })
+    .reduce<{ path: string; pen: "down" | "up" }>(
+      (state, projected) => {
+        if (!projected.visible) return { path: state.path, pen: "up" };
+        const head = state.pen === "up" ? "M" : "L";
+        const separator = state.path.length > 0 ? " " : "";
+        return {
+          path: `${state.path}${separator}${head}${projected.x.toString()},${projected.y.toString()}`,
+          pen: "down",
+        };
+      },
+      { path: "", pen: "up" },
+    ).path;
+}
+
+/**
+ * Great-circle-style arc between two coordinates. The component clips
+ * any segment on the far side of the globe.
+ *
+ * @public
+ */
+export const GlobeArc = forwardRef<SVGPathElement, GlobeArcProps>(
+  (props, ref) => {
+    const { color = "cyan", from, id, strokeWidth = 2, to, ...rest } = props;
+    const { rotationLat, rotationLng } = useGlobeContext();
+    const path = buildArc({ from, rotationLat, rotationLng, to });
+    if (!path) return null;
+    const palette = PALETTE[color];
+    return (
+      <path
+        className={cn("fill-none", palette.stroke)}
+        d={path}
+        data-arc-id={id}
+        ref={ref}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+        {...rest}
+      />
+    );
+  },
+);
+GlobeArc.displayName = "GlobeArc";
+
+type GraticuleProps = {
+  rotationLat: number;
+  rotationLng: number;
+};
+
+function buildLine(arguments_: {
+  points: GlobeCoord[];
+  rotationLat: number;
+  rotationLng: number;
+}): string {
+  const { points, rotationLat, rotationLng } = arguments_;
+  return points
+    .map((coord) => project(coord, rotationLng, rotationLat))
+    .reduce<{ path: string; pen: "down" | "up" }>(
+      (state, projected) => {
+        if (!projected.visible) return { path: state.path, pen: "up" };
+        const head = state.pen === "up" ? "M" : "L";
+        const separator = state.path.length > 0 ? " " : "";
+        return {
+          path: `${state.path}${separator}${head}${projected.x.toString()},${projected.y.toString()}`,
+          pen: "down",
+        };
+      },
+      { path: "", pen: "up" },
+    ).path;
+}
+
+function range(start: number, end: number, step: number): number[] {
+  const length = Math.floor((end - start) / step) + 1;
+  return Array.from({ length }).map((_, index) => start + index * step);
+}
+
+function Graticule({ rotationLat, rotationLng }: GraticuleProps): ReactNode {
+  const parallels = range(-60, 60, 30).map<GlobeCoord[]>((lat) =>
+    range(-180, 180, 5).map((lng) => ({ lat, lng })),
+  );
+  const meridians = range(-150, 180, 30).map<GlobeCoord[]>((lng) =>
+    range(-85, 85, 5).map((lat) => ({ lat, lng })),
+  );
+  const lines = [...parallels, ...meridians]
+    .map((points) => buildLine({ points, rotationLat, rotationLng }))
+    .filter((path) => path.length > 0);
+  return (
+    <g
+      className="fill-none stroke-foreground/20"
+      data-globe-graticule
+      strokeWidth={0.5}
+    >
+      {lines.map((path) => (
+        <path d={path} key={path} />
+      ))}
+    </g>
+  );
+}
+
+type SphereProps = {
+  children: ReactNode;
+  rotationLat: number;
+  rotationLng: number;
+};
+
+function Sphere({
+  children,
+  rotationLat,
+  rotationLng,
+}: SphereProps): ReactNode {
+  return (
+    <svg
+      aria-hidden="true"
+      className="block h-full w-full touch-none"
+      data-rotation-lat={rotationLat}
+      data-rotation-lng={rotationLng}
+      preserveAspectRatio="xMidYMid meet"
+      viewBox={`0 0 ${VIEWBOX.toString()} ${VIEWBOX.toString()}`}
+    >
+      <defs>
+        <radialGradient cx="50%" cy="40%" id="globe-shade" r="60%">
+          <stop offset="0%" stopColor="rgba(99, 102, 241, 0.4)" />
+          <stop offset="100%" stopColor="rgba(15, 23, 42, 0.85)" />
+        </radialGradient>
+      </defs>
+      <circle
+        className="fill-[url(#globe-shade)] stroke-foreground/30"
+        cx={CENTER}
+        cy={CENTER}
+        data-globe-sphere
+        r={SPHERE_RADIUS}
+        strokeWidth={1}
+      />
+      <Graticule rotationLat={rotationLat} rotationLng={rotationLng} />
+      {children}
+    </svg>
+  );
+}
+
+/**
+ * Props for {@link Globe3D}.
+ *
+ * @public
+ */
+export type Globe3DProps = {
+  /** When `true`, the globe rotates on its own. Defaults to `true`. */
+  autoRotate?: boolean;
+  /** Initial view position. */
+  initialPosition?: GlobeCoord;
+  /** Localizable strings. */
+  labels?: Globe3DLabels;
+  /** Auto-rotation rate in degrees per second. Defaults to `8`. */
+  rotationSpeed?: number;
+} & ComponentPropsWithoutRef<"section">;
+
+function useAutoRotation(arguments_: {
+  autoRotate: boolean;
+  isDragging: boolean;
+  rotationSpeed: number;
+  setRotationLng: (next: (current: number) => number) => void;
+}): void {
+  const { autoRotate, isDragging, rotationSpeed, setRotationLng } = arguments_;
+  useEffect(() => {
+    if (!autoRotate || isDragging) return;
+    if (typeof window === "undefined") return;
+    let frame = 0;
+    let last: null | number = null;
+    const step = (timestamp: number): void => {
+      if (last !== null) {
+        const delta = (timestamp - last) / 1000;
+        setRotationLng((current) => current + delta * rotationSpeed);
+      }
+      last = timestamp;
+      frame = window.requestAnimationFrame(step);
+    };
+    frame = window.requestAnimationFrame(step);
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [autoRotate, isDragging, rotationSpeed, setRotationLng]);
+}
+
+type DragState = null | {
+  originLat: number;
+  originLng: number;
+  originX: number;
+  originY: number;
+};
+
+type DragHandlers = {
+  onPointerCancel: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerUp: (event: ReactPointerEvent<HTMLDivElement>) => void;
+};
+
+function useDragRotation(arguments_: {
+  rotationLat: number;
+  rotationLng: number;
+  setIsDragging: (next: boolean) => void;
+  setRotationLat: (next: number) => void;
+  setRotationLng: (next: number) => void;
+}): DragHandlers {
+  const {
+    rotationLat,
+    rotationLng,
+    setIsDragging,
+    setRotationLat,
+    setRotationLng,
+  } = arguments_;
+  const dragRef = useRef<DragState>(null);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      dragRef.current = {
+        originLat: rotationLat,
+        originLng: rotationLng,
+        originX: event.clientX,
+        originY: event.clientY,
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+      setIsDragging(true);
+    },
+    [rotationLat, rotationLng, setIsDragging],
+  );
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      const dx = event.clientX - drag.originX;
+      const dy = event.clientY - drag.originY;
+      setRotationLng(drag.originLng + dx * 0.4);
+      setRotationLat(clamp(drag.originLat - dy * 0.4, -85, 85));
+    },
+    [setRotationLat, setRotationLng],
+  );
+
+  const onPointerEnd = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      const target = event.currentTarget;
+      if (target.hasPointerCapture(event.pointerId)) {
+        target.releasePointerCapture(event.pointerId);
+      }
+      dragRef.current = null;
+      setIsDragging(false);
+    },
+    [setIsDragging],
+  );
+
+  return {
+    onPointerCancel: onPointerEnd,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp: onPointerEnd,
+  };
+}
+
+function useGlobeRotation(initialPosition: GlobeCoord): {
+  isDragging: boolean;
+  rotationLat: number;
+  rotationLng: number;
+  setIsDragging: (next: boolean) => void;
+  setRotationLat: (next: number) => void;
+  setRotationLng: (next: ((current: number) => number) | number) => void;
+} {
+  const [rotationLng, setRotationLng] = useState<number>(-initialPosition.lng);
+  const [rotationLat, setRotationLat] = useState<number>(initialPosition.lat);
+  const [isDragging, setIsDragging] = useState(false);
+  return {
+    isDragging,
+    rotationLat,
+    rotationLng,
+    setIsDragging,
+    setRotationLat,
+    setRotationLng,
+  };
+}
+
+type DataSummaryProps = {
+  children: ReactNode;
+  titleId: string;
+};
+
+function DataSummary({ children, titleId }: DataSummaryProps): ReactNode {
+  const markers: {
+    color: string;
+    label: ReactNode;
+    lat: number;
+    lng: number;
+  }[] = [];
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    const element = child as ReactElement<GlobeMarkerProps>;
+    if (
+      typeof element.props.lat === "number" &&
+      typeof element.props.lng === "number"
+    ) {
+      markers.push({
+        color: element.props.color ?? "red",
+        label: element.props.label ?? null,
+        lat: element.props.lat,
+        lng: element.props.lng,
+      });
+    }
+  });
+  return (
+    <div aria-labelledby={titleId} className="sr-only" role="region">
+      <h3 id={titleId}>Globe data summary</h3>
+      <p>{markers.length.toString()} marker(s) plotted on the globe.</p>
+      <ul>
+        {markers.map((marker, index) => (
+          <li
+            key={`${index.toString()}-${marker.lat.toString()}-${marker.lng.toString()}`}
+          >
+            {`${marker.lat.toString()}, ${marker.lng.toString()}: ${marker.label ? String(marker.label) : marker.color}`}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * Standalone SVG pseudo-3D globe. Renders a unit sphere with
+ * orthographic projection, a graticule (lat/lng lines), and any
+ * {@link GlobeMarker} / {@link GlobeArc} children. Auto-rotates around
+ * the Y axis; drag to rotate manually (auto-rotation pauses while
+ * dragging). No external 3D library — pure SVG + React state.
+ *
+ * @example
+ * ```tsx
+ * <Globe3D autoRotate>
+ *   <GlobeMarker lat={48.85} lng={2.35} label="Paris" color="blue" />
+ *   <GlobeMarker lat={40.71} lng={-74} label="New York" color="red" />
+ *   <GlobeArc
+ *     from={{ lat: 48.85, lng: 2.35 }}
+ *     to={{ lat: 40.71, lng: -74 }}
+ *     color="cyan"
+ *   />
+ * </Globe3D>
+ * ```
+ *
+ * @public
+ */
+export const Globe3D = forwardRef<HTMLElement, Globe3DProps>((props, ref) => {
+  const {
+    autoRotate = true,
+    children,
+    className,
+    initialPosition = { lat: 20, lng: 0 },
+    labels,
+    rotationSpeed = 8,
+    ...rest
+  } = props;
+  const titleId = useId();
+  const resolvedLabels = useMemo(
+    () => ({ ...DEFAULT_LABELS, ...labels }),
+    [labels],
+  );
+  const {
+    isDragging,
+    rotationLat,
+    rotationLng,
+    setIsDragging,
+    setRotationLat,
+    setRotationLng,
+  } = useGlobeRotation(initialPosition);
+
+  useAutoRotation({ autoRotate, isDragging, rotationSpeed, setRotationLng });
+
+  const handlers = useDragRotation({
+    rotationLat,
+    rotationLng,
+    setIsDragging,
+    setRotationLat,
+    setRotationLng: (next) => {
+      setRotationLng(next);
+    },
+  });
+
+  const ctx = useMemo<Ctx>(
+    () => ({ rotationLat, rotationLng }),
+    [rotationLat, rotationLng],
+  );
+
+  return (
+    <GlobeContext.Provider value={ctx}>
+      <section
+        aria-labelledby={titleId}
+        className={cn(
+          "relative aspect-square w-full max-w-md overflow-hidden rounded-2xl border bg-background text-foreground",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <span className="sr-only" id={titleId}>
+          {resolvedLabels.region}
+        </span>
+        <div
+          className="block h-full w-full cursor-grab active:cursor-grabbing"
+          data-globe-stage
+          {...handlers}
+        >
+          <Sphere rotationLat={rotationLat} rotationLng={rotationLng}>
+            {children}
+          </Sphere>
+        </div>
+        <DataSummary titleId={titleId}>{children}</DataSummary>
+      </section>
+    </GlobeContext.Provider>
+  );
+});
+Globe3D.displayName = "Globe3D";

--- a/apps/registry/registry/default/group-hull/group-hull.tsx
+++ b/apps/registry/registry/default/group-hull/group-hull.tsx
@@ -1,1 +1,48 @@
-export { GroupHull, type GroupHullProps } from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type GroupHullProps = React.ComponentPropsWithoutRef<"section"> & {
+  description?: string;
+  eyebrow?: ReactNode;
+  title: string;
+};
+
+const GroupHull = forwardRef<HTMLElement, GroupHullProps>(
+  ({ children, className, description, eyebrow, title, ...props }, ref) => (
+    <section
+      className={cn(
+        "relative flex min-h-[280px] flex-col gap-4 rounded-[2rem] border border-dashed border-border/70 bg-muted/12 p-5",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    >
+      <div className="absolute inset-3 rounded-[1.5rem] border border-border/40" />
+      <div className="relative space-y-1">
+        {eyebrow ? (
+          <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+            {eyebrow}
+          </div>
+        ) : null}
+        <h3 className="text-lg font-semibold tracking-tight text-foreground">
+          {title}
+        </h3>
+        {description ? (
+          <p className="max-w-[48ch] text-sm leading-6 text-muted-foreground">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      <div className="relative flex flex-1 flex-wrap items-start gap-4">
+        {children}
+      </div>
+    </section>
+  ),
+);
+
+GroupHull.displayName = "GroupHull";
+
+export { GroupHull };

--- a/apps/registry/registry/default/handoff-beacon/handoff-beacon.tsx
+++ b/apps/registry/registry/default/handoff-beacon/handoff-beacon.tsx
@@ -1,6 +1,140 @@
-export {
-  HandoffBeacon,
-  type HandoffBeaconLabels,
-  type HandoffBeaconLevel,
-  type HandoffBeaconProps,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Beacon urgency.
+ *
+ * @public
+ */
+export type HandoffBeaconLevel = "info" | "request" | "urgent";
+
+const LEVEL_RING: Record<HandoffBeaconLevel, string> = {
+  info: "ring-blue-500",
+  request: "ring-amber-500",
+  urgent: "ring-red-500 animate-pulse",
+};
+
+const LEVEL_DOT: Record<HandoffBeaconLevel, string> = {
+  info: "bg-blue-500",
+  request: "bg-amber-500",
+  urgent: "bg-red-500",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type HandoffBeaconLabels = {
+  /** Aria-label for the beacon. Defaults to `"Attention"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Attention",
+} as const satisfies Required<HandoffBeaconLabels>;
+
+/**
+ * Props for {@link HandoffBeacon}.
+ *
+ * @public
+ */
+export type HandoffBeaconProps = {
+  /** Localizable strings. */
+  labels?: HandoffBeaconLabels;
+  /** Urgency level. Defaults to `"info"`. */
+  level?: HandoffBeaconLevel;
+  /** Optional message body rendered inside the beacon. */
+  message?: ReactNode;
+  /** Origin participant name (who is requesting attention). */
+  source?: ReactNode;
+  /** X coordinate in container px. */
+  x: number;
+  /** Y coordinate in container px. */
+  y: number;
+} & Omit<ComponentPropsWithoutRef<"div">, "style">;
+
+/**
+ * Attention-routing beacon. Drop a beacon at the position a remote
+ * participant wants to redirect attention to — the local user sees a
+ * pulsing ring + optional message at that coordinate. Pure
+ * presentation; the host pipes the request through your realtime
+ * channel and unmounts the beacon on dismiss.
+ *
+ * @example
+ * ```tsx
+ * <HandoffBeacon
+ *   x={120}
+ *   y={80}
+ *   level="urgent"
+ *   source="Sam"
+ *   message="Take this — schema mismatch"
+ * />
+ * ```
+ *
+ * @public
+ */
+export const HandoffBeacon = forwardRef<HTMLDivElement, HandoffBeaconProps>(
+  (props, ref) => {
+    const {
+      className,
+      labels,
+      level = "info",
+      message,
+      source,
+      x,
+      y,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "pointer-events-none absolute z-30 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-1",
+          className,
+        )}
+        data-handoff-level={level}
+        ref={ref}
+        role="status"
+        style={{ left: `${x.toString()}px`, top: `${y.toString()}px` }}
+        {...rest}
+      >
+        <span
+          aria-hidden="true"
+          className={cn(
+            "block h-3 w-3 rounded-full ring-2 ring-offset-2 ring-offset-background",
+            LEVEL_DOT[level],
+            LEVEL_RING[level],
+          )}
+        />
+        {source || message ? (
+          <div
+            className="pointer-events-auto rounded-md border border-border bg-popover px-2 py-1 text-center text-[11px] font-medium shadow-md"
+            data-handoff-card
+          >
+            {source ? (
+              <p className="text-foreground">
+                <span className="font-semibold">{source}</span>
+                {message ? (
+                  <span className="text-muted-foreground"> · </span>
+                ) : null}
+                {message ? <span>{message}</span> : null}
+              </p>
+            ) : message ? (
+              <p className="text-foreground">{message}</p>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    );
+  },
+);
+HandoffBeacon.displayName = "HandoffBeacon";

--- a/apps/registry/registry/default/heat-map-overlay/heat-map-overlay.tsx
+++ b/apps/registry/registry/default/heat-map-overlay/heat-map-overlay.tsx
@@ -1,7 +1,349 @@
-export {
-  type HeatGradient,
-  HeatMapOverlay,
-  type HeatMapOverlayLabels,
-  type HeatMapOverlayProps,
-  type HeatPoint,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useId,
+  useMemo,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+const VIEWBOX_WIDTH = 1000;
+const VIEWBOX_HEIGHT = 500;
+
+/**
+ * A heat point — geographic position plus optional weight.
+ *
+ * @public
+ */
+export type HeatMapPoint = {
+  /** Stable identifier (used as React key). */
+  id: string;
+  /** Latitude. Positive = north. */
+  lat: number;
+  /** Longitude. Positive = east. */
+  lng: number;
+  /** Optional weight `0..1`. Drives both radius scale and color stop. Defaults to `1`. */
+  weight?: number;
+};
+
+/**
+ * Gradient stops `{ stop: color }`. Each stop is a `0..1` ratio.
+ *
+ * @public
+ */
+export type HeatGradient = Record<number, string>;
+
+const DEFAULT_GRADIENT: HeatGradient = {
+  0.2: "rgba(0, 0, 255, 0.6)",
+  0.5: "rgba(0, 255, 0, 0.7)",
+  0.8: "rgba(255, 165, 0, 0.85)",
+  1: "rgba(255, 0, 0, 0.95)",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type HeatMapOverlayLabels = {
+  /** Aria-label for the heat map region. Defaults to `"Heat map"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Heat map",
+} as const satisfies Required<HeatMapOverlayLabels>;
+
+function projectEquirectangular(
+  lng: number,
+  lat: number,
+): { x: number; y: number } {
+  const x = ((lng + 180) / 360) * VIEWBOX_WIDTH;
+  const y = ((90 - lat) / 180) * VIEWBOX_HEIGHT;
+  return { x, y };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function gradientStops(
+  gradient: HeatGradient,
+): { color: string; offset: number }[] {
+  return Object.entries(gradient)
+    .map(([key, value]) => ({ color: value, offset: Number.parseFloat(key) }))
+    .sort((a, b) => a.offset - b.offset);
+}
+
+/**
+ * Props for {@link HeatMapOverlay}.
+ *
+ * @public
+ */
+export type HeatMapOverlayProps = {
+  /** Optional backdrop image URL (world map, terrain). */
+  backdrop?: string;
+  /** Aria-label for the backdrop image. */
+  backdropAlt?: string;
+  /** Gaussian blur radius in viewBox units. Defaults to `12`. */
+  blur?: number;
+  /** Heat point data. */
+  data: HeatMapPoint[];
+  /** Color gradient stops `0..1` → CSS color. Defaults to a blue→green→orange→red ramp. */
+  gradient?: HeatGradient;
+  /** Localizable strings. */
+  labels?: HeatMapOverlayLabels;
+  /** Layer opacity `0..1`. Defaults to `0.7`. */
+  opacity?: number;
+  /** Top heat-blob radius in viewBox units. Defaults to `30`. Per-point radius scales with `weight`. */
+  radius?: number;
+} & ComponentPropsWithoutRef<"section">;
+
+type ProjectedPoint = {
+  raw: HeatMapPoint;
+  weight: number;
+  x: number;
+  y: number;
+};
+
+function projectPoints(points: HeatMapPoint[]): ProjectedPoint[] {
+  return points.map((point) => {
+    const { x, y } = projectEquirectangular(point.lng, point.lat);
+    return {
+      raw: point,
+      weight: clamp(point.weight ?? 1, 0, 1),
+      x,
+      y,
+    };
+  });
+}
+
+type HeatBlobProps = {
+  gradientId: string;
+  point: ProjectedPoint;
+  radius: number;
+};
+
+function HeatBlob({ gradientId, point, radius }: HeatBlobProps): ReactNode {
+  const blobRadius = Math.max(2, radius * (0.4 + 0.6 * point.weight));
+  return (
+    <circle
+      cx={point.x}
+      cy={point.y}
+      data-point-id={point.raw.id}
+      data-weight={point.weight}
+      fill={`url(#${gradientId})`}
+      opacity={point.weight}
+      r={blobRadius}
+    />
+  );
+}
+
+type GradientDefsProps = {
+  blurId: string;
+  gradient: HeatGradient;
+  gradientId: string;
+};
+
+function GradientDefs({
+  blurId,
+  gradient,
+  gradientId,
+}: GradientDefsProps): ReactNode {
+  const stops = gradientStops(gradient);
+  return (
+    <defs>
+      <radialGradient cx="50%" cy="50%" id={gradientId} r="50%">
+        {stops.map((stop) => (
+          <stop
+            key={stop.offset}
+            offset={`${(stop.offset * 100).toString()}%`}
+            stopColor={stop.color}
+          />
+        ))}
+      </radialGradient>
+      <filter id={blurId}>
+        <feGaussianBlur stdDeviation={12} />
+      </filter>
+    </defs>
+  );
+}
+
+type DataSummaryProps = {
+  data: HeatMapPoint[];
+  titleId: string;
+};
+
+function DataSummary({ data, titleId }: DataSummaryProps): ReactNode {
+  return (
+    <div aria-labelledby={titleId} className="sr-only" role="region">
+      <h3 id={titleId}>Heat map data summary</h3>
+      <p>
+        {data.length.toString()} point{data.length === 1 ? "" : "s"} plotted on
+        the heat map.
+      </p>
+      <ul>
+        {data.map((point) => (
+          <li key={point.id}>
+            {`${point.lat.toString()}, ${point.lng.toString()}: weight ${(point.weight ?? 1).toString()}`}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+type StageProps = {
+  backdrop?: string;
+  backdropAlt?: string;
+  blur: number;
+  blurId: string;
+  data: ProjectedPoint[];
+  gradient: HeatGradient;
+  gradientId: string;
+  opacity: number;
+  radius: number;
+};
+
+function Stage({
+  backdrop,
+  backdropAlt,
+  blur,
+  blurId,
+  data,
+  gradient,
+  gradientId,
+  opacity,
+  radius,
+}: StageProps): ReactNode {
+  return (
+    <svg
+      aria-hidden="true"
+      className="block h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+      viewBox={`0 0 ${VIEWBOX_WIDTH.toString()} ${VIEWBOX_HEIGHT.toString()}`}
+    >
+      <GradientDefs
+        blurId={blurId}
+        gradient={gradient}
+        gradientId={gradientId}
+      />
+      <rect
+        className="fill-muted"
+        height={VIEWBOX_HEIGHT}
+        width={VIEWBOX_WIDTH}
+        x="0"
+        y="0"
+      />
+      {backdrop ? (
+        <image
+          aria-label={backdropAlt}
+          height={VIEWBOX_HEIGHT}
+          href={backdrop}
+          preserveAspectRatio="xMidYMid slice"
+          width={VIEWBOX_WIDTH}
+          x="0"
+          y="0"
+        />
+      ) : null}
+      <g
+        data-heat-layer
+        filter={blur > 0 ? `url(#${blurId})` : undefined}
+        opacity={opacity}
+      >
+        {data.map((point) => (
+          <HeatBlob
+            gradientId={gradientId}
+            key={point.raw.id}
+            point={point}
+            radius={radius}
+          />
+        ))}
+      </g>
+    </svg>
+  );
+}
+
+/**
+ * Standalone SVG heat-map overlay for geographic density / intensity
+ * data. Plot heat points by `[lng, lat]` with optional `weight`. Each
+ * point renders as a radial-gradient blob; the layer is Gaussian-blurred
+ * to merge neighbours into smooth heat clouds.
+ *
+ * Use for: troop concentrations, population density, event / incident
+ * hotspots, archaeological site density, environmental pollution maps.
+ *
+ * @example
+ * ```tsx
+ * <HeatMapOverlay
+ *   data={[
+ *     { id: "a", lat: 40.7, lng: -74, weight: 0.9 },
+ *     { id: "b", lat: 51.5, lng: -0.13, weight: 0.6 },
+ *   ]}
+ *   radius={40}
+ *   blur={18}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const HeatMapOverlay = forwardRef<HTMLElement, HeatMapOverlayProps>(
+  (props, ref) => {
+    const {
+      backdrop,
+      backdropAlt,
+      blur = 12,
+      children,
+      className,
+      data,
+      gradient = DEFAULT_GRADIENT,
+      labels,
+      opacity = 0.7,
+      radius = 30,
+      ...rest
+    } = props;
+    const titleId = useId();
+    const gradientId = useId();
+    const blurId = useId();
+
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const projected = useMemo(() => projectPoints(data), [data]);
+
+    return (
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "relative aspect-[2/1] w-full overflow-hidden rounded-2xl border bg-background text-foreground",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <Stage
+          backdrop={backdrop}
+          backdropAlt={backdropAlt}
+          blur={blur}
+          blurId={blurId}
+          data={projected}
+          gradient={gradient}
+          gradientId={gradientId}
+          opacity={opacity}
+          radius={radius}
+        />
+        {children ? (
+          <div className="absolute bottom-3 left-3 z-10 max-w-xs rounded-md border bg-background/95 px-3 py-2 text-xs text-foreground shadow-sm backdrop-blur">
+            {children}
+          </div>
+        ) : null}
+        <DataSummary data={data} titleId={titleId} />
+      </section>
+    );
+  },
+);
+HeatMapOverlay.displayName = "HeatMapOverlay";

--- a/apps/registry/registry/default/heat-overlay/heat-overlay.tsx
+++ b/apps/registry/registry/default/heat-overlay/heat-overlay.tsx
@@ -1,7 +1,174 @@
-export {
-  HeatOverlay,
-  type HeatOverlayLabels,
-  type HeatOverlayProps,
-  type HeatOverlayTone,
-  type HeatPoint,
-} from '@vllnt/ui'
+"use client";
+
+import { type ComponentPropsWithoutRef, forwardRef, useId } from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Tone of the heat gradient — drives the inner circle color.
+ *
+ * @public
+ */
+export type HeatOverlayTone = "cool" | "danger" | "neutral" | "warn";
+
+const TONE_FILL: Record<HeatOverlayTone, string> = {
+  cool: "fill-blue-500",
+  danger: "fill-red-500",
+  neutral: "fill-foreground",
+  warn: "fill-amber-500",
+};
+
+/**
+ * One heat sample.
+ *
+ * @public
+ */
+export type HeatPoint = {
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Optional per-point tone override. */
+  tone?: HeatOverlayTone;
+  /** Sample weight `0..1` — drives the circle opacity + radius. */
+  weight: number;
+  /** X coordinate in canvas pixels. */
+  x: number;
+  /** Y coordinate in canvas pixels. */
+  y: number;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type HeatOverlayLabels = {
+  /** Aria-label override. Defaults to `"Heat overlay"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Heat overlay",
+} as const satisfies Required<HeatOverlayLabels>;
+
+/**
+ * Props for {@link HeatOverlay}.
+ *
+ * @public
+ */
+export type HeatOverlayProps = {
+  /** Optional global tone applied to every point that omits its own. Defaults to `"warn"`. */
+  defaultTone?: HeatOverlayTone;
+  /** Sample radius in pixels at full weight. Defaults to `48`. */
+  intensity?: number;
+  /** Localizable strings. */
+  labels?: HeatOverlayLabels;
+  /** Sample points in render order. */
+  points: HeatPoint[];
+} & ComponentPropsWithoutRef<"svg">;
+
+const clamp01 = (v: number): number => {
+  if (v < 0) {
+    return 0;
+  }
+  if (v > 1) {
+    return 1;
+  }
+  return v;
+};
+
+const HeatBlob = (props: {
+  defaultTone: HeatOverlayTone;
+  gradientId: string;
+  intensity: number;
+  point: HeatPoint;
+}): React.ReactElement => {
+  const { defaultTone, gradientId, intensity, point } = props;
+  const weight = clamp01(point.weight);
+  const tone = point.tone ?? defaultTone;
+  return (
+    <circle
+      className={cn("mix-blend-multiply", TONE_FILL[tone])}
+      cx={point.x}
+      cy={point.y}
+      data-heat-point={point.id}
+      data-heat-tone={tone}
+      fill={`url(#${gradientId})`}
+      fillOpacity={weight * 0.6}
+      r={Math.max(8, intensity * weight)}
+    />
+  );
+};
+
+/**
+ * Heatmap-style overlay drawn on top of a canvas. Each sample renders
+ * as a soft radial blob whose radius + opacity scale with its weight.
+ * Pure presentation; the host computes the point list from the
+ * activity stream.
+ *
+ * Render inside a `position: relative` parent that shares the canvas
+ * pixel coordinate space; the SVG is `pointer-events: none` so host
+ * gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <HeatOverlay
+ *     points={[
+ *       { id: "a", x: 120, y: 80,  weight: 1.0, tone: "danger" },
+ *       { id: "b", x: 320, y: 220, weight: 0.4 },
+ *     ]}
+ *   />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const HeatOverlay = forwardRef<SVGSVGElement, HeatOverlayProps>(
+  (props, ref) => {
+    const {
+      className,
+      defaultTone = "warn",
+      intensity = 48,
+      labels,
+      points,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const gradientId = useId();
+    if (points.length === 0) {
+      return null;
+    }
+    return (
+      <svg
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "pointer-events-none absolute inset-0 z-10 h-full w-full",
+          className,
+        )}
+        data-heat-overlay
+        ref={ref}
+        role="img"
+        {...rest}
+      >
+        <defs>
+          <radialGradient cx="50%" cy="50%" id={gradientId} r="50%">
+            <stop offset="0%" stopColor="currentColor" stopOpacity="1" />
+            <stop offset="70%" stopColor="currentColor" stopOpacity="0.4" />
+            <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+          </radialGradient>
+        </defs>
+        {points.map((point) => (
+          <HeatBlob
+            defaultTone={defaultTone}
+            gradientId={gradientId}
+            intensity={intensity}
+            key={point.id}
+            point={point}
+          />
+        ))}
+      </svg>
+    );
+  },
+);
+HeatOverlay.displayName = "HeatOverlay";

--- a/apps/registry/registry/default/historic-timeline/historic-timeline.tsx
+++ b/apps/registry/registry/default/historic-timeline/historic-timeline.tsx
@@ -1,10 +1,560 @@
-export {
-  type HistoricCategory,
-  type HistoricColor,
-  type HistoricEra,
-  type HistoricEvent,
-  type HistoricPeriod,
-  HistoricTimeline,
-  type HistoricTimelineLabels,
-  type HistoricTimelineProps,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useMemo,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+const DEFAULT_TICK_COUNT = 8;
+
+/**
+ * Color theme for eras and event categories.
+ *
+ * @public
+ */
+export type HistoricColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "neutral"
+  | "purple"
+  | "red"
+  | "rose";
+
+const COLOR_PALETTE: Record<
+  HistoricColor,
+  { band: string; chip: string; marker: string }
+> = {
+  amber: {
+    band: "bg-amber-500/15",
+    chip: "bg-amber-500/15 text-amber-700 dark:text-amber-300",
+    marker: "border-amber-500 bg-amber-500",
+  },
+  blue: {
+    band: "bg-blue-500/15",
+    chip: "bg-blue-500/15 text-blue-700 dark:text-blue-300",
+    marker: "border-blue-500 bg-blue-500",
+  },
+  emerald: {
+    band: "bg-emerald-500/15",
+    chip: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+    marker: "border-emerald-500 bg-emerald-500",
+  },
+  neutral: {
+    band: "bg-muted",
+    chip: "bg-muted text-muted-foreground",
+    marker: "border-muted-foreground bg-muted-foreground",
+  },
+  purple: {
+    band: "bg-purple-500/15",
+    chip: "bg-purple-500/15 text-purple-700 dark:text-purple-300",
+    marker: "border-purple-500 bg-purple-500",
+  },
+  red: {
+    band: "bg-red-500/15",
+    chip: "bg-red-500/15 text-red-700 dark:text-red-300",
+    marker: "border-red-500 bg-red-500",
+  },
+  rose: {
+    band: "bg-rose-500/15",
+    chip: "bg-rose-500/15 text-rose-700 dark:text-rose-300",
+    marker: "border-rose-500 bg-rose-500",
+  },
+};
+
+/**
+ * Background era band rendered behind the timeline.
+ *
+ * @public
+ */
+export type HistoricEra = {
+  /** Color theme. Defaults to `"neutral"`. */
+  color?: HistoricColor;
+  /** End year (inclusive). */
+  endYear: number;
+  /** Stable identifier. */
+  id: string;
+  /** Display name. */
+  name: ReactNode;
+  /** Start year (inclusive). */
+  startYear: number;
+};
+
+/**
+ * Mapping from category id to color theme + display label.
+ *
+ * @public
+ */
+export type HistoricCategory = {
+  /** Color theme. Defaults to `"neutral"`. */
+  color?: HistoricColor;
+  /** Stable identifier; matches {@link HistoricEvent.category}. */
+  id: string;
+  /** Display label. */
+  label: ReactNode;
+};
+
+/**
+ * Point-in-time event marker.
+ *
+ * @public
+ */
+export type HistoricEvent = {
+  /** Optional category id. Drives the marker color when provided. */
+  category?: string;
+  /** Optional description. */
+  description?: ReactNode;
+  /** Optional anchor href. Renders the event title as a link. */
+  href?: string;
+  /** Stable identifier. */
+  id: string;
+  /** Event title. */
+  title: ReactNode;
+  /** Year. Negative for BCE / positive for CE. */
+  year: number;
+};
+
+/**
+ * Span event (a period or duration).
+ *
+ * @public
+ */
+export type HistoricPeriod = {
+  /** Optional category id. Drives the band color when provided. */
+  category?: string;
+  /** End year (inclusive). */
+  endYear: number;
+  /** Stable identifier. */
+  id: string;
+  /** Start year (inclusive). */
+  startYear: number;
+  /** Display title. */
+  title: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type HistoricTimelineLabels = {
+  /** Aria-label for the timeline section. Defaults to `"Historic timeline"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Historic timeline",
+} as const satisfies Required<HistoricTimelineLabels>;
+
+/**
+ * Props for {@link HistoricTimeline}.
+ *
+ * @public
+ */
+export type HistoricTimelineProps = {
+  /** Optional category list — drives event marker colors and the legend. */
+  categories?: HistoricCategory[];
+  /** End year of the visible window. */
+  endYear: number;
+  /** Eras rendered as background bands. */
+  eras?: HistoricEra[];
+  /** Point-in-time event markers. */
+  events?: HistoricEvent[];
+  /** Localizable strings. */
+  labels?: HistoricTimelineLabels;
+  /** Span events (durations). */
+  periods?: HistoricPeriod[];
+  /** Start year of the visible window (negative for BCE). */
+  startYear: number;
+  /** Number of axis ticks. Defaults to `8`. */
+  tickCount?: number;
+} & ComponentPropsWithoutRef<"section">;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function formatYear(year: number): string {
+  if (year < 0) return `${Math.abs(year).toString()} BCE`;
+  return `${year.toString()} CE`;
+}
+
+function yearToPercent(year: number, start: number, end: number): number {
+  const span = end - start;
+  if (span <= 0) return 0;
+  return clamp(((year - start) / span) * 100, 0, 100);
+}
+
+function buildTicks(
+  start: number,
+  end: number,
+  count: number,
+): { label: string; offset: number }[] {
+  const safeCount = Math.max(2, count);
+  const span = end - start;
+  if (span <= 0) return [];
+  const step = span / (safeCount - 1);
+  return Array.from({ length: safeCount }).map((_, index) => {
+    const year = Math.round(start + step * index);
+    return {
+      label: formatYear(year),
+      offset: yearToPercent(year, start, end),
+    };
+  });
+}
+
+function resolveCategoryColor(
+  categoryId: string | undefined,
+  categories: HistoricCategory[],
+): HistoricColor {
+  if (!categoryId) return "neutral";
+  const match = categories.find((category) => category.id === categoryId);
+  return match?.color ?? "neutral";
+}
+
+type AxisProps = {
+  ticks: { label: string; offset: number }[];
+};
+
+function Axis({ ticks }: AxisProps): ReactNode {
+  return (
+    <div
+      aria-hidden="true"
+      className="relative h-7 border-b border-border text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+    >
+      {ticks.map((tick) => (
+        <span
+          className="absolute top-1 -translate-x-1/2"
+          key={tick.label}
+          style={{ left: `${tick.offset.toString()}%` }}
+        >
+          {tick.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+type EraBandsProps = {
+  endYear: number;
+  eras: HistoricEra[];
+  startYear: number;
+};
+
+function EraBands({ endYear, eras, startYear }: EraBandsProps): ReactNode {
+  if (eras.length === 0) return null;
+  return (
+    <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+      {eras.map((era) => {
+        const left = yearToPercent(era.startYear, startYear, endYear);
+        const right = yearToPercent(era.endYear, startYear, endYear);
+        const width = Math.max(0, right - left);
+        if (width <= 0) return null;
+        const palette = COLOR_PALETTE[era.color ?? "neutral"];
+        return (
+          <div
+            className={cn("absolute inset-y-0", palette.band)}
+            data-era-id={era.id}
+            key={era.id}
+            style={{
+              left: `${left.toString()}%`,
+              width: `${width.toString()}%`,
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+type EraLabelsProps = {
+  endYear: number;
+  eras: HistoricEra[];
+  startYear: number;
+};
+
+function EraLabels({ endYear, eras, startYear }: EraLabelsProps): ReactNode {
+  if (eras.length === 0) return null;
+  return (
+    <div className="relative flex h-6 border-b border-border">
+      {eras.map((era) => {
+        const left = yearToPercent(era.startYear, startYear, endYear);
+        const right = yearToPercent(era.endYear, startYear, endYear);
+        const width = Math.max(0, right - left);
+        if (width <= 0) return null;
+        const palette = COLOR_PALETTE[era.color ?? "neutral"];
+        return (
+          <span
+            className={cn(
+              "absolute top-1 truncate rounded px-1 text-[10px] font-semibold uppercase tracking-wide",
+              palette.chip,
+            )}
+            key={`${era.id}-label`}
+            style={{
+              left: `${left.toString()}%`,
+              width: `${width.toString()}%`,
+            }}
+          >
+            {era.name}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+type PeriodLaneProps = {
+  categories: HistoricCategory[];
+  endYear: number;
+  periods: HistoricPeriod[];
+  startYear: number;
+};
+
+function PeriodLane({
+  categories,
+  endYear,
+  periods,
+  startYear,
+}: PeriodLaneProps): ReactNode {
+  if (periods.length === 0) return null;
+  return (
+    <div className="relative flex h-7 items-center border-b border-border/60">
+      {periods.map((period) => {
+        const left = yearToPercent(period.startYear, startYear, endYear);
+        const right = yearToPercent(period.endYear, startYear, endYear);
+        const width = Math.max(0, right - left);
+        if (width <= 0) return null;
+        const color = resolveCategoryColor(period.category, categories);
+        const palette = COLOR_PALETTE[color];
+        const titleText = typeof period.title === "string" ? period.title : "";
+        return (
+          <div
+            aria-label={
+              titleText
+                ? `${titleText}, ${formatYear(period.startYear)} – ${formatYear(period.endYear)}`
+                : undefined
+            }
+            className={cn(
+              "absolute top-1 flex h-5 items-center overflow-hidden rounded-sm px-1 text-[10px] font-medium",
+              palette.chip,
+            )}
+            data-period-id={period.id}
+            key={period.id}
+            style={{
+              left: `${left.toString()}%`,
+              width: `${width.toString()}%`,
+            }}
+          >
+            <span className="truncate">{period.title}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+type EventMarkerProps = {
+  categories: HistoricCategory[];
+  endYear: number;
+  event: HistoricEvent;
+  startYear: number;
+};
+
+function EventMarker({
+  categories,
+  endYear,
+  event,
+  startYear,
+}: EventMarkerProps): ReactNode {
+  if (event.year < startYear || event.year > endYear) return null;
+  const left = yearToPercent(event.year, startYear, endYear);
+  const color = resolveCategoryColor(event.category, categories);
+  const palette = COLOR_PALETTE[color];
+  const titleText = typeof event.title === "string" ? event.title : "";
+  const ariaLabel = titleText
+    ? `${titleText}, ${formatYear(event.year)}`
+    : undefined;
+  return (
+    <div
+      aria-label={ariaLabel}
+      className="absolute top-1/2 z-10 -translate-x-1/2 -translate-y-1/2"
+      data-event-id={event.id}
+      data-event-year={event.year}
+      style={{ left: `${left.toString()}%` }}
+    >
+      <div
+        aria-hidden="true"
+        className={cn(
+          "h-3 w-3 rounded-full border-2 ring-2 ring-background",
+          palette.marker,
+        )}
+      />
+      <div className="absolute left-1/2 top-4 w-44 -translate-x-1/2 text-center">
+        {event.href ? (
+          <a
+            className="block truncate text-xs font-medium text-foreground underline-offset-4 hover:underline"
+            href={event.href}
+          >
+            {event.title}
+          </a>
+        ) : (
+          <p className="truncate text-xs font-medium text-foreground">
+            {event.title}
+          </p>
+        )}
+        <p className="truncate text-[10px] text-muted-foreground">
+          {formatYear(event.year)}
+          {event.description ? <span> · {event.description}</span> : null}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+type EventLaneProps = {
+  categories: HistoricCategory[];
+  endYear: number;
+  events: HistoricEvent[];
+  startYear: number;
+};
+
+function EventLane({
+  categories,
+  endYear,
+  events,
+  startYear,
+}: EventLaneProps): ReactNode {
+  return (
+    <div className="relative h-20">
+      <div className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-border" />
+      {events.map((event) => (
+        <EventMarker
+          categories={categories}
+          endYear={endYear}
+          event={event}
+          key={event.id}
+          startYear={startYear}
+        />
+      ))}
+    </div>
+  );
+}
+
+type LegendProps = {
+  categories: HistoricCategory[];
+};
+
+function Legend({ categories }: LegendProps): ReactNode {
+  if (categories.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1.5 border-t border-border px-3 py-2 text-xs">
+      {categories.map((category) => {
+        const palette = COLOR_PALETTE[category.color ?? "neutral"];
+        return (
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full px-2 py-0.5",
+              palette.chip,
+            )}
+            data-category-id={category.id}
+            key={category.id}
+          >
+            <span
+              aria-hidden="true"
+              className={cn("h-2 w-2 rounded-full", palette.marker)}
+            />
+            {category.label}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Specialized timeline for historical events spanning centuries or
+ * millennia. Renders era bands as a background layer, period bars in a
+ * lane, and point events as markers. Negative years format as `BCE`,
+ * positive as `CE`. Composes nothing — pure CSS.
+ *
+ * @example
+ * ```tsx
+ * <HistoricTimeline
+ *   startYear={-500}
+ *   endYear={2025}
+ *   eras={[{ id: "ancient", name: "Ancient", startYear: -3000, endYear: 476, color: "amber" }]}
+ *   periods={[{ id: "100yr", title: "Hundred Years' War", startYear: 1337, endYear: 1453, category: "conflict" }]}
+ *   events={[
+ *     { id: "olympics", year: -776, title: "First Olympic Games", category: "culture" },
+ *     { id: "moon", year: 1969, title: "Moon landing", category: "science" },
+ *   ]}
+ *   categories={[
+ *     { id: "culture", label: "Culture", color: "amber" },
+ *     { id: "science", label: "Science", color: "blue" },
+ *     { id: "conflict", label: "Conflict", color: "red" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const HistoricTimeline = forwardRef<HTMLElement, HistoricTimelineProps>(
+  (props, ref) => {
+    const {
+      categories = [],
+      className,
+      endYear,
+      eras = [],
+      events = [],
+      labels,
+      periods = [],
+      startYear,
+      tickCount = DEFAULT_TICK_COUNT,
+      ...rest
+    } = props;
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const ticks = useMemo(
+      () => buildTicks(startYear, endYear, tickCount),
+      [endYear, startYear, tickCount],
+    );
+
+    return (
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "flex w-full flex-col overflow-hidden rounded-2xl border bg-background text-foreground",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <Axis ticks={ticks} />
+        <EraLabels endYear={endYear} eras={eras} startYear={startYear} />
+        <PeriodLane
+          categories={categories}
+          endYear={endYear}
+          periods={periods}
+          startYear={startYear}
+        />
+        <div className="relative">
+          <EraBands endYear={endYear} eras={eras} startYear={startYear} />
+          <EventLane
+            categories={categories}
+            endYear={endYear}
+            events={events}
+            startYear={startYear}
+          />
+        </div>
+        <Legend categories={categories} />
+      </section>
+    );
+  },
+);
+HistoricTimeline.displayName = "HistoricTimeline";

--- a/apps/registry/registry/default/historical-figure-card/historical-figure-card.tsx
+++ b/apps/registry/registry/default/historical-figure-card/historical-figure-card.tsx
@@ -1,2 +1,506 @@
-// Re-export from @vllnt/ui package
-export { HistoricalFigureCard } from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useState,
+} from "react";
+
+import { ChevronDown, User } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Avatar, AvatarFallback, AvatarImage } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+
+const FALLBACK_LIFESPAN_MIN_YEAR = 1500;
+const FALLBACK_LIFESPAN_SPAN_YEARS = 100;
+
+/**
+ * Birth or death record for {@link HistoricalFigureCardProps}.
+ *
+ * @public
+ */
+export type HistoricalFigureCardLifeEvent = {
+  /** Optional secondary line (e.g. "Vinci, Italy"). */
+  place?: ReactNode;
+  /**
+   * Year as a positive integer for AD / a negative integer for BC.
+   * Pass `undefined` for unknown.
+   */
+  year?: number;
+};
+
+/**
+ * Connection between this figure and another.
+ *
+ * @public
+ */
+export type HistoricalFigureCardConnection = {
+  /** Optional URL for the connected figure's profile. */
+  href?: string;
+  /** Connected figure's display name. */
+  name: ReactNode;
+  /** Free-form relation label (e.g. "Patron", "Contemporary/rival"). */
+  relation: ReactNode;
+};
+
+/**
+ * Pull-quote with attribution for {@link HistoricalFigureCardProps}.
+ *
+ * @public
+ */
+export type HistoricalFigureCardQuote = {
+  /** Source/citation for the quote (book, letter, year). */
+  source?: ReactNode;
+  /** Quote text. */
+  text: ReactNode;
+};
+
+/**
+ * Localizable strings for the bio toggle button.
+ *
+ * @public
+ */
+export type HistoricalFigureCardLabels = {
+  /** Caption for the bio toggle when expanded. Defaults to `"Hide biography"`. */
+  collapseBio?: string;
+  /** Heading rendered above the connections list. Defaults to `"Connections"`. */
+  connections?: string;
+  /** Caption for the bio toggle when collapsed. Defaults to `"Read biography"`. */
+  expandBio?: string;
+  /** Heading rendered above the fields list. Defaults to `"Fields"`. */
+  fields?: string;
+  /** Aria-label for the lifespan timeline bar. Defaults to `"Lifespan"`. */
+  lifespan?: string;
+  /** Heading rendered above the works list. Defaults to `"Notable works"`. */
+  works?: string;
+};
+
+/**
+ * Props for {@link HistoricalFigureCard}.
+ *
+ * @public
+ */
+export type HistoricalFigureCardProps = {
+  /** Optional expandable biography content. */
+  biography?: ReactNode;
+  /** Birth event (year + optional place). */
+  birth?: HistoricalFigureCardLifeEvent;
+  /** Connections / relationships to other figures. */
+  connections?: HistoricalFigureCardConnection[];
+  /** Death event (year + optional place). */
+  death?: HistoricalFigureCardLifeEvent;
+  /** Era label, rendered as a Badge. */
+  era?: ReactNode;
+  /** Fields / domains tags (e.g. "Art", "Anatomy"). */
+  fields?: ReactNode[];
+  /** Localizable captions. */
+  labels?: HistoricalFigureCardLabels;
+  /** Display name. */
+  name: ReactNode;
+  /** Portrait image src. Falls back to a silhouette when omitted. */
+  portrait?: string;
+  /** Optional URL pointing to the full profile. */
+  profileHref?: string;
+  /** Optional pull-quote with attribution. */
+  quote?: HistoricalFigureCardQuote;
+  /** Optional descriptor under the name (e.g. "Polymath"). */
+  title?: ReactNode;
+  /** Notable works list. */
+  works?: ReactNode[];
+} & ComponentPropsWithoutRef<"article">;
+
+const DEFAULT_LABELS = {
+  collapseBio: "Hide biography",
+  connections: "Connections",
+  expandBio: "Read biography",
+  fields: "Fields",
+  lifespan: "Lifespan",
+  works: "Notable works",
+} as const satisfies Required<HistoricalFigureCardLabels>;
+
+function formatYear(year: number | undefined): string | undefined {
+  if (year === undefined) return undefined;
+  if (year < 0) return `${Math.abs(year).toString()} BC`;
+  return year.toString();
+}
+
+function getInitials(name: ReactNode): string {
+  if (typeof name !== "string") return "";
+  const parts = name.trim().split(/\s+/).slice(0, 2);
+  return parts
+    .map((part) => part.charAt(0).toUpperCase())
+    .join("")
+    .slice(0, 2);
+}
+
+type LifespanBarProps = {
+  birthYear?: number;
+  deathYear?: number;
+  label: string;
+};
+
+function LifespanBar({
+  birthYear,
+  deathYear,
+  label,
+}: LifespanBarProps): ReactNode {
+  if (birthYear === undefined || deathYear === undefined) return null;
+  if (deathYear <= birthYear) return null;
+
+  const span = deathYear - birthYear;
+  const min = Math.min(birthYear, FALLBACK_LIFESPAN_MIN_YEAR);
+  const range =
+    Math.max(deathYear, min + FALLBACK_LIFESPAN_SPAN_YEARS) - min || 1;
+  const start = ((birthYear - min) / range) * 100;
+  const width = (span / range) * 100;
+
+  return (
+    <div
+      aria-label={`${label}: ${formatYear(birthYear) ?? ""} – ${formatYear(deathYear) ?? ""}`}
+      className="relative mt-2 h-1.5 w-full rounded-full bg-muted"
+      role="img"
+    >
+      <span
+        className="absolute h-full rounded-full bg-primary"
+        style={{ left: `${start.toString()}%`, width: `${width.toString()}%` }}
+      />
+    </div>
+  );
+}
+
+type LifeEventLineProps = {
+  caption: string;
+  event?: HistoricalFigureCardLifeEvent;
+};
+
+function LifeEventLine({ caption, event }: LifeEventLineProps): ReactNode {
+  if (!event) return null;
+  const year = formatYear(event.year);
+  if (year === undefined && !event.place) return null;
+  return (
+    <p className="text-xs text-muted-foreground">
+      <span className="font-semibold text-foreground">{caption}</span>{" "}
+      {year ?? "Unknown"}
+      {event.place ? <span> · {event.place}</span> : null}
+    </p>
+  );
+}
+
+type FigureChipsProps = {
+  heading: string;
+  items: ReactNode[];
+};
+
+function FigureChips({ heading, items }: FigureChipsProps): ReactNode {
+  if (items.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2">
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {heading}
+      </h4>
+      <div className="flex flex-wrap gap-1.5">
+        {items.map((item, index) => (
+          <Badge key={`chip-${index.toString()}`} variant="secondary">
+            {item}
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type FigureWorksListProps = {
+  heading: string;
+  items: ReactNode[];
+};
+
+function FigureWorksList({ heading, items }: FigureWorksListProps): ReactNode {
+  if (items.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2">
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {heading}
+      </h4>
+      <ul className="flex flex-col gap-1 text-sm text-foreground">
+        {items.map((item, index) => (
+          <li className="leading-tight" key={`work-${index.toString()}`}>
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+type FigureConnectionsProps = {
+  heading: string;
+  items: HistoricalFigureCardConnection[];
+};
+
+function FigureConnections({
+  heading,
+  items,
+}: FigureConnectionsProps): ReactNode {
+  if (items.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2">
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {heading}
+      </h4>
+      <ul className="flex flex-col gap-1.5 text-sm">
+        {items.map((connection, index) => {
+          const labelNode = connection.href ? (
+            <a
+              className="font-medium text-foreground underline-offset-4 hover:underline"
+              href={connection.href}
+            >
+              {connection.name}
+            </a>
+          ) : (
+            <span className="font-medium text-foreground">
+              {connection.name}
+            </span>
+          );
+          return (
+            <li
+              className="flex items-baseline justify-between gap-3"
+              key={`connection-${index.toString()}`}
+            >
+              {labelNode}
+              <span className="text-xs text-muted-foreground">
+                {connection.relation}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+type FigureQuoteProps = {
+  quote: HistoricalFigureCardQuote;
+};
+
+function FigureQuote({ quote }: FigureQuoteProps): ReactNode {
+  return (
+    <blockquote className="border-l-2 border-primary/40 pl-3 text-sm italic text-muted-foreground">
+      “{quote.text}”
+      {quote.source ? (
+        <footer className="mt-1 text-xs not-italic text-muted-foreground/80">
+          — {quote.source}
+        </footer>
+      ) : null}
+    </blockquote>
+  );
+}
+
+type FigureBioProps = {
+  biography: ReactNode;
+  collapseLabel: string;
+  expandLabel: string;
+};
+
+function FigureBio({
+  biography,
+  collapseLabel,
+  expandLabel,
+}: FigureBioProps): ReactNode {
+  const [open, setOpen] = useState(false);
+  const handleToggle = useCallback(() => {
+    setOpen((value) => !value);
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        aria-expanded={open}
+        className="inline-flex w-fit items-center gap-1 text-sm font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        onClick={handleToggle}
+        type="button"
+      >
+        {open ? collapseLabel : expandLabel}
+        <ChevronDown
+          aria-hidden="true"
+          className={cn(
+            "h-4 w-4 transition-transform",
+            open ? "rotate-180" : "rotate-0",
+          )}
+        />
+      </button>
+      {open ? (
+        <div className="text-sm leading-relaxed text-foreground">
+          {biography}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Profile card for historical figures with portrait, lifespan timeline,
+ * fields / works / connections, optional pull-quote, and an expandable
+ * biography section. Composes Avatar and Badge.
+ *
+ * @example
+ * ```tsx
+ * <HistoricalFigureCard
+ *   name="Leonardo da Vinci"
+ *   title="Polymath"
+ *   era="Renaissance"
+ *   birth={{ year: 1452, place: "Vinci, Italy" }}
+ *   death={{ year: 1519, place: "Amboise, France" }}
+ *   fields={["Art", "Science"]}
+ *   works={["Mona Lisa", "Vitruvian Man"]}
+ *   quote={{ text: "Learning never exhausts the mind.", source: "Notebooks" }}
+ *   profileHref="/figures/da-vinci"
+ * />
+ * ```
+ *
+ * @public
+ */
+type FigureHeaderProps = {
+  era?: ReactNode;
+  name: ReactNode;
+  portrait?: string;
+  title?: ReactNode;
+};
+
+function FigureHeader({
+  era,
+  name,
+  portrait,
+  title,
+}: FigureHeaderProps): ReactNode {
+  const initials = getInitials(name);
+  const altName = typeof name === "string" ? name : undefined;
+  return (
+    <header className="flex items-start gap-4">
+      <Avatar className="h-14 w-14 shrink-0 ring-2 ring-border">
+        {portrait ? <AvatarImage alt={altName} src={portrait} /> : null}
+        <AvatarFallback className="text-sm">
+          {initials || <User aria-hidden="true" className="h-5 w-5" />}
+        </AvatarFallback>
+      </Avatar>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <h3 className="text-base font-semibold leading-tight tracking-tight">
+          {name}
+        </h3>
+        {title ? (
+          <p className="text-sm text-muted-foreground">{title}</p>
+        ) : null}
+        {era ? (
+          <Badge className="self-start" variant="outline">
+            {era}
+          </Badge>
+        ) : null}
+      </div>
+    </header>
+  );
+}
+
+type FigureLifeBlockProps = {
+  birth?: HistoricalFigureCardLifeEvent;
+  death?: HistoricalFigureCardLifeEvent;
+  lifespanLabel: string;
+};
+
+function FigureLifeBlock({
+  birth,
+  death,
+  lifespanLabel,
+}: FigureLifeBlockProps): ReactNode {
+  return (
+    <div className="flex flex-col gap-1">
+      <LifeEventLine caption="Born" event={birth} />
+      <LifeEventLine caption="Died" event={death} />
+      <LifespanBar
+        birthYear={birth?.year}
+        deathYear={death?.year}
+        label={lifespanLabel}
+      />
+    </div>
+  );
+}
+
+export const HistoricalFigureCard = forwardRef<
+  HTMLElement,
+  HistoricalFigureCardProps
+>((props, ref) => {
+  const {
+    biography,
+    birth,
+    className,
+    connections,
+    death,
+    era,
+    fields,
+    labels,
+    name,
+    portrait,
+    profileHref,
+    quote,
+    title,
+    works,
+    ...rest
+  } = props;
+
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+
+  return (
+    <article
+      className={cn(
+        "flex flex-col gap-4 rounded-2xl border bg-background p-5 text-foreground shadow-sm",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      <FigureHeader era={era} name={name} portrait={portrait} title={title} />
+
+      <FigureLifeBlock
+        birth={birth}
+        death={death}
+        lifespanLabel={resolvedLabels.lifespan}
+      />
+
+      {fields && fields.length > 0 ? (
+        <FigureChips heading={resolvedLabels.fields} items={fields} />
+      ) : null}
+
+      {works && works.length > 0 ? (
+        <FigureWorksList heading={resolvedLabels.works} items={works} />
+      ) : null}
+
+      {quote ? <FigureQuote quote={quote} /> : null}
+
+      {connections && connections.length > 0 ? (
+        <FigureConnections
+          heading={resolvedLabels.connections}
+          items={connections}
+        />
+      ) : null}
+
+      {biography ? (
+        <FigureBio
+          biography={biography}
+          collapseLabel={resolvedLabels.collapseBio}
+          expandLabel={resolvedLabels.expandBio}
+        />
+      ) : null}
+
+      {profileHref ? (
+        <a
+          className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+          href={profileHref}
+        >
+          View full profile →
+        </a>
+      ) : null}
+    </article>
+  );
+});
+HistoricalFigureCard.displayName = "HistoricalFigureCard";

--- a/apps/registry/registry/default/horizontal-scroll-row/horizontal-scroll-row.tsx
+++ b/apps/registry/registry/default/horizontal-scroll-row/horizontal-scroll-row.tsx
@@ -1,1 +1,80 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { memo, type ReactNode } from "react";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { useHorizontalScroll } from "@vllnt/ui";
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+
+type HorizontalScrollRowProps = {
+  children: ReactNode;
+  className?: string;
+  description?: string;
+  title: string;
+};
+
+const HorizontalScrollRow = memo(function HorizontalScrollRow({
+  children,
+  className,
+  description,
+  title,
+}: HorizontalScrollRowProps) {
+  const { canScrollLeft, canScrollRight, containerRef, scroll } =
+    useHorizontalScroll();
+
+  const showControls = canScrollLeft || canScrollRight;
+
+  return (
+    <section className={cn("space-y-4", className)}>
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">{title}</h3>
+          {description ? (
+            <p className="text-sm text-muted-foreground">{description}</p>
+          ) : null}
+        </div>
+        {showControls ? (
+          <div className="flex gap-1">
+            <Button
+              aria-label="Scroll left"
+              className="h-8 w-8"
+              disabled={!canScrollLeft}
+              onClick={() => {
+                scroll("left");
+              }}
+              size="icon"
+              variant="outline"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <Button
+              aria-label="Scroll right"
+              className="h-8 w-8"
+              disabled={!canScrollRight}
+              onClick={() => {
+                scroll("right");
+              }}
+              size="icon"
+              variant="outline"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        ) : null}
+      </div>
+      <div
+        className="flex gap-4 overflow-x-auto snap-x snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        ref={containerRef}
+      >
+        {children}
+      </div>
+    </section>
+  );
+});
+
+HorizontalScrollRow.displayName = "HorizontalScrollRow";
+
+export { HorizontalScrollRow };
+export type { HorizontalScrollRowProps };

--- a/apps/registry/registry/default/hover-card/hover-card.tsx
+++ b/apps/registry/registry/default/hover-card/hover-card.tsx
@@ -1,1 +1,30 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
+
+import { cn } from "@vllnt/ui";
+
+const HoverCard = HoverCardPrimitive.Root;
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger;
+
+const HoverCardContent = forwardRef<
+  React.ComponentRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ align = "center", className, sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Content
+    align={align}
+    className={cn(
+      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    ref={ref}
+    sideOffset={sideOffset}
+    {...props}
+  />
+));
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
+
+export { HoverCard, HoverCardContent, HoverCardTrigger };

--- a/apps/registry/registry/default/infinite-plane/infinite-plane.tsx
+++ b/apps/registry/registry/default/infinite-plane/infinite-plane.tsx
@@ -1,6 +1,143 @@
-export {
-  InfinitePlane,
-  type InfinitePlaneLabels,
-  type InfinitePlanePattern,
-  type InfinitePlaneProps,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Pattern style for the plane backdrop.
+ *
+ * @public
+ */
+export type InfinitePlanePattern = "blank" | "dot" | "grid";
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type InfinitePlaneLabels = {
+  /** Aria-label override. Defaults to `"Infinite plane"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Infinite plane",
+} as const satisfies Required<InfinitePlaneLabels>;
+
+/**
+ * Props for {@link InfinitePlane}.
+ *
+ * @public
+ */
+export type InfinitePlaneProps = {
+  /** Children render in the plane's coordinate space. */
+  children?: ReactNode;
+  /** Localizable strings. */
+  labels?: InfinitePlaneLabels;
+  /** Backdrop pattern. Defaults to `"dot"`. */
+  pattern?: InfinitePlanePattern;
+  /** Pattern grid spacing in pixels. Defaults to `32`. */
+  spacing?: number;
+  /** Optional offset applied to the pattern (drift with viewport translation). Defaults to `{ x: 0, y: 0 }`. */
+  translate?: { x: number; y: number };
+  /** Zoom factor — drives the pattern's effective spacing. Defaults to `1`. */
+  zoom?: number;
+} & ComponentPropsWithoutRef<"div">;
+
+const safeSpacing = (value: number): number => (value < 4 ? 4 : value);
+
+const safeZoom = (value: number): number => {
+  if (value < 0.1) {
+    return 0.1;
+  }
+  if (value > 10) {
+    return 10;
+  }
+  return value;
+};
+
+const buildBackground = (input: {
+  pattern: InfinitePlanePattern;
+  spacing: number;
+  translate: { x: number; y: number };
+  zoom: number;
+}): React.CSSProperties => {
+  if (input.pattern === "blank") {
+    return {};
+  }
+  const size = safeSpacing(input.spacing) * safeZoom(input.zoom);
+  const pos = `${input.translate.x}px ${input.translate.y}px`;
+  if (input.pattern === "grid") {
+    return {
+      backgroundImage:
+        "linear-gradient(to right, hsl(var(--border)) 1px, transparent 1px), linear-gradient(to bottom, hsl(var(--border)) 1px, transparent 1px)",
+      backgroundPosition: pos,
+      backgroundSize: `${size}px ${size}px`,
+    };
+  }
+  return {
+    backgroundImage:
+      "radial-gradient(circle, hsl(var(--border)) 1px, transparent 1px)",
+    backgroundPosition: pos,
+    backgroundSize: `${size}px ${size}px`,
+  };
+};
+
+/**
+ * Tiled pannable backdrop for the canvas. Renders a `dot` or `grid`
+ * pattern that drifts with the viewport translate + scales with the
+ * zoom, plus a slot for spatial children that share its coordinate
+ * space.
+ *
+ * Pure presentation; the host owns the viewport transform and supplies
+ * `translate` + `zoom` from its pan / zoom controller.
+ *
+ * @example
+ * ```tsx
+ * <InfinitePlane translate={{ x: pan.x, y: pan.y }} zoom={zoom}>
+ *   <ObjectCard …/>
+ *   <ObjectCard …/>
+ * </InfinitePlane>
+ * ```
+ *
+ * @public
+ */
+export const InfinitePlane = forwardRef<HTMLDivElement, InfinitePlaneProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      labels,
+      pattern = "dot",
+      spacing = 32,
+      translate = { x: 0, y: 0 },
+      zoom = 1,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const background = buildBackground({ pattern, spacing, translate, zoom });
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "relative h-full w-full overflow-hidden bg-background",
+          className,
+        )}
+        data-infinite-plane
+        data-infinite-plane-pattern={pattern}
+        ref={ref}
+        role="region"
+        style={background}
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+InfinitePlane.displayName = "InfinitePlane";

--- a/apps/registry/registry/default/inline-input/inline-input.tsx
+++ b/apps/registry/registry/default/inline-input/inline-input.tsx
@@ -1,20 +1,21 @@
-'use client'
+"use client";
 
-import type { KeyboardEvent } from 'react'
+import type { KeyboardEvent } from "react";
 
-import { cn } from '../../../lib/utils'
+import { cn } from "@vllnt/ui";
+import { Input } from "@vllnt/ui";
 
 export type InlineInputProps = {
-  className?: string
-  /** Called when editing is cancelled (Escape key or blur without changes). */
-  onCancel?: () => void
-  /** Called when editing is committed (Enter key or blur with changes). */
-  onCommit: (value: string) => void
+  className?: string;
+  /** Called when user presses Escape or blurs without changes. */
+  onCancel?: () => void;
   /** Called when the input value changes. */
-  onChange: (value: string) => void
+  onChange: (value: string) => void;
+  /** Called when user presses Enter or blurs with changes. */
+  onCommit: (value: string) => void;
   /** Current input value. */
-  value: string
-}
+  value: string;
+};
 
 /**
  * Inline input for editing text with keyboard support.
@@ -30,37 +31,30 @@ export function InlineInput({
   value,
 }: InlineInputProps) {
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Enter') {
-      event.preventDefault()
-      onCommit(value)
-    } else if (event.key === 'Escape') {
-      event.preventDefault()
-      onCancel?.()
+    if (event.key === "Enter") {
+      event.preventDefault();
+      onCommit(value);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      onCancel?.();
     }
-  }
+  };
 
   return (
-    <input
+    <Input
       autoFocus // eslint-disable-line jsx-a11y/no-autofocus
-      className={cn(
-        'flex h-7 flex-1 rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors',
-        'file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground',
-        'placeholder:text-muted-foreground',
-        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
-        'disabled:cursor-not-allowed disabled:opacity-50',
-        className
-      )}
+      className={cn("flex-1 h-7 text-sm", className)}
       onBlur={() => {
-        onCommit(value)
+        onCommit(value);
       }}
       onChange={(event) => {
-        onChange(event.target.value)
+        onChange(event.target.value);
       }}
       onClick={(event) => {
-        event.stopPropagation()
+        event.stopPropagation();
       }}
       onKeyDown={handleKeyDown}
       value={value}
     />
-  )
+  );
 }

--- a/apps/registry/registry/default/input-otp/input-otp.tsx
+++ b/apps/registry/registry/default/input-otp/input-otp.tsx
@@ -1,1 +1,78 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef, useContext } from "react";
+
+import { OTPInput, OTPInputContext } from "input-otp";
+import { Dot } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+const InputOTP = forwardRef<
+  React.ComponentRef<typeof OTPInput>,
+  React.ComponentPropsWithoutRef<typeof OTPInput>
+>(({ className, containerClassName, ...props }, ref) => (
+  <OTPInput
+    className={cn("disabled:cursor-not-allowed", className)}
+    containerClassName={cn(
+      "flex items-center gap-2 has-[:disabled]:opacity-50",
+      containerClassName,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+InputOTP.displayName = "InputOTP";
+
+const InputOTPGroup = forwardRef<
+  React.ComponentRef<"div">,
+  React.ComponentPropsWithoutRef<"div">
+>(({ className, ...props }, ref) => (
+  <div className={cn("flex items-center", className)} ref={ref} {...props} />
+));
+InputOTPGroup.displayName = "InputOTPGroup";
+
+const InputOTPSlot = forwardRef<
+  React.ComponentRef<"div">,
+  React.ComponentPropsWithoutRef<"div"> & { index: number }
+>(({ className, index, ...props }, ref) => {
+  const inputOTPContext = useContext(OTPInputContext);
+  const slot = inputOTPContext.slots[index];
+
+  if (!slot) {
+    return null;
+  }
+
+  const { char, hasFakeCaret, isActive } = slot;
+
+  return (
+    <div
+      className={cn(
+        "relative flex h-10 w-10 items-center justify-center border-y border-r border-input text-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md",
+        isActive && "z-10 ring-2 ring-ring ring-offset-background",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret ? (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="h-4 w-px animate-caret-blink bg-foreground duration-1000" />
+        </div>
+      ) : null}
+    </div>
+  );
+});
+InputOTPSlot.displayName = "InputOTPSlot";
+
+const InputOTPSeparator = forwardRef<
+  React.ComponentRef<"div">,
+  React.ComponentPropsWithoutRef<"div">
+>(({ ...props }, ref) => (
+  <div ref={ref} role="separator" {...props}>
+    <Dot />
+  </div>
+));
+InputOTPSeparator.displayName = "InputOTPSeparator";
+
+export { InputOTP, InputOTPGroup, InputOTPSeparator, InputOTPSlot };

--- a/apps/registry/registry/default/input/input.tsx
+++ b/apps/registry/registry/default/input/input.tsx
@@ -1,2 +1,22 @@
-// Re-export from @vllnt/ui package
-export { Input } from '@vllnt/ui'
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, reference) => {
+    return (
+      <input
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className,
+        )}
+        ref={reference}
+        type={type}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/apps/registry/registry/default/interactive-timeline/interactive-timeline.tsx
+++ b/apps/registry/registry/default/interactive-timeline/interactive-timeline.tsx
@@ -1,15 +1,1081 @@
-export {
-  type InteractiveTimelineCategory,
-  type InteractiveTimelineColor,
-  type InteractiveTimelineEvent,
-  type InteractiveTimelineFilterProps,
-  type InteractiveTimelineLabels,
-  type InteractiveTimelineProps,
-  type InteractiveTimelineTrack,
-  InteractiveTimeline,
-  InteractiveTimelineFilter,
-  InteractiveTimelineToday,
-  InteractiveTimelineToolbar,
-  InteractiveTimelineZoomIn,
-  InteractiveTimelineZoomOut,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 32;
+const ZOOM_STEP = 2;
+const MS_PER_DAY = 86_400_000;
+const TICK_TARGET_PX = 120;
+
+/**
+ * Color theme for tracks and event categories.
+ *
+ * @public
+ */
+export type InteractiveTimelineColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "neutral"
+  | "purple"
+  | "red"
+  | "rose";
+
+const COLOR_PALETTE: Record<
+  InteractiveTimelineColor,
+  { bar: string; chip: string; chipActive: string; dot: string }
+> = {
+  amber: {
+    bar: "bg-amber-500/80",
+    chip: "border-amber-400 text-amber-700 dark:text-amber-300",
+    chipActive: "bg-amber-500 text-white border-amber-500",
+    dot: "border-amber-500 bg-amber-500",
+  },
+  blue: {
+    bar: "bg-blue-500/80",
+    chip: "border-blue-400 text-blue-700 dark:text-blue-300",
+    chipActive: "bg-blue-500 text-white border-blue-500",
+    dot: "border-blue-500 bg-blue-500",
+  },
+  emerald: {
+    bar: "bg-emerald-500/80",
+    chip: "border-emerald-400 text-emerald-700 dark:text-emerald-300",
+    chipActive: "bg-emerald-500 text-white border-emerald-500",
+    dot: "border-emerald-500 bg-emerald-500",
+  },
+  neutral: {
+    bar: "bg-muted-foreground/70",
+    chip: "border-border text-muted-foreground",
+    chipActive: "bg-foreground text-background border-foreground",
+    dot: "border-muted-foreground bg-muted-foreground",
+  },
+  purple: {
+    bar: "bg-purple-500/80",
+    chip: "border-purple-400 text-purple-700 dark:text-purple-300",
+    chipActive: "bg-purple-500 text-white border-purple-500",
+    dot: "border-purple-500 bg-purple-500",
+  },
+  red: {
+    bar: "bg-red-500/80",
+    chip: "border-red-400 text-red-700 dark:text-red-300",
+    chipActive: "bg-red-500 text-white border-red-500",
+    dot: "border-red-500 bg-red-500",
+  },
+  rose: {
+    bar: "bg-rose-500/80",
+    chip: "border-rose-400 text-rose-700 dark:text-rose-300",
+    chipActive: "bg-rose-500 text-white border-rose-500",
+    dot: "border-rose-500 bg-rose-500",
+  },
+};
+
+/**
+ * Track / lane definition.
+ *
+ * @public
+ */
+export type InteractiveTimelineTrack = {
+  /** Color theme. Defaults to `"neutral"`. */
+  color?: InteractiveTimelineColor;
+  /** Stable id; matches {@link InteractiveTimelineEvent.track}. */
+  id: string;
+  /** Display label. */
+  label: ReactNode;
+};
+
+/**
+ * Category definition (drives the legend filter).
+ *
+ * @public
+ */
+export type InteractiveTimelineCategory = {
+  /** Color theme override; falls back to the track color. */
+  color?: InteractiveTimelineColor;
+  /** Stable id; matches {@link InteractiveTimelineEvent.category}. */
+  id: string;
+  /** Display label. */
+  label: ReactNode;
+};
+
+/**
+ * A point or duration event.
+ *
+ * @public
+ */
+export type InteractiveTimelineEvent = {
+  /** Optional category id used by the filter chips. */
+  category?: string;
+  /** Optional explicit color theme for this event. Overrides track + category. */
+  color?: InteractiveTimelineColor;
+  /** Optional description shown in the tooltip. */
+  description?: ReactNode;
+  /** End date for duration events. Omit for point events. */
+  endDate?: Date;
+  /** Stable id. */
+  id: string;
+  /** Start date. */
+  startDate: Date;
+  /** Display title. */
+  title: ReactNode;
+  /** Optional id of the track to render in. Defaults to the first track. */
+  track?: string;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type InteractiveTimelineLabels = {
+  /** Aria-label for the timeline section. Defaults to `"Interactive timeline"`. */
+  region?: string;
+  /** Aria-label for the today button. Defaults to `"Jump to today"`. */
+  today?: string;
+  /** Aria-label for the zoom-in button. Defaults to `"Zoom in"`. */
+  zoomIn?: string;
+  /** Aria-label for the zoom-out button. Defaults to `"Zoom out"`. */
+  zoomOut?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Interactive timeline",
+  today: "Jump to today",
+  zoomIn: "Zoom in",
+  zoomOut: "Zoom out",
+} as const satisfies Required<InteractiveTimelineLabels>;
+
+/**
+ * Props for {@link InteractiveTimeline}.
+ *
+ * @public
+ */
+export type InteractiveTimelineProps = {
+  /** Optional category filter list. Renders a chip row that toggles per category. */
+  categories?: InteractiveTimelineCategory[];
+  /** End of the visible window. */
+  endDate: Date;
+  /** Events to render. */
+  events?: InteractiveTimelineEvent[];
+  /** Localizable strings. */
+  labels?: InteractiveTimelineLabels;
+  /** Fires after a marker click. */
+  onEventClick?: (event: InteractiveTimelineEvent) => void;
+  /** Start of the visible window. */
+  startDate: Date;
+  /** Track / lane definitions. Falls back to a single anonymous lane. */
+  tracks?: InteractiveTimelineTrack[];
+} & ComponentPropsWithoutRef<"section">;
+
+type TimelineCtx = {
+  centerToday: () => void;
+  labels: Required<InteractiveTimelineLabels>;
+  toggleCategory: (id: string) => void;
+  visibleCategories: ReadonlySet<string>;
+  zoom: number;
+  zoomIn: () => void;
+  zoomOut: () => void;
+};
+
+const TimelineContext = createContext<null | TimelineCtx>(null);
+
+function useTimelineContext(): TimelineCtx {
+  const ctx = useContext(TimelineContext);
+  if (!ctx) {
+    throw new Error("InteractiveTimeline subcomponent used outside its root.");
+  }
+  return ctx;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function dateToOffset(date: Date, start: number, span: number): number {
+  if (span <= 0) return 0;
+  return (date.getTime() - start) / span;
+}
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function dayCount(start: number, end: number): number {
+  return Math.max(1, Math.round((end - start) / MS_PER_DAY));
+}
+
+function buildTicks(
+  start: number,
+  end: number,
+  containerWidth: number,
+): { date: Date; offset: number }[] {
+  if (containerWidth <= 0) return [];
+  const targetCount = Math.max(2, Math.floor(containerWidth / TICK_TARGET_PX));
+  const span = end - start;
+  if (span <= 0) return [];
+  const totalDays = dayCount(start, end);
+  const stepDays = Math.max(1, Math.round(totalDays / (targetCount - 1)));
+  const stepMs = stepDays * MS_PER_DAY;
+  return Array.from({ length: targetCount }).map((_, index) => {
+    const time = start + stepMs * index;
+    const clamped = Math.min(time, end);
+    return {
+      date: new Date(clamped),
+      offset: (clamped - start) / span,
+    };
+  });
+}
+
+function resolveEventColor(
+  event: InteractiveTimelineEvent,
+  tracks: InteractiveTimelineTrack[],
+  categories: InteractiveTimelineCategory[],
+): InteractiveTimelineColor {
+  if (event.color) return event.color;
+  if (event.category) {
+    const cat = categories.find((c) => c.id === event.category);
+    if (cat?.color) return cat.color;
+  }
+  if (event.track) {
+    const track = tracks.find((t) => t.id === event.track);
+    if (track?.color) return track.color;
+  }
+  return "neutral";
+}
+
+type AxisProps = {
+  endTime: number;
+  startTime: number;
+  ticks: { date: Date; offset: number }[];
+};
+
+function Axis({ endTime, startTime, ticks }: AxisProps): ReactNode {
+  return (
+    <div
+      aria-hidden="true"
+      className="relative h-7 border-b border-border text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+      data-end={endTime}
+      data-start={startTime}
+    >
+      {ticks.map((tick) => (
+        <span
+          className="absolute top-1 -translate-x-1/2 whitespace-nowrap"
+          key={tick.date.getTime()}
+          style={{ left: `${(tick.offset * 100).toString()}%` }}
+        >
+          {formatDate(tick.date)}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+type TodayMarkerProps = {
+  endTime: number;
+  startTime: number;
+};
+
+function getNow(): number {
+  return Date.now();
+}
+
+function noopUnsubscribe(): void {
+  return;
+}
+
+function emptySubscribe(): () => void {
+  return noopUnsubscribe;
+}
+
+function useNow(): number {
+  return useSyncExternalStore(emptySubscribe, getNow, getNow);
+}
+
+function TodayMarker({ endTime, startTime }: TodayMarkerProps): ReactNode {
+  const now = useNow();
+  if (now < startTime || now > endTime) return null;
+  const offset = (now - startTime) / (endTime - startTime);
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-y-0 z-20 w-px bg-primary"
+      data-testid="today-marker"
+      style={{ left: `${(offset * 100).toString()}%` }}
+    >
+      <span className="absolute -top-2 -translate-x-1/2 rounded bg-primary px-1 text-[10px] font-medium text-primary-foreground">
+        Today
+      </span>
+    </div>
+  );
+}
+
+type EventNodeProps = {
+  active: boolean;
+  categories: InteractiveTimelineCategory[];
+  endTime: number;
+  event: InteractiveTimelineEvent;
+  onSelect: (event: InteractiveTimelineEvent) => void;
+  startTime: number;
+  tracks: InteractiveTimelineTrack[];
+};
+
+type EventGeometry = {
+  isDuration: boolean;
+  left: number;
+  visible: boolean;
+  width: number;
+};
+
+function eventGeometry(
+  event: InteractiveTimelineEvent,
+  startTime: number,
+  endTime: number,
+): EventGeometry {
+  const span = endTime - startTime;
+  const startOffset = dateToOffset(event.startDate, startTime, span);
+  const endOffset = event.endDate
+    ? dateToOffset(event.endDate, startTime, span)
+    : startOffset;
+  const visible =
+    endOffset >= 0 && startOffset <= 1 && event.startDate.getTime() <= endTime;
+  const left = clamp(startOffset, 0, 1);
+  const width = Math.max(0, Math.min(1, endOffset) - left);
+  return {
+    isDuration: width > 0 && Boolean(event.endDate),
+    left,
+    visible,
+    width,
+  };
+}
+
+type EventTooltipProps = {
+  event: InteractiveTimelineEvent;
+  tooltipId: string;
+};
+
+function EventTooltip({ event, tooltipId }: EventTooltipProps): ReactNode {
+  return (
+    <span
+      className="pointer-events-none absolute left-1/2 top-5 hidden -translate-x-1/2 whitespace-nowrap rounded border bg-popover px-2 py-1 text-[11px] font-medium text-popover-foreground shadow-md group-hover:block group-focus-visible:block"
+      id={tooltipId}
+      role="tooltip"
+    >
+      <span className="block">{event.title}</span>
+      <span className="block text-[10px] text-muted-foreground">
+        {formatDate(event.startDate)}
+        {event.endDate ? ` – ${formatDate(event.endDate)}` : null}
+      </span>
+      {event.description ? (
+        <span className="block text-[10px] text-muted-foreground">
+          {event.description}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+function EventNode({
+  active,
+  categories,
+  endTime,
+  event,
+  onSelect,
+  startTime,
+  tracks,
+}: EventNodeProps): ReactNode {
+  const color = resolveEventColor(event, tracks, categories);
+  const palette = COLOR_PALETTE[color];
+  const { isDuration, left, visible, width } = eventGeometry(
+    event,
+    startTime,
+    endTime,
+  );
+  if (!visible) return null;
+  const titleText = typeof event.title === "string" ? event.title : "Event";
+  const tooltipId = `${event.id}-tooltip`;
+
+  const handleClick = (
+    mouseEvent: ReactMouseEvent<HTMLButtonElement>,
+  ): void => {
+    mouseEvent.stopPropagation();
+    onSelect(event);
+  };
+
+  return (
+    <button
+      aria-describedby={event.description ? tooltipId : undefined}
+      aria-label={titleText}
+      aria-pressed={active}
+      className={cn(
+        "group absolute top-1/2 z-10 -translate-y-1/2 cursor-pointer rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        isDuration ? "" : "-translate-x-1/2",
+      )}
+      data-event-id={event.id}
+      data-event-track={event.track ?? ""}
+      data-selected={active ? "true" : undefined}
+      onClick={handleClick}
+      style={{
+        left: `${(left * 100).toString()}%`,
+        width: isDuration ? `${(width * 100).toString()}%` : undefined,
+      }}
+      type="button"
+    >
+      {isDuration ? (
+        <span
+          className={cn(
+            "block h-3 rounded-sm shadow-sm ring-2 ring-background",
+            palette.bar,
+            active ? "ring-primary" : "",
+          )}
+        />
+      ) : (
+        <span
+          className={cn(
+            "block h-3 w-3 rounded-full border-2 ring-2 ring-background",
+            palette.dot,
+            active ? "ring-primary" : "",
+          )}
+        />
+      )}
+      <EventTooltip event={event} tooltipId={tooltipId} />
+    </button>
+  );
+}
+
+type TrackRowProps = {
+  categories: InteractiveTimelineCategory[];
+  endTime: number;
+  events: InteractiveTimelineEvent[];
+  onSelect: (event: InteractiveTimelineEvent) => void;
+  selectedId?: string;
+  startTime: number;
+  track: InteractiveTimelineTrack;
+};
+
+function TrackRow({
+  categories,
+  endTime,
+  events,
+  onSelect,
+  selectedId,
+  startTime,
+  track,
+}: TrackRowProps): ReactNode {
+  const palette = COLOR_PALETTE[track.color ?? "neutral"];
+  return (
+    <div
+      className="relative flex h-12 items-center border-t border-border/60"
+      data-track-id={track.id}
+    >
+      <div className="absolute left-0 z-30 flex h-full w-32 shrink-0 items-center gap-2 border-r border-border bg-background px-3 text-xs font-medium">
+        <span
+          aria-hidden="true"
+          className={cn("h-2 w-2 rounded-full", palette.dot)}
+        />
+        <span className="truncate">{track.label}</span>
+      </div>
+      <div className="relative ml-32 h-full flex-1">
+        <div className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-border" />
+        {events.map((event) => (
+          <EventNode
+            active={selectedId === event.id}
+            categories={categories}
+            endTime={endTime}
+            event={event}
+            key={event.id}
+            onSelect={onSelect}
+            startTime={startTime}
+            tracks={[track]}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type ScrollAreaProps = {
+  categories: InteractiveTimelineCategory[];
+  endTime: number;
+  events: InteractiveTimelineEvent[];
+  onSelect: (event: InteractiveTimelineEvent) => void;
+  selectedId?: string;
+  startTime: number;
+  tracks: InteractiveTimelineTrack[];
+  zoom: number;
+};
+
+type ScrollDragHandlers = {
+  onPointerCancel: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onPointerUp: (event: ReactPointerEvent<HTMLDivElement>) => void;
+};
+
+function useScrollDrag(
+  ref: React.RefObject<HTMLDivElement | null>,
+): ScrollDragHandlers {
+  const dragRef = useRef<null | { originScroll: number; originX: number }>(
+    null,
+  );
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      const node = ref.current;
+      if (!node) return;
+      dragRef.current = {
+        originScroll: node.scrollLeft,
+        originX: event.clientX,
+      };
+      node.setPointerCapture(event.pointerId);
+    },
+    [ref],
+  );
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      const node = ref.current;
+      const drag = dragRef.current;
+      if (!node || !drag) return;
+      node.scrollLeft = drag.originScroll - (event.clientX - drag.originX);
+    },
+    [ref],
+  );
+
+  const onPointerEnd = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      const node = ref.current;
+      if (!node) return;
+      if (node.hasPointerCapture(event.pointerId)) {
+        node.releasePointerCapture(event.pointerId);
+      }
+      dragRef.current = null;
+    },
+    [ref],
+  );
+
+  return {
+    onPointerCancel: onPointerEnd,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp: onPointerEnd,
+  };
+}
+
+function ScrollArea({
+  categories,
+  endTime,
+  events,
+  onSelect,
+  selectedId,
+  startTime,
+  tracks,
+  zoom,
+}: ScrollAreaProps): ReactNode {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [containerWidth, setContainerWidth] = useState(800);
+  const dragHandlers = useScrollDrag(ref);
+
+  const handleRef = useCallback((node: HTMLDivElement | null) => {
+    ref.current = node;
+    if (node) setContainerWidth(node.clientWidth);
+  }, []);
+
+  const innerWidth = `${(zoom * 100).toString()}%`;
+  const ticks = useMemo(
+    () => buildTicks(startTime, endTime, containerWidth * zoom),
+    [containerWidth, endTime, startTime, zoom],
+  );
+
+  return (
+    <div
+      className="relative w-full cursor-grab overflow-x-auto active:cursor-grabbing"
+      data-zoom={zoom}
+      ref={handleRef}
+      {...dragHandlers}
+    >
+      <div className="relative" style={{ width: innerWidth }}>
+        <Axis endTime={endTime} startTime={startTime} ticks={ticks} />
+        <div className="relative">
+          <TodayMarker endTime={endTime} startTime={startTime} />
+          {tracks.map((track) => {
+            const trackEvents = events.filter(
+              (event) => (event.track ?? tracks[0]?.id) === track.id,
+            );
+            return (
+              <TrackRow
+                categories={categories}
+                endTime={endTime}
+                events={trackEvents}
+                key={track.id}
+                onSelect={onSelect}
+                selectedId={selectedId}
+                startTime={startTime}
+                track={track}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Toolbar slot. Pass {@link InteractiveTimelineZoomIn},
+ * {@link InteractiveTimelineZoomOut}, {@link InteractiveTimelineToday},
+ * {@link InteractiveTimelineFilter} as children.
+ *
+ * @public
+ */
+export const InteractiveTimelineToolbar = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ children, className, ...rest }, ref) => (
+  <div
+    className={cn(
+      "flex flex-wrap items-center gap-2 border-b border-border bg-muted/30 px-3 py-2",
+      className,
+    )}
+    ref={ref}
+    role="toolbar"
+    {...rest}
+  >
+    {children}
+  </div>
+));
+InteractiveTimelineToolbar.displayName = "InteractiveTimelineToolbar";
+
+/**
+ * Zoom-in button. Doubles the zoom factor up to a max.
+ *
+ * @public
+ */
+export const InteractiveTimelineZoomIn = forwardRef<
+  HTMLButtonElement,
+  Omit<ComponentPropsWithoutRef<"button">, "type">
+>(({ className, ...rest }, ref) => {
+  const { labels, zoomIn } = useTimelineContext();
+  return (
+    <button
+      aria-label={labels.zoomIn}
+      className={cn(
+        "inline-flex h-8 w-8 items-center justify-center rounded-md border border-border bg-background text-sm font-medium hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+      onClick={zoomIn}
+      ref={ref}
+      type="button"
+      {...rest}
+    >
+      <span aria-hidden="true">+</span>
+    </button>
+  );
+});
+InteractiveTimelineZoomIn.displayName = "InteractiveTimelineZoomIn";
+
+/**
+ * Zoom-out button.
+ *
+ * @public
+ */
+export const InteractiveTimelineZoomOut = forwardRef<
+  HTMLButtonElement,
+  Omit<ComponentPropsWithoutRef<"button">, "type">
+>(({ className, ...rest }, ref) => {
+  const { labels, zoomOut } = useTimelineContext();
+  return (
+    <button
+      aria-label={labels.zoomOut}
+      className={cn(
+        "inline-flex h-8 w-8 items-center justify-center rounded-md border border-border bg-background text-sm font-medium hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+      onClick={zoomOut}
+      ref={ref}
+      type="button"
+      {...rest}
+    >
+      <span aria-hidden="true">−</span>
+    </button>
+  );
+});
+InteractiveTimelineZoomOut.displayName = "InteractiveTimelineZoomOut";
+
+/**
+ * Today button. Centers the view on `Date.now()` if it falls inside the
+ * timeline window.
+ *
+ * @public
+ */
+export const InteractiveTimelineToday = forwardRef<
+  HTMLButtonElement,
+  Omit<ComponentPropsWithoutRef<"button">, "type">
+>(({ children, className, ...rest }, ref) => {
+  const { centerToday, labels } = useTimelineContext();
+  return (
+    <button
+      aria-label={labels.today}
+      className={cn(
+        "inline-flex h-8 items-center rounded-md border border-border bg-background px-3 text-xs font-medium hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+      onClick={centerToday}
+      ref={ref}
+      type="button"
+      {...rest}
+    >
+      {children ?? "Today"}
+    </button>
+  );
+});
+InteractiveTimelineToday.displayName = "InteractiveTimelineToday";
+
+/**
+ * Category filter chips. Toggles visibility of events by category.
+ *
+ * @public
+ */
+export type InteractiveTimelineFilterProps = {
+  categories: InteractiveTimelineCategory[];
+} & Omit<ComponentPropsWithoutRef<"div">, "children">;
+
+export const InteractiveTimelineFilter = forwardRef<
+  HTMLDivElement,
+  InteractiveTimelineFilterProps
+>(({ categories, className, ...rest }, ref) => {
+  const { toggleCategory, visibleCategories } = useTimelineContext();
+  return (
+    <div
+      className={cn("flex flex-wrap items-center gap-1.5", className)}
+      ref={ref}
+      role="group"
+      {...rest}
+    >
+      {categories.map((category) => {
+        const active = visibleCategories.has(category.id);
+        const palette = COLOR_PALETTE[category.color ?? "neutral"];
+        return (
+          <button
+            aria-pressed={active}
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium",
+              active ? palette.chipActive : palette.chip,
+            )}
+            data-category-id={category.id}
+            key={category.id}
+            onClick={() => {
+              toggleCategory(category.id);
+            }}
+            type="button"
+          >
+            {category.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+});
+InteractiveTimelineFilter.displayName = "InteractiveTimelineFilter";
+
+const FALLBACK_TRACK: InteractiveTimelineTrack = {
+  color: "neutral",
+  id: "default",
+  label: "Events",
+};
+
+function noop(): void {
+  return;
+}
+
+function useToolbarHandlers(arguments_: {
+  endTime: number;
+  scrollerId: string;
+  setZoom: (next: ((previous: number) => number) | number) => void;
+  startTime: number;
+  zoom: number;
+}): {
+  centerToday: () => void;
+  zoomIn: () => void;
+  zoomOut: () => void;
+} {
+  const { endTime, scrollerId, setZoom, startTime } = arguments_;
+  const zoomIn = useCallback(() => {
+    setZoom((current) => clamp(current * ZOOM_STEP, MIN_ZOOM, MAX_ZOOM));
+  }, [setZoom]);
+  const zoomOut = useCallback(() => {
+    setZoom((current) => clamp(current / ZOOM_STEP, MIN_ZOOM, MAX_ZOOM));
+  }, [setZoom]);
+  const centerToday = useCallback(() => {
+    if (typeof document === "undefined") return;
+    const node = document.querySelector<HTMLElement>(
+      `[data-scroller-id="${scrollerId}"]`,
+    );
+    if (!node) return;
+    const span = endTime - startTime;
+    if (span <= 0) return;
+    const now = Date.now();
+    const offset = clamp((now - startTime) / span, 0, 1);
+    const targetX = offset * node.scrollWidth - node.clientWidth / 2;
+    node.scrollLeft = clamp(targetX, 0, node.scrollWidth);
+  }, [endTime, scrollerId, startTime]);
+  return { centerToday, zoomIn, zoomOut };
+}
+
+type FilterState = {
+  filteredEvents: InteractiveTimelineEvent[];
+  toggleCategory: (id: string) => void;
+  visibleCategories: ReadonlySet<string>;
+};
+
+type SelectionState = {
+  handleSelect: (event: InteractiveTimelineEvent) => void;
+  selectedId?: string;
+};
+
+type Frame = {
+  endTime: number;
+  resolvedLabels: Required<InteractiveTimelineLabels>;
+  startTime: number;
+  tracks: InteractiveTimelineTrack[];
+};
+
+function useTimelineFrame(arguments_: {
+  endDate: Date;
+  labels?: InteractiveTimelineLabels;
+  startDate: Date;
+  trackProperty?: InteractiveTimelineTrack[];
+}): Frame {
+  const { endDate, labels, startDate, trackProperty } = arguments_;
+  const tracks =
+    trackProperty && trackProperty.length > 0
+      ? trackProperty
+      : [FALLBACK_TRACK];
+  const resolvedLabels = useMemo(
+    () => ({ ...DEFAULT_LABELS, ...labels }),
+    [labels],
+  );
+  return {
+    endTime: endDate.getTime(),
+    resolvedLabels,
+    startTime: startDate.getTime(),
+    tracks,
+  };
+}
+
+function useEventSelection(
+  onEventClick: (event: InteractiveTimelineEvent) => void,
+): SelectionState {
+  const [selectedId, setSelectedId] = useState<string | undefined>();
+  const handleSelect = useCallback(
+    (event: InteractiveTimelineEvent) => {
+      setSelectedId(event.id);
+      onEventClick(event);
+    },
+    [onEventClick],
+  );
+  return { handleSelect, selectedId };
+}
+
+function useTimelineContextValue(arguments_: {
+  centerToday: () => void;
+  labels: Required<InteractiveTimelineLabels>;
+  toggleCategory: (id: string) => void;
+  visibleCategories: ReadonlySet<string>;
+  zoom: number;
+  zoomIn: () => void;
+  zoomOut: () => void;
+}): TimelineCtx {
+  const {
+    centerToday,
+    labels,
+    toggleCategory,
+    visibleCategories,
+    zoom,
+    zoomIn,
+    zoomOut,
+  } = arguments_;
+  return useMemo<TimelineCtx>(
+    () => ({
+      centerToday,
+      labels,
+      toggleCategory,
+      visibleCategories,
+      zoom,
+      zoomIn,
+      zoomOut,
+    }),
+    [
+      centerToday,
+      labels,
+      toggleCategory,
+      visibleCategories,
+      zoom,
+      zoomIn,
+      zoomOut,
+    ],
+  );
+}
+
+function useTimelineFilter(
+  categories: InteractiveTimelineCategory[],
+  events: InteractiveTimelineEvent[],
+): FilterState {
+  const [hidden, setHidden] = useState<ReadonlySet<string>>(() => new Set());
+
+  const visibleCategories = useMemo(
+    () =>
+      new Set(
+        categories
+          .filter((category) => !hidden.has(category.id))
+          .map((category) => category.id),
+      ),
+    [categories, hidden],
+  );
+
+  const toggleCategory = useCallback((id: string) => {
+    setHidden((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const filteredEvents = useMemo(() => {
+    if (categories.length === 0) return events;
+    return events.filter((event) => {
+      if (!event.category) return true;
+      return !hidden.has(event.category);
+    });
+  }, [categories.length, events, hidden]);
+
+  return { filteredEvents, toggleCategory, visibleCategories };
+}
+
+/**
+ * Zoomable, pannable, multi-track timeline. Drag horizontally to pan;
+ * use {@link InteractiveTimelineZoomIn} / {@link InteractiveTimelineZoomOut}
+ * to change zoom; click events to select. Out of scope for the MVP:
+ * minimap, virtual rendering, image export, pinch-to-zoom — pan + button
+ * zoom cover the data-rich case.
+ *
+ * @example
+ * ```tsx
+ * <InteractiveTimeline
+ *   startDate={new Date("2024-01-01")}
+ *   endDate={new Date("2026-12-31")}
+ *   tracks={[{ id: "release", label: "Releases", color: "blue" }]}
+ *   events={[
+ *     { id: "v1", title: "v1.0", startDate: new Date("2024-06-01"), track: "release" },
+ *   ]}
+ *   onEventClick={(event) => console.info(event.id)}
+ * >
+ *   <InteractiveTimelineToolbar>
+ *     <InteractiveTimelineZoomIn />
+ *     <InteractiveTimelineZoomOut />
+ *     <InteractiveTimelineToday />
+ *   </InteractiveTimelineToolbar>
+ * </InteractiveTimeline>
+ * ```
+ *
+ * @public
+ */
+export const InteractiveTimeline = forwardRef<
+  HTMLElement,
+  InteractiveTimelineProps
+>((props, ref) => {
+  const {
+    categories = [],
+    children,
+    className,
+    endDate,
+    events = [],
+    labels,
+    onEventClick = noop,
+    startDate,
+    tracks: trackProperty,
+    ...rest
+  } = props;
+
+  const { endTime, resolvedLabels, startTime, tracks } = useTimelineFrame({
+    endDate,
+    labels,
+    startDate,
+    trackProperty,
+  });
+  const scrollerId = useId();
+
+  const [zoom, setZoom] = useState<number>(1);
+
+  const { filteredEvents, toggleCategory, visibleCategories } =
+    useTimelineFilter(categories, events);
+
+  const { centerToday, zoomIn, zoomOut } = useToolbarHandlers({
+    endTime,
+    scrollerId,
+    setZoom,
+    startTime,
+    zoom,
+  });
+
+  const { handleSelect, selectedId } = useEventSelection(onEventClick);
+
+  const ctx = useTimelineContextValue({
+    centerToday,
+    labels: resolvedLabels,
+    toggleCategory,
+    visibleCategories,
+    zoom,
+    zoomIn,
+    zoomOut,
+  });
+
+  return (
+    <TimelineContext.Provider value={ctx}>
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "flex w-full flex-col overflow-hidden rounded-2xl border bg-background text-foreground",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+        <div data-scroller-id={scrollerId} id={scrollerId}>
+          <ScrollArea
+            categories={categories}
+            endTime={endTime}
+            events={filteredEvents}
+            onSelect={handleSelect}
+            selectedId={selectedId}
+            startTime={startTime}
+            tracks={tracks}
+            zoom={zoom}
+          />
+        </div>
+      </section>
+    </TimelineContext.Provider>
+  );
+});
+InteractiveTimeline.displayName = "InteractiveTimeline";

--- a/apps/registry/registry/default/jarvis-dock/jarvis-dock.tsx
+++ b/apps/registry/registry/default/jarvis-dock/jarvis-dock.tsx
@@ -1,7 +1,174 @@
-export {
-  JarvisDock,
-  type JarvisDockAction,
-  type JarvisDockLabels,
-  type JarvisDockProps,
-  type JarvisDockTone,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Tone of a dock action — drives its accent color.
+ *
+ * @public
+ */
+export type JarvisDockTone = "danger" | "neutral" | "primary" | "success";
+
+const TONE_CLASS: Record<JarvisDockTone, string> = {
+  danger: "text-red-600 dark:text-red-400",
+  neutral: "text-foreground",
+  primary: "text-blue-600 dark:text-blue-400",
+  success: "text-emerald-600 dark:text-emerald-400",
+};
+
+/**
+ * One action button slotted in the dock.
+ *
+ * @public
+ */
+export type JarvisDockAction = {
+  /** Optional badge value rendered as a small dot or count. */
+  badge?: ReactNode;
+  /** Glyph rendered above the label (single character or icon). */
+  glyph: ReactNode;
+  /** Stable identifier — used as the React key + analytics hook. */
+  id: string;
+  /** Short label shown beneath the glyph. */
+  label: ReactNode;
+  /** Click handler. */
+  onActivate: () => void;
+  /** Optional tone. Defaults to `"neutral"`. */
+  tone?: JarvisDockTone;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type JarvisDockLabels = {
+  /** Aria-label for the command-palette trigger. Defaults to `"Open command palette"`. */
+  paletteTrigger?: string;
+  /** Aria-label for the dock. Defaults to `"Jarvis dock"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  paletteTrigger: "Open command palette",
+  region: "Jarvis dock",
+} as const satisfies Required<JarvisDockLabels>;
+
+/**
+ * Props for {@link JarvisDock}.
+ *
+ * @public
+ */
+export type JarvisDockProps = {
+  /** Action buttons in render order. */
+  actions: JarvisDockAction[];
+  /** Localizable strings. */
+  labels?: JarvisDockLabels;
+  /** Optional handler for the "..." command-palette trigger. */
+  onOpenPalette?: () => void;
+} & ComponentPropsWithoutRef<"nav">;
+
+const ActionButton = (props: {
+  action: JarvisDockAction;
+}): React.ReactElement => {
+  const { action } = props;
+  const tone = action.tone ?? "neutral";
+  const handleClick = (): void => {
+    action.onActivate();
+  };
+  return (
+    <button
+      className="group relative flex h-12 w-12 flex-col items-center justify-center gap-0.5 rounded-md border border-transparent text-[10px] uppercase tracking-wide text-muted-foreground transition-colors hover:border-border hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      data-jarvis-action={action.id}
+      data-jarvis-tone={tone}
+      onClick={handleClick}
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "text-base leading-none transition-transform group-hover:scale-110",
+          TONE_CLASS[tone],
+        )}
+      >
+        {action.glyph}
+      </span>
+      <span className="truncate">{action.label}</span>
+      {action.badge ? (
+        <span
+          className="absolute right-1 top-1 inline-flex min-h-[14px] min-w-[14px] items-center justify-center rounded-full bg-foreground px-1 text-[9px] font-medium text-background"
+          data-jarvis-badge
+        >
+          {action.badge}
+        </span>
+      ) : null}
+    </button>
+  );
+};
+
+/**
+ * Floating bottom dock for the spatial canvas. Renders a compact row
+ * of agent / quick-action buttons plus a trailing command-palette
+ * trigger. Pure presentation; the host wires `onActivate` per action
+ * and `onOpenPalette` for the palette button.
+ *
+ * @example
+ * ```tsx
+ * <JarvisDock
+ *   actions={[
+ *     { id: "summon", glyph: "+", label: "Summon", tone: "primary",
+ *       onActivate: () => spawnAgent() },
+ *     { id: "review", glyph: "✓", label: "Review", tone: "success",
+ *       onActivate: () => openReview() },
+ *   ]}
+ *   onOpenPalette={() => openCommandPalette()}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const JarvisDock = forwardRef<HTMLElement, JarvisDockProps>(
+  (props, ref) => {
+    const { actions, className, labels, onOpenPalette, ...rest } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const handlePalette = (): void => {
+      onOpenPalette?.();
+    };
+    return (
+      <nav
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "inline-flex items-center gap-1 rounded-2xl border bg-background/90 p-1.5 shadow-md backdrop-blur",
+          className,
+        )}
+        data-jarvis-dock
+        ref={ref}
+        {...rest}
+      >
+        {actions.map((action) => (
+          <ActionButton action={action} key={action.id} />
+        ))}
+        {onOpenPalette ? (
+          <>
+            <span aria-hidden="true" className="mx-1 h-8 w-px bg-border" />
+            <button
+              aria-label={resolvedLabels.paletteTrigger}
+              className="flex h-12 w-12 items-center justify-center rounded-md border border-transparent text-base text-muted-foreground transition-colors hover:border-border hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              data-jarvis-palette-trigger
+              onClick={handlePalette}
+              type="button"
+            >
+              <span aria-hidden="true">⌘</span>
+            </button>
+          </>
+        ) : null}
+      </nav>
+    );
+  },
+);
+JarvisDock.displayName = "JarvisDock";

--- a/apps/registry/registry/default/kbd/kbd.tsx
+++ b/apps/registry/registry/default/kbd/kbd.tsx
@@ -1,2 +1,174 @@
-// Re-export from @vllnt/ui package
-export { Kbd, kbdVariants } from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useSyncExternalStore,
+} from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+
+const kbdVariants = cva(
+  "inline-flex select-none items-center justify-center rounded border border-border bg-muted font-mono font-medium text-foreground shadow-[0_1px_0_0_hsl(var(--border))] [&>svg]:h-3 [&>svg]:w-3",
+  {
+    defaultVariants: {
+      size: "md",
+    },
+    variants: {
+      size: {
+        lg: "h-7 min-w-[1.75rem] px-2 text-sm",
+        md: "h-5 min-w-[1.25rem] px-1.5 text-xs",
+        sm: "h-4 min-w-[1rem] px-1 text-[10px]",
+      },
+    },
+  },
+);
+
+const MAC_PLATFORM_PATTERN = /mac|iphone|ipad|ipod/i;
+
+const MODIFIER_LABELS: Record<
+  "alt" | "ctrl" | "meta" | "mod" | "shift",
+  { mac: string; other: string }
+> = {
+  alt: { mac: "⌥", other: "Alt" },
+  ctrl: { mac: "⌃", other: "Ctrl" },
+  meta: { mac: "⌘", other: "Win" },
+  mod: { mac: "⌘", other: "Ctrl" },
+  shift: { mac: "⇧", other: "Shift" },
+};
+
+const SPECIAL_KEY_LABELS: Record<string, string> = {
+  arrowdown: "↓",
+  arrowleft: "←",
+  arrowright: "→",
+  arrowup: "↑",
+  backspace: "⌫",
+  delete: "⌦",
+  enter: "↵",
+  escape: "Esc",
+  return: "↵",
+  space: "Space",
+  tab: "⇥",
+};
+
+const SHORTCUT_SEPARATOR = /\s*\+\s*/;
+
+function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return MAC_PLATFORM_PATTERN.test(navigator.userAgent);
+}
+
+function noopUnsubscribe(): void {
+  return;
+}
+
+function subscribeNoop(): () => void {
+  return noopUnsubscribe;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+function useIsMac(): boolean {
+  return useSyncExternalStore(subscribeNoop, isMacPlatform, getServerSnapshot);
+}
+
+function isModifier(value: string): value is keyof typeof MODIFIER_LABELS {
+  return Object.hasOwn(MODIFIER_LABELS, value);
+}
+
+function formatToken(token: string, mac: boolean): string {
+  const lowered = token.toLowerCase();
+  if (isModifier(lowered)) {
+    const labels = MODIFIER_LABELS[lowered];
+    return mac ? labels.mac : labels.other;
+  }
+  const special = SPECIAL_KEY_LABELS[lowered];
+  if (special !== undefined) return special;
+  return token.length === 1 ? token.toUpperCase() : token;
+}
+
+/**
+ * Props for {@link Kbd}.
+ *
+ * @public
+ */
+export type KbdProps = {
+  /** Optional explicit children. Takes precedence over `shortcut`. */
+  children?: ReactNode;
+  /**
+   * Shortcut string in the form `"mod+k"` or `"ctrl+shift+p"`. The `mod`
+   * token expands to `⌘` on Mac and `Ctrl` elsewhere.
+   */
+  shortcut?: string;
+} & ComponentPropsWithoutRef<"kbd"> &
+  VariantProps<typeof kbdVariants>;
+
+/**
+ * Keyboard key indicator. Renders a single key when used with `children`,
+ * or expands a shortcut string with platform-aware modifiers when given a
+ * `shortcut` prop.
+ *
+ * @example
+ * ```tsx
+ * <Kbd>Ctrl</Kbd> + <Kbd>K</Kbd>
+ *
+ * {/* Renders ⌘+K on Mac, Ctrl+K elsewhere *\/}
+ * <Kbd shortcut="mod+k" />
+ * ```
+ *
+ * @public
+ */
+export const Kbd = forwardRef<HTMLElement, KbdProps>(
+  ({ children, className, shortcut, size, ...rest }, ref) => {
+    const isMac = useIsMac();
+
+    if (children !== undefined) {
+      return (
+        <kbd
+          className={cn(kbdVariants({ size }), className)}
+          ref={ref}
+          {...rest}
+        >
+          {children}
+        </kbd>
+      );
+    }
+
+    if (shortcut) {
+      const tokens = shortcut.split(SHORTCUT_SEPARATOR).filter(Boolean);
+      const ariaLabel = tokens
+        .map((token) => formatToken(token, isMac))
+        .join(" + ");
+      return (
+        <span aria-label={ariaLabel} className="inline-flex items-center gap-1">
+          {tokens.map((token, index) => (
+            <kbd
+              className={cn(kbdVariants({ size }), className)}
+              key={`${token}-${index.toString()}`}
+              ref={index === 0 ? ref : undefined}
+              {...(index === 0 ? rest : {})}
+            >
+              {formatToken(token, isMac)}
+            </kbd>
+          ))}
+        </span>
+      );
+    }
+
+    return (
+      <kbd
+        className={cn(kbdVariants({ size }), className)}
+        ref={ref}
+        {...rest}
+      />
+    );
+  },
+);
+Kbd.displayName = "Kbd";
+
+export { kbdVariants };

--- a/apps/registry/registry/default/key-concept/key-concept.tsx
+++ b/apps/registry/registry/default/key-concept/key-concept.tsx
@@ -1,14 +1,14 @@
-import type { ReactNode } from 'react'
+import type { ReactNode } from "react";
 
-import { cn } from '../../../lib/utils'
+import { cn } from "@vllnt/ui";
 
 export type KeyConceptProps = {
-  children: ReactNode
-  className?: string
-  highlight?: boolean
-  icon?: ReactNode
-  term: string
-}
+  children: ReactNode;
+  className?: string;
+  highlight?: boolean;
+  icon?: ReactNode;
+  term: string;
+};
 
 export function KeyConcept({
   children,
@@ -20,14 +20,18 @@ export function KeyConcept({
   return (
     <div
       className={cn(
-        'my-4 rounded-lg border p-4',
-        highlight ? 'border-primary/50 bg-primary/5' : 'border-border bg-muted/30',
+        "my-4 rounded-lg border p-4",
+        highlight
+          ? "border-primary/50 bg-primary/5"
+          : "border-border bg-muted/30",
         className,
       )}
     >
       <div className="flex items-start gap-3">
         {icon ? (
-          <span className="h-5 w-5 text-primary flex-shrink-0 mt-0.5">{icon}</span>
+          <span className="h-5 w-5 text-primary flex-shrink-0 mt-0.5">
+            {icon}
+          </span>
         ) : (
           <svg
             className="h-5 w-5 text-primary flex-shrink-0 mt-0.5"
@@ -45,33 +49,40 @@ export function KeyConcept({
         )}
         <div className="flex-1 min-w-0">
           <dt className="font-bold text-foreground mb-1">{term}</dt>
-          <dd className="text-sm text-muted-foreground [&>p]:mb-0">{children}</dd>
+          <dd className="text-sm text-muted-foreground [&>p]:mb-0">
+            {children}
+          </dd>
         </div>
       </div>
     </div>
-  )
+  );
 }
 
 export type GlossaryProps = {
-  children: ReactNode
-  className?: string
-  icon?: ReactNode
-  title?: string
-}
+  children: ReactNode;
+  className?: string;
+  icon?: ReactNode;
+  title?: string;
+};
 
 export function Glossary({
   children,
   className,
   icon,
-  title = 'Key Terms',
+  title = "Key Terms",
 }: GlossaryProps): React.ReactNode {
   return (
-    <div className={cn('my-6', className)}>
+    <div className={cn("my-6", className)}>
       <h4 className="font-semibold mb-3 flex items-center gap-2">
         {icon ? (
           <span className="h-4 w-4">{icon}</span>
         ) : (
-          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
             <path
               d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
               strokeLinecap="round"
@@ -84,5 +95,5 @@ export function Glossary({
       </h4>
       <dl className="space-y-2">{children}</dl>
     </div>
-  )
+  );
 }

--- a/apps/registry/registry/default/keyboard-shortcuts-help/keyboard-shortcuts-help.tsx
+++ b/apps/registry/registry/default/keyboard-shortcuts-help/keyboard-shortcuts-help.tsx
@@ -1,2 +1,152 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { memo, useEffect, useRef } from "react";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type KeyboardShortcut = {
+  description: string;
+  keys: readonly string[];
+};
+
+export type KeyboardShortcutsHelpProps = {
+  className?: string;
+  closeIcon?: ReactNode;
+  footer?: ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+  shortcuts: readonly KeyboardShortcut[];
+  title?: string;
+};
+
+// eslint-disable-next-line max-lines-per-function -- Modal with keyboard handling and focus trap
+function KeyboardShortcutsHelpImpl({
+  className,
+  closeIcon,
+  footer,
+  isOpen,
+  onClose,
+  shortcuts,
+  title = "Keyboard Shortcuts",
+}: KeyboardShortcutsHelpProps): React.ReactNode {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Focus trap and close on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+
+    closeButtonRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  // Prevent body scroll when open
+  useEffect(() => {
+    document.body.style.overflow = isOpen ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      aria-labelledby="shortcuts-title"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+    >
+      {/* Backdrop */}
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div
+        className={cn(
+          "relative z-10 w-full max-w-sm rounded-lg bg-background p-6 shadow-xl mx-4",
+          className,
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold" id="shortcuts-title">
+            {title}
+          </h2>
+          <button
+            aria-label="Close shortcuts help"
+            className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
+            onClick={onClose}
+            ref={closeButtonRef}
+            type="button"
+          >
+            {closeIcon ?? (
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M6 18L18 6M6 6l12 12"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                />
+              </svg>
+            )}
+          </button>
+        </div>
+
+        {/* Shortcuts List */}
+        <div className="space-y-3">
+          {shortcuts.map((shortcut) => (
+            <div
+              className="flex items-center justify-between text-sm"
+              key={shortcut.description}
+            >
+              <span className="text-muted-foreground">
+                {shortcut.description}
+              </span>
+              <div className="flex gap-1">
+                {shortcut.keys.map((key) => (
+                  <kbd
+                    className="inline-flex h-6 min-w-[24px] items-center justify-center rounded border border-border bg-muted px-1.5 font-mono text-xs"
+                    key={key}
+                  >
+                    {key}
+                  </kbd>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        {footer ? (
+          <div className="mt-4 text-xs text-muted-foreground text-center">
+            {footer}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export const KeyboardShortcutsHelp = memo(KeyboardShortcutsHelpImpl);
+KeyboardShortcutsHelp.displayName = "KeyboardShortcutsHelp";

--- a/apps/registry/registry/default/knowledge-check/knowledge-check.tsx
+++ b/apps/registry/registry/default/knowledge-check/knowledge-check.tsx
@@ -1,2 +1,765 @@
-// Re-export from @vllnt/ui package
-export { KnowledgeCheck } from '@vllnt/ui'
+"use client";
+
+import {
+  type ChangeEvent,
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+
+import { CheckCircle2, RotateCcw, XCircle } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import { Input } from "@vllnt/ui";
+
+/**
+ * Question kind for {@link KnowledgeCheckQuestion}.
+ *
+ * @public
+ */
+export type KnowledgeCheckQuestionType =
+  | "fill-blank"
+  | "multiple-choice"
+  | "true-false";
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type KnowledgeCheckLabels = {
+  /** Caption for the previous-question button. Defaults to `"Back"`. */
+  back?: string;
+  /** Caption for the check-answer button. Defaults to `"Check"`. */
+  check?: string;
+  /** Caption for the correct-answer feedback. Defaults to `"Correct"`. */
+  correct?: string;
+  /** Caption for the false option. Defaults to `"False"`. */
+  falseOption?: string;
+  /** Caption for the incorrect-answer feedback. Defaults to `"Try again"`. */
+  incorrect?: string;
+  /** Caption for the next-question button. Defaults to `"Next"`. */
+  next?: string;
+  /** Caption for the summary "out of" connector. Defaults to `"of"`. */
+  outOf?: string;
+  /** Caption for the retry button. Defaults to `"Retry"`. */
+  retry?: string;
+  /** Heading above the score summary. Defaults to `"You scored"`. */
+  scored?: string;
+  /** Caption for the true option. Defaults to `"True"`. */
+  trueOption?: string;
+};
+
+const DEFAULT_LABELS = {
+  back: "Back",
+  check: "Check",
+  correct: "Correct",
+  falseOption: "False",
+  incorrect: "Try again",
+  next: "Next",
+  outOf: "of",
+  retry: "Retry",
+  scored: "You scored",
+  trueOption: "True",
+} as const satisfies Required<KnowledgeCheckLabels>;
+
+/**
+ * Choice option entry passed to a choice question.
+ *
+ * @public
+ */
+export type KnowledgeCheckOption = {
+  /** When true, this option is the correct answer. */
+  correct?: boolean;
+  /** Display label. */
+  label: ReactNode;
+  /** Stable identifier within the question. */
+  value: string;
+};
+
+type FillBlankQuestion = {
+  /** Expected answer string. */
+  answer: string;
+  /** When true, comparison is case-sensitive. Defaults to `false`. */
+  caseSensitive?: boolean;
+  /** Optional explanation shown after the user submits. */
+  explanation?: ReactNode;
+  /** Stable identifier. */
+  id: string;
+  /** Question prompt. */
+  question: ReactNode;
+  type: "fill-blank";
+};
+
+type MultipleChoiceQuestion = {
+  /** Optional explanation shown after the user submits. */
+  explanation?: ReactNode;
+  /** Stable identifier. */
+  id: string;
+  /** Option list. Mark the correct option(s) with `correct: true`. */
+  options: KnowledgeCheckOption[];
+  /** Question prompt. */
+  question: ReactNode;
+  type: "multiple-choice";
+};
+
+type TrueFalseQuestion = {
+  /** Expected boolean answer. */
+  answer: boolean;
+  /** Optional explanation shown after the user submits. */
+  explanation?: ReactNode;
+  /** Stable identifier. */
+  id: string;
+  /** Question prompt. */
+  question: ReactNode;
+  type: "true-false";
+};
+
+/**
+ * Question entry passed to {@link KnowledgeCheckProps.questions}.
+ *
+ * @public
+ */
+export type KnowledgeCheckQuestion =
+  | FillBlankQuestion
+  | MultipleChoiceQuestion
+  | TrueFalseQuestion;
+
+/**
+ * Per-question result reported to the consumer.
+ *
+ * @public
+ */
+export type KnowledgeCheckAnswer = {
+  /** True when the user's response matched the expected answer. */
+  correct: boolean;
+  /** Question id. */
+  questionId: string;
+  /** The user's raw response (string for `fill-blank`, option value for choice, boolean for `true-false`). */
+  response: boolean | string;
+};
+
+/**
+ * Score payload reported on completion.
+ *
+ * @public
+ */
+export type KnowledgeCheckScore = {
+  /** Map of question id → answer. */
+  answers: Record<string, KnowledgeCheckAnswer>;
+  /** Right-answer count. */
+  correct: number;
+  /** Total number of questions. */
+  total: number;
+};
+
+function compareFillBlank(
+  question: FillBlankQuestion,
+  response: string,
+): boolean {
+  const normalize = (value: string): string =>
+    question.caseSensitive ? value.trim() : value.trim().toLowerCase();
+  return normalize(response) === normalize(question.answer);
+}
+
+function isMultipleChoiceCorrect(
+  question: MultipleChoiceQuestion,
+  value: string,
+): boolean {
+  return question.options.some(
+    (option) => option.value === value && option.correct === true,
+  );
+}
+
+function evaluateAnswer(
+  question: KnowledgeCheckQuestion,
+  response: boolean | string,
+): boolean {
+  switch (question.type) {
+    case "fill-blank":
+      return (
+        typeof response === "string" && compareFillBlank(question, response)
+      );
+    case "multiple-choice":
+      return (
+        typeof response === "string" &&
+        isMultipleChoiceCorrect(question, response)
+      );
+    case "true-false":
+      return typeof response === "boolean" && response === question.answer;
+  }
+}
+
+type ResponseMap = Record<string, boolean | string>;
+type AnswerMap = Record<string, KnowledgeCheckAnswer>;
+
+type ControllerState = {
+  answers: AnswerMap;
+  current: KnowledgeCheckQuestion;
+  handleNext: () => void;
+  handlePrevious: () => void;
+  handleReset: () => void;
+  handleSubmit: () => void;
+  index: number;
+  isComplete: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+  responses: ResponseMap;
+  score?: KnowledgeCheckScore;
+  setResponse: (questionId: string, value: boolean | string) => void;
+};
+
+type ControllerOptions = {
+  onAnswer?: (answer: KnowledgeCheckAnswer) => void;
+  onComplete?: (score: KnowledgeCheckScore) => void;
+  questions: KnowledgeCheckQuestion[];
+};
+
+function useKnowledgeCheckController(
+  options: ControllerOptions,
+): ControllerState {
+  const { onAnswer, onComplete, questions } = options;
+  const [index, setIndex] = useState(0);
+  const [responses, setResponses] = useState<ResponseMap>({});
+  const [answers, setAnswers] = useState<AnswerMap>({});
+  const [completed, setCompleted] = useState(false);
+
+  const setResponse = useCallback(
+    (questionId: string, value: boolean | string) => {
+      setResponses((current) => ({ ...current, [questionId]: value }));
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(() => {
+    const question = questions[index];
+    if (!question) return;
+    const response = responses[question.id];
+    if (response === undefined) return;
+    const answer: KnowledgeCheckAnswer = {
+      correct: evaluateAnswer(question, response),
+      questionId: question.id,
+      response,
+    };
+    setAnswers((current) => ({ ...current, [question.id]: answer }));
+    onAnswer?.(answer);
+  }, [index, onAnswer, questions, responses]);
+
+  const handleNext = useCallback(() => {
+    if (index >= questions.length - 1) {
+      const finalScore = computeScore(questions, answers);
+      setCompleted(true);
+      onComplete?.(finalScore);
+      return;
+    }
+    setIndex((value) => value + 1);
+  }, [answers, index, onComplete, questions]);
+
+  const handlePrevious = useCallback(() => {
+    setIndex((value) => Math.max(0, value - 1));
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setIndex(0);
+    setResponses({});
+    setAnswers({});
+    setCompleted(false);
+  }, []);
+
+  const score: KnowledgeCheckScore | undefined = useMemo(
+    () => (completed ? computeScore(questions, answers) : undefined),
+    [answers, completed, questions],
+  );
+
+  const current = questions[index] ?? questions[0];
+  if (!current) {
+    throw new Error("KnowledgeCheck requires at least one question");
+  }
+  return {
+    answers,
+    current,
+    handleNext,
+    handlePrevious,
+    handleReset,
+    handleSubmit,
+    index,
+    isComplete: completed,
+    isFirst: index === 0,
+    isLast: index === questions.length - 1,
+    responses,
+    score,
+    setResponse,
+  };
+}
+
+function computeScore(
+  questions: KnowledgeCheckQuestion[],
+  answers: AnswerMap,
+): KnowledgeCheckScore {
+  const correct = Object.values(answers).filter(
+    (entry) => entry.correct,
+  ).length;
+  return { answers, correct, total: questions.length };
+}
+
+/**
+ * Props for {@link KnowledgeCheck}.
+ *
+ * @public
+ */
+export type KnowledgeCheckProps = {
+  /** Localizable strings. */
+  labels?: KnowledgeCheckLabels;
+  /** Fires after the user submits an answer. */
+  onAnswer?: (answer: KnowledgeCheckAnswer) => void;
+  /** Fires when the user finishes the last question. */
+  onComplete?: (score: KnowledgeCheckScore) => void;
+  /** Question list. Must contain at least one entry. */
+  questions: KnowledgeCheckQuestion[];
+  /** Optional title shown above the questions. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+type FeedbackProps = {
+  answer?: KnowledgeCheckAnswer;
+  correctLabel: string;
+  explanation?: ReactNode;
+  incorrectLabel: string;
+};
+
+function Feedback({
+  answer,
+  correctLabel,
+  explanation,
+  incorrectLabel,
+}: FeedbackProps): ReactNode {
+  if (!answer) return null;
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        "flex items-start gap-2 rounded-md border p-3 text-sm",
+        answer.correct
+          ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-900 dark:text-emerald-200"
+          : "border-destructive/40 bg-destructive/10 text-destructive",
+      )}
+      role="status"
+    >
+      {answer.correct ? (
+        <CheckCircle2 aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0" />
+      ) : (
+        <XCircle aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0" />
+      )}
+      <div className="flex flex-col gap-1">
+        <span className="font-medium">
+          {answer.correct ? correctLabel : incorrectLabel}
+        </span>
+        {explanation ? (
+          <span className="text-xs opacity-80">{explanation}</span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+type MultipleChoiceFieldProps = {
+  groupName: string;
+  onChange: (value: string) => void;
+  options: KnowledgeCheckOption[];
+  value?: string;
+};
+
+type MultipleChoiceOptionProps = {
+  groupName: string;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  option: KnowledgeCheckOption;
+  value?: string;
+};
+
+function MultipleChoiceOption({
+  groupName,
+  onChange,
+  option,
+  value,
+}: MultipleChoiceOptionProps): ReactNode {
+  const id = `${groupName}-${option.value}`;
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm hover:bg-accent">
+      <input
+        checked={value === option.value}
+        className="h-4 w-4"
+        id={id}
+        name={groupName}
+        onChange={onChange}
+        type="radio"
+        value={option.value}
+      />
+      <label className="flex-1 cursor-pointer" htmlFor={id}>
+        {option.label}
+      </label>
+    </div>
+  );
+}
+
+function MultipleChoiceField({
+  groupName,
+  onChange,
+  options,
+  value,
+}: MultipleChoiceFieldProps): ReactNode {
+  const handleSelect = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onChange(event.target.value);
+    },
+    [onChange],
+  );
+  return (
+    <div className="flex flex-col gap-1.5" role="radiogroup">
+      {options.map((option) => (
+        <MultipleChoiceOption
+          groupName={groupName}
+          key={option.value}
+          onChange={handleSelect}
+          option={option}
+          value={value}
+        />
+      ))}
+    </div>
+  );
+}
+
+type TrueFalseFieldProps = {
+  falseLabel: string;
+  groupName: string;
+  onChange: (value: boolean) => void;
+  trueLabel: string;
+  value?: boolean;
+};
+
+function TrueFalseField({
+  falseLabel,
+  groupName,
+  onChange,
+  trueLabel,
+  value,
+}: TrueFalseFieldProps): ReactNode {
+  const handleSelectTrue = useCallback(() => {
+    onChange(true);
+  }, [onChange]);
+  const handleSelectFalse = useCallback(() => {
+    onChange(false);
+  }, [onChange]);
+  return (
+    <div
+      aria-label={groupName}
+      className="flex flex-wrap gap-2"
+      role="radiogroup"
+    >
+      <Button
+        aria-pressed={value === true}
+        onClick={handleSelectTrue}
+        size="sm"
+        type="button"
+        variant={value === true ? "default" : "outline"}
+      >
+        {trueLabel}
+      </Button>
+      <Button
+        aria-pressed={value === false}
+        onClick={handleSelectFalse}
+        size="sm"
+        type="button"
+        variant={value === false ? "default" : "outline"}
+      >
+        {falseLabel}
+      </Button>
+    </div>
+  );
+}
+
+type FillBlankFieldProps = {
+  inputId: string;
+  onChange: (value: string) => void;
+  value: string;
+};
+
+function FillBlankField({
+  inputId,
+  onChange,
+  value,
+}: FillBlankFieldProps): ReactNode {
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onChange(event.target.value);
+    },
+    [onChange],
+  );
+  return <Input id={inputId} onChange={handleChange} value={value} />;
+}
+
+type QuestionFieldProps = {
+  groupName: string;
+  inputId: string;
+  labels: Required<KnowledgeCheckLabels>;
+  onResponse: (value: boolean | string) => void;
+  question: KnowledgeCheckQuestion;
+  response?: boolean | string;
+};
+
+function QuestionField({
+  groupName,
+  inputId,
+  labels,
+  onResponse,
+  question,
+  response,
+}: QuestionFieldProps): ReactNode {
+  switch (question.type) {
+    case "fill-blank":
+      return (
+        <FillBlankField
+          inputId={inputId}
+          onChange={onResponse}
+          value={typeof response === "string" ? response : ""}
+        />
+      );
+    case "multiple-choice":
+      return (
+        <MultipleChoiceField
+          groupName={groupName}
+          onChange={onResponse}
+          options={question.options}
+          value={typeof response === "string" ? response : undefined}
+        />
+      );
+    case "true-false":
+      return (
+        <TrueFalseField
+          falseLabel={labels.falseOption}
+          groupName={groupName}
+          onChange={onResponse}
+          trueLabel={labels.trueOption}
+          value={typeof response === "boolean" ? response : undefined}
+        />
+      );
+  }
+}
+
+type ScoreSummaryProps = {
+  labels: Required<KnowledgeCheckLabels>;
+  onRetry: () => void;
+  score: KnowledgeCheckScore;
+};
+
+function ScoreSummary({
+  labels,
+  onRetry,
+  score,
+}: ScoreSummaryProps): ReactNode {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-lg border border-border bg-muted/20 p-6 text-center">
+      <p className="text-sm text-muted-foreground">{labels.scored}</p>
+      <p className="text-3xl font-bold tracking-tight text-foreground">
+        {score.correct} {labels.outOf} {score.total}
+      </p>
+      <Button onClick={onRetry} size="sm" type="button" variant="outline">
+        <RotateCcw aria-hidden="true" className="mr-2 h-4 w-4" />
+        {labels.retry}
+      </Button>
+    </div>
+  );
+}
+
+type QuestionPaneProps = {
+  controller: ControllerState;
+  groupName: string;
+  inputId: string;
+  labels: Required<KnowledgeCheckLabels>;
+  questions: KnowledgeCheckQuestion[];
+};
+
+function QuestionPane({
+  controller,
+  groupName,
+  inputId,
+  labels,
+  questions,
+}: QuestionPaneProps): ReactNode {
+  const question = controller.current;
+  const response = controller.responses[question.id];
+  const answer = controller.answers[question.id];
+  const handleResponse = useCallback(
+    (value: boolean | string) => {
+      controller.setResponse(question.id, value);
+    },
+    [controller, question.id],
+  );
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {`${(controller.index + 1).toString()} ${labels.outOf} ${questions.length.toString()}`}
+      </p>
+      <p className="text-sm font-medium text-foreground">{question.question}</p>
+      <QuestionField
+        groupName={groupName}
+        inputId={inputId}
+        labels={labels}
+        onResponse={handleResponse}
+        question={question}
+        response={response}
+      />
+      <Feedback
+        answer={answer}
+        correctLabel={labels.correct}
+        explanation={question.explanation}
+        incorrectLabel={labels.incorrect}
+      />
+      <PaneActions
+        answered={answer !== undefined}
+        controller={controller}
+        labels={labels}
+        responseSet={response !== undefined}
+      />
+    </div>
+  );
+}
+
+type PaneActionsProps = {
+  answered: boolean;
+  controller: ControllerState;
+  labels: Required<KnowledgeCheckLabels>;
+  responseSet: boolean;
+};
+
+function PaneActions({
+  answered,
+  controller,
+  labels,
+  responseSet,
+}: PaneActionsProps): ReactNode {
+  return (
+    <div className="flex items-center justify-between gap-2 pt-1">
+      <Button
+        disabled={controller.isFirst}
+        onClick={controller.handlePrevious}
+        size="sm"
+        type="button"
+        variant="ghost"
+      >
+        {labels.back}
+      </Button>
+      <div className="flex items-center gap-2">
+        {answered ? (
+          <Button onClick={controller.handleNext} size="sm" type="button">
+            {controller.isLast ? labels.scored : labels.next}
+          </Button>
+        ) : (
+          <Button
+            disabled={!responseSet}
+            onClick={controller.handleSubmit}
+            size="sm"
+            type="button"
+          >
+            {labels.check}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Inline knowledge check for embedding within content. Supports three
+ * question types (choice, true-false, fill-blank) with per-question
+ * feedback (correct / incorrect + optional `explanation`) and a final
+ * score summary with retry. Composes {@link Input} and {@link Button}.
+ *
+ * Question state lives inside the component. Drive analytics or
+ * persistence from the `onAnswer` and `onComplete` callbacks.
+ *
+ * @example
+ * ```tsx
+ * <KnowledgeCheck
+ *   title="Check your understanding"
+ *   questions={[
+ *     {
+ *       id: "react-framework",
+ *       type: "true-false",
+ *       question: "React is a framework.",
+ *       answer: false,
+ *     },
+ *     {
+ *       id: "state-hook",
+ *       type: "fill-blank",
+ *       question: "The hook for state is ___",
+ *       answer: "useState",
+ *     },
+ *   ]}
+ *   onComplete={(score) => track("kc:complete", score)}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const KnowledgeCheck = forwardRef<HTMLElement, KnowledgeCheckProps>(
+  (props, ref) => {
+    const {
+      className,
+      labels,
+      onAnswer,
+      onComplete,
+      questions,
+      title,
+      ...rest
+    } = props;
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const groupName = useId();
+    const inputId = useId();
+    const controller = useKnowledgeCheckController({
+      onAnswer,
+      onComplete,
+      questions,
+    });
+
+    return (
+      <section
+        className={cn(
+          "flex flex-col gap-4 rounded-2xl border bg-background p-4",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        {title ? (
+          <h3 className="text-base font-semibold tracking-tight text-foreground">
+            {title}
+          </h3>
+        ) : null}
+        {controller.isComplete && controller.score ? (
+          <ScoreSummary
+            labels={resolvedLabels}
+            onRetry={controller.handleReset}
+            score={controller.score}
+          />
+        ) : (
+          <QuestionPane
+            controller={controller}
+            groupName={groupName}
+            inputId={inputId}
+            labels={resolvedLabels}
+            questions={questions}
+          />
+        )}
+      </section>
+    );
+  },
+);
+KnowledgeCheck.displayName = "KnowledgeCheck";

--- a/apps/registry/registry/default/lang-provider/lang-provider.tsx
+++ b/apps/registry/registry/default/lang-provider/lang-provider.tsx
@@ -1,4 +1,34 @@
-// Re-export from @vllnt/ui package
-export { LangProvider } from '@vllnt/ui'
+"use client";
 
+import { useEffect } from "react";
 
+import { usePathname } from "next/navigation";
+
+import type { SupportedLanguage } from "@vllnt/ui";
+
+type LangProviderProps = {
+  defaultLanguage?: SupportedLanguage;
+  supportedLanguages?: SupportedLanguage[];
+};
+
+export function LangProvider({
+  defaultLanguage = "en",
+  supportedLanguages = ["en", "fr"],
+}: LangProviderProps) {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // Extract language from pathname - matches /en, /fr, /en/, /fr/, etc.
+    const langMatch = /^\/([a-z]{2})(?:\/|$)/.exec(pathname);
+    const lang =
+      langMatch &&
+      supportedLanguages.includes(langMatch[1] as SupportedLanguage)
+        ? (langMatch[1] as SupportedLanguage)
+        : defaultLanguage;
+
+    // Update the HTML lang attribute
+    document.documentElement.setAttribute("lang", lang);
+  }, [pathname, defaultLanguage, supportedLanguages]);
+
+  return null;
+}

--- a/apps/registry/registry/default/learning-objectives/learning-objectives.tsx
+++ b/apps/registry/registry/default/learning-objectives/learning-objectives.tsx
@@ -1,2 +1,117 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { CheckCircle2, Clock, GraduationCap, Target } from "lucide-react";
+import type { ReactNode } from "react";
+
+export type LearningObjectivesProps = {
+  estimatedTime?: string;
+  objectives: string[];
+  title?: string;
+};
+
+export function LearningObjectives({
+  estimatedTime,
+  objectives,
+  title = "What you'll learn",
+}: LearningObjectivesProps) {
+  return (
+    <div className="my-6 rounded-lg border bg-gradient-to-br from-primary/5 to-primary/10 p-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Target className="h-5 w-5 text-primary" />
+          <h4 className="font-semibold text-foreground">{title}</h4>
+        </div>
+        {estimatedTime ? (
+          <div className="flex items-center gap-1 text-sm text-muted-foreground">
+            <Clock className="h-4 w-4" />
+            <span>{estimatedTime}</span>
+          </div>
+        ) : null}
+      </div>
+      <ul className="space-y-2">
+        {objectives.map((objective, index) => (
+          <li className="flex items-start gap-2" key={index}>
+            <CheckCircle2 className="h-4 w-4 text-primary flex-shrink-0 mt-0.5" />
+            <span className="text-sm text-muted-foreground">{objective}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export type PrerequisitesProps = {
+  items: string[];
+  level?: "advanced" | "beginner" | "intermediate";
+  title?: string;
+};
+
+export function Prerequisites({
+  items,
+  level,
+  title = "Prerequisites",
+}: PrerequisitesProps) {
+  return (
+    <div className="my-6 rounded-lg border bg-muted/30 p-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <GraduationCap className="h-5 w-5 text-muted-foreground" />
+          <h4 className="font-semibold text-foreground">{title}</h4>
+        </div>
+        {level ? (
+          <span className="text-xs font-medium px-2 py-1 rounded-full bg-primary/10 text-primary capitalize">
+            {level}
+          </span>
+        ) : null}
+      </div>
+      <ul className="space-y-2">
+        {items.map((item, index) => (
+          <li
+            className="flex items-start gap-2 text-sm text-muted-foreground"
+            key={index}
+          >
+            <span className="text-primary">•</span>
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export type SummaryProps = {
+  children: ReactNode;
+  keyTakeaways?: string[];
+  title?: string;
+};
+
+export function Summary({
+  children,
+  keyTakeaways,
+  title = "Summary",
+}: SummaryProps) {
+  return (
+    <div className="my-6 rounded-lg border bg-muted/30 p-6">
+      <h4 className="font-semibold text-foreground mb-3 flex items-center gap-2">
+        <GraduationCap className="h-5 w-5" />
+        {title}
+      </h4>
+      <div className="text-sm text-muted-foreground [&>p]:mb-2">{children}</div>
+      {keyTakeaways && keyTakeaways.length > 0 ? (
+        <div className="mt-4 pt-4 border-t border-border">
+          <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-2">
+            Key Takeaways
+          </p>
+          <ul className="space-y-1">
+            {keyTakeaways.map((takeaway, index) => (
+              <li className="flex items-start gap-2 text-sm" key={index}>
+                <CheckCircle2 className="h-4 w-4 text-green-500 flex-shrink-0 mt-0.5" />
+                <span className="text-muted-foreground">{takeaway}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/registry/registry/default/left-rail/left-rail.tsx
+++ b/apps/registry/registry/default/left-rail/left-rail.tsx
@@ -1,1 +1,39 @@
-export { LeftRail, type LeftRailProps } from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type LeftRailProps = React.ComponentPropsWithoutRef<"aside"> & {
+  footer?: ReactNode;
+  title?: ReactNode;
+};
+
+const LeftRail = forwardRef<HTMLElement, LeftRailProps>(
+  ({ children, className, footer, title, ...props }, ref) => (
+    <aside
+      className={cn(
+        "flex h-full w-[4.5rem] shrink-0 flex-col items-center gap-3 border-r border-border bg-background px-2 py-3",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    >
+      {title ? (
+        <div className="flex min-h-9 items-center text-[11px] font-medium uppercase tracking-[0.24em] text-muted-foreground">
+          {title}
+        </div>
+      ) : null}
+      <div className="flex w-full flex-1 flex-col items-center gap-2">
+        {children}
+      </div>
+      {footer ? (
+        <div className="flex w-full flex-col items-center gap-2">{footer}</div>
+      ) : null}
+    </aside>
+  ),
+);
+
+LeftRail.displayName = "LeftRail";
+
+export { LeftRail };

--- a/apps/registry/registry/default/live-cursor/live-cursor.tsx
+++ b/apps/registry/registry/default/live-cursor/live-cursor.tsx
@@ -1,5 +1,113 @@
-export {
-  LiveCursor,
-  type LiveCursorLabels,
-  type LiveCursorProps,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type LiveCursorLabels = {
+  /** Aria-label override. Defaults to `"Live cursor"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Live cursor",
+} as const satisfies Required<LiveCursorLabels>;
+
+/**
+ * Props for {@link LiveCursor}.
+ *
+ * @public
+ */
+export type LiveCursorProps = {
+  /** Tailwind / arbitrary CSS color used for the pointer + name chip. Defaults to `var(--foreground)`. */
+  color?: string;
+  /** Localizable strings. */
+  labels?: LiveCursorLabels;
+  /** Display name shown in the chip. Pass `null` to hide the chip. */
+  name?: ReactNode;
+  /** Optional secondary line in the chip (e.g. status, role). */
+  status?: ReactNode;
+  /** Cursor X in canvas pixels. */
+  x: number;
+  /** Cursor Y in canvas pixels. */
+  y: number;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * Remote user's cursor rendered at canvas coordinates with an optional
+ * name + status chip. Pure presentation; the host owns the websocket
+ * stream + maps user ids to colors.
+ *
+ * The wrapper is `pointer-events: none` so host gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <LiveCursor x={420} y={180} name="Bea" color="#5b8def" />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const LiveCursor = forwardRef<HTMLDivElement, LiveCursorProps>(
+  (props, ref) => {
+    const { className, color, labels, name, status, x, y, ...rest } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const resolvedColor = color ?? "var(--foreground)";
+    return (
+      <div
+        aria-label={
+          typeof name === "string"
+            ? `${resolvedLabels.region}: ${name}`
+            : resolvedLabels.region
+        }
+        className={cn(
+          "pointer-events-none absolute z-30 flex items-start gap-1",
+          className,
+        )}
+        data-live-cursor
+        ref={ref}
+        role="img"
+        style={{ left: x, top: y }}
+        {...rest}
+      >
+        <svg
+          aria-hidden="true"
+          className="-ml-1 -mt-1 drop-shadow-sm"
+          data-live-cursor-pointer
+          fill={resolvedColor}
+          height={18}
+          viewBox="0 0 16 18"
+          width={16}
+        >
+          <path d="M0 0 L0 14 L4 11 L7 17 L10 16 L7 10 L13 10 Z" />
+        </svg>
+        {name === null || name === undefined ? null : (
+          <span
+            className="ml-2 mt-2 inline-flex flex-col rounded-md px-1.5 py-0.5 text-[10px] font-medium text-white shadow-sm"
+            data-live-cursor-chip
+            style={{ backgroundColor: resolvedColor }}
+          >
+            <span>{name}</span>
+            {status ? (
+              <span className="text-[9px] opacity-80" data-live-cursor-status>
+                {status}
+              </span>
+            ) : null}
+          </span>
+        )}
+      </div>
+    );
+  },
+);
+LiveCursor.displayName = "LiveCursor";

--- a/apps/registry/registry/default/live-feed/live-feed.tsx
+++ b/apps/registry/registry/default/live-feed/live-feed.tsx
@@ -1,1 +1,232 @@
-export * from "@vllnt/ui";
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@vllnt/ui";
+import {
+  SeverityBadge,
+  type SeverityBadgeLevel,
+} from "@vllnt/ui";
+
+export type LiveFeedEvent = {
+  id: string;
+  message?: string;
+  severity: SeverityBadgeLevel;
+  source?: string;
+  timestamp: Date | number | string;
+  title: string;
+};
+
+export type LiveFeedProps = React.ComponentPropsWithoutRef<"div"> & {
+  description?: string;
+  emptyLabel?: string;
+  events: LiveFeedEvent[];
+  maxItems?: number;
+  now?: Date | number | string;
+  tickMs?: number;
+  title?: string;
+};
+
+const SECOND_MS = 1000;
+const MINUTE_MS = 60 * SECOND_MS;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+function normalizeDate(input: Date | number | string): Date {
+  if (input instanceof Date) {
+    return new Date(input.getTime());
+  }
+
+  return new Date(input);
+}
+
+function useLiveDate(now: LiveFeedProps["now"], tickMs: number) {
+  const fixedNow = React.useMemo(
+    () => (now ? normalizeDate(now) : undefined),
+    [now],
+  );
+  const [liveNow, setLiveNow] = React.useState<Date>(fixedNow ?? new Date());
+
+  React.useEffect(() => {
+    if (fixedNow) {
+      setLiveNow(fixedNow);
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      setLiveNow(new Date());
+    }, tickMs);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [fixedNow, tickMs]);
+
+  return liveNow;
+}
+
+function formatRelative(eventDate: Date, now: Date): string {
+  const deltaMs = now.getTime() - eventDate.getTime();
+
+  if (deltaMs < 5 * SECOND_MS) {
+    return "just now";
+  }
+
+  if (deltaMs < MINUTE_MS) {
+    return `${Math.floor(deltaMs / SECOND_MS)}s ago`;
+  }
+
+  if (deltaMs < HOUR_MS) {
+    return `${Math.floor(deltaMs / MINUTE_MS)}m ago`;
+  }
+
+  if (deltaMs < DAY_MS) {
+    return `${Math.floor(deltaMs / HOUR_MS)}h ago`;
+  }
+
+  if (deltaMs < 7 * DAY_MS) {
+    return `${Math.floor(deltaMs / DAY_MS)}d ago`;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+  }).format(eventDate);
+}
+
+function formatAbsolute(eventDate: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    month: "short",
+    second: "2-digit",
+  }).format(eventDate);
+}
+
+function sortEventsDesc(events: LiveFeedEvent[]): LiveFeedEvent[] {
+  return [...events].sort(
+    (a, b) =>
+      normalizeDate(b.timestamp).getTime() -
+      normalizeDate(a.timestamp).getTime(),
+  );
+}
+
+function LiveFeedRow({
+  event,
+  isLatest,
+  now,
+}: {
+  event: LiveFeedEvent;
+  isLatest: boolean;
+  now: Date;
+}) {
+  const eventDate = normalizeDate(event.timestamp);
+
+  return (
+    <li className="flex gap-3 border-b border-border/60 py-3 last:border-b-0">
+      <div className="pt-1">
+        <SeverityBadge
+          level={event.severity}
+          pulse={isLatest ? event.severity === "critical" : undefined}
+          tone="soft"
+        />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between gap-2">
+          <p className="truncate text-sm font-medium">{event.title}</p>
+          <time
+            className="whitespace-nowrap text-xs text-muted-foreground"
+            dateTime={eventDate.toISOString()}
+            title={formatAbsolute(eventDate)}
+          >
+            {formatRelative(eventDate, now)}
+          </time>
+        </div>
+        {event.message ? (
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            {event.message}
+          </p>
+        ) : null}
+        {event.source ? (
+          <p className="mt-1 text-xs uppercase tracking-[0.14em] text-muted-foreground">
+            {event.source}
+          </p>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+export const LiveFeed = React.forwardRef<HTMLDivElement, LiveFeedProps>(
+  (
+    {
+      className,
+      description,
+      emptyLabel = "No events yet",
+      events,
+      maxItems = 50,
+      now,
+      tickMs = 30_000,
+      title = "Live feed",
+      ...props
+    },
+    ref,
+  ) => {
+    const liveNow = useLiveDate(now, tickMs);
+    const visibleEvents = React.useMemo(
+      () => sortEventsDesc(events).slice(0, maxItems),
+      [events, maxItems],
+    );
+
+    return (
+      <Card className={cn("shadow-sm", className)} ref={ref} {...props}>
+        <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0 pb-3">
+          <div className="space-y-1">
+            <CardTitle className="text-base">{title}</CardTitle>
+            {description ? (
+              <CardDescription>{description}</CardDescription>
+            ) : null}
+          </div>
+          <Badge variant="outline">
+            <span
+              aria-hidden="true"
+              className="relative mr-1.5 inline-flex h-2 w-2"
+            >
+              <span className="absolute inline-flex h-2 w-2 animate-ping rounded-full bg-emerald-500 opacity-70" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+            </span>{" "}
+            Live
+          </Badge>
+        </CardHeader>
+        <CardContent className="pt-0">
+          {visibleEvents.length === 0 ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              {emptyLabel}
+            </div>
+          ) : (
+            <ul className="max-h-[360px] divide-y divide-border/60 overflow-y-auto">
+              {visibleEvents.map((event, index) => (
+                <LiveFeedRow
+                  event={event}
+                  isLatest={index === 0}
+                  key={event.id}
+                  now={liveNow}
+                />
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    );
+  },
+);
+
+LiveFeed.displayName = "LiveFeed";

--- a/apps/registry/registry/default/map-2d/map-2d.tsx
+++ b/apps/registry/registry/default/map-2d/map-2d.tsx
@@ -1,17 +1,716 @@
-export {
-  type GeoJSONPolygon,
-  type GeoPosition,
-  Map2D,
-  type Map2DLabels,
-  type Map2DProps,
-  MapControls,
-  MapLayer,
-  type MapLayerProps,
-  MapMarker,
-  MapMarkerIcon,
-  type MapMarkerProps,
-  MapPopup,
-  type MapPopupProps,
-  MapZoomIn,
-  MapZoomOut,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 32;
+const ZOOM_STEP = 1.5;
+const VIEWBOX_WIDTH = 1000;
+const VIEWBOX_HEIGHT = 500;
+
+/**
+ * Geographic coordinate `[longitude, latitude]`.
+ *
+ * @public
+ */
+export type GeoPosition = [number, number];
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type Map2DLabels = {
+  /** Aria-label for the map region. Defaults to `"Map"`. */
+  region?: string;
+  /** Aria-label for the zoom-in button. Defaults to `"Zoom in"`. */
+  zoomIn?: string;
+  /** Aria-label for the zoom-out button. Defaults to `"Zoom out"`. */
+  zoomOut?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Map",
+  zoomIn: "Zoom in",
+  zoomOut: "Zoom out",
+} as const satisfies Required<Map2DLabels>;
+
+type MapCtx = {
+  height: number;
+  labels: Required<Map2DLabels>;
+  pan: { x: number; y: number };
+  project: (position: GeoPosition) => { x: number; y: number };
+  setPan: (next: { x: number; y: number }) => void;
+  width: number;
+  zoom: number;
+  zoomIn: () => void;
+  zoomOut: () => void;
+};
+
+const MapContext = createContext<MapCtx | null>(null);
+
+function useMapContext(): MapCtx {
+  const ctx = useContext(MapContext);
+  if (!ctx) {
+    throw new Error("Map2D subcomponent used outside its root.");
+  }
+  return ctx;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function projectEquirectangular(
+  position: GeoPosition,
+  width: number,
+  height: number,
+): { x: number; y: number } {
+  const [lng, lat] = position;
+  const x = ((lng + 180) / 360) * width;
+  const y = ((90 - lat) / 180) * height;
+  return { x, y };
+}
+
+/**
+ * Props for {@link Map2D}.
+ *
+ * @public
+ */
+export type Map2DProps = {
+  /** Optional URL of a backdrop image (world map, terrain, etc.). */
+  backdrop?: string;
+  /** Aria-label for an optional backdrop image. */
+  backdropAlt?: string;
+  /** Initial center as `[lng, lat]`. Defaults to `[0, 20]`. */
+  center?: GeoPosition;
+  /** Localizable strings. */
+  labels?: Map2DLabels;
+  /** Initial zoom factor. Defaults to `1`. */
+  zoom?: number;
+} & ComponentPropsWithoutRef<"section">;
+
+function useMapState(arguments_: {
+  center: GeoPosition;
+  initialZoom: number;
+  resolvedLabels: Required<Map2DLabels>;
+}): MapCtx {
+  const { center, initialZoom, resolvedLabels } = arguments_;
+  const initialPan = useMemo(() => {
+    const target = projectEquirectangular(
+      center,
+      VIEWBOX_WIDTH,
+      VIEWBOX_HEIGHT,
+    );
+    return {
+      x: VIEWBOX_WIDTH / 2 - target.x,
+      y: VIEWBOX_HEIGHT / 2 - target.y,
+    };
+  }, [center]);
+  const [pan, setPan] = useState<{ x: number; y: number }>(initialPan);
+  const [zoom, setZoom] = useState<number>(
+    clamp(initialZoom, MIN_ZOOM, MAX_ZOOM),
+  );
+
+  const zoomIn = useCallback(() => {
+    setZoom((current) => clamp(current * ZOOM_STEP, MIN_ZOOM, MAX_ZOOM));
+  }, []);
+  const zoomOut = useCallback(() => {
+    setZoom((current) => clamp(current / ZOOM_STEP, MIN_ZOOM, MAX_ZOOM));
+  }, []);
+
+  const project = useCallback(
+    (position: GeoPosition) =>
+      projectEquirectangular(position, VIEWBOX_WIDTH, VIEWBOX_HEIGHT),
+    [],
+  );
+
+  return useMemo(
+    () => ({
+      height: VIEWBOX_HEIGHT,
+      labels: resolvedLabels,
+      pan,
+      project,
+      setPan,
+      width: VIEWBOX_WIDTH,
+      zoom,
+      zoomIn,
+      zoomOut,
+    }),
+    [pan, project, resolvedLabels, zoom, zoomIn, zoomOut],
+  );
+}
+
+/**
+ * Container for `MapZoomIn` / `MapZoomOut` controls.
+ *
+ * @public
+ */
+export const MapControls = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ children, className, ...rest }, ref) => (
+  <div
+    aria-label="Map controls"
+    className={cn(
+      "absolute right-3 top-3 z-20 flex flex-col gap-1 rounded-md border border-border bg-background/95 p-1 shadow-sm backdrop-blur",
+      className,
+    )}
+    ref={ref}
+    {...rest}
+  >
+    {children}
+  </div>
+));
+MapControls.displayName = "MapControls";
+
+type ControlButtonProps = {
+  ariaLabel: string;
+  glyph: ReactNode;
+  onActivate: () => void;
+} & Omit<ComponentPropsWithoutRef<"button">, "aria-label" | "onClick" | "type">;
+
+const ControlButton = forwardRef<HTMLButtonElement, ControlButtonProps>(
+  ({ ariaLabel, className, glyph, onActivate, ...rest }, ref) => (
+    <button
+      aria-label={ariaLabel}
+      className={cn(
+        "inline-flex h-7 w-7 items-center justify-center rounded text-sm font-semibold hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+      onClick={onActivate}
+      ref={ref}
+      type="button"
+      {...rest}
+    >
+      {glyph}
+    </button>
+  ),
+);
+ControlButton.displayName = "ControlButton";
+
+/**
+ * Zoom-in button. Multiplies the zoom factor up to a max.
+ *
+ * @public
+ */
+export const MapZoomIn = forwardRef<
+  HTMLButtonElement,
+  Omit<ComponentPropsWithoutRef<"button">, "aria-label" | "onClick" | "type">
+>(({ ...rest }, ref) => {
+  const { labels, zoomIn } = useMapContext();
+  return (
+    <ControlButton
+      ariaLabel={labels.zoomIn}
+      glyph="+"
+      onActivate={zoomIn}
+      ref={ref}
+      {...rest}
+    />
+  );
+});
+MapZoomIn.displayName = "MapZoomIn";
+
+/**
+ * Zoom-out button.
+ *
+ * @public
+ */
+export const MapZoomOut = forwardRef<
+  HTMLButtonElement,
+  Omit<ComponentPropsWithoutRef<"button">, "aria-label" | "onClick" | "type">
+>(({ ...rest }, ref) => {
+  const { labels, zoomOut } = useMapContext();
+  return (
+    <ControlButton
+      ariaLabel={labels.zoomOut}
+      glyph="−"
+      onActivate={zoomOut}
+      ref={ref}
+      {...rest}
+    />
+  );
+});
+MapZoomOut.displayName = "MapZoomOut";
+
+/**
+ * Props for {@link MapMarker}.
+ *
+ * @public
+ */
+export type MapMarkerProps = {
+  /** Optional click handler. */
+  onSelect?: () => void;
+  /** Optional popup content rendered above the marker on hover/focus. */
+  popup?: ReactNode;
+  /** Geographic position. */
+  position: GeoPosition;
+  /** Optional accessible label. */
+  title?: string;
+} & Omit<ComponentPropsWithoutRef<"button">, "onClick" | "title" | "type">;
+
+/**
+ * Custom marker icon slot. Pass any SVG element as children. Falls back
+ * to a circle if omitted.
+ *
+ * @public
+ */
+export const MapMarkerIcon = forwardRef<
+  SVGGElement,
+  ComponentPropsWithoutRef<"g">
+>(({ children, className, ...rest }, ref) => (
+  <g className={cn("text-primary", className)} ref={ref} {...rest}>
+    {children}
+  </g>
+));
+MapMarkerIcon.displayName = "MapMarkerIcon";
+
+type MarkerVisualProps = {
+  children?: ReactNode;
+};
+
+function MarkerVisual({ children }: MarkerVisualProps): ReactNode {
+  if (children) return children;
+  return (
+    <g>
+      <circle
+        className="fill-primary stroke-background"
+        cx="0"
+        cy="0"
+        r="7"
+        strokeWidth="2"
+      />
+      <circle className="fill-background" cx="0" cy="0" r="2" />
+    </g>
+  );
+}
+
+/**
+ * A marker placed at a geographic position.
+ *
+ * @public
+ */
+export const MapMarker = forwardRef<HTMLButtonElement, MapMarkerProps>(
+  (props, ref) => {
+    const { children, className, onSelect, popup, position, title, ...rest } =
+      props;
+    const { project } = useMapContext();
+    const point = project(position);
+    const markerId = useId();
+    const popupId = `${markerId}-popup`;
+    const labelText =
+      title ??
+      (typeof popup === "string" ? popup : `Marker at ${position.join(", ")}`);
+
+    return (
+      <foreignObject height="48" width="48" x={point.x - 24} y={point.y - 24}>
+        <button
+          aria-describedby={popup ? popupId : undefined}
+          aria-label={labelText}
+          className={cn(
+            "group relative inline-flex h-full w-full cursor-pointer items-center justify-center bg-transparent p-0 outline-none focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            className,
+          )}
+          data-marker-id={markerId}
+          onClick={onSelect}
+          ref={ref}
+          type="button"
+          {...rest}
+        >
+          <svg
+            className="pointer-events-none h-6 w-6 overflow-visible"
+            viewBox="-10 -10 20 20"
+          >
+            <MarkerVisual>{children}</MarkerVisual>
+          </svg>
+          {popup ? (
+            <span
+              className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-1 hidden min-w-32 max-w-xs -translate-x-1/2 rounded-md border bg-popover px-2 py-1 text-center text-xs text-popover-foreground shadow-md group-hover:block group-focus-visible:block"
+              id={popupId}
+              role="tooltip"
+            >
+              {popup}
+            </span>
+          ) : null}
+        </button>
+      </foreignObject>
+    );
+  },
+);
+MapMarker.displayName = "MapMarker";
+
+/**
+ * Props for {@link MapPopup}.
+ *
+ * @public
+ */
+export type MapPopupProps = {
+  /** Geographic anchor. */
+  position: GeoPosition;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * Always-visible popup anchored at a geographic position. Use this when
+ * you need a popup that lives outside the marker hover lifecycle.
+ *
+ * @public
+ */
+export const MapPopup = forwardRef<HTMLDivElement, MapPopupProps>(
+  (props, ref) => {
+    const { children, className, position, ...rest } = props;
+    const { project } = useMapContext();
+    const point = project(position);
+    return (
+      <foreignObject
+        height="200"
+        width="320"
+        x={point.x - 160}
+        y={point.y - 220}
+      >
+        <div
+          className={cn(
+            "pointer-events-auto inline-block max-w-xs -translate-y-2 rounded-md border bg-popover px-3 py-2 text-sm text-popover-foreground shadow-md",
+            className,
+          )}
+          ref={ref}
+          {...rest}
+        >
+          {children}
+        </div>
+      </foreignObject>
+    );
+  },
+);
+MapPopup.displayName = "MapPopup";
+
+/**
+ * GeoJSON polygon-style payload accepted by {@link MapLayer}.
+ *
+ * @public
+ */
+export type GeoJSONPolygon = {
+  /** Outer ring positions; close the ring by repeating the first point. */
+  coordinates: GeoPosition[];
+  /** Stable id. */
+  id: string;
+  /** Polygon kind. */
+  type: "polygon";
+};
+
+/**
+ * Props for {@link MapLayer}.
+ *
+ * @public
+ */
+export type MapLayerProps = {
+  /** Polygon shapes to render. */
+  data: GeoJSONPolygon[];
+  /** Fill color (CSS color). Defaults to `"rgba(59,130,246,0.15)"` (blue/15). */
+  fill?: string;
+  /** Stroke color (CSS color). Defaults to `"currentColor"`. */
+  stroke?: string;
+  /** Stroke width in viewBox units. Defaults to `2`. */
+  strokeWidth?: number;
+} & Omit<ComponentPropsWithoutRef<"g">, "fill">;
+
+/**
+ * GeoJSON-style polygon overlay layer. Pass `data` as an array of polygon
+ * descriptors; the marker projection handles the coordinates the same way.
+ *
+ * @public
+ */
+export const MapLayer = forwardRef<SVGGElement, MapLayerProps>((props, ref) => {
+  const {
+    className,
+    data,
+    fill = "rgba(59, 130, 246, 0.15)",
+    stroke = "currentColor",
+    strokeWidth = 2,
+    ...rest
+  } = props;
+  const { project } = useMapContext();
+  return (
+    <g
+      className={cn("text-blue-500/70", className)}
+      data-layer="polygon"
+      ref={ref}
+      {...rest}
+    >
+      {data.map((shape) => {
+        const points = shape.coordinates
+          .map((coord) => {
+            const projected = project(coord);
+            return `${projected.x.toString()},${projected.y.toString()}`;
+          })
+          .join(" ");
+        return (
+          <polygon
+            data-shape-id={shape.id}
+            fill={fill}
+            key={shape.id}
+            points={points}
+            stroke={stroke}
+            strokeWidth={strokeWidth}
+          />
+        );
+      })}
+    </g>
+  );
+});
+MapLayer.displayName = "MapLayer";
+
+type StageProps = {
+  backdrop?: string;
+  backdropAlt?: string;
+  children?: ReactNode;
+};
+
+type DragState = null | {
+  originPan: { x: number; y: number };
+  originX: number;
+  originY: number;
+};
+
+type PanHandlers = {
+  onPointerCancel: (event: ReactPointerEvent<SVGSVGElement>) => void;
+  onPointerDown: (event: ReactPointerEvent<SVGSVGElement>) => void;
+  onPointerMove: (event: ReactPointerEvent<SVGSVGElement>) => void;
+  onPointerUp: (event: ReactPointerEvent<SVGSVGElement>) => void;
+};
+
+function usePanHandlers(): PanHandlers {
+  const { height, pan, setPan, width, zoom } = useMapContext();
+  const dragRef = useRef<DragState>(null);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<SVGSVGElement>): void => {
+      dragRef.current = {
+        originPan: pan,
+        originX: event.clientX,
+        originY: event.clientY,
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [pan],
+  );
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent<SVGSVGElement>): void => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      const target = event.currentTarget;
+      const rect = target.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return;
+      const scaleX = width / rect.width;
+      const scaleY = height / rect.height;
+      const dx = (event.clientX - drag.originX) * scaleX;
+      const dy = (event.clientY - drag.originY) * scaleY;
+      setPan({
+        x: drag.originPan.x + dx / zoom,
+        y: drag.originPan.y + dy / zoom,
+      });
+    },
+    [height, setPan, width, zoom],
+  );
+
+  const onPointerEnd = useCallback(
+    (event: ReactPointerEvent<SVGSVGElement>): void => {
+      const target = event.currentTarget;
+      if (target.hasPointerCapture(event.pointerId)) {
+        target.releasePointerCapture(event.pointerId);
+      }
+      dragRef.current = null;
+    },
+    [],
+  );
+
+  return {
+    onPointerCancel: onPointerEnd,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp: onPointerEnd,
+  };
+}
+
+function Stage({ backdrop, backdropAlt, children }: StageProps): ReactNode {
+  const { height, pan, width, zoom } = useMapContext();
+  const handlers = usePanHandlers();
+
+  const innerWidth = width / zoom;
+  const innerHeight = height / zoom;
+  const viewX = (width - innerWidth) / 2 - pan.x;
+  const viewY = (height - innerHeight) / 2 - pan.y;
+
+  return (
+    <svg
+      className="block h-full w-full cursor-grab touch-none active:cursor-grabbing"
+      data-pan-x={pan.x}
+      data-pan-y={pan.y}
+      data-zoom={zoom}
+      preserveAspectRatio="xMidYMid slice"
+      role="presentation"
+      viewBox={`${viewX.toString()} ${viewY.toString()} ${innerWidth.toString()} ${innerHeight.toString()}`}
+      {...handlers}
+    >
+      <rect className="fill-muted" height={height} width={width} x="0" y="0" />
+      {backdrop ? (
+        <image
+          aria-label={backdropAlt}
+          height={height}
+          href={backdrop}
+          preserveAspectRatio="xMidYMid slice"
+          width={width}
+          x="0"
+          y="0"
+        />
+      ) : null}
+      {children}
+    </svg>
+  );
+}
+
+type ChildBuckets = {
+  controls: ReactNode;
+  layers: ReactNode[];
+  markers: ReactNode[];
+  popups: ReactNode[];
+};
+
+const SLOT_DISPLAY_NAMES = {
+  controls: MapControls.displayName,
+  layer: MapLayer.displayName,
+  marker: MapMarker.displayName,
+  popup: MapPopup.displayName,
+} as const;
+
+function displayName(child: ReactNode): string | undefined {
+  if (typeof child !== "object" || child === null) return undefined;
+  if (!("type" in child)) return undefined;
+  const type = (child as { type: unknown }).type;
+  if (typeof type !== "object" && typeof type !== "function") return undefined;
+  const name = (type as { displayName?: unknown }).displayName;
+  return typeof name === "string" ? name : undefined;
+}
+
+type SlotKey = "controls" | "layer" | "marker" | "popup";
+
+const SLOT_KEY_BY_NAME: Record<string, SlotKey> = {
+  [SLOT_DISPLAY_NAMES.controls]: "controls",
+  [SLOT_DISPLAY_NAMES.layer]: "layer",
+  [SLOT_DISPLAY_NAMES.marker]: "marker",
+  [SLOT_DISPLAY_NAMES.popup]: "popup",
+};
+
+function bucketChildren(children: ReactNode): ChildBuckets {
+  const list: ReactNode[] = Array.isArray(children) ? children : [children];
+  return list.reduce<ChildBuckets>(
+    (accumulator, child) => {
+      const name = displayName(child);
+      if (!name) return accumulator;
+      const key = SLOT_KEY_BY_NAME[name];
+      if (!key) return accumulator;
+      switch (key) {
+        case "controls":
+          accumulator.controls = child;
+          break;
+
+        case "marker":
+          accumulator.markers.push(child);
+          break;
+
+        case "layer":
+          accumulator.layers.push(child);
+          break;
+
+        case "popup":
+          accumulator.popups.push(child);
+          break;
+      }
+      return accumulator;
+    },
+    { controls: null, layers: [], markers: [], popups: [] },
+  );
+}
+
+/**
+ * Lightweight 2D map primitive — renders an SVG canvas with an
+ * equirectangular projection so children placed by `[lng, lat]` land in
+ * the right spot. Compose with {@link MapMarker}, {@link MapPopup},
+ * {@link MapLayer}, and {@link MapControls}. An optional backdrop image
+ * (Natural Earth SVG, terrain raster, etc.) renders behind the overlays.
+ *
+ * Out of scope for the MVP: live map tiles (no Mapbox / MapLibre runtime),
+ * marker clustering, fullscreen mode, scale + compass controls, fit-bounds.
+ * The component stays small enough to drop into any project — swap the
+ * backdrop image to change the basemap.
+ *
+ * @example
+ * ```tsx
+ * <Map2D center={[2.3522, 48.8566]} zoom={4}>
+ *   <MapMarker position={[2.3522, 48.8566]} popup="Paris" />
+ *   <MapMarker position={[-0.1276, 51.5074]} popup="London" />
+ *   <MapControls>
+ *     <MapZoomIn />
+ *     <MapZoomOut />
+ *   </MapControls>
+ * </Map2D>
+ * ```
+ *
+ * @public
+ */
+export const Map2D = forwardRef<HTMLElement, Map2DProps>((props, ref) => {
+  const {
+    backdrop,
+    backdropAlt,
+    center = [0, 20],
+    children,
+    className,
+    labels,
+    zoom: initialZoom = 1,
+    ...rest
+  } = props;
+
+  const resolvedLabels = useMemo(
+    () => ({ ...DEFAULT_LABELS, ...labels }),
+    [labels],
+  );
+
+  const ctx = useMapState({ center, initialZoom, resolvedLabels });
+  const buckets = useMemo(() => bucketChildren(children), [children]);
+
+  return (
+    <MapContext.Provider value={ctx}>
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "relative aspect-[2/1] w-full overflow-hidden rounded-2xl border bg-background text-foreground",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <Stage backdrop={backdrop} backdropAlt={backdropAlt}>
+          {buckets.layers}
+          {buckets.markers}
+          {buckets.popups}
+        </Stage>
+        {buckets.controls}
+      </section>
+    </MapContext.Provider>
+  );
+});
+Map2D.displayName = "Map2D";

--- a/apps/registry/registry/default/map-timeline/map-timeline.tsx
+++ b/apps/registry/registry/default/map-timeline/map-timeline.tsx
@@ -1,14 +1,775 @@
-export {
-  MapTimeline,
-  type MapTimelineColor,
-  MapTimelineControls,
-  MapTimelineEvent,
-  type MapTimelineEventProps,
-  type MapTimelineGeometry,
-  type MapTimelineLabels,
-  MapTimelineLayer,
-  type MapTimelineLayerProps,
-  MapTimelinePlayButton,
-  type MapTimelineProps,
-  MapTimelineSlider,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  type ChangeEvent,
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+const VIEWBOX_WIDTH = 1000;
+const VIEWBOX_HEIGHT = 500;
+
+/**
+ * Geographic coordinate `[longitude, latitude]`.
+ *
+ * @public
+ */
+export type GeoPosition = [number, number];
+
+/**
+ * Color theme for layers and event markers.
+ *
+ * @public
+ */
+export type MapTimelineColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "purple"
+  | "red"
+  | "rose";
+
+const PALETTE: Record<
+  MapTimelineColor,
+  { dot: string; fill: string; stroke: string }
+> = {
+  amber: {
+    dot: "fill-amber-500",
+    fill: "rgba(245, 158, 11, 0.25)",
+    stroke: "#b45309",
+  },
+  blue: {
+    dot: "fill-blue-500",
+    fill: "rgba(59, 130, 246, 0.25)",
+    stroke: "#1d4ed8",
+  },
+  emerald: {
+    dot: "fill-emerald-500",
+    fill: "rgba(16, 185, 129, 0.25)",
+    stroke: "#047857",
+  },
+  purple: {
+    dot: "fill-purple-500",
+    fill: "rgba(168, 85, 247, 0.25)",
+    stroke: "#7c3aed",
+  },
+  red: {
+    dot: "fill-red-500",
+    fill: "rgba(239, 68, 68, 0.25)",
+    stroke: "#b91c1c",
+  },
+  rose: {
+    dot: "fill-rose-500",
+    fill: "rgba(244, 63, 94, 0.25)",
+    stroke: "#be123c",
+  },
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type MapTimelineLabels = {
+  /** Pause-button label. Defaults to `"Pause"`. */
+  pause?: string;
+  /** Play-button label. Defaults to `"Play"`. */
+  play?: string;
+  /** Aria-label for the map region. Defaults to `"Map timeline"`. */
+  region?: string;
+  /** Aria-label for the timeline slider. Defaults to `"Year"`. */
+  slider?: string;
+};
+
+const DEFAULT_LABELS = {
+  pause: "Pause",
+  play: "Play",
+  region: "Map timeline",
+  slider: "Year",
+} as const satisfies Required<MapTimelineLabels>;
+
+type Ctx = {
+  endYear: number;
+  isPlaying: boolean;
+  labels: Required<MapTimelineLabels>;
+  setIsPlaying: (next: boolean) => void;
+  setYear: (next: number) => void;
+  speed: number;
+  startYear: number;
+  year: number;
+};
+
+const TimelineContext = createContext<Ctx | null>(null);
+
+function useTimelineContext(): Ctx {
+  const ctx = useContext(TimelineContext);
+  if (!ctx) {
+    throw new Error("MapTimeline subcomponent used outside its root.");
+  }
+  return ctx;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function projectEquirectangular(position: GeoPosition): {
+  x: number;
+  y: number;
+} {
+  const [lng, lat] = position;
+  return {
+    x: ((lng + 180) / 360) * VIEWBOX_WIDTH,
+    y: ((90 - lat) / 180) * VIEWBOX_HEIGHT,
+  };
+}
+
+function formatYear(year: number): string {
+  if (year < 0) return `${Math.abs(year).toString()} BCE`;
+  return `${year.toString()} CE`;
+}
+
+function ringToPath(ring: GeoPosition[]): string {
+  return ring
+    .map((position, index) => {
+      const projected = projectEquirectangular(position);
+      return `${index === 0 ? "M" : "L"}${projected.x.toString()},${projected.y.toString()}`;
+    })
+    .join(" ");
+}
+
+/**
+ * GeoJSON-style polygon for a {@link MapTimelineLayer}. Pass either a
+ * `polygon` (single ring) or a `polygons` array (multi-polygon).
+ *
+ * @public
+ */
+export type MapTimelineGeometry =
+  | { polygon: GeoPosition[]; polygons?: never; type: "polygon" }
+  | { polygon?: never; polygons: GeoPosition[][]; type: "multipolygon" };
+
+/**
+ * Props for {@link MapTimelineLayer}.
+ *
+ * @public
+ */
+export type MapTimelineLayerProps = {
+  /** Color theme. Defaults to `"blue"`. */
+  color?: MapTimelineColor;
+  /** Year (inclusive) when the layer disappears. */
+  endYear: number;
+  /** Polygon geometry. */
+  geometry: MapTimelineGeometry;
+  /** Stable id used for analytics + React keys. */
+  id?: string;
+  /** Display label rendered in the centroid when visible. */
+  label?: ReactNode;
+  /** Year (inclusive) when the layer first appears. */
+  startYear: number;
+} & Omit<ComponentPropsWithoutRef<"g">, "id">;
+
+function geometryRings(geometry: MapTimelineGeometry): GeoPosition[][] {
+  if (geometry.type === "polygon") return [geometry.polygon];
+  return geometry.polygons;
+}
+
+function ringCentroid(ring: GeoPosition[]): { x: number; y: number } {
+  if (ring.length === 0) return { x: 0, y: 0 };
+  const total = ring.reduce<{ x: number; y: number }>(
+    (accumulator, position) => {
+      const projected = projectEquirectangular(position);
+      return { x: accumulator.x + projected.x, y: accumulator.y + projected.y };
+    },
+    { x: 0, y: 0 },
+  );
+  return { x: total.x / ring.length, y: total.y / ring.length };
+}
+
+/**
+ * Geographic layer pinned to a year window.
+ *
+ * @public
+ */
+export const MapTimelineLayer = forwardRef<SVGGElement, MapTimelineLayerProps>(
+  (props, ref) => {
+    const {
+      color = "blue",
+      endYear,
+      geometry,
+      id,
+      label,
+      startYear,
+      ...rest
+    } = props;
+    const { year } = useTimelineContext();
+    if (year < startYear || year > endYear) return null;
+    const palette = PALETTE[color];
+    const rings = geometryRings(geometry);
+    const centroid = rings[0] ? ringCentroid(rings[0]) : { x: 0, y: 0 };
+    return (
+      <g data-layer-id={id} data-state="visible" ref={ref} {...rest}>
+        {rings.map((ring, index) => (
+          <path
+            d={`${ringToPath(ring)} Z`}
+            fill={palette.fill}
+            key={`${id ?? "layer"}-ring-${index.toString()}`}
+            stroke={palette.stroke}
+            strokeWidth={1.5}
+          />
+        ))}
+        {label ? (
+          <text
+            className="select-none fill-foreground text-[11px] font-semibold"
+            dominantBaseline="middle"
+            textAnchor="middle"
+            x={centroid.x}
+            y={centroid.y}
+          >
+            {label}
+          </text>
+        ) : null}
+      </g>
+    );
+  },
+);
+MapTimelineLayer.displayName = "MapTimelineLayer";
+
+/**
+ * Props for {@link MapTimelineEvent}.
+ *
+ * @public
+ */
+export type MapTimelineEventProps = {
+  /** Color theme. Defaults to `"red"`. */
+  color?: MapTimelineColor;
+  /** Optional description rendered in the tooltip. */
+  description?: ReactNode;
+  /** Stable identifier. */
+  id?: string;
+  /** Geographic position. */
+  position: GeoPosition;
+  /** Title rendered in the tooltip. */
+  title?: ReactNode;
+  /** Inclusive ± window in years around `year` when the marker shows. Defaults to `0` (exact match). */
+  toleranceYears?: number;
+  /** Year the event happened. */
+  year: number;
+} & Omit<ComponentPropsWithoutRef<"g">, "id">;
+
+/**
+ * Year-pinned event marker.
+ *
+ * @public
+ */
+export const MapTimelineEvent = forwardRef<SVGGElement, MapTimelineEventProps>(
+  (props, ref) => {
+    const {
+      color = "red",
+      description,
+      id,
+      position,
+      title,
+      toleranceYears = 0,
+      year: eventYear,
+      ...rest
+    } = props;
+    const { year } = useTimelineContext();
+    const visible = Math.abs(year - eventYear) <= toleranceYears;
+    if (!visible) return null;
+    const palette = PALETTE[color];
+    const projected = projectEquirectangular(position);
+    return (
+      <g
+        data-event-id={id}
+        data-event-year={eventYear}
+        ref={ref}
+        transform={`translate(${projected.x.toString()}, ${projected.y.toString()})`}
+        {...rest}
+      >
+        <circle
+          className={cn("stroke-background", palette.dot)}
+          r="6"
+          strokeWidth="2"
+        >
+          {title ? (
+            <title>{typeof title === "string" ? title : ""}</title>
+          ) : null}
+        </circle>
+        {title ? (
+          <text
+            className="select-none fill-foreground text-[10px] font-semibold"
+            dominantBaseline="middle"
+            textAnchor="middle"
+            y="-12"
+          >
+            {title}
+          </text>
+        ) : null}
+        {description ? (
+          <text
+            className="select-none fill-muted-foreground text-[9px]"
+            dominantBaseline="middle"
+            textAnchor="middle"
+            y="20"
+          >
+            {description}
+          </text>
+        ) : null}
+      </g>
+    );
+  },
+);
+MapTimelineEvent.displayName = "MapTimelineEvent";
+
+/**
+ * Container for the slider + play button row.
+ *
+ * @public
+ */
+export const MapTimelineControls = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ children, className, ...rest }, ref) => (
+  <div
+    className={cn(
+      "flex items-center gap-3 border-t border-border bg-muted/40 px-4 py-2",
+      className,
+    )}
+    ref={ref}
+    {...rest}
+  >
+    {children}
+  </div>
+));
+MapTimelineControls.displayName = "MapTimelineControls";
+
+/**
+ * Range-input slider bound to the current year.
+ *
+ * @public
+ */
+export const MapTimelineSlider = forwardRef<
+  HTMLInputElement,
+  Omit<
+    ComponentPropsWithoutRef<"input">,
+    "max" | "min" | "onChange" | "type" | "value"
+  >
+>(({ className, ...rest }, ref) => {
+  const { endYear, labels, setYear, startYear, year } = useTimelineContext();
+  const sliderId = useId();
+  const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    setYear(Number.parseInt(event.target.value, 10));
+  };
+  return (
+    <div className="flex flex-1 items-center gap-2 text-xs font-medium text-muted-foreground">
+      <span aria-hidden="true">{formatYear(startYear)}</span>
+      <input
+        aria-label={labels.slider}
+        aria-valuemax={endYear}
+        aria-valuemin={startYear}
+        aria-valuenow={year}
+        className={cn("flex-1 accent-primary", className)}
+        id={sliderId}
+        max={endYear}
+        min={startYear}
+        onChange={handleChange}
+        ref={ref}
+        type="range"
+        value={year}
+        {...rest}
+      />
+      <span aria-hidden="true">{formatYear(endYear)}</span>
+      <span
+        className="ml-2 inline-flex min-w-20 justify-center rounded-md border border-border bg-background px-2 py-0.5 text-foreground"
+        data-current-year={year}
+      >
+        {formatYear(year)}
+      </span>
+    </div>
+  );
+});
+MapTimelineSlider.displayName = "MapTimelineSlider";
+
+/**
+ * Play / pause toggle that auto-advances the year on `requestAnimationFrame`.
+ *
+ * @public
+ */
+export const MapTimelinePlayButton = forwardRef<
+  HTMLButtonElement,
+  Omit<ComponentPropsWithoutRef<"button">, "aria-pressed" | "onClick" | "type">
+>(({ className, ...rest }, ref) => {
+  const { isPlaying, labels, setIsPlaying } = useTimelineContext();
+  const handleClick = (): void => {
+    setIsPlaying(!isPlaying);
+  };
+  return (
+    <button
+      aria-label={isPlaying ? labels.pause : labels.play}
+      aria-pressed={isPlaying}
+      className={cn(
+        "inline-flex h-8 items-center rounded-md border border-border bg-background px-3 text-xs font-medium hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+      data-playing={isPlaying ? "true" : undefined}
+      onClick={handleClick}
+      ref={ref}
+      type="button"
+      {...rest}
+    >
+      <span aria-hidden="true">{isPlaying ? "❚❚" : "▶"}</span>
+    </button>
+  );
+});
+MapTimelinePlayButton.displayName = "MapTimelinePlayButton";
+
+/**
+ * Props for {@link MapTimeline}.
+ *
+ * @public
+ */
+export type MapTimelineProps = {
+  /** Optional URL of a backdrop image (world map, terrain). */
+  backdrop?: string;
+  /** Aria-label for the backdrop image. */
+  backdropAlt?: string;
+  /** End of the timeline window (inclusive). */
+  endYear: number;
+  /** Initial year. Defaults to `startYear`. */
+  initialYear?: number;
+  /** Localizable strings. */
+  labels?: MapTimelineLabels;
+  /** Fires when the year changes (slider drag, play tick, or programmatic). */
+  onYearChange?: (next: number) => void;
+  /** Years per second when playing. Defaults to `25`. */
+  speed?: number;
+  /** Start of the timeline window (inclusive). Negative for BCE. */
+  startYear: number;
+} & Omit<ComponentPropsWithoutRef<"section">, "onChange">;
+
+function useTimelineCtx(arguments_: {
+  endYear: number;
+  isPlaying: boolean;
+  labels: Required<MapTimelineLabels>;
+  setIsPlaying: (next: boolean) => void;
+  setYear: (next: number) => void;
+  speed: number;
+  startYear: number;
+  year: number;
+}): Ctx {
+  const {
+    endYear,
+    isPlaying,
+    labels,
+    setIsPlaying,
+    setYear,
+    speed,
+    startYear,
+    year,
+  } = arguments_;
+  return useMemo<Ctx>(
+    () => ({
+      endYear,
+      isPlaying,
+      labels,
+      setIsPlaying,
+      setYear,
+      speed,
+      startYear,
+      year,
+    }),
+    [endYear, isPlaying, labels, setIsPlaying, setYear, speed, startYear, year],
+  );
+}
+
+function useTimelineState(arguments_: {
+  endYear: number;
+  initialYear?: number;
+  onYearChange?: (next: number) => void;
+  speed: number;
+  startYear: number;
+}): {
+  isPlaying: boolean;
+  setIsPlaying: (next: boolean) => void;
+  setYear: (next: number) => void;
+  year: number;
+} {
+  const { endYear, initialYear, onYearChange, startYear } = arguments_;
+  const [year, setYear] = useState<number>(
+    clamp(initialYear ?? startYear, startYear, endYear),
+  );
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const updateYear = useCallback(
+    (next: number) => {
+      const clamped = clamp(next, startYear, endYear);
+      setYear((current) => {
+        if (clamped >= endYear) setIsPlaying(false);
+        if (current === clamped) return current;
+        onYearChange?.(clamped);
+        return clamped;
+      });
+    },
+    [endYear, onYearChange, startYear],
+  );
+
+  return { isPlaying, setIsPlaying, setYear: updateYear, year };
+}
+
+function usePlayback(arguments_: {
+  endYear: number;
+  isPlaying: boolean;
+  setIsPlaying: (next: boolean) => void;
+  setYear: (next: number) => void;
+  speed: number;
+  startYear: number;
+  year: number;
+}): void {
+  const { endYear, isPlaying, setIsPlaying, setYear, speed, year } = arguments_;
+  const yearRef = useRef(year);
+  useEffect(() => {
+    yearRef.current = year;
+  }, [year]);
+  useEffect(() => {
+    if (!isPlaying) return;
+    if (typeof window === "undefined") return;
+    let frame = 0;
+    let last: null | number = null;
+    const step = (timestamp: number): void => {
+      if (last !== null) {
+        const delta = (timestamp - last) / 1000;
+        const next = yearRef.current + delta * speed;
+        if (next >= endYear) {
+          setYear(endYear);
+          setIsPlaying(false);
+          return;
+        }
+        setYear(next);
+      }
+      last = timestamp;
+      frame = window.requestAnimationFrame(step);
+    };
+    frame = window.requestAnimationFrame(step);
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [endYear, isPlaying, setIsPlaying, setYear, speed]);
+}
+
+type StageProps = {
+  backdrop?: string;
+  backdropAlt?: string;
+  children: ReactNode;
+};
+
+function Stage({ backdrop, backdropAlt, children }: StageProps): ReactNode {
+  return (
+    <svg
+      aria-hidden="true"
+      className="block h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+      viewBox={`0 0 ${VIEWBOX_WIDTH.toString()} ${VIEWBOX_HEIGHT.toString()}`}
+    >
+      <rect
+        className="fill-muted"
+        height={VIEWBOX_HEIGHT}
+        width={VIEWBOX_WIDTH}
+        x="0"
+        y="0"
+      />
+      {backdrop ? (
+        <image
+          aria-label={backdropAlt}
+          height={VIEWBOX_HEIGHT}
+          href={backdrop}
+          preserveAspectRatio="xMidYMid slice"
+          width={VIEWBOX_WIDTH}
+          x="0"
+          y="0"
+        />
+      ) : null}
+      {children}
+    </svg>
+  );
+}
+
+type ChildBuckets = {
+  footer: ReactNode[];
+  stage: ReactNode[];
+};
+
+function bucketChildren(children: ReactNode): ChildBuckets {
+  const list: ReactNode[] = Array.isArray(children) ? children : [children];
+  return list.reduce<ChildBuckets>(
+    (accumulator, child) => {
+      const name = displayName(child);
+      if (name === MapTimelineControls.displayName)
+        accumulator.footer.push(child);
+      else accumulator.stage.push(child);
+      return accumulator;
+    },
+    { footer: [], stage: [] },
+  );
+}
+
+function displayName(child: ReactNode): string | undefined {
+  if (typeof child !== "object" || child === null) return undefined;
+  if (!("type" in child)) return undefined;
+  const type = (child as { type: unknown }).type;
+  if (typeof type !== "object" && typeof type !== "function") return undefined;
+  const name = (type as { displayName?: unknown }).displayName;
+  return typeof name === "string" ? name : undefined;
+}
+
+type ShellProps = {
+  backdrop?: string;
+  backdropAlt?: string;
+  buckets: ChildBuckets;
+  className?: string;
+  region: string;
+  titleId: string;
+  year: number;
+};
+
+const Shell = forwardRef<HTMLElement, ShellProps>(function Shell(props, ref) {
+  const { backdrop, backdropAlt, buckets, className, region, titleId, year } =
+    props;
+  return (
+    <section
+      aria-labelledby={titleId}
+      className={cn(
+        "flex w-full flex-col overflow-hidden rounded-2xl border bg-background text-foreground",
+        className,
+      )}
+      ref={ref}
+    >
+      <span className="sr-only" id={titleId}>
+        {region}
+      </span>
+      <div
+        className="relative aspect-[2/1] w-full overflow-hidden"
+        data-current-year={year}
+      >
+        <Stage backdrop={backdrop} backdropAlt={backdropAlt}>
+          {buckets.stage}
+        </Stage>
+      </div>
+      {buckets.footer}
+    </section>
+  );
+});
+
+/**
+ * Combined map + timeline. Pass {@link MapTimelineLayer} (era polygons),
+ * {@link MapTimelineEvent} (year-pinned markers), and
+ * {@link MapTimelineControls} as children. The slider scrubs the
+ * current year; layers and events appear / disappear as the year
+ * crosses their windows.
+ *
+ * Standalone SVG primitive — no external map library required.
+ *
+ * @example
+ * ```tsx
+ * <MapTimeline startYear={-500} endYear={2025} initialYear={1}>
+ *   <MapTimelineLayer
+ *     startYear={-27}
+ *     endYear={476}
+ *     color="red"
+ *     label="Roman Empire"
+ *     geometry={{ type: 'polygon', polygon: romanRing }}
+ *   />
+ *   <MapTimelineEvent
+ *     year={79}
+ *     position={[14.48, 40.75]}
+ *     title="Vesuvius"
+ *     description="Pompeii destroyed"
+ *   />
+ *   <MapTimelineControls>
+ *     <MapTimelinePlayButton />
+ *     <MapTimelineSlider />
+ *   </MapTimelineControls>
+ * </MapTimeline>
+ * ```
+ *
+ * @public
+ */
+export const MapTimeline = forwardRef<HTMLElement, MapTimelineProps>(
+  (props, ref) => {
+    const {
+      backdrop,
+      backdropAlt,
+      children,
+      className,
+      endYear,
+      initialYear,
+      labels,
+      onYearChange,
+      speed = 25,
+      startYear,
+      ...rest
+    } = props;
+    const titleId = useId();
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+
+    const { isPlaying, setIsPlaying, setYear, year } = useTimelineState({
+      endYear,
+      initialYear,
+      onYearChange,
+      speed,
+      startYear,
+    });
+
+    usePlayback({
+      endYear,
+      isPlaying,
+      setIsPlaying,
+      setYear,
+      speed,
+      startYear,
+      year,
+    });
+
+    const ctx = useTimelineCtx({
+      endYear,
+      isPlaying,
+      labels: resolvedLabels,
+      setIsPlaying,
+      setYear,
+      speed,
+      startYear,
+      year,
+    });
+
+    const buckets = bucketChildren(children);
+    return (
+      <TimelineContext.Provider value={ctx}>
+        <Shell
+          backdrop={backdrop}
+          backdropAlt={backdropAlt}
+          buckets={buckets}
+          className={className}
+          ref={ref}
+          region={resolvedLabels.region}
+          titleId={titleId}
+          year={year}
+          {...rest}
+        />
+      </TimelineContext.Provider>
+    );
+  },
+);
+MapTimeline.displayName = "MapTimeline";

--- a/apps/registry/registry/default/market-treemap/market-treemap.tsx
+++ b/apps/registry/registry/default/market-treemap/market-treemap.tsx
@@ -1,1 +1,137 @@
-export { MarketTreemap } from "@vllnt/ui";
+import * as React from "react";
+
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+export type MarketTreemapItem = {
+  change: number;
+  label: string;
+  sector?: string;
+  value: number;
+};
+
+export type MarketTreemapProps = {
+  items: MarketTreemapItem[];
+} & React.HTMLAttributes<HTMLDivElement>;
+
+function getSpan(value: number, maxValue: number) {
+  const normalized = value / Math.max(maxValue, 1);
+
+  if (normalized >= 0.7) {
+    return "md:col-span-2 md:row-span-2";
+  }
+
+  if (normalized >= 0.4) {
+    return "md:col-span-2";
+  }
+
+  return "";
+}
+
+function getTone(change: number) {
+  const isPositive = change >= 0;
+
+  return {
+    isPositive,
+    tileClassName: isPositive
+      ? "border-emerald-500/30 bg-emerald-500/10"
+      : "border-rose-500/30 bg-rose-500/10",
+    trendClassName: isPositive
+      ? "text-emerald-600 dark:text-emerald-400"
+      : "text-rose-600 dark:text-rose-400",
+  };
+}
+
+function MarketTreemapTile({
+  item,
+  maxValue,
+}: {
+  item: MarketTreemapItem;
+  maxValue: number;
+}) {
+  const tone = getTone(item.change);
+  const TrendIcon = tone.isPositive ? ArrowUpRight : ArrowDownRight;
+
+  return (
+    <article
+      className={cn(
+        "flex min-h-[120px] flex-col justify-between rounded-2xl border p-4 transition-transform duration-200 hover:-translate-y-0.5",
+        tone.tileClassName,
+        getSpan(item.value, maxValue),
+      )}
+    >
+      <div className="space-y-2">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-[0.24em] text-muted-foreground">
+              {item.sector ?? "Market"}
+            </p>
+            <h3 className="mt-1 text-xl font-semibold text-foreground">
+              {item.label}
+            </h3>
+          </div>
+          <div
+            className={cn(
+              "inline-flex items-center gap-1 text-sm font-medium",
+              tone.trendClassName,
+            )}
+          >
+            <TrendIcon className="h-4 w-4" />
+            {item.change > 0 ? "+" : ""}
+            {item.change.toFixed(2)}%
+          </div>
+        </div>
+      </div>
+      <div className="flex items-end justify-between gap-3 text-sm text-muted-foreground">
+        <span>Weight {item.value.toLocaleString()}</span>
+        <span className="rounded-full bg-background/70 px-2 py-1 text-xs uppercase tracking-[0.2em] text-foreground">
+          {tone.isPositive ? "Advancing" : "Declining"}
+        </span>
+      </div>
+    </article>
+  );
+}
+
+export const MarketTreemap = React.forwardRef<
+  HTMLDivElement,
+  MarketTreemapProps
+>(({ className, items, ...props }, reference) => {
+  if (items.length === 0) {
+    return null;
+  }
+
+  const maxValue = Math.max(...items.map((item) => item.value));
+
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-border bg-card/80 p-4 shadow-sm",
+        className,
+      )}
+      ref={reference}
+      {...props}
+    >
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-[0.28em] text-muted-foreground">
+            Sector heatmap
+          </p>
+          <h2 className="text-lg font-semibold text-foreground">
+            Market treemap
+          </h2>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Tile size maps market cap proxy; color reflects session change.
+        </p>
+      </div>
+      <div className="grid auto-rows-[120px] grid-cols-1 gap-3 md:auto-rows-[120px] md:grid-cols-4">
+        {items.map((item) => (
+          <MarketTreemapTile item={item} key={item.label} maxValue={maxValue} />
+        ))}
+      </div>
+    </div>
+  );
+});
+
+MarketTreemap.displayName = "MarketTreemap";

--- a/apps/registry/registry/default/marquee/marquee.tsx
+++ b/apps/registry/registry/default/marquee/marquee.tsx
@@ -1,2 +1,132 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type MarqueeSpeed = "fast" | "normal" | "slow";
+
+export type MarqueeProps = React.ComponentPropsWithoutRef<"div"> & {
+  duration?: number;
+  fade?: boolean;
+  gap?: number | string;
+  pauseOnHover?: boolean;
+  repeat?: number;
+  reverse?: boolean;
+  speed?: MarqueeSpeed;
+  vertical?: boolean;
+};
+
+function getGapValue(gap: number | string): string {
+  return typeof gap === "number" ? `${gap}px` : gap;
+}
+
+function getMaskImage(vertical: boolean): string {
+  return vertical
+    ? "linear-gradient(to bottom, transparent, black 12%, black 88%, transparent)"
+    : "linear-gradient(to right, transparent, black 12%, black 88%, transparent)";
+}
+
+function getTrackItems(
+  children: React.ReactNode,
+  repeat: number,
+): React.ReactNode[] {
+  const items = React.Children.toArray(children);
+
+  return Array.from({ length: Math.max(1, repeat) }, (_, copyIndex) =>
+    items.map((item, itemIndex) => (
+      <div className="shrink-0" key={`${copyIndex}-${itemIndex}`}>
+        {item}
+      </div>
+    )),
+  ).flat();
+}
+
+function getDuration(
+  duration: number | undefined,
+  speed: MarqueeSpeed,
+): number {
+  if (duration !== undefined) {
+    return duration;
+  }
+
+  switch (speed) {
+    case "fast":
+      return 10;
+    case "normal":
+      return 20;
+    case "slow":
+      return 32;
+  }
+}
+
+export const Marquee = React.forwardRef<HTMLDivElement, MarqueeProps>(
+  (
+    {
+      children,
+      className,
+      duration,
+      fade = true,
+      gap = "1rem",
+      pauseOnHover = false,
+      repeat = 1,
+      reverse = false,
+      speed = "normal",
+      style,
+      vertical = false,
+      ...props
+    },
+    ref,
+  ) => {
+    const resolvedGap = getGapValue(gap);
+    const resolvedDuration = getDuration(duration, speed);
+    const trackItems = getTrackItems(children, repeat);
+
+    const animationStyle: React.CSSProperties = {
+      animationDirection: reverse ? "reverse" : "normal",
+      animationDuration: `${resolvedDuration}s`,
+      animationIterationCount: "infinite",
+      animationName: vertical ? "vllnt-marquee-y" : "vllnt-marquee-x",
+      animationTimingFunction: "linear",
+    };
+    const maskImage = getMaskImage(vertical);
+
+    return (
+      <div
+        className={cn(
+          "group relative overflow-hidden",
+          vertical ? "flex h-full flex-col" : "flex w-full flex-row",
+          className,
+        )}
+        ref={ref}
+        style={
+          fade ? { ...style, maskImage, WebkitMaskImage: maskImage } : style
+        }
+        {...props}
+      >
+        <div
+          className={cn(
+            "flex shrink-0 will-change-transform motion-reduce:animate-none motion-reduce:transform-none",
+            pauseOnHover && "group-hover:[animation-play-state:paused]",
+            vertical ? "min-h-full flex-col" : "min-w-full flex-row",
+          )}
+          style={animationStyle}
+        >
+          {[0, 1].map((groupIndex) => (
+            <div
+              aria-hidden={groupIndex === 1}
+              className={cn(
+                "flex shrink-0",
+                vertical ? "flex-col items-stretch" : "flex-row items-center",
+              )}
+              key={groupIndex}
+              style={{ gap: resolvedGap }}
+            >
+              {trackItems}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  },
+);
+
+Marquee.displayName = "Marquee";

--- a/apps/registry/registry/default/mdx-content/mdx-content.tsx
+++ b/apps/registry/registry/default/mdx-content/mdx-content.tsx
@@ -1,2 +1,214 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+import { evaluate } from "@mdx-js/mdx";
+import type React from "react";
+import * as runtime from "react/jsx-runtime";
+import ReactMarkdown, { type Components } from "react-markdown";
+
+import { CodeBlock } from "@vllnt/ui";
+
+type MDXContentProps = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  components?: Record<string, React.ComponentType<any>>;
+  content: string;
+  enableMDX?: boolean;
+};
+
+const MDXComponents: Components = {
+  a: ({ children, href, ...props }: React.ComponentProps<"a">) => (
+    <a
+      className="text-primary underline underline-offset-4 hover:text-primary/80 font-medium"
+      href={href}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+  blockquote: ({ children, ...props }: React.ComponentProps<"blockquote">) => (
+    <blockquote
+      className="border-l-4 border-primary pl-4 italic text-muted-foreground my-6 py-2 text-sm"
+      {...props}
+    >
+      {children}
+    </blockquote>
+  ),
+  code: ({ children, className, ...props }: React.ComponentProps<"code">) => {
+    if (typeof className === "string" && className.startsWith("language-")) {
+      const language = className.replace(/^language-/, "");
+      const text =
+        typeof children === "string"
+          ? children.replace(/\n$/, "")
+          : String(children ?? "");
+      return <CodeBlock language={language}>{text}</CodeBlock>;
+    }
+    return (
+      <code
+        className="bg-muted px-1 py-0.5 rounded text-sm font-mono"
+        {...props}
+      >
+        {children}
+      </code>
+    );
+  },
+  em: ({ children, ...props }: React.ComponentProps<"em">) => (
+    <em className="italic" {...props}>
+      {children}
+    </em>
+  ),
+  h1: ({ children, ...props }: React.ComponentProps<"h1">) => (
+    <h1 className="text-2xl font-bold mt-8 mb-4" {...props}>
+      {children}
+    </h1>
+  ),
+  h2: ({ children, ...props }: React.ComponentProps<"h2">) => (
+    <h2 className="text-xl font-bold mt-6 mb-3" {...props}>
+      {children}
+    </h2>
+  ),
+  h3: ({ children, ...props }: React.ComponentProps<"h3">) => (
+    <h3 className="text-lg font-bold mt-4 mb-2" {...props}>
+      {children}
+    </h3>
+  ),
+  hr: ({ ...props }: React.ComponentProps<"hr">) => (
+    <hr className="my-8 border-border" {...props} />
+  ),
+  li: ({ children, ...props }: React.ComponentProps<"li">) => (
+    <li
+      className="mb-2 leading-relaxed text-muted-foreground text-sm pl-2"
+      {...props}
+    >
+      {children}
+    </li>
+  ),
+  ol: ({ children, ...props }: React.ComponentProps<"ol">) => (
+    <ol
+      className="list-decimal list-outside mb-6 space-y-2 ml-6 text-muted-foreground text-sm"
+      {...props}
+    >
+      {children}
+    </ol>
+  ),
+  p: ({ children, ...props }: React.ComponentProps<"p">) => (
+    <p
+      className="mb-6 leading-relaxed text-muted-foreground text-sm max-w-none"
+      {...props}
+    >
+      {children}
+    </p>
+  ),
+  pre: ({ children }: React.ComponentProps<"pre">) => (
+    <div className="contents">{children}</div>
+  ),
+  strong: ({ children, ...props }: React.ComponentProps<"strong">) => (
+    <strong className="font-semibold" {...props}>
+      {children}
+    </strong>
+  ),
+  ul: ({ children, ...props }: React.ComponentProps<"ul">) => (
+    <ul
+      className="list-disc list-outside mb-6 space-y-2 ml-6 text-muted-foreground text-sm"
+      {...props}
+    >
+      {children}
+    </ul>
+  ),
+};
+
+const proseClasses = [
+  "prose prose-lg dark:prose-invert max-w-none",
+  "prose-headings:font-bold prose-headings:tracking-tight",
+  "prose-h1:text-2xl prose-h1:mt-8 prose-h1:mb-4",
+  "prose-h2:text-xl prose-h2:mt-6 prose-h2:mb-3",
+  "prose-h3:text-lg prose-h3:mt-4 prose-h3:mb-2",
+  "prose-p:leading-relaxed prose-p:mb-6 prose-p:text-muted-foreground prose-p:text-sm prose-p:max-w-none",
+  "prose-ul:my-6 prose-ul:ml-6 prose-ul:list-disc prose-ul:list-outside",
+  "prose-ol:my-6 prose-ol:ml-6 prose-ol:list-decimal prose-ol:list-outside",
+  "prose-li:mb-2 prose-li:leading-relaxed prose-li:pl-2",
+  "prose-strong:font-semibold prose-em:italic",
+  "prose-a:text-primary prose-a:underline prose-a:underline-offset-4 hover:prose-a:text-primary/80",
+  "prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:font-mono",
+  "prose-pre:my-6 prose-pre:overflow-x-auto prose-pre:rounded-lg prose-pre:border prose-pre:bg-black prose-pre:py-4 prose-pre:font-mono prose-pre:text-sm prose-pre:text-white prose-pre:shadow-lg dark:prose-pre:bg-zinc-900",
+  "prose-blockquote:border-l-4 prose-blockquote:border-primary prose-blockquote:pl-4 prose-blockquote:italic prose-blockquote:text-muted-foreground prose-blockquote:my-6 prose-blockquote:py-2",
+  "prose-hr:my-8 prose-hr:border-border",
+  "prose-table:w-full prose-table:border-collapse prose-table:border prose-table:border-border",
+  "prose-th:border prose-th:border-border prose-th:bg-muted prose-th:p-2 prose-th:text-left prose-th:font-medium",
+  "prose-td:border prose-td:border-border prose-td:p-2",
+  "prose-img:rounded-lg prose-img:border prose-img:border-border prose-img:shadow-lg",
+].join(" ");
+
+function removeImportStatements(
+  content: string,
+  componentNames: string[],
+): string {
+  let processed = content.replaceAll(/^import\s+.*CodeBlock.*from.*$/gm, "");
+  componentNames.forEach((name) => {
+    processed = processed.replaceAll(
+      new RegExp(`^import\\s+.*${name}.*from.*$`, "gm"),
+      "",
+    );
+  });
+  return processed;
+}
+
+function buildCustomComponents(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  injectedComponents: Record<string, React.ComponentType<any>>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Record<string, React.ComponentType<any>> {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    CodeBlock: CodeBlock as React.ComponentType<any>,
+    ...injectedComponents,
+  };
+}
+
+export async function MDXContent({
+  components = {},
+  content,
+  enableMDX = true,
+}: MDXContentProps) {
+  const componentNames = Object.keys(components);
+  const processedContent = removeImportStatements(content, componentNames);
+  const contentWithoutCodeBlocks = processedContent.replaceAll(
+    /```[\S\s]*?```/g,
+    "",
+  );
+  const hasJSX = /<[A-Z][A-Za-z]*/.test(contentWithoutCodeBlocks);
+
+  const customComponents = buildCustomComponents(components);
+  const allComponents = { ...MDXComponents, ...customComponents };
+
+  if (enableMDX && hasJSX) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let Component: React.ComponentType<{ components: any }> | undefined;
+
+    try {
+      const result = await evaluate(processedContent, {
+        ...runtime,
+        baseUrl: import.meta.url,
+      });
+      Component = result.default;
+    } catch (error) {
+      console.error("Error rendering MDX:", error);
+    }
+
+    if (Component) {
+      return (
+        <div className={proseClasses}>
+          <Component components={allComponents} />
+        </div>
+      );
+    }
+
+    return (
+      <div className={proseClasses}>
+        <ReactMarkdown components={allComponents}>{content}</ReactMarkdown>
+      </div>
+    );
+  }
+
+  return (
+    <div className={proseClasses}>
+      <ReactMarkdown components={allComponents}>{content}</ReactMarkdown>
+    </div>
+  );
+}

--- a/apps/registry/registry/default/menubar/menubar.tsx
+++ b/apps/registry/registry/default/menubar/menubar.tsx
@@ -1,1 +1,238 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import * as MenubarPrimitive from "@radix-ui/react-menubar";
+import { Check, ChevronRight, Circle } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+const MenubarMenu: typeof MenubarPrimitive.Menu = MenubarPrimitive.Menu;
+
+const MenubarGroup: typeof MenubarPrimitive.Group = MenubarPrimitive.Group;
+
+const MenubarPortal: typeof MenubarPrimitive.Portal = MenubarPrimitive.Portal;
+
+const MenubarSub: typeof MenubarPrimitive.Sub = MenubarPrimitive.Sub;
+
+const MenubarRadioGroup: typeof MenubarPrimitive.RadioGroup =
+  MenubarPrimitive.RadioGroup;
+
+const Menubar = forwardRef<
+  React.ComponentRef<typeof MenubarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <MenubarPrimitive.Root
+    className={cn(
+      "flex h-10 items-center space-x-1 rounded-md border bg-background p-1",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+Menubar.displayName = MenubarPrimitive.Root.displayName;
+
+const MenubarTrigger = forwardRef<
+  React.ComponentRef<typeof MenubarPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <MenubarPrimitive.Trigger
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-3 py-1.5 text-sm font-medium outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+MenubarTrigger.displayName = MenubarPrimitive.Trigger.displayName;
+
+const MenubarSubTrigger = forwardRef<
+  React.ComponentRef<typeof MenubarPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ children, className, inset, ...props }, ref) => (
+  <MenubarPrimitive.SubTrigger
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      inset && "pl-8",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </MenubarPrimitive.SubTrigger>
+));
+MenubarSubTrigger.displayName = MenubarPrimitive.SubTrigger.displayName;
+
+const MenubarSubContent = forwardRef<
+  React.ComponentRef<typeof MenubarPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <MenubarPrimitive.SubContent
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+MenubarSubContent.displayName = MenubarPrimitive.SubContent.displayName;
+
+const MenubarContent = forwardRef<
+  React.ComponentRef<typeof MenubarPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Content>
+>(
+  (
+    { align = "start", alignOffset = -4, className, sideOffset = 8, ...props },
+    ref,
+  ) => (
+    <MenubarPrimitive.Portal>
+      <MenubarPrimitive.Content
+        align={align}
+        alignOffset={alignOffset}
+        className={cn(
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className,
+        )}
+        ref={ref}
+        sideOffset={sideOffset}
+        {...props}
+      />
+    </MenubarPrimitive.Portal>
+  ),
+);
+MenubarContent.displayName = MenubarPrimitive.Content.displayName;
+
+const MenubarItem = forwardRef<
+  React.ComponentRef<typeof MenubarPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <MenubarPrimitive.Item
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+MenubarItem.displayName = MenubarPrimitive.Item.displayName;
+
+const MenubarCheckboxItem = forwardRef<
+  React.ComponentRef<typeof MenubarPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.CheckboxItem>
+>(({ checked, children, className, ...props }, ref) => (
+  <MenubarPrimitive.CheckboxItem
+    checked={checked}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <MenubarPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </MenubarPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </MenubarPrimitive.CheckboxItem>
+));
+MenubarCheckboxItem.displayName = MenubarPrimitive.CheckboxItem.displayName;
+
+const MenubarRadioItem = forwardRef<
+  React.ComponentRef<typeof MenubarPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.RadioItem>
+>(({ children, className, ...props }, ref) => (
+  <MenubarPrimitive.RadioItem
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <MenubarPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </MenubarPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </MenubarPrimitive.RadioItem>
+));
+MenubarRadioItem.displayName = MenubarPrimitive.RadioItem.displayName;
+
+const MenubarLabel = forwardRef<
+  React.ComponentRef<typeof MenubarPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <MenubarPrimitive.Label
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold",
+      inset && "pl-8",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+MenubarLabel.displayName = MenubarPrimitive.Label.displayName;
+
+const MenubarSeparator = forwardRef<
+  React.ComponentRef<typeof MenubarPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <MenubarPrimitive.Separator
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    ref={ref}
+    {...props}
+  />
+));
+MenubarSeparator.displayName = MenubarPrimitive.Separator.displayName;
+
+const MenubarShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+MenubarShortcut.displayName = "MenubarShortcut";
+
+export {
+  Menubar,
+  MenubarCheckboxItem,
+  MenubarContent,
+  MenubarGroup,
+  MenubarItem,
+  MenubarLabel,
+  MenubarMenu,
+  MenubarPortal,
+  MenubarRadioGroup,
+  MenubarRadioItem,
+  MenubarSeparator,
+  MenubarShortcut,
+  MenubarSub,
+  MenubarSubContent,
+  MenubarSubTrigger,
+  MenubarTrigger,
+};

--- a/apps/registry/registry/default/metric-cluster/metric-cluster.tsx
+++ b/apps/registry/registry/default/metric-cluster/metric-cluster.tsx
@@ -1,8 +1,187 @@
-export {
-  MetricCluster,
-  type MetricClusterAnchor,
-  type MetricClusterEntry,
-  type MetricClusterLabels,
-  type MetricClusterProps,
-  type MetricClusterTone,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Tone of a single metric line — drives the dot color.
+ *
+ * @public
+ */
+export type MetricClusterTone = "danger" | "neutral" | "success" | "warn";
+
+const TONE_DOT: Record<MetricClusterTone, string> = {
+  danger: "bg-red-500",
+  neutral: "bg-muted-foreground",
+  success: "bg-emerald-500",
+  warn: "bg-amber-500",
+};
+
+/**
+ * Anchor corner relative to the canvas object the cluster attaches to.
+ *
+ * @public
+ */
+export type MetricClusterAnchor =
+  | "bottom-left"
+  | "bottom-right"
+  | "top-left"
+  | "top-right";
+
+const ANCHOR_TRANSFORM: Record<MetricClusterAnchor, string> = {
+  "bottom-left": "translate(-100%, 100%)",
+  "bottom-right": "translate(0%, 100%)",
+  "top-left": "translate(-100%, -100%)",
+  "top-right": "translate(0%, -100%)",
+};
+
+/**
+ * One metric in the cluster.
+ *
+ * @public
+ */
+export type MetricClusterEntry = {
+  /** Stable identifier — used as the React key + analytics hook. */
+  id: string;
+  /** Short label (e.g. `"errs/min"`). */
+  label: ReactNode;
+  /** Optional tone for the leading dot. Defaults to `"neutral"`. */
+  tone?: MetricClusterTone;
+  /** Display value (already formatted by host). */
+  value: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type MetricClusterLabels = {
+  /** Aria-label override. Defaults to `"Metric cluster"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Metric cluster",
+} as const satisfies Required<MetricClusterLabels>;
+
+/**
+ * Props for {@link MetricCluster}.
+ *
+ * @public
+ */
+export type MetricClusterProps = {
+  /** Anchor corner. Defaults to `"top-right"`. */
+  anchor?: MetricClusterAnchor;
+  /** Localizable strings. */
+  labels?: MetricClusterLabels;
+  /** Metric entries in render order. */
+  metrics: MetricClusterEntry[];
+  /** Optional cluster title rendered above the rows. */
+  title?: ReactNode;
+  /** Anchor X in canvas pixels. */
+  x: number;
+  /** Anchor Y in canvas pixels. */
+  y: number;
+} & ComponentPropsWithoutRef<"div">;
+
+const Row = (props: { entry: MetricClusterEntry }): React.ReactElement => {
+  const { entry } = props;
+  const tone = entry.tone ?? "neutral";
+  return (
+    <li
+      className="flex items-center justify-between gap-2 text-[11px]"
+      data-metric-cluster-row={entry.id}
+      data-metric-cluster-tone={tone}
+    >
+      <span className="flex items-center gap-1.5 text-muted-foreground">
+        <span
+          aria-hidden="true"
+          className={cn("h-1.5 w-1.5 rounded-full", TONE_DOT[tone])}
+        />
+        {entry.label}
+      </span>
+      <span className="font-semibold text-foreground">{entry.value}</span>
+    </li>
+  );
+};
+
+/**
+ * Compact stack of related metrics pinned to a canvas object's corner.
+ * Use when a single `StickyMetric` doesn't carry enough signal — for
+ * runs whose throughput, latency, and error rate must all be visible
+ * at once. Pure presentation; the host supplies the anchor coords + the
+ * metric list.
+ *
+ * The wrapper is `pointer-events: none` — host gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <MetricCluster
+ *   x={420} y={180}
+ *   anchor="top-right"
+ *   title="research-2025"
+ *   metrics={[
+ *     { id: "qps",  label: "qps",   value: "240", tone: "success" },
+ *     { id: "errs", label: "errs",  value: "14",  tone: "danger" },
+ *     { id: "p95",  label: "p95",   value: "180ms" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const MetricCluster = forwardRef<HTMLDivElement, MetricClusterProps>(
+  (props, ref) => {
+    const {
+      anchor = "top-right",
+      className,
+      labels,
+      metrics,
+      title,
+      x,
+      y,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "pointer-events-none absolute z-20 flex flex-col gap-1 rounded-md border border-border bg-background/90 p-2 shadow-sm backdrop-blur",
+          className,
+        )}
+        data-metric-cluster
+        data-metric-cluster-anchor={anchor}
+        ref={ref}
+        role="status"
+        style={{
+          left: x,
+          top: y,
+          transform: ANCHOR_TRANSFORM[anchor],
+        }}
+        {...rest}
+      >
+        {title ? (
+          <header
+            className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+            data-metric-cluster-title
+          >
+            {title}
+          </header>
+        ) : null}
+        <ul className="space-y-0.5">
+          {metrics.map((entry) => (
+            <Row entry={entry} key={entry.id} />
+          ))}
+        </ul>
+      </div>
+    );
+  },
+);
+MetricCluster.displayName = "MetricCluster";

--- a/apps/registry/registry/default/metric-gauge/metric-gauge.tsx
+++ b/apps/registry/registry/default/metric-gauge/metric-gauge.tsx
@@ -1,1 +1,261 @@
-export * from "@vllnt/ui";
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@vllnt/ui";
+
+export type MetricGaugeThreshold = {
+  colorClassName: string;
+  label: string;
+  value: number;
+};
+
+export type MetricGaugeProps = React.ComponentPropsWithoutRef<"div"> & {
+  description?: string;
+  label: string;
+  max: number;
+  min?: number;
+  thresholds?: MetricGaugeThreshold[];
+  unit?: string;
+  value: number;
+};
+
+type Point = {
+  x: number;
+  y: number;
+};
+
+const DEFAULT_THRESHOLDS: MetricGaugeThreshold[] = [
+  { colorClassName: "text-emerald-500", label: "Nominal", value: 60 },
+  { colorClassName: "text-amber-500", label: "Elevated", value: 85 },
+  { colorClassName: "text-destructive", label: "Critical", value: 100 },
+];
+const GAUGE_CENTER: Point = { x: 100, y: 100 };
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function polarToCartesian(radius: number, angle: number, center: Point): Point {
+  const radians = ((angle - 90) * Math.PI) / 180;
+
+  return {
+    x: center.x + radius * Math.cos(radians),
+    y: center.y + radius * Math.sin(radians),
+  };
+}
+
+function describeArc(
+  radius: number,
+  angles: { end: number; start: number },
+  center: Point,
+) {
+  const start = polarToCartesian(radius, angles.end, center);
+  const end = polarToCartesian(radius, angles.start, center);
+  const largeArcFlag = angles.end - angles.start <= 180 ? 0 : 1;
+
+  return `M ${start.x} ${start.y} A ${radius} ${radius} 0 ${largeArcFlag} 0 ${end.x} ${end.y}`;
+}
+
+function formatMetricValue(value: number, unit?: string): string {
+  const rounded = Number.isInteger(value) ? value.toString() : value.toFixed(1);
+
+  return unit ? `${rounded}${unit}` : rounded;
+}
+
+function getActiveThreshold(
+  percent: number,
+  thresholds: MetricGaugeThreshold[],
+) {
+  return (
+    thresholds.find((threshold) => percent <= threshold.value) ??
+    thresholds.at(-1)
+  );
+}
+
+function GaugeDialSvg({
+  activeThreshold,
+  endAngle,
+  label,
+}: {
+  activeThreshold: MetricGaugeThreshold;
+  endAngle: number;
+  label: string;
+}) {
+  const gaugePath = describeArc(72, { end: 90, start: -90 }, GAUGE_CENTER);
+  const activePath = describeArc(
+    72,
+    { end: endAngle, start: -90 },
+    GAUGE_CENTER,
+  );
+  const needlePoint = polarToCartesian(60, endAngle, GAUGE_CENTER);
+
+  return (
+    <svg aria-label={label} className="h-auto w-full" viewBox="0 0 200 128">
+      <path
+        d={gaugePath}
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeOpacity="0.12"
+        strokeWidth="14"
+      />
+      <path
+        className={cn(activeThreshold.colorClassName)}
+        d={activePath}
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="14"
+      />
+      <line
+        className={cn(activeThreshold.colorClassName)}
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="4"
+        x1={GAUGE_CENTER.x}
+        x2={needlePoint.x}
+        y1={GAUGE_CENTER.y}
+        y2={needlePoint.y}
+      />
+      <circle
+        className="fill-background stroke-border"
+        cx={GAUGE_CENTER.x}
+        cy={GAUGE_CENTER.y}
+        r="8"
+      />
+    </svg>
+  );
+}
+
+function GaugeDial({
+  activeThreshold,
+  endAngle,
+  label,
+  max,
+  min,
+  percent,
+  safeValue,
+  unit,
+}: {
+  activeThreshold: MetricGaugeThreshold;
+  endAngle: number;
+  label: string;
+  max: number;
+  min: number;
+  percent: number;
+  safeValue: number;
+  unit?: string;
+}) {
+  return (
+    <>
+      <div className="relative mx-auto w-full max-w-[280px]">
+        <GaugeDialSvg
+          activeThreshold={activeThreshold}
+          endAngle={endAngle}
+          label={label}
+        />
+        <div className="absolute inset-x-0 top-12 text-center">
+          <div className="text-3xl font-semibold tracking-tight">
+            {formatMetricValue(safeValue, unit)}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            Range {formatMetricValue(min, unit)}–{formatMetricValue(max, unit)}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>{formatMetricValue(min, unit)}</span>
+        <span>{Math.round(percent)}%</span>
+        <span>{formatMetricValue(max, unit)}</span>
+      </div>
+    </>
+  );
+}
+
+function GaugeLegend({ thresholds }: { thresholds: MetricGaugeThreshold[] }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {thresholds.map((threshold) => (
+        <div
+          className="flex items-center gap-2 rounded-md border px-2.5 py-1 text-xs"
+          key={`${threshold.label}-${threshold.value}`}
+        >
+          <span
+            aria-hidden="true"
+            className={cn(
+              "h-2 w-2 rounded-full bg-current",
+              threshold.colorClassName,
+            )}
+          />
+          <span>{threshold.label}</span>
+          <span className="text-muted-foreground">≤ {threshold.value}%</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export const MetricGauge = React.forwardRef<HTMLDivElement, MetricGaugeProps>(
+  (
+    {
+      className,
+      description,
+      label,
+      max,
+      min = 0,
+      thresholds = DEFAULT_THRESHOLDS,
+      unit,
+      value,
+      ...props
+    },
+    ref,
+  ) => {
+    const safeValue = clamp(value, min, max);
+    const percent = max === min ? 0 : ((safeValue - min) / (max - min)) * 100;
+    const endAngle = -90 + 180 * (percent / 100);
+    const activeThreshold = getActiveThreshold(percent, thresholds);
+
+    return (
+      <Card className={cn("shadow-sm", className)} ref={ref} {...props}>
+        <CardHeader className="space-y-2 pb-3">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <CardTitle className="text-base">{label}</CardTitle>
+              {description ? (
+                <CardDescription>{description}</CardDescription>
+              ) : null}
+            </div>
+            {activeThreshold ? (
+              <Badge variant="outline">{activeThreshold.label}</Badge>
+            ) : null}
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {activeThreshold ? (
+            <GaugeDial
+              activeThreshold={activeThreshold}
+              endAngle={endAngle}
+              label={label}
+              max={max}
+              min={min}
+              percent={percent}
+              safeValue={safeValue}
+              unit={unit}
+            />
+          ) : null}
+          <GaugeLegend thresholds={thresholds} />
+        </CardContent>
+      </Card>
+    );
+  },
+);
+
+MetricGauge.displayName = "MetricGauge";

--- a/apps/registry/registry/default/mini-map-panel/mini-map-panel.tsx
+++ b/apps/registry/registry/default/mini-map-panel/mini-map-panel.tsx
@@ -1,1 +1,98 @@
-export { MiniMapPanel, type MiniMapPanelProps } from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type MiniMapMarker = {
+  id: string;
+  label?: string;
+  x: number;
+  y: number;
+};
+
+export type MiniMapPanelProps = React.ComponentPropsWithoutRef<"div"> & {
+  markers?: MiniMapMarker[];
+  title?: string;
+  viewport: {
+    height: number;
+    width: number;
+    x: number;
+    y: number;
+    zoom: number;
+  };
+  world: {
+    height: number;
+    width: number;
+  };
+};
+
+const MiniMapPanel = forwardRef<HTMLDivElement, MiniMapPanelProps>(
+  (
+    { className, markers = [], title = "Overview", viewport, world, ...props },
+    ref,
+  ) => {
+    const viewportWidth = Math.max(
+      (viewport.width / viewport.zoom / world.width) * 100,
+      8,
+    );
+    const viewportHeight = Math.max(
+      (viewport.height / viewport.zoom / world.height) * 100,
+      8,
+    );
+    const viewportLeft = Math.min(
+      Math.max((viewport.x / world.width) * 100, 0),
+      100 - viewportWidth,
+    );
+    const viewportTop = Math.min(
+      Math.max((viewport.y / world.height) * 100, 0),
+      100 - viewportHeight,
+    );
+
+    return (
+      <div
+        className={cn(
+          "w-52 rounded-sm border border-border bg-background p-3 font-mono",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <div>
+            <div className="text-xs font-medium uppercase tracking-[0.24em] text-muted-foreground">
+              {title}
+            </div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              Zoom {Math.round(viewport.zoom * 100)}%
+            </div>
+          </div>
+        </div>
+        <div className="relative aspect-[4/3] overflow-hidden rounded-sm border border-border bg-background">
+          {markers.map((marker) => (
+            <div
+              className="absolute size-1.5 -translate-x-1/2 -translate-y-1/2 bg-foreground"
+              key={marker.id}
+              style={{
+                left: `${(marker.x / world.width) * 100}%`,
+                top: `${(marker.y / world.height) * 100}%`,
+              }}
+              title={marker.label}
+            />
+          ))}
+          <div
+            className="absolute border border-foreground/80 bg-transparent"
+            style={{
+              height: `${viewportHeight}%`,
+              left: `${viewportLeft}%`,
+              top: `${viewportTop}%`,
+              width: `${viewportWidth}%`,
+            }}
+          />
+        </div>
+      </div>
+    );
+  },
+);
+
+MiniMapPanel.displayName = "MiniMapPanel";
+
+export { MiniMapPanel };

--- a/apps/registry/registry/default/model-comparison/model-comparison.tsx
+++ b/apps/registry/registry/default/model-comparison/model-comparison.tsx
@@ -1,7 +1,405 @@
-// Re-export from @vllnt/ui package
-export {
-  ModelComparison,
-  ModelComparisonColumn,
-  ModelComparisonMeta,
-  ModelComparisonVote,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+
+import { Eye, EyeOff } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+
+const HIDDEN_LABEL_PREFIX = "Model";
+
+/**
+ * Localizable strings for {@link ModelComparison}.
+ *
+ * @public
+ */
+export type ModelComparisonLabels = {
+  /** Caption for the cost stat. Defaults to `"Cost"`. */
+  cost?: string;
+  /** Caption for the blind-mode toggle when on. Defaults to `"Hide models"`. */
+  hide?: string;
+  /** Caption for the latency stat. Defaults to `"Latency"`. */
+  latency?: string;
+  /** Caption for the prompt heading. Defaults to `"Prompt"`. */
+  prompt?: string;
+  /** Caption for the blind-mode toggle when off. Defaults to `"Reveal models"`. */
+  reveal?: string;
+  /** Caption for the token count stat. Defaults to `"Tokens"`. */
+  tokens?: string;
+  /** Caption for the vote heading. Defaults to `"Which response is better?"`. */
+  voteHeading?: string;
+  /** Caption for the "tie" vote option. Defaults to `"Tie"`. */
+  voteTie?: string;
+};
+
+const DEFAULT_LABELS = {
+  cost: "Cost",
+  hide: "Hide models",
+  latency: "Latency",
+  prompt: "Prompt",
+  reveal: "Reveal models",
+  tokens: "Tokens",
+  voteHeading: "Which response is better?",
+  voteTie: "Tie",
+} as const satisfies Required<ModelComparisonLabels>;
+
+type ModelComparisonContextValue = {
+  blind: boolean;
+  labels: Required<ModelComparisonLabels>;
+};
+
+const DEFAULT_CONTEXT: ModelComparisonContextValue = {
+  blind: false,
+  labels: DEFAULT_LABELS,
+};
+
+const ModelComparisonContext = createContext(DEFAULT_CONTEXT);
+
+/**
+ * Props for {@link ModelComparison}.
+ *
+ * @public
+ */
+export type ModelComparisonProps = {
+  /** When true, replaces model labels with anonymous placeholders. */
+  blindDefault?: boolean;
+  /** When true, suppresses the built-in blind-mode toggle. */
+  hideBlindToggle?: boolean;
+  /** Localizable strings. */
+  labels?: ModelComparisonLabels;
+  /** The prompt that drove all responses. Hidden when omitted. */
+  prompt?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+type ComparisonHeaderProps = {
+  blind: boolean;
+  hideBlindToggle: boolean;
+  labels: Required<ModelComparisonLabels>;
+  onToggleBlind: () => void;
+  prompt?: ReactNode;
+};
+
+function ComparisonHeader({
+  blind,
+  hideBlindToggle,
+  labels,
+  onToggleBlind,
+  prompt,
+}: ComparisonHeaderProps): ReactNode {
+  if (!prompt && hideBlindToggle) return null;
+  return (
+    <header className="flex items-start justify-between gap-3">
+      {prompt ? (
+        <div className="flex min-w-0 flex-col gap-1">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {labels.prompt}
+          </span>
+          <p className="text-sm text-foreground">{prompt}</p>
+        </div>
+      ) : (
+        <span aria-hidden="true" />
+      )}
+      {hideBlindToggle ? null : (
+        <Button
+          aria-pressed={blind}
+          onClick={onToggleBlind}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          {blind ? (
+            <>
+              <Eye aria-hidden="true" className="mr-2 h-4 w-4" />
+              {labels.reveal}
+            </>
+          ) : (
+            <>
+              <EyeOff aria-hidden="true" className="mr-2 h-4 w-4" />
+              {labels.hide}
+            </>
+          )}
+        </Button>
+      )}
+    </header>
+  );
+}
+
+/**
+ * Side-by-side comparison of AI model responses to the same prompt.
+ * Composes {@link Badge} and {@link Button}.
+ *
+ * @example
+ * ```tsx
+ * <ModelComparison prompt="Explain closures in JavaScript">
+ *   <ModelComparisonColumn model="claude-sonnet-4-6" label="Sonnet">
+ *     {sonnetResponse}
+ *     <ModelComparisonMeta tokens={320} latency="0.8s" cost="$0.003" />
+ *   </ModelComparisonColumn>
+ *   <ModelComparisonColumn model="gpt-4o" label="GPT-4o">
+ *     {gptResponse}
+ *     <ModelComparisonMeta tokens={410} latency="1.1s" cost="$0.005" />
+ *   </ModelComparisonColumn>
+ *   <ModelComparisonVote onVote={handleVote} />
+ * </ModelComparison>
+ * ```
+ *
+ * @public
+ */
+export const ModelComparison = forwardRef<HTMLElement, ModelComparisonProps>(
+  (props, ref) => {
+    const {
+      blindDefault = false,
+      children,
+      className,
+      hideBlindToggle = false,
+      labels,
+      prompt,
+      ...rest
+    } = props;
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const [blind, setBlind] = useState(blindDefault);
+
+    const contextValue = useMemo<ModelComparisonContextValue>(
+      () => ({ blind, labels: resolvedLabels }),
+      [blind, resolvedLabels],
+    );
+
+    const handleToggleBlind = useCallback(() => {
+      setBlind((value) => !value);
+    }, []);
+
+    return (
+      <ModelComparisonContext.Provider value={contextValue}>
+        <section
+          className={cn(
+            "flex flex-col gap-4 rounded-2xl border bg-background p-4",
+            className,
+          )}
+          ref={ref}
+          {...rest}
+        >
+          <ComparisonHeader
+            blind={blind}
+            hideBlindToggle={hideBlindToggle}
+            labels={resolvedLabels}
+            onToggleBlind={handleToggleBlind}
+            prompt={prompt}
+          />
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {children}
+          </div>
+        </section>
+      </ModelComparisonContext.Provider>
+    );
+  },
+);
+ModelComparison.displayName = "ModelComparison";
+
+/**
+ * Props for {@link ModelComparisonColumn}.
+ *
+ * @public
+ */
+export type ModelComparisonColumnProps = {
+  /** Optional badge text shown alongside the label (e.g. "Winner"). */
+  badge?: ReactNode;
+  /** Friendly display label for the model. Hidden in blind mode. */
+  label?: ReactNode;
+  /** Model identifier. Hidden in blind mode. */
+  model: string;
+} & ComponentPropsWithoutRef<"article">;
+
+/**
+ * Column for {@link ModelComparison}. Renders the model label and badge in
+ * the header and the response content in the body.
+ *
+ * @public
+ */
+export const ModelComparisonColumn = forwardRef<
+  HTMLElement,
+  ModelComparisonColumnProps
+>((props, ref) => {
+  const { badge, children, className, label, model, ...rest } = props;
+  const id = useId();
+  const { blind } = useContext(ModelComparisonContext);
+  const displayLabel = blind
+    ? `${HIDDEN_LABEL_PREFIX} ${id.slice(-2)}`
+    : (label ?? model);
+
+  return (
+    <article
+      aria-label={typeof displayLabel === "string" ? displayLabel : undefined}
+      className={cn(
+        "flex flex-col gap-3 rounded-xl border border-border bg-muted/30 p-3",
+        className,
+      )}
+      data-blind={blind ? "true" : "false"}
+      data-model={blind ? undefined : model}
+      ref={ref}
+      {...rest}
+    >
+      <header className="flex items-center justify-between gap-2">
+        <h4 className="text-sm font-semibold tracking-tight text-foreground">
+          {displayLabel}
+        </h4>
+        {badge ? <Badge variant="secondary">{badge}</Badge> : null}
+      </header>
+      <div className="flex flex-1 flex-col gap-2 text-sm text-foreground">
+        {children}
+      </div>
+    </article>
+  );
+});
+ModelComparisonColumn.displayName = "ModelComparisonColumn";
+
+/**
+ * Props for {@link ModelComparisonMeta}.
+ *
+ * @public
+ */
+export type ModelComparisonMetaProps = {
+  /** Cost stat (formatted). */
+  cost?: ReactNode;
+  /** Latency stat (formatted). */
+  latency?: ReactNode;
+  /** Token count. */
+  tokens?: number | ReactNode;
+} & ComponentPropsWithoutRef<"dl">;
+
+/**
+ * Inline statistics row for a {@link ModelComparisonColumn}: tokens,
+ * latency, cost. Renders the stats whose props are present.
+ *
+ * @public
+ */
+export const ModelComparisonMeta = forwardRef<
+  HTMLDListElement,
+  ModelComparisonMetaProps
+>((props, ref) => {
+  const { className, cost, latency, tokens, ...rest } = props;
+  const { labels } = useContext(ModelComparisonContext);
+
+  const items: { caption: string; value: ReactNode }[] = [];
+  if (tokens !== undefined && tokens !== null) {
+    items.push({
+      caption: labels.tokens,
+      value: typeof tokens === "number" ? tokens.toLocaleString() : tokens,
+    });
+  }
+  if (latency !== undefined && latency !== null) {
+    items.push({ caption: labels.latency, value: latency });
+  }
+  if (cost !== undefined && cost !== null) {
+    items.push({ caption: labels.cost, value: cost });
+  }
+  if (items.length === 0) return null;
+
+  return (
+    <dl
+      className={cn(
+        "mt-auto flex flex-wrap gap-x-3 gap-y-1 border-t border-border pt-2 text-xs",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      {items.map((item) => (
+        <div className="flex items-baseline gap-1" key={item.caption}>
+          <dt className="font-medium uppercase tracking-wide text-muted-foreground">
+            {item.caption}
+          </dt>
+          <dd className="text-foreground">{item.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+});
+ModelComparisonMeta.displayName = "ModelComparisonMeta";
+
+/**
+ * Vote payload shape passed to {@link ModelComparisonVoteProps.onVote}.
+ *
+ * @public
+ */
+export type ModelComparisonVoteValue = "left" | "right" | "tie";
+
+type VoteLabels = {
+  left?: ReactNode;
+  right?: ReactNode;
+  tie?: ReactNode;
+};
+
+/**
+ * Props for {@link ModelComparisonVote}.
+ *
+ * @public
+ */
+export type ModelComparisonVoteProps = {
+  /** Optional captions for the left / right / tie buttons. */
+  buttonLabels?: VoteLabels;
+  /** Fires with the user's choice. */
+  onVote?: (vote: ModelComparisonVoteValue) => void;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * Vote bar for {@link ModelComparison}. Renders three buttons — left, tie,
+ * right — that each emit `onVote` with the chosen value.
+ *
+ * @public
+ */
+export const ModelComparisonVote = forwardRef<
+  HTMLDivElement,
+  ModelComparisonVoteProps
+>((props, ref) => {
+  const { buttonLabels, className, onVote, ...rest } = props;
+  const { labels: contextLabels } = useContext(ModelComparisonContext);
+
+  const handleLeft = useCallback(() => {
+    onVote?.("left");
+  }, [onVote]);
+  const handleTie = useCallback(() => {
+    onVote?.("tie");
+  }, [onVote]);
+  const handleRight = useCallback(() => {
+    onVote?.("right");
+  }, [onVote]);
+
+  return (
+    <div
+      className={cn("flex flex-col items-center gap-2", className)}
+      ref={ref}
+      {...rest}
+    >
+      <p className="text-sm font-medium text-foreground">
+        {contextLabels.voteHeading}
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <Button onClick={handleLeft} size="sm" type="button" variant="outline">
+          {buttonLabels?.left ?? "← Left"}
+        </Button>
+        <Button onClick={handleTie} size="sm" type="button" variant="ghost">
+          {buttonLabels?.tie ?? contextLabels.voteTie}
+        </Button>
+        <Button onClick={handleRight} size="sm" type="button" variant="outline">
+          {buttonLabels?.right ?? "Right →"}
+        </Button>
+      </div>
+    </div>
+  );
+});
+ModelComparisonVote.displayName = "ModelComparisonVote";

--- a/apps/registry/registry/default/model-selector/model-selector.tsx
+++ b/apps/registry/registry/default/model-selector/model-selector.tsx
@@ -1,4 +1,527 @@
-// Re-export from @vllnt/ui package
-// ModelSelector is a complex component with many dependencies (Dialog, Command, DropdownMenu, etc.)
-// Use directly from @vllnt/ui for best compatibility
-export { ModelSelector, type ModelInfo, type ModelSelectorProps } from '@vllnt/ui'
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+
+import { ArrowUpDown, Filter } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@vllnt/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@vllnt/ui";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@vllnt/ui";
+import { Input } from "@vllnt/ui";
+
+/** Model information for the selector. */
+export type ModelInfo = {
+  description?: string;
+  id: string;
+  name: string;
+  pricing?: {
+    input?: number; // per 1M tokens
+    output?: number; // per 1M tokens
+  };
+};
+
+export type ModelSelectorProps = {
+  models: ModelInfo[];
+  onOpenChange: (open: boolean) => void;
+  onSelectModel: (modelId: string) => void;
+  open: boolean;
+  selectedModelId: string;
+};
+
+type SortOption = "name" | "price-high" | "price-low" | "provider";
+type SelectionGuardReference = { current: null | string };
+
+function getProvider(modelId: string): string {
+  const parts = modelId.split("/");
+  return parts[0] || "unknown";
+}
+
+function getAveragePrice(model: ModelInfo): number {
+  if (!model.pricing) return Number.POSITIVE_INFINITY;
+  const inputPrice = model.pricing.input ?? 0;
+  const outputPrice = model.pricing.output ?? inputPrice;
+  return (inputPrice + outputPrice) / 2;
+}
+
+function formatPrice(price?: number): string {
+  if (!price) return "N/A";
+  return `$${price.toFixed(2)}/1M`;
+}
+
+function getProviders(models: ModelInfo[]): string[] {
+  const { providers } = models.reduce<{
+    providers: string[];
+    seen: Set<string>;
+  }>(
+    (accumulator, model) => {
+      const provider = getProvider(model.id);
+      if (!accumulator.seen.has(provider)) {
+        accumulator.seen.add(provider);
+        accumulator.providers.push(provider);
+      }
+      return accumulator;
+    },
+    { providers: [], seen: new Set<string>() },
+  );
+  return providers.sort();
+}
+
+function applyProviderFilter(models: ModelInfo[], providerFilter: string) {
+  if (providerFilter === "all") return models;
+  return models.filter((model) => getProvider(model.id) === providerFilter);
+}
+
+function applySearchFilter(models: ModelInfo[], modelSearchQuery: string) {
+  if (!modelSearchQuery.trim()) return models;
+  const query = modelSearchQuery.toLowerCase();
+  return models.filter(
+    (model) =>
+      model.name.toLowerCase().includes(query) ||
+      model.id.toLowerCase().includes(query) ||
+      model.description?.toLowerCase().includes(query) ||
+      getProvider(model.id).toLowerCase().includes(query),
+  );
+}
+
+function sortModelsBy(models: ModelInfo[], sortBy: SortOption) {
+  const sorted = [...models];
+  return sorted.sort((a, b) => {
+    switch (sortBy) {
+      case "name":
+        return a.name.localeCompare(b.name);
+      case "price-low":
+        return getAveragePrice(a) - getAveragePrice(b);
+      case "price-high":
+        return getAveragePrice(b) - getAveragePrice(a);
+      case "provider": {
+        const providerA = getProvider(a.id);
+        const providerB = getProvider(b.id);
+        if (providerA !== providerB) return providerA.localeCompare(providerB);
+        return a.name.localeCompare(b.name);
+      }
+      default:
+        return 0;
+    }
+  });
+}
+
+function promoteSelected(models: ModelInfo[], selectedModelId: string) {
+  const sorted = [...models];
+  const selectedIndex = sorted.findIndex(
+    (model) => model.id === selectedModelId,
+  );
+  if (selectedIndex > 0) {
+    const [selected] = sorted.splice(selectedIndex, 1);
+    if (selected) sorted.unshift(selected);
+  }
+  return sorted;
+}
+
+function resetFilters(
+  setModelSearchQuery: (value: string) => void,
+  setProviderFilter: (value: string) => void,
+  setSortBy: (value: SortOption) => void,
+) {
+  setModelSearchQuery("");
+  setProviderFilter("all");
+  setSortBy("name");
+}
+
+type HandleModelSelectArguments = {
+  handleClose: (nextOpen: boolean) => void;
+  id: string;
+  onSelectModel: (id: string) => void;
+  selectionGuardReference: SelectionGuardReference;
+};
+
+function handleModelSelect({
+  handleClose,
+  id,
+  onSelectModel,
+  selectionGuardReference,
+}: HandleModelSelectArguments) {
+  if (selectionGuardReference.current === id) return;
+  selectionGuardReference.current = id;
+  onSelectModel(id);
+  setTimeout(() => {
+    if (selectionGuardReference.current === id)
+      selectionGuardReference.current = null;
+  }, 0);
+  handleClose(false);
+}
+
+type FilterAndSortArguments = {
+  models: ModelInfo[];
+  modelSearchQuery: string;
+  providerFilter: string;
+  selectedModelId: string;
+  sortBy: SortOption;
+};
+
+function filterAndSortModels({
+  models,
+  modelSearchQuery,
+  providerFilter,
+  selectedModelId,
+  sortBy,
+}: FilterAndSortArguments): ModelInfo[] {
+  const filtered = applySearchFilter(
+    applyProviderFilter(models, providerFilter),
+    modelSearchQuery,
+  );
+  return promoteSelected(sortModelsBy(filtered, sortBy), selectedModelId);
+}
+
+function useFilteredModels(options: FilterAndSortArguments) {
+  const { models, modelSearchQuery, providerFilter, selectedModelId, sortBy } =
+    options;
+  return useMemo(
+    () =>
+      filterAndSortModels({
+        models,
+        modelSearchQuery,
+        providerFilter,
+        selectedModelId,
+        sortBy,
+      }),
+    [models, modelSearchQuery, sortBy, providerFilter, selectedModelId],
+  );
+}
+
+type ModelSelectorState = {
+  filteredAndSortedModels: ModelInfo[];
+  handleClose: (nextOpen: boolean) => void;
+  handleSelect: (id: string) => void;
+  modelSearchQuery: string;
+  providerFilter: string;
+  providers: string[];
+  setModelSearchQuery: (value: string) => void;
+  setProviderFilter: (value: string) => void;
+  setSortBy: (value: SortOption) => void;
+  sortBy: SortOption;
+};
+
+function useModelSelectorState({
+  models,
+  onOpenChange,
+  onSelectModel,
+  selectedModelId,
+}: ModelSelectorProps): ModelSelectorState {
+  const [modelSearchQuery, setModelSearchQuery] = useState("");
+  const [sortBy, setSortBy] = useState<SortOption>("name");
+  const [providerFilter, setProviderFilter] = useState<string>("all");
+  const selectionGuardReference = useRef<null | string>(null);
+  const providers = useMemo(() => getProviders(models), [models]);
+  const filteredAndSortedModels = useFilteredModels({
+    models,
+    modelSearchQuery,
+    providerFilter,
+    selectedModelId,
+    sortBy,
+  });
+  const handleClose = (nextOpen: boolean) => {
+    onOpenChange(nextOpen);
+    if (!nextOpen) {
+      resetFilters(setModelSearchQuery, setProviderFilter, setSortBy);
+    }
+  };
+  const handleSelect = (id: string) => {
+    handleModelSelect({
+      handleClose,
+      id,
+      onSelectModel,
+      selectionGuardReference,
+    });
+  };
+  return {
+    filteredAndSortedModels,
+    handleClose,
+    handleSelect,
+    modelSearchQuery,
+    providerFilter,
+    providers,
+    setModelSearchQuery,
+    setProviderFilter,
+    setSortBy,
+    sortBy,
+  };
+}
+
+type ProviderFilterMenuProps = {
+  onChange: (value: string) => void;
+  providerFilter: string;
+  providers: string[];
+};
+
+function ProviderFilterMenu({
+  onChange,
+  providerFilter,
+  providers,
+}: ProviderFilterMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button className="h-9 gap-2" size="sm" variant="outline">
+          <Filter className="h-4 w-4" />
+          {providerFilter === "all" ? "All Providers" : providerFilter}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        <DropdownMenuLabel>Filter by Provider</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuRadioGroup onValueChange={onChange} value={providerFilter}>
+          <DropdownMenuRadioItem value="all">
+            All Providers
+          </DropdownMenuRadioItem>
+          {providers.map((provider) => (
+            <DropdownMenuRadioItem key={provider} value={provider}>
+              {provider}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+type SortMenuProps = {
+  onChange: (value: SortOption) => void;
+  sortBy: SortOption;
+};
+
+function SortMenu({ onChange, sortBy }: SortMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button className="h-9 gap-2" size="sm" variant="outline">
+          <ArrowUpDown className="h-4 w-4" />
+          Sort
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuRadioGroup
+          onValueChange={(value) => {
+            onChange(value as SortOption);
+          }}
+          value={sortBy}
+        >
+          <DropdownMenuRadioItem value="name">Name</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="provider">
+            Provider
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="price-low">
+            Price: Low to High
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="price-high">
+            Price: High to Low
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+type ModelSelectorFiltersProps = {
+  modelSearchQuery: string;
+  onProviderChange: (value: string) => void;
+  onSearchChange: (value: string) => void;
+  onSortChange: (value: SortOption) => void;
+  providerFilter: string;
+  providers: string[];
+  sortBy: SortOption;
+};
+
+function ModelSelectorFilters({
+  modelSearchQuery,
+  onProviderChange,
+  onSearchChange,
+  onSortChange,
+  providerFilter,
+  providers,
+  sortBy,
+}: ModelSelectorFiltersProps) {
+  return (
+    <div className="flex items-center gap-2 px-1 pb-2 border-b">
+      <div className="flex-1">
+        <Input
+          className="h-9"
+          onChange={(event) => {
+            onSearchChange(event.target.value);
+          }}
+          placeholder="Search models or providers..."
+          value={modelSearchQuery}
+        />
+      </div>
+      <ProviderFilterMenu
+        onChange={onProviderChange}
+        providerFilter={providerFilter}
+        providers={providers}
+      />
+      <SortMenu onChange={onSortChange} sortBy={sortBy} />
+    </div>
+  );
+}
+
+type ModelListProps = {
+  models: ModelInfo[];
+  onSelect: (id: string) => void;
+  selectedModelId: string;
+};
+
+function ModelList({ models, onSelect, selectedModelId }: ModelListProps) {
+  return (
+    <Command className="flex-1" shouldFilter={false}>
+      <CommandList className="max-h-[60vh]">
+        <CommandEmpty>No models found.</CommandEmpty>
+        <CommandGroup>
+          {models.map((model) => (
+            <ModelListItem
+              key={model.id}
+              model={model}
+              onSelect={onSelect}
+              selectedModelId={selectedModelId}
+            />
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+}
+
+type ModelPricingProps = {
+  pricing?: ModelInfo["pricing"];
+};
+
+function ModelPricing({ pricing }: ModelPricingProps) {
+  if (!pricing) return null;
+
+  return (
+    <div className="flex items-center gap-3 text-xs text-muted-foreground pointer-events-none">
+      {pricing.input ? <span>In: {formatPrice(pricing.input)}</span> : null}
+      {pricing.output ? <span>Out: {formatPrice(pricing.output)}</span> : null}
+    </div>
+  );
+}
+
+type ModelListItemProps = {
+  model: ModelInfo;
+  onSelect: (id: string) => void;
+  selectedModelId: string;
+};
+
+function ModelListItem({
+  model,
+  onSelect,
+  selectedModelId,
+}: ModelListItemProps) {
+  const isSelected = selectedModelId === model.id;
+  const provider = getProvider(model.id);
+
+  return (
+    <CommandItem
+      className={cn(
+        "flex flex-col items-start py-3",
+        isSelected && "bg-accent",
+      )}
+      disabled={isSelected}
+      onSelect={() => {
+        onSelect(model.id);
+      }}
+      value={model.id}
+    >
+      <div className="flex items-center justify-between w-full pointer-events-none">
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{model.name}</span>
+          {isSelected ? (
+            <Badge className="text-xs pointer-events-none" variant="secondary">
+              Selected
+            </Badge>
+          ) : null}
+          <Badge
+            className="text-xs font-mono pointer-events-none"
+            variant="outline"
+          >
+            {provider}
+          </Badge>
+        </div>
+        <ModelPricing pricing={model.pricing} />
+      </div>
+      {model.description ? (
+        <span className="text-xs text-muted-foreground mt-1 pointer-events-none">
+          {model.description}
+        </span>
+      ) : null}
+      <span className="text-xs text-muted-foreground mt-1 font-mono pointer-events-none">
+        {model.id}
+      </span>
+    </CommandItem>
+  );
+}
+
+/** Model selector dialog with search, filtering, and sorting. */
+export function ModelSelector(props: ModelSelectorProps) {
+  const {
+    filteredAndSortedModels,
+    handleClose,
+    handleSelect,
+    modelSearchQuery,
+    providerFilter,
+    providers,
+    setModelSearchQuery,
+    setProviderFilter,
+    setSortBy,
+    sortBy,
+  } = useModelSelectorState(props);
+
+  return (
+    <Dialog onOpenChange={handleClose} open={props.open}>
+      <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Select Model</DialogTitle>
+          <DialogDescription className="sr-only">
+            Search, filter, and select an AI model
+          </DialogDescription>
+        </DialogHeader>
+        <ModelSelectorFilters
+          modelSearchQuery={modelSearchQuery}
+          onProviderChange={setProviderFilter}
+          onSearchChange={setModelSearchQuery}
+          onSortChange={setSortBy}
+          providerFilter={providerFilter}
+          providers={providers}
+          sortBy={sortBy}
+        />
+        <ModelList
+          models={filteredAndSortedModels}
+          onSelect={handleSelect}
+          selectedModelId={props.selectedModelId}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/registry/registry/default/multi-select-lasso/multi-select-lasso.tsx
+++ b/apps/registry/registry/default/multi-select-lasso/multi-select-lasso.tsx
@@ -1,6 +1,139 @@
-export {
-  type LassoRect,
-  MultiSelectLasso,
-  type MultiSelectLassoLabels,
-  type MultiSelectLassoProps,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Lasso geometry — pixel coordinates on the underlying canvas.
+ *
+ * @public
+ */
+export type LassoRect = {
+  /** Height in pixels (always positive after normalization). */
+  height: number;
+  /** Width in pixels (always positive after normalization). */
+  width: number;
+  /** Left edge in pixels. */
+  x: number;
+  /** Top edge in pixels. */
+  y: number;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type MultiSelectLassoLabels = {
+  /** Plural noun for the count badge. Defaults to `"items"`. */
+  plural?: string;
+  /** Aria-label for the lasso layer. Defaults to `"Multi-select lasso"`. */
+  region?: string;
+  /** Singular noun for the count badge. Defaults to `"item"`. */
+  singular?: string;
+};
+
+const DEFAULT_LABELS = {
+  plural: "items",
+  region: "Multi-select lasso",
+  singular: "item",
+} as const satisfies Required<MultiSelectLassoLabels>;
+
+/**
+ * Props for {@link MultiSelectLasso}.
+ *
+ * @public
+ */
+export type MultiSelectLassoProps = {
+  /** Optional count badge — rendered near the bottom-right corner. */
+  count?: number;
+  /** Optional override slot rendered inside the lasso (e.g. a label). */
+  hint?: ReactNode;
+  /** Localizable strings. */
+  labels?: MultiSelectLassoLabels;
+  /** Drag rectangle in pixels. When `null`, nothing renders. */
+  rect: LassoRect | null;
+} & ComponentPropsWithoutRef<"div">;
+
+const normalizeRect = (rect: LassoRect): LassoRect => {
+  const x = rect.width < 0 ? rect.x + rect.width : rect.x;
+  const y = rect.height < 0 ? rect.y + rect.height : rect.y;
+  const width = Math.abs(rect.width);
+  const height = Math.abs(rect.height);
+  return { height, width, x, y };
+};
+
+/**
+ * Selection rectangle for canvas multi-select. Render as a sibling of
+ * the canvas with `position: absolute` parent so the `rect` coordinates
+ * land in the same pixel space. Pure presentation; the host owns the
+ * pointer-down/move/up lifecycle and produces the rect (or `null` to
+ * hide the lasso).
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen" onPointerDown={…}>
+ *   <Canvas />
+ *   <MultiSelectLasso rect={lassoRect} count={hoveredIds.length} />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const MultiSelectLasso = forwardRef<
+  HTMLDivElement,
+  MultiSelectLassoProps
+>((props, ref) => {
+  const { className, count, hint, labels, rect, ...rest } = props;
+  if (!rect) {
+    return null;
+  }
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const normalized = normalizeRect(rect);
+  if (normalized.width === 0 || normalized.height === 0) {
+    return null;
+  }
+  const noun = count === 1 ? resolvedLabels.singular : resolvedLabels.plural;
+  return (
+    <div
+      aria-hidden="true"
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "pointer-events-none absolute z-30 rounded-md border-2 border-blue-500/70 bg-blue-500/10",
+        className,
+      )}
+      data-multi-select-lasso
+      ref={ref}
+      style={{
+        height: normalized.height,
+        left: normalized.x,
+        top: normalized.y,
+        width: normalized.width,
+      }}
+      {...rest}
+    >
+      {hint ? (
+        <span
+          className="absolute -top-7 left-0 rounded-md bg-foreground/90 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-background"
+          data-multi-select-hint
+        >
+          {hint}
+        </span>
+      ) : null}
+      {typeof count === "number" ? (
+        <span
+          className="absolute -bottom-7 right-0 rounded-full bg-foreground px-2 py-0.5 text-[10px] font-semibold text-background"
+          data-multi-select-count
+        >
+          {count} {noun}
+        </span>
+      ) : null}
+    </div>
+  );
+});
+MultiSelectLasso.displayName = "MultiSelectLasso";

--- a/apps/registry/registry/default/multi-select/multi-select.tsx
+++ b/apps/registry/registry/default/multi-select/multi-select.tsx
@@ -1,2 +1,364 @@
-// Re-export from @vllnt/ui package
-export { MultiSelect } from "@vllnt/ui";
+"use client";
+
+import * as React from "react";
+
+import { Check, ChevronDown } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@vllnt/ui";
+import { Popover, PopoverContent, PopoverTrigger } from "@vllnt/ui";
+
+export type MultiSelectOption = {
+  disabled?: boolean;
+  label: string;
+  value: string;
+};
+
+export type MultiSelectProps = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "defaultValue" | "onChange" | "value"
+> & {
+  defaultValue?: string[];
+  emptyText?: string;
+  onOpenChange?: (open: boolean) => void;
+  onValueChange?: (value: string[]) => void;
+  options: MultiSelectOption[];
+  placeholder?: string;
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  value?: string[];
+};
+
+type TriggerContentProps = {
+  placeholder: string;
+  selectedOptions: MultiSelectOption[];
+};
+
+type OptionListProps = {
+  disabled: boolean;
+  emptyText: string;
+  onSelect: (value: string) => void;
+  options: MultiSelectOption[];
+  searchable: boolean;
+  searchPlaceholder: string;
+  selectedValues: string[];
+};
+
+type MultiSelectStateOptions = {
+  defaultValue: string[];
+  onOpenChange?: (open: boolean) => void;
+  onValueChange?: (value: string[]) => void;
+  value?: string[];
+};
+
+type MultiSelectTriggerProps = Omit<
+  MultiSelectProps,
+  | "defaultValue"
+  | "emptyText"
+  | "onOpenChange"
+  | "onValueChange"
+  | "options"
+  | "searchable"
+  | "searchPlaceholder"
+  | "value"
+> & {
+  contentId: string;
+  open: boolean;
+  selectedOptions: MultiSelectOption[];
+};
+
+type MultiSelectContentProps = {
+  contentId: string;
+  disabled: boolean;
+  emptyText: string;
+  onSelect: (value: string) => void;
+  options: MultiSelectOption[];
+  searchable: boolean;
+  searchPlaceholder: string;
+  selectedValues: string[];
+};
+
+function getUniqueValues(values: string[]) {
+  return values.filter((value, index) => values.indexOf(value) === index);
+}
+
+function shouldOpenFromKey(key: string) {
+  return key === " " || key === "ArrowDown" || key === "Enter";
+}
+
+function TriggerContent({ placeholder, selectedOptions }: TriggerContentProps) {
+  if (selectedOptions.length === 0) {
+    return <span>{placeholder}</span>;
+  }
+
+  return (
+    <>
+      {selectedOptions.map((option) => (
+        <Badge className="max-w-full" key={option.value} variant="secondary">
+          <span className="truncate">{option.label}</span>
+        </Badge>
+      ))}
+    </>
+  );
+}
+
+function OptionList({
+  disabled,
+  emptyText,
+  onSelect,
+  options,
+  searchable,
+  searchPlaceholder,
+  selectedValues,
+}: OptionListProps) {
+  return (
+    <Command>
+      {searchable ? <CommandInput placeholder={searchPlaceholder} /> : null}
+      <CommandList aria-multiselectable="true">
+        <CommandEmpty>{emptyText}</CommandEmpty>
+        <CommandGroup>
+          <div>
+            {options.map((option) => {
+              const isSelected = selectedValues.includes(option.value);
+
+              return (
+                <CommandItem
+                  aria-disabled={option.disabled || undefined}
+                  aria-selected={isSelected}
+                  className="gap-2"
+                  disabled={disabled || option.disabled}
+                  key={option.value}
+                  onSelect={() => {
+                    onSelect(option.value);
+                  }}
+                  role="option"
+                  value={option.label}
+                >
+                  <span
+                    className={cn(
+                      "flex h-4 w-4 items-center justify-center rounded-sm border border-input bg-background text-primary transition-opacity",
+                      isSelected ? "opacity-100" : "opacity-50",
+                    )}
+                  >
+                    {isSelected ? <Check className="h-3.5 w-3.5" /> : null}
+                  </span>
+                  <span className="flex-1">{option.label}</span>
+                </CommandItem>
+              );
+            })}
+          </div>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+}
+
+function MultiSelectContent({
+  contentId,
+  disabled,
+  emptyText,
+  onSelect,
+  options,
+  searchable,
+  searchPlaceholder,
+  selectedValues,
+}: MultiSelectContentProps) {
+  return (
+    <PopoverContent
+      align="start"
+      className="w-[var(--radix-popover-trigger-width)] p-0"
+      id={contentId}
+    >
+      <OptionList
+        disabled={disabled}
+        emptyText={emptyText}
+        onSelect={onSelect}
+        options={options}
+        searchable={searchable}
+        searchPlaceholder={searchPlaceholder}
+        selectedValues={selectedValues}
+      />
+    </PopoverContent>
+  );
+}
+
+function useMultiSelectState({
+  defaultValue,
+  onOpenChange,
+  onValueChange,
+  value,
+}: MultiSelectStateOptions) {
+  const [open, setOpen] = React.useState(false);
+  const [uncontrolledValue, setUncontrolledValue] = React.useState(() =>
+    getUniqueValues(defaultValue),
+  );
+  const isControlled = value !== undefined;
+  const selectedValues = React.useMemo(
+    () => getUniqueValues(value ?? uncontrolledValue),
+    [uncontrolledValue, value],
+  );
+
+  const setSelectedValues = React.useCallback(
+    (nextValue: string[]) => {
+      const uniqueValues = getUniqueValues(nextValue);
+
+      if (!isControlled) {
+        setUncontrolledValue(uniqueValues);
+      }
+
+      onValueChange?.(uniqueValues);
+    },
+    [isControlled, onValueChange],
+  );
+
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      onOpenChange?.(nextOpen);
+    },
+    [onOpenChange],
+  );
+
+  return {
+    handleOpenChange,
+    open,
+    selectedValues,
+    setSelectedValues,
+  };
+}
+
+const MultiSelectTrigger = React.forwardRef<
+  HTMLButtonElement,
+  MultiSelectTriggerProps
+>(
+  (
+    {
+      className,
+      contentId,
+      disabled = false,
+      onKeyDown,
+      open,
+      placeholder = "Select options",
+      selectedOptions,
+      ...props
+    },
+    ref,
+  ) => (
+    <Button
+      aria-controls={contentId}
+      aria-expanded={open}
+      aria-haspopup="listbox"
+      className={cn(
+        "min-h-10 w-full justify-between px-3 py-2 text-sm font-normal",
+        selectedOptions.length === 0 && "text-muted-foreground",
+        className,
+      )}
+      disabled={disabled}
+      onKeyDown={onKeyDown}
+      ref={ref}
+      role="combobox"
+      type="button"
+      variant="outline"
+      {...props}
+    >
+      <span className="flex min-w-0 flex-1 flex-wrap items-center gap-1 text-left">
+        <TriggerContent
+          placeholder={placeholder}
+          selectedOptions={selectedOptions}
+        />
+      </span>
+      <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+    </Button>
+  ),
+);
+MultiSelectTrigger.displayName = "MultiSelectTrigger";
+
+const MultiSelect = React.forwardRef<HTMLButtonElement, MultiSelectProps>(
+  (
+    {
+      defaultValue = [],
+      emptyText = "No options found.",
+      onKeyDown,
+      onOpenChange,
+      onValueChange,
+      options,
+      searchable = false,
+      searchPlaceholder = "Search options...",
+      value,
+      ...props
+    },
+    ref,
+  ) => {
+    const contentId = React.useId();
+    const { handleOpenChange, open, selectedValues, setSelectedValues } =
+      useMultiSelectState({ defaultValue, onOpenChange, onValueChange, value });
+    const selectedOptions = React.useMemo(
+      () => options.filter((option) => selectedValues.includes(option.value)),
+      [options, selectedValues],
+    );
+
+    const handleSelect = React.useCallback(
+      (nextValue: string) => {
+        const nextSelectedValues = selectedValues.includes(nextValue)
+          ? selectedValues.filter((valueItem) => valueItem !== nextValue)
+          : [...selectedValues, nextValue];
+
+        setSelectedValues(nextSelectedValues);
+      },
+      [selectedValues, setSelectedValues],
+    );
+
+    const handleTriggerKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLButtonElement>) => {
+        onKeyDown?.(event);
+
+        if (event.defaultPrevented || props.disabled) {
+          return;
+        }
+
+        if (shouldOpenFromKey(event.key)) {
+          event.preventDefault();
+          handleOpenChange(true);
+        }
+      },
+      [handleOpenChange, onKeyDown, props.disabled],
+    );
+
+    return (
+      <Popover onOpenChange={handleOpenChange} open={open}>
+        <PopoverTrigger asChild>
+          <MultiSelectTrigger
+            {...props}
+            contentId={contentId}
+            onKeyDown={handleTriggerKeyDown}
+            open={open}
+            ref={ref}
+            selectedOptions={selectedOptions}
+          />
+        </PopoverTrigger>
+        <MultiSelectContent
+          contentId={contentId}
+          disabled={props.disabled || false}
+          emptyText={emptyText}
+          onSelect={handleSelect}
+          options={options}
+          searchable={searchable}
+          searchPlaceholder={searchPlaceholder}
+          selectedValues={selectedValues}
+        />
+      </Popover>
+    );
+  },
+);
+MultiSelect.displayName = "MultiSelect";
+
+export { MultiSelect };

--- a/apps/registry/registry/default/navbar-saas/navbar-saas.tsx
+++ b/apps/registry/registry/default/navbar-saas/navbar-saas.tsx
@@ -1,2 +1,103 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { Menu, X } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import { useSidebar } from "@vllnt/ui";
+import { ThemeToggle } from "@vllnt/ui";
+
+import { useMobile } from "./use-mobile";
+
+export type NavItem = {
+  href: string;
+  title: string;
+};
+
+export type NavbarSaasProps = {
+  brand?: ReactNode;
+  navItems?: NavItem[];
+  rightSlot?: ReactNode;
+  showMobileMenu?: boolean;
+};
+
+export function NavbarSaas({
+  brand,
+  navItems = [],
+  rightSlot,
+  showMobileMenu = true,
+}: NavbarSaasProps) {
+  const pathname = usePathname();
+  const { open, setOpen } = useSidebar();
+  const isMobile = useMobile();
+
+  return (
+    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 shrink-0">
+      <div className="w-full">
+        <div className="mx-auto flex h-16 items-center justify-between px-4">
+          <div className="flex items-center gap-4">
+            {showMobileMenu && isMobile ? (
+              <Button
+                className="lg:hidden"
+                onClick={() => {
+                  setOpen(!open);
+                }}
+                size="icon"
+                variant="ghost"
+              >
+                {open ? (
+                  <X className="h-4 w-4" />
+                ) : (
+                  <Menu className="h-4 w-4" />
+                )}
+              </Button>
+            ) : null}
+            {brand ? (
+              typeof brand === "string" ? (
+                <Link className="text-xl font-bold truncate" href="/">
+                  {brand}
+                </Link>
+              ) : (
+                brand
+              )
+            ) : null}
+            {navItems.length > 0 ? (
+              <nav className="hidden md:flex gap-6">
+                {navItems.map((item) => (
+                  <Link
+                    className={cn(
+                      "text-sm font-medium transition-colors hover:text-foreground/80",
+                      pathname === item.href
+                        ? "text-foreground"
+                        : "text-foreground/60",
+                    )}
+                    href={item.href}
+                    key={item.href}
+                  >
+                    {item.title}
+                  </Link>
+                ))}
+              </nav>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-4">
+            {rightSlot}
+            <ThemeToggle
+              dict={{
+                theme: {
+                  dark: "Dark",
+                  light: "Light",
+                  system: "System",
+                  toggle_theme: "Toggle theme",
+                },
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/registry/registry/default/navigation-menu/navigation-menu.tsx
+++ b/apps/registry/registry/default/navigation-menu/navigation-menu.tsx
@@ -1,1 +1,131 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
+import { cva } from "class-variance-authority";
+import { ChevronDown } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+const NavigationMenu = forwardRef<
+  React.ComponentRef<typeof NavigationMenuPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root>
+>(({ children, className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Root
+    className={cn(
+      "relative z-10 flex max-w-max flex-1 items-center justify-center",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  >
+    {children}
+    <NavigationMenuViewport />
+  </NavigationMenuPrimitive.Root>
+));
+NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName;
+
+const NavigationMenuList = forwardRef<
+  React.ComponentRef<typeof NavigationMenuPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.List
+    className={cn(
+      "group flex flex-1 list-none items-center justify-center space-x-1",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
+
+const NavigationMenuItem = NavigationMenuPrimitive.Item;
+
+const navigationMenuTriggerStyle = cva(
+  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50",
+);
+
+const NavigationMenuTrigger = forwardRef<
+  React.ComponentRef<typeof NavigationMenuPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Trigger>
+>(({ children, className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Trigger
+    className={cn(navigationMenuTriggerStyle(), "group", className)}
+    ref={ref}
+    {...props}
+  >
+    {children}{" "}
+    <ChevronDown
+      aria-hidden="true"
+      className="relative top-[1px] ml-1 h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180"
+    />
+  </NavigationMenuPrimitive.Trigger>
+));
+NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName;
+
+const NavigationMenuContent = forwardRef<
+  React.ComponentRef<typeof NavigationMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Content
+    className={cn(
+      "left-0 top-0 w-full data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 md:absolute md:w-auto",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName;
+
+const NavigationMenuLink = NavigationMenuPrimitive.Link;
+
+const NavigationMenuViewport = forwardRef<
+  React.ComponentRef<typeof NavigationMenuPrimitive.Viewport>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
+>(({ className, ...props }, ref) => (
+  <div className={cn("absolute left-0 top-full flex justify-center")}>
+    <NavigationMenuPrimitive.Viewport
+      className={cn(
+        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  </div>
+));
+NavigationMenuViewport.displayName =
+  NavigationMenuPrimitive.Viewport.displayName;
+
+const NavigationMenuIndicator = forwardRef<
+  React.ComponentRef<typeof NavigationMenuPrimitive.Indicator>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Indicator>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Indicator
+    className={cn(
+      "top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  >
+    <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md" />
+  </NavigationMenuPrimitive.Indicator>
+));
+NavigationMenuIndicator.displayName =
+  NavigationMenuPrimitive.Indicator.displayName;
+
+export {
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuIndicator,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+  navigationMenuTriggerStyle,
+  NavigationMenuViewport,
+};

--- a/apps/registry/registry/default/newsletter-signup/newsletter-signup.tsx
+++ b/apps/registry/registry/default/newsletter-signup/newsletter-signup.tsx
@@ -1,2 +1,446 @@
-// Re-export from @vllnt/ui package
-export { NewsletterSignup, newsletterSignupReducer } from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  type SyntheticEvent,
+  useCallback,
+  useId,
+  useReducer,
+  useRef,
+} from "react";
+
+import { CheckCircle2, Loader2, XCircle } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import { Input } from "@vllnt/ui";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Localizable strings for {@link NewsletterSignup}.
+ *
+ * @public
+ */
+export type NewsletterSignupLabels = {
+  /** Caption when validation rejects the email. Defaults to a generic message. */
+  emailInvalid?: string;
+  /** Aria-label / fallback for the email input. Defaults to `"Email address"`. */
+  emailLabel?: string;
+  /** Generic error message when `onSubmit` rejects without a usable reason. Defaults to `"Something went wrong. Try again."`. */
+  errorFallback?: string;
+  /** Input placeholder. Defaults to `"you@example.com"`. */
+  placeholder?: string;
+  /** Caption while the submit promise is in flight. Defaults to `"Subscribing…"`. */
+  sending?: string;
+  /** Submit button label in idle state. Defaults to `"Subscribe"`. */
+  submit?: string;
+  /** Success caption shown after a successful submission. Defaults to `"You're on the list. Check your inbox to confirm."`. */
+  success?: string;
+  /** Caption for the retry control after an error. Defaults to `"Try again"`. */
+  tryAgain?: string;
+};
+
+/**
+ * Visual variant for {@link NewsletterSignup}.
+ *
+ * - `inline` — input + button on a single row (default).
+ * - `stacked` — input above, full-width button below.
+ *
+ * @public
+ */
+export type NewsletterSignupVariant = "inline" | "stacked";
+
+/**
+ * Status reported to {@link NewsletterSignupProps.onStatusChange}.
+ *
+ * @public
+ */
+export type NewsletterSignupStatus = "error" | "idle" | "sending" | "sent";
+
+const DEFAULT_LABELS = {
+  emailInvalid: "Enter a valid email address.",
+  emailLabel: "Email address",
+  errorFallback: "Something went wrong. Try again.",
+  placeholder: "you@example.com",
+  sending: "Subscribing…",
+  submit: "Subscribe",
+  success: "You're on the list. Check your inbox to confirm.",
+  tryAgain: "Try again",
+} as const satisfies Required<NewsletterSignupLabels>;
+
+type State =
+  | { kind: "error"; message: string }
+  | { kind: "idle" }
+  | { kind: "sending" }
+  | { kind: "sent" };
+
+type Action =
+  | { kind: "fail"; message: string }
+  | { kind: "reset" }
+  | { kind: "send" }
+  | { kind: "succeed" };
+
+function reducer(state: State, action: Action): State {
+  switch (action.kind) {
+    case "fail":
+      return { kind: "error", message: action.message };
+
+    case "reset":
+      return { kind: "idle" };
+
+    case "send":
+      return state.kind === "sending" ? state : { kind: "sending" };
+
+    case "succeed":
+      return { kind: "sent" };
+  }
+}
+
+function actionToStatus(action: Action): NewsletterSignupStatus {
+  switch (action.kind) {
+    case "fail":
+      return "error";
+
+    case "reset":
+      return "idle";
+
+    case "send":
+      return "sending";
+
+    case "succeed":
+      return "sent";
+  }
+}
+
+function defaultValidate(email: string, label: string): string | true {
+  const trimmed = email.trim();
+  if (!trimmed) return label;
+  if (!EMAIL_PATTERN.test(trimmed)) return label;
+  return true;
+}
+
+function extractErrorMessage(value: unknown, fallback: string): string {
+  if (value instanceof Error && value.message) return value.message;
+  if (typeof value === "string" && value.length > 0) return value;
+  return fallback;
+}
+
+/**
+ * Props for {@link NewsletterSignup}.
+ *
+ * @public
+ */
+export type NewsletterSignupProps = {
+  /** Override the input's autocomplete attribute. Defaults to `"email"`. */
+  autoComplete?: string;
+  /** Localizable strings. */
+  labels?: NewsletterSignupLabels;
+  /** Fires whenever the internal status transitions. */
+  onStatusChange?: (status: NewsletterSignupStatus) => void;
+  /**
+   * Submission handler. The component awaits the returned promise. Throw to
+   * surface an error message — `Error` instances use their `message` and
+   * thrown strings render verbatim; everything else falls back to
+   * `labels.errorFallback`.
+   */
+  onSubmit: (email: string) => Promise<void> | void;
+  /**
+   * Optional custom validator. Return a string to render as the validation
+   * error, or `true` for valid. Defaults to a basic email regex.
+   */
+  validate?: (email: string) => string | true;
+  /** Visual variant. Defaults to `"inline"`. */
+  variant?: NewsletterSignupVariant;
+} & Omit<ComponentPropsWithoutRef<"form">, "onSubmit">;
+
+type SubmitButtonProps = {
+  labels: Required<NewsletterSignupLabels>;
+  stacked: boolean;
+  status: NewsletterSignupStatus;
+};
+
+function SubmitButton({
+  labels,
+  stacked,
+  status,
+}: SubmitButtonProps): ReactNode {
+  let content: ReactNode;
+  if (status === "sending") {
+    content = (
+      <>
+        <Loader2 aria-hidden="true" className="mr-2 h-4 w-4 animate-spin" />
+        {labels.sending}
+      </>
+    );
+  } else if (status === "error") {
+    content = (
+      <>
+        <XCircle aria-hidden="true" className="mr-2 h-4 w-4" />
+        {labels.tryAgain}
+      </>
+    );
+  } else {
+    content = labels.submit;
+  }
+
+  return (
+    <Button
+      className={stacked ? "w-full" : ""}
+      disabled={status === "sending"}
+      type="submit"
+    >
+      {content}
+    </Button>
+  );
+}
+
+type SuccessPanelProps = {
+  className?: string;
+  message: string;
+};
+
+function SuccessPanel({ className, message }: SuccessPanelProps): ReactNode {
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        "flex items-start gap-2 rounded-lg border border-emerald-500/40 bg-emerald-500/10 p-3 text-sm text-emerald-900 dark:text-emerald-200",
+        className,
+      )}
+      role="status"
+    >
+      <CheckCircle2 aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+/**
+ * Email-capture compound with a built-in state machine for the universal
+ * "drop your email" pattern. Composes {@link Input} and {@link Button}.
+ *
+ * State machine: `idle → sending → sent | error`. `error → sending` when
+ * the user retries; `error → idle` when they edit the input. Status
+ * changes are also reported via `onStatusChange` so callers can drive
+ * external UI off the same machine.
+ *
+ * @example
+ * ```tsx
+ * <NewsletterSignup
+ *   onSubmit={async (email) => subscribe(email)}
+ *   labels={{ submit: "Join", success: "Welcome aboard." }}
+ * />
+ * ```
+ *
+ * @public
+ */
+type SignupController = {
+  errorMessage: null | string;
+  handleChange: () => void;
+  handleSubmit: (event: SyntheticEvent<HTMLFormElement>) => void;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  status: NewsletterSignupStatus;
+};
+
+type ControllerOptions = {
+  labels: Required<NewsletterSignupLabels>;
+  onStatusChange?: (status: NewsletterSignupStatus) => void;
+  onSubmit: (email: string) => Promise<void> | void;
+  validate?: (email: string) => string | true;
+};
+
+function useNewsletterSignupController(
+  options: ControllerOptions,
+): SignupController {
+  const { labels, onStatusChange, onSubmit, validate } = options;
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [state, dispatch] = useReducer(reducer, { kind: "idle" });
+  const status: NewsletterSignupStatus = state.kind;
+
+  const transition = useCallback(
+    (action: Action) => {
+      dispatch(action);
+      onStatusChange?.(actionToStatus(action));
+    },
+    [onStatusChange],
+  );
+
+  const handleChange = useCallback(() => {
+    if (state.kind === "error") transition({ kind: "reset" });
+  }, [state.kind, transition]);
+
+  const performSubmit = useCallback(
+    async (value: string) => {
+      const validator =
+        validate ??
+        ((email: string) => defaultValidate(email, labels.emailInvalid));
+      const validation = validator(value);
+      if (validation !== true) {
+        transition({ kind: "fail", message: validation });
+        inputRef.current?.focus();
+        return;
+      }
+      transition({ kind: "send" });
+      try {
+        await onSubmit(value);
+        transition({ kind: "succeed" });
+      } catch (error) {
+        transition({
+          kind: "fail",
+          message: extractErrorMessage(error, labels.errorFallback),
+        });
+        inputRef.current?.focus();
+      }
+    },
+    [labels.emailInvalid, labels.errorFallback, onSubmit, transition, validate],
+  );
+
+  const handleSubmit = useCallback(
+    (event: SyntheticEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (state.kind === "sending") return;
+      const value = inputRef.current?.value.trim() ?? "";
+      void performSubmit(value);
+    },
+    [performSubmit, state.kind],
+  );
+
+  return {
+    errorMessage: state.kind === "error" ? state.message : null,
+    handleChange,
+    handleSubmit,
+    inputRef,
+    status,
+  };
+}
+
+export const NewsletterSignup = forwardRef<
+  HTMLFormElement,
+  NewsletterSignupProps
+>((props, ref) => {
+  const {
+    autoComplete = "email",
+    className,
+    labels,
+    onStatusChange,
+    onSubmit,
+    validate,
+    variant = "inline",
+    ...rest
+  } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const inputId = useId();
+  const errorId = useId();
+  const controller = useNewsletterSignupController({
+    labels: resolvedLabels,
+    onStatusChange,
+    onSubmit,
+    validate,
+  });
+
+  if (controller.status === "sent") {
+    return (
+      <SuccessPanel className={className} message={resolvedLabels.success} />
+    );
+  }
+
+  return (
+    <FormBody
+      autoComplete={autoComplete}
+      className={className}
+      errorId={errorId}
+      formRef={ref}
+      inputId={inputId}
+      inputRef={controller.inputRef}
+      labels={resolvedLabels}
+      message={controller.errorMessage}
+      onChange={controller.handleChange}
+      onSubmit={controller.handleSubmit}
+      rest={rest}
+      stacked={variant === "stacked"}
+      status={controller.status}
+    />
+  );
+});
+NewsletterSignup.displayName = "NewsletterSignup";
+
+type FormBodyProps = {
+  autoComplete: string;
+  className?: string;
+  errorId: string;
+  formRef: React.ForwardedRef<HTMLFormElement>;
+  inputId: string;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  labels: Required<NewsletterSignupLabels>;
+  message: null | string;
+  onChange: () => void;
+  onSubmit: (event: SyntheticEvent<HTMLFormElement>) => void;
+  rest: Omit<ComponentPropsWithoutRef<"form">, "onSubmit">;
+  stacked: boolean;
+  status: NewsletterSignupStatus;
+};
+
+function FormBody({
+  autoComplete,
+  className,
+  errorId,
+  formRef,
+  inputId,
+  inputRef,
+  labels,
+  message,
+  onChange,
+  onSubmit,
+  rest,
+  stacked,
+  status,
+}: FormBodyProps): ReactNode {
+  return (
+    <form
+      aria-busy={status === "sending"}
+      className={cn(
+        "flex w-full",
+        stacked
+          ? "flex-col gap-2"
+          : "flex-col gap-2 sm:flex-row sm:items-start",
+        className,
+      )}
+      noValidate
+      onSubmit={onSubmit}
+      ref={formRef}
+      {...rest}
+    >
+      <div className={cn("flex flex-col gap-1", stacked ? "" : "sm:flex-1")}>
+        <label className="sr-only" htmlFor={inputId}>
+          {labels.emailLabel}
+        </label>
+        <Input
+          aria-describedby={message ? errorId : undefined}
+          aria-invalid={message !== null}
+          autoComplete={autoComplete}
+          disabled={status === "sending"}
+          id={inputId}
+          name="email"
+          onChange={onChange}
+          placeholder={labels.placeholder}
+          ref={inputRef}
+          type="email"
+        />
+        <p
+          aria-live="polite"
+          className={cn("text-xs", message ? "text-destructive" : "sr-only")}
+          id={errorId}
+          role={message ? "alert" : undefined}
+        >
+          {message ?? ""}
+        </p>
+      </div>
+      <SubmitButton labels={labels} stacked={stacked} status={status} />
+    </form>
+  );
+}
+
+export { reducer as newsletterSignupReducer };

--- a/apps/registry/registry/default/number-input/number-input.tsx
+++ b/apps/registry/registry/default/number-input/number-input.tsx
@@ -1,1 +1,209 @@
-export { NumberInput } from '@vllnt/ui'
+"use client";
+
+import * as React from "react";
+
+import { Minus, Plus } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+
+export type NumberInputProps = Omit<
+  React.ComponentPropsWithoutRef<"input">,
+  "defaultValue" | "onChange" | "type" | "value"
+> & {
+  defaultValue?: number;
+  onValueChange?: (value?: number) => void;
+  step?: number;
+  value?: number;
+};
+
+function getNumericBound(bound: number | string | undefined) {
+  if (bound === undefined) {
+    return;
+  }
+
+  const parsedBound = Number(bound);
+  return Number.isNaN(parsedBound) ? undefined : parsedBound;
+}
+
+function useNumberInputState(
+  controlledValue: number | undefined,
+  defaultValue: number | undefined,
+  onValueChange?: (value?: number) => void,
+) {
+  const [internalValue, setInternalValue] = React.useState<number | undefined>(
+    defaultValue,
+  );
+  const resolvedValue = controlledValue ?? internalValue;
+
+  const commitValue = (nextValue?: number) => {
+    if (controlledValue === undefined) {
+      setInternalValue(nextValue);
+    }
+
+    onValueChange?.(nextValue);
+  };
+
+  return { commitValue, resolvedValue };
+}
+
+function clampNumber(
+  nextValue: number,
+  min: number | undefined,
+  max: number | undefined,
+) {
+  let result = nextValue;
+
+  if (min !== undefined) {
+    result = Math.max(min, result);
+  }
+  if (max !== undefined) {
+    result = Math.min(max, result);
+  }
+
+  return result;
+}
+
+function StepButton({
+  direction,
+  disabled,
+  onClick,
+}: {
+  direction: "decrement" | "increment";
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      className={cn(
+        "h-full px-3",
+        direction === "decrement"
+          ? "rounded-r-none border-r"
+          : "rounded-l-none border-l",
+      )}
+      disabled={disabled}
+      onClick={onClick}
+      tabIndex={-1}
+      type="button"
+      variant="ghost"
+    >
+      {direction === "decrement" ? (
+        <Minus className="h-4 w-4" />
+      ) : (
+        <Plus className="h-4 w-4" />
+      )}
+    </Button>
+  );
+}
+
+function NumberInputField({
+  disabled,
+  onValueChange,
+  placeholder,
+  reference,
+  resolvedValue,
+  ...props
+}: React.ComponentPropsWithoutRef<"input"> & {
+  onValueChange: (value?: number) => void;
+  reference: React.ForwardedRef<HTMLInputElement>;
+  resolvedValue?: number;
+}) {
+  return (
+    <input
+      {...props}
+      className="h-full w-full border-0 bg-transparent px-3 text-center text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed"
+      disabled={disabled}
+      inputMode="decimal"
+      onChange={(event) => {
+        if (event.target.value === "") {
+          onValueChange();
+          return;
+        }
+
+        const parsedValue = Number(event.target.value);
+        if (!Number.isNaN(parsedValue)) {
+          onValueChange(parsedValue);
+        }
+      }}
+      placeholder={placeholder}
+      ref={reference}
+      type="number"
+      value={resolvedValue ?? ""}
+    />
+  );
+}
+
+function NumberInputComponent(
+  {
+    className,
+    defaultValue,
+    disabled,
+    max,
+    min,
+    onValueChange,
+    placeholder,
+    step = 1,
+    value,
+    ...props
+  }: NumberInputProps,
+  reference: React.ForwardedRef<HTMLInputElement>,
+) {
+  const { commitValue, resolvedValue } = useNumberInputState(
+    value,
+    defaultValue,
+    onValueChange,
+  );
+  const parsedMin = getNumericBound(min);
+  const parsedMax = getNumericBound(max);
+
+  const handleStepChange = (direction: number) => {
+    const baseValue = resolvedValue ?? parsedMin ?? 0;
+    commitValue(
+      clampNumber(baseValue + direction * step, parsedMin, parsedMax),
+    );
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex h-10 w-full items-center rounded-md border border-input bg-background ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
+        disabled && "cursor-not-allowed opacity-50",
+        className,
+      )}
+    >
+      <StepButton
+        direction="decrement"
+        disabled={disabled}
+        onClick={() => {
+          handleStepChange(-1);
+        }}
+      />
+      <NumberInputField
+        {...props}
+        disabled={disabled}
+        onValueChange={(nextValue) => {
+          commitValue(
+            nextValue === undefined
+              ? undefined
+              : clampNumber(nextValue, parsedMin, parsedMax),
+          );
+        }}
+        placeholder={placeholder}
+        reference={reference}
+        resolvedValue={resolvedValue}
+      />
+      <StepButton
+        direction="increment"
+        disabled={disabled}
+        onClick={() => {
+          handleStepChange(1);
+        }}
+      />
+    </div>
+  );
+}
+
+const NumberInput = React.forwardRef(NumberInputComponent);
+NumberInput.displayName = "NumberInput";
+
+export { NumberInput };

--- a/apps/registry/registry/default/number-ticker/number-ticker.tsx
+++ b/apps/registry/registry/default/number-ticker/number-ticker.tsx
@@ -1,2 +1,92 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type NumberTickerProps = React.ComponentPropsWithoutRef<"span"> & {
+  delay?: number;
+  duration?: number;
+  formatOptions?: Intl.NumberFormatOptions;
+  from?: number;
+  locale?: string;
+  value: number;
+};
+
+export const NumberTicker = React.forwardRef<
+  HTMLSpanElement,
+  NumberTickerProps
+>(
+  (
+    {
+      className,
+      delay = 0,
+      duration = 1.2,
+      formatOptions,
+      from = 0,
+      locale,
+      value,
+      ...props
+    },
+    ref,
+  ) => {
+    const [currentValue, setCurrentValue] = React.useState(from);
+
+    React.useEffect(() => {
+      const reducedMotion =
+        typeof window !== "undefined" &&
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+      if (reducedMotion || duration <= 0) {
+        setCurrentValue(value);
+        return;
+      }
+
+      let animationFrame = 0;
+      let timeoutId = 0;
+      const startDelay = Math.max(0, delay * 1000);
+      const durationMs = duration * 1000;
+
+      timeoutId = window.setTimeout(() => {
+        const startTime = performance.now();
+
+        const tick = (timestamp: number) => {
+          const elapsed = timestamp - startTime;
+          const progress = Math.min(elapsed / durationMs, 1);
+          const nextValue = from + (value - from) * progress;
+
+          setCurrentValue(nextValue);
+
+          if (progress < 1) {
+            animationFrame = window.requestAnimationFrame(tick);
+          }
+        };
+
+        animationFrame = window.requestAnimationFrame(tick);
+      }, startDelay);
+
+      return () => {
+        window.clearTimeout(timeoutId);
+        window.cancelAnimationFrame(animationFrame);
+      };
+    }, [delay, duration, from, value]);
+
+    const formatter = React.useMemo(
+      () => new Intl.NumberFormat(locale, formatOptions),
+      [formatOptions, locale],
+    );
+
+    return (
+      <span
+        className={cn("tabular-nums tracking-tight", className)}
+        ref={ref}
+        {...props}
+      >
+        {formatter.format(currentValue)}
+      </span>
+    );
+  },
+);
+
+NumberTicker.displayName = "NumberTicker";

--- a/apps/registry/registry/default/object-card/object-card.tsx
+++ b/apps/registry/registry/default/object-card/object-card.tsx
@@ -1,1 +1,185 @@
-export { ObjectCard, type ObjectCardProps } from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+
+export type ObjectCardMetric = {
+  label: string;
+  value: ReactNode;
+};
+
+export type ObjectCardAction = {
+  label: string;
+  onClick?: () => void;
+};
+
+export type ObjectCardProps = React.ComponentPropsWithoutRef<"article"> & {
+  actions?: ObjectCardAction[];
+  footer?: ReactNode;
+  kind?: string;
+  metrics?: ObjectCardMetric[];
+  ports?: ReactNode;
+  state?: "blocked" | "complete" | "idle" | "running";
+  summary?: string;
+  title: string;
+};
+
+const stateClasses: Record<NonNullable<ObjectCardProps["state"]>, string> = {
+  blocked:
+    "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  complete:
+    "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  idle: "border-border/70 bg-muted/60 text-muted-foreground",
+  running: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+};
+
+function ObjectCardHeader({
+  kind,
+  ports,
+  state,
+  summary,
+  title,
+}: {
+  kind: string;
+  ports?: ReactNode;
+  state: NonNullable<ObjectCardProps["state"]>;
+  summary?: string;
+  title: string;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge
+            className="rounded-full border-border/60 bg-background/70 px-2.5 py-1 text-[11px] uppercase tracking-[0.2em] text-muted-foreground"
+            variant="outline"
+          >
+            {kind}
+          </Badge>
+          <span
+            className={cn(
+              "inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium capitalize",
+              stateClasses[state],
+            )}
+          >
+            {state}
+          </span>
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold tracking-tight text-foreground">
+            {title}
+          </h3>
+          {summary ? (
+            <p className="max-w-[32ch] text-sm leading-6 text-muted-foreground">
+              {summary}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      {ports ? <div className="flex shrink-0 items-start">{ports}</div> : null}
+    </div>
+  );
+}
+
+function ObjectCardMetrics({ metrics }: Pick<ObjectCardProps, "metrics">) {
+  if (!metrics?.length) {
+    return null;
+  }
+
+  return (
+    <dl className="grid grid-cols-2 gap-3 rounded-2xl border border-border/60 bg-background/75 p-3">
+      {metrics.map((metric) => (
+        <div className="space-y-1" key={metric.label}>
+          <dt className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+            {metric.label}
+          </dt>
+          <dd className="text-sm font-medium text-foreground">
+            {metric.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function ObjectCardActions({ actions }: Pick<ObjectCardProps, "actions">) {
+  if (!actions?.length) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {actions.map((action) => {
+        const handleActionClick = () => {
+          action.onClick?.();
+        };
+
+        return (
+          <Button
+            className="rounded-full"
+            key={action.label}
+            onClick={handleActionClick}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            {action.label}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
+
+const ObjectCard = forwardRef<HTMLElement, ObjectCardProps>(
+  (
+    {
+      actions,
+      children,
+      className,
+      footer,
+      kind = "Object",
+      metrics = [],
+      ports,
+      state = "idle",
+      summary,
+      title,
+      ...props
+    },
+    ref,
+  ) => (
+    <article
+      className={cn(
+        "group relative flex min-w-[320px] max-w-[420px] flex-col gap-4 rounded-[1.5rem] border border-border/70 bg-[linear-gradient(180deg,hsl(var(--background)),hsl(var(--muted)/0.22))] p-5 shadow-[0_24px_80px_hsl(var(--foreground)/0.08)] transition-transform duration-200 hover:-translate-y-0.5",
+        className,
+      )}
+      data-state={state}
+      ref={ref}
+      {...props}
+    >
+      <div className="pointer-events-none absolute inset-x-5 top-0 h-px bg-[linear-gradient(90deg,transparent,hsl(var(--foreground)/0.22),transparent)]" />
+      <ObjectCardHeader
+        kind={kind}
+        ports={ports}
+        state={state}
+        summary={summary}
+        title={title}
+      />
+      <ObjectCardMetrics metrics={metrics} />
+      {children ? <div className="space-y-3">{children}</div> : null}
+      <ObjectCardActions actions={actions} />
+      {footer ? (
+        <div className="border-t border-border/60 pt-3 text-sm text-muted-foreground">
+          {footer}
+        </div>
+      ) : null}
+    </article>
+  ),
+);
+
+ObjectCard.displayName = "ObjectCard";
+
+export { ObjectCard };

--- a/apps/registry/registry/default/object-handle/object-handle.tsx
+++ b/apps/registry/registry/default/object-handle/object-handle.tsx
@@ -1,1 +1,43 @@
-export { ObjectHandle, type ObjectHandleProps } from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type ObjectHandleProps = Omit<
+  React.ComponentPropsWithoutRef<"button">,
+  "type"
+> & {
+  hint?: ReactNode;
+  label?: ReactNode;
+};
+
+const ObjectHandle = forwardRef<HTMLButtonElement, ObjectHandleProps>(
+  ({ className, hint, label = "Move", ...props }, ref) => (
+    <button
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/85 px-3 py-1.5 text-xs font-medium text-muted-foreground shadow-sm transition-colors hover:border-border hover:text-foreground",
+        className,
+      )}
+      ref={ref}
+      type="button"
+      {...props}
+    >
+      <span
+        aria-hidden="true"
+        className="grid grid-cols-2 gap-0.5 text-[8px] leading-none"
+      >
+        <span>•</span>
+        <span>•</span>
+        <span>•</span>
+        <span>•</span>
+      </span>
+      <span>{label}</span>
+      {hint ? <span className="text-muted-foreground/80">{hint}</span> : null}
+    </button>
+  ),
+);
+
+ObjectHandle.displayName = "ObjectHandle";
+
+export { ObjectHandle };

--- a/apps/registry/registry/default/object-inspector/object-inspector.tsx
+++ b/apps/registry/registry/default/object-inspector/object-inspector.tsx
@@ -1,7 +1,228 @@
-export {
-  ObjectInspector,
-  type ObjectInspectorKind,
-  type ObjectInspectorLabels,
-  type ObjectInspectorProps,
-  type ObjectInspectorStatus,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Object kind — drives the chip glyph + label.
+ *
+ * @public
+ */
+export type ObjectInspectorKind =
+  | "agent"
+  | "artifact"
+  | "input"
+  | "output"
+  | "run"
+  | "task";
+
+const KIND_LABEL: Record<ObjectInspectorKind, string> = {
+  agent: "Agent",
+  artifact: "Artifact",
+  input: "Input",
+  output: "Output",
+  run: "Run",
+  task: "Task",
+};
+
+const KIND_GLYPH: Record<ObjectInspectorKind, string> = {
+  agent: "◇",
+  artifact: "◌",
+  input: "↘",
+  output: "↗",
+  run: "▶",
+  task: "▢",
+};
+
+/**
+ * Live status — drives the colored dot.
+ *
+ * @public
+ */
+export type ObjectInspectorStatus =
+  | "complete"
+  | "failed"
+  | "idle"
+  | "queued"
+  | "running";
+
+const STATUS_DOT: Record<ObjectInspectorStatus, string> = {
+  complete: "bg-emerald-500",
+  failed: "bg-red-500",
+  idle: "bg-muted-foreground",
+  queued: "bg-amber-500",
+  running: "bg-blue-500 animate-pulse",
+};
+
+const STATUS_LABEL: Record<ObjectInspectorStatus, string> = {
+  complete: "Complete",
+  failed: "Failed",
+  idle: "Idle",
+  queued: "Queued",
+  running: "Running",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type ObjectInspectorLabels = {
+  /** Empty-state copy. Defaults to `"No selection"`. */
+  empty?: string;
+  /** Aria-label for the inspector. Defaults to `"Object inspector"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No selection",
+  region: "Object inspector",
+} as const satisfies Required<ObjectInspectorLabels>;
+
+/**
+ * Props for {@link ObjectInspector}.
+ *
+ * @public
+ */
+export type ObjectInspectorProps = {
+  /** Object kind. When omitted, the inspector renders the empty state. */
+  kind?: ObjectInspectorKind;
+  /** Localizable strings. */
+  labels?: ObjectInspectorLabels;
+  /** Object status. Defaults to `"idle"`. */
+  status?: ObjectInspectorStatus;
+  /** Optional subtitle (id, owner, model). */
+  subtitle?: ReactNode;
+  /** Object title. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const KindChip = (props: { kind: ObjectInspectorKind }): React.ReactElement => (
+  <span
+    aria-label={KIND_LABEL[props.kind]}
+    className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+  >
+    <span aria-hidden="true">{KIND_GLYPH[props.kind]}</span>
+    {KIND_LABEL[props.kind]}
+  </span>
+);
+
+const StatusDot = (props: {
+  status: ObjectInspectorStatus;
+}): React.ReactElement => (
+  <span
+    aria-label={`Status ${STATUS_LABEL[props.status]}`}
+    className="inline-flex items-center gap-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+  >
+    <span
+      aria-hidden="true"
+      className={cn("h-1.5 w-1.5 rounded-full", STATUS_DOT[props.status])}
+    />
+    {STATUS_LABEL[props.status]}
+  </span>
+);
+
+const Header = (props: {
+  kind: ObjectInspectorKind;
+  status: ObjectInspectorStatus;
+  subtitle?: ReactNode;
+  title: ReactNode;
+}): React.ReactElement => (
+  <header className="flex flex-col gap-2">
+    <div className="flex items-center justify-between gap-2">
+      <KindChip kind={props.kind} />
+      <StatusDot status={props.status} />
+    </div>
+    <div className="space-y-0.5">
+      <h3 className="truncate text-sm font-semibold text-foreground">
+        {props.title}
+      </h3>
+      {props.subtitle ? (
+        <p className="truncate text-xs text-muted-foreground">
+          {props.subtitle}
+        </p>
+      ) : null}
+    </div>
+  </header>
+);
+
+/**
+ * Inspector header for the right dock. Renders kind chip + status dot
+ * + title + subtitle, then any children below (typically a stack of
+ * {@link "../property-section/property-section".PropertySection} blocks). Pure presentation; the host
+ * derives props from the current selection and slots the property
+ * sections.
+ *
+ * @example
+ * ```tsx
+ * <ObjectInspector
+ *   kind="run"
+ *   status="running"
+ *   title="research-2025-04-15"
+ *   subtitle="claude-3.7"
+ * >
+ *   <PropertySection title="Layout" entries={…} />
+ *   <PropertySection title="State" entries={…} />
+ * </ObjectInspector>
+ * ```
+ *
+ * @public
+ */
+export const ObjectInspector = forwardRef<HTMLElement, ObjectInspectorProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      kind,
+      labels,
+      status = "idle",
+      subtitle,
+      title,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    if (!kind || !title) {
+      return (
+        <section
+          aria-label={resolvedLabels.region}
+          className={cn(
+            "flex w-full flex-col items-center justify-center gap-1 rounded-2xl border bg-background p-6 text-center text-xs text-muted-foreground",
+            className,
+          )}
+          data-object-inspector
+          data-object-state="empty"
+          ref={ref}
+          {...rest}
+        >
+          <span aria-hidden="true" className="text-lg">
+            ◇
+          </span>
+          <span>{resolvedLabels.empty}</span>
+        </section>
+      );
+    }
+    return (
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "flex w-full flex-col gap-3 rounded-2xl border bg-background p-3 text-foreground",
+          className,
+        )}
+        data-object-inspector
+        data-object-kind={kind}
+        data-object-status={status}
+        ref={ref}
+        {...rest}
+      >
+        <Header kind={kind} status={status} subtitle={subtitle} title={title} />
+        {children ? <div className="space-y-2">{children}</div> : null}
+      </section>
+    );
+  },
+);
+ObjectInspector.displayName = "ObjectInspector";

--- a/apps/registry/registry/default/order-book/order-book.tsx
+++ b/apps/registry/registry/default/order-book/order-book.tsx
@@ -1,1 +1,161 @@
-export { OrderBook } from "@vllnt/ui";
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type OrderBookLevel = {
+  price: number;
+  size: number;
+  total?: number;
+};
+
+export type OrderBookProps = {
+  asks: OrderBookLevel[];
+  bids: OrderBookLevel[];
+  precision?: number;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+function withCumulativeTotal(levels: OrderBookLevel[]) {
+  let runningTotal = 0;
+  return levels.map((level) => {
+    runningTotal += level.total ?? level.size;
+    return {
+      ...level,
+      total: level.total ?? runningTotal,
+    };
+  });
+}
+
+function formatNumber(value: number, precision = 2) {
+  return value.toLocaleString(undefined, {
+    maximumFractionDigits: precision,
+    minimumFractionDigits: precision,
+  });
+}
+
+function BookSide({
+  accent,
+  levels,
+  precision,
+  title,
+}: {
+  accent: "ask" | "bid";
+  levels: OrderBookLevel[];
+  precision: number;
+  title: string;
+}) {
+  const maxTotal = Math.max(...levels.map((level) => level.total ?? 0), 1);
+  const barClassName =
+    accent === "ask"
+      ? "bg-rose-500/12 border-rose-500/15"
+      : "bg-emerald-500/12 border-emerald-500/15";
+  const priceClassName =
+    accent === "ask"
+      ? "text-rose-600 dark:text-rose-400"
+      : "text-emerald-600 dark:text-emerald-400";
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+          {title}
+        </h3>
+        <span className="text-xs text-muted-foreground">
+          Depth by total size
+        </span>
+      </div>
+      <div className="rounded-2xl border border-border/70 bg-background/60 p-2">
+        <div className="grid grid-cols-[1.2fr_1fr_1fr] gap-3 px-3 py-2 text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+          <span>Price</span>
+          <span className="text-right">Size</span>
+          <span className="text-right">Total</span>
+        </div>
+        <div className="space-y-1">
+          {levels.map((level) => {
+            const width = `${((level.total ?? 0) / maxTotal) * 100}%`;
+            return (
+              <div
+                className="relative overflow-hidden rounded-xl border border-transparent px-3 py-2"
+                key={`${accent}-${level.price}-${level.size}`}
+              >
+                <div
+                  className={cn(
+                    "absolute inset-y-0 right-0 rounded-xl border",
+                    barClassName,
+                  )}
+                  style={{ width }}
+                />
+                <div className="relative grid grid-cols-[1.2fr_1fr_1fr] gap-3 text-sm tabular-nums">
+                  <span className={cn("font-medium", priceClassName)}>
+                    {formatNumber(level.price, precision)}
+                  </span>
+                  <span className="text-right text-foreground">
+                    {formatNumber(level.size, 3)}
+                  </span>
+                  <span className="text-right text-muted-foreground">
+                    {formatNumber(level.total ?? 0, 3)}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const OrderBook = React.forwardRef<HTMLDivElement, OrderBookProps>(
+  ({ asks, bids, className, precision = 2, ...props }, reference) => {
+    if (asks.length === 0 && bids.length === 0) {
+      return null;
+    }
+
+    const askLevels = withCumulativeTotal(asks);
+    const bidLevels = withCumulativeTotal(bids);
+    const bestAsk = askLevels[0];
+    const bestBid = bidLevels[0];
+    const spread =
+      bestAsk && bestBid ? Math.max(bestAsk.price - bestBid.price, 0) : 0;
+
+    return (
+      <div
+        className={cn(
+          "rounded-2xl border border-border bg-card/80 p-4 shadow-sm",
+          className,
+        )}
+        ref={reference}
+        {...props}
+      >
+        <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-[0.28em] text-muted-foreground">
+              Level II
+            </p>
+            <h2 className="text-lg font-semibold text-foreground">
+              Order book
+            </h2>
+          </div>
+          <div className="rounded-full border border-border bg-background/70 px-3 py-1 text-sm text-muted-foreground tabular-nums">
+            Spread {formatNumber(spread, precision)}
+          </div>
+        </div>
+        <div className="grid gap-4 lg:grid-cols-2">
+          <BookSide
+            accent="ask"
+            levels={askLevels}
+            precision={precision}
+            title="Asks"
+          />
+          <BookSide
+            accent="bid"
+            levels={bidLevels}
+            precision={precision}
+            title="Bids"
+          />
+        </div>
+      </div>
+    );
+  },
+);
+
+OrderBook.displayName = "OrderBook";

--- a/apps/registry/registry/default/pagination/pagination.tsx
+++ b/apps/registry/registry/default/pagination/pagination.tsx
@@ -1,2 +1,75 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+import Link from "next/link";
+
+import { Button } from "@vllnt/ui";
+
+export type PaginationProps = {
+  baseUrl: string;
+  className?: string;
+  currentPage: number;
+  totalPages: number;
+};
+
+export function Pagination({
+  baseUrl,
+  className,
+  currentPage,
+  totalPages,
+}: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const maxVisiblePages = 5;
+  let startPage = Math.max(1, currentPage - Math.floor(maxVisiblePages / 2));
+  const endPage = Math.min(totalPages, startPage + maxVisiblePages - 1);
+
+  if (endPage - startPage + 1 < maxVisiblePages) {
+    startPage = Math.max(1, endPage - maxVisiblePages + 1);
+  }
+
+  // Previous button
+  const previousButton =
+    currentPage > 1 ? (
+      <Link href={`${baseUrl}?page=${currentPage - 1}`} key="prev">
+        <Button size="sm" variant="outline">
+          <span className="text-sm">‹</span>
+          <span className="sr-only">Previous</span>
+        </Button>
+      </Link>
+    ) : null;
+
+  // Page numbers
+  const pageNumbers = Array.from(
+    { length: endPage - startPage + 1 },
+    (_, index) => {
+      const pageNumber = startPage + index;
+      return (
+        <Link href={`${baseUrl}?page=${pageNumber}`} key={pageNumber}>
+          <Button
+            size="sm"
+            variant={pageNumber === currentPage ? "default" : "outline"}
+          >
+            {pageNumber}
+          </Button>
+        </Link>
+      );
+    },
+  );
+
+  // Next button
+  const nextButton =
+    currentPage < totalPages ? (
+      <Link href={`${baseUrl}?page=${currentPage + 1}`} key="next">
+        <Button size="sm" variant="outline">
+          <span className="sr-only">Next</span>
+          <span className="text-sm">›</span>
+        </Button>
+      </Link>
+    ) : null;
+
+  const pages = [previousButton, ...pageNumbers, nextButton].filter(Boolean);
+
+  return (
+    <div className={`flex items-center justify-center gap-2 ${className}`}>
+      {pages}
+    </div>
+  );
+}

--- a/apps/registry/registry/default/parallel-timeline/parallel-timeline.tsx
+++ b/apps/registry/registry/default/parallel-timeline/parallel-timeline.tsx
@@ -1,2 +1,426 @@
-// Re-export from @vllnt/ui package
-export { ParallelTimeline } from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useMemo,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+const DEFAULT_TICK_COUNT = 8;
+
+/**
+ * Color theme for a {@link ParallelTimelineTrack} accent strip and
+ * {@link ParallelTimelineEvent} markers.
+ *
+ * @public
+ */
+export type ParallelTimelineColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "neutral"
+  | "purple"
+  | "red"
+  | "rose";
+
+const COLOR_CLASSES: Record<
+  ParallelTimelineColor,
+  { accent: string; chip: string; marker: string }
+> = {
+  amber: {
+    accent: "bg-amber-500",
+    chip: "bg-amber-500/15 text-amber-700 dark:text-amber-300",
+    marker: "border-amber-500 bg-amber-500",
+  },
+  blue: {
+    accent: "bg-blue-500",
+    chip: "bg-blue-500/15 text-blue-700 dark:text-blue-300",
+    marker: "border-blue-500 bg-blue-500",
+  },
+  emerald: {
+    accent: "bg-emerald-500",
+    chip: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+    marker: "border-emerald-500 bg-emerald-500",
+  },
+  neutral: {
+    accent: "bg-muted-foreground/40",
+    chip: "bg-muted text-muted-foreground",
+    marker: "border-muted-foreground bg-muted-foreground",
+  },
+  purple: {
+    accent: "bg-purple-500",
+    chip: "bg-purple-500/15 text-purple-700 dark:text-purple-300",
+    marker: "border-purple-500 bg-purple-500",
+  },
+  red: {
+    accent: "bg-red-500",
+    chip: "bg-red-500/15 text-red-700 dark:text-red-300",
+    marker: "border-red-500 bg-red-500",
+  },
+  rose: {
+    accent: "bg-rose-500",
+    chip: "bg-rose-500/15 text-rose-700 dark:text-rose-300",
+    marker: "border-rose-500 bg-rose-500",
+  },
+};
+
+/**
+ * One event marker on a {@link ParallelTimelineTrack}.
+ *
+ * @public
+ */
+export type ParallelTimelineEvent = {
+  /** Stable identifier within the track. */
+  id: string;
+  /** Optional secondary line (date detail, place, etc.). */
+  meta?: ReactNode;
+  /** Event title. */
+  title: ReactNode;
+  /** Year. Negative for BCE / positive for CE. */
+  year: number;
+};
+
+/**
+ * Single horizontal track inside a {@link ParallelTimeline}.
+ *
+ * @public
+ */
+export type ParallelTimelineTrack = {
+  /** Color theme. Defaults to `"neutral"`. */
+  color?: ParallelTimelineColor;
+  /** Event markers. */
+  events: ParallelTimelineEvent[];
+  /** Stable identifier. */
+  id: string;
+  /** Display name. */
+  name: ReactNode;
+  /** Optional region label rendered next to the name. */
+  region?: ReactNode;
+};
+
+/**
+ * Background era band rendered behind every track.
+ *
+ * @public
+ */
+export type ParallelTimelineEra = {
+  /** Color theme — drives the band tint. Defaults to `"neutral"`. */
+  color?: ParallelTimelineColor;
+  /** End year (inclusive). */
+  end: number;
+  /** Stable identifier. */
+  id: string;
+  /** Display name. */
+  name: ReactNode;
+  /** Start year (inclusive). */
+  start: number;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type ParallelTimelineLabels = {
+  /** Aria-label for the timeline region. Defaults to `"Parallel timeline"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Parallel timeline",
+} as const satisfies Required<ParallelTimelineLabels>;
+
+/**
+ * Props for {@link ParallelTimeline}.
+ *
+ * @public
+ */
+export type ParallelTimelineProps = {
+  /** End year (positive for CE). */
+  endYear: number;
+  /** Optional background era bands shared across tracks. */
+  eras?: ParallelTimelineEra[];
+  /** Localizable strings. */
+  labels?: ParallelTimelineLabels;
+  /** Start year (negative for BCE). */
+  startYear: number;
+  /** Number of axis ticks to render. Defaults to `8`. */
+  tickCount?: number;
+  /** Track list, rendered in order. */
+  tracks: ParallelTimelineTrack[];
+} & ComponentPropsWithoutRef<"section">;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function formatYear(year: number): string {
+  if (year < 0) return `${Math.abs(year).toString()} BCE`;
+  return `${year.toString()} CE`;
+}
+
+function yearToPercent(year: number, start: number, end: number): number {
+  const span = end - start;
+  if (span <= 0) return 0;
+  return clamp(((year - start) / span) * 100, 0, 100);
+}
+
+function buildTicks(
+  start: number,
+  end: number,
+  count: number,
+): { label: string; offset: number }[] {
+  const safeCount = Math.max(2, count);
+  const span = end - start;
+  if (span <= 0) return [];
+  const step = span / (safeCount - 1);
+  return Array.from({ length: safeCount }).map((_, index) => {
+    const year = Math.round(start + step * index);
+    return {
+      label: formatYear(year),
+      offset: yearToPercent(year, start, end),
+    };
+  });
+}
+
+type AxisProps = {
+  ticks: { label: string; offset: number }[];
+};
+
+function Axis({ ticks }: AxisProps): ReactNode {
+  return (
+    <div
+      aria-hidden="true"
+      className="relative h-7 border-b border-border text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+    >
+      {ticks.map((tick) => (
+        <span
+          className="absolute top-1 -translate-x-1/2"
+          key={tick.label}
+          style={{ left: `${tick.offset.toString()}%` }}
+        >
+          {tick.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+type EraBandsProps = {
+  endYear: number;
+  eras: ParallelTimelineEra[];
+  startYear: number;
+};
+
+function EraBands({ endYear, eras, startYear }: EraBandsProps): ReactNode {
+  if (eras.length === 0) return null;
+  return (
+    <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+      {eras.map((era) => {
+        const left = yearToPercent(era.start, startYear, endYear);
+        const right = yearToPercent(era.end, startYear, endYear);
+        const width = Math.max(0, right - left);
+        if (width <= 0) return null;
+        const palette = COLOR_CLASSES[era.color ?? "neutral"];
+        return (
+          <div
+            className={cn("absolute inset-y-0", palette.chip)}
+            data-era-id={era.id}
+            key={era.id}
+            style={{
+              left: `${left.toString()}%`,
+              width: `${width.toString()}%`,
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+type EventMarkerProps = {
+  color: ParallelTimelineColor;
+  endYear: number;
+  event: ParallelTimelineEvent;
+  startYear: number;
+};
+
+function EventMarker({
+  color,
+  endYear,
+  event,
+  startYear,
+}: EventMarkerProps): ReactNode {
+  if (event.year < startYear || event.year > endYear) return null;
+  const left = yearToPercent(event.year, startYear, endYear);
+  const palette = COLOR_CLASSES[color];
+  const titleText = typeof event.title === "string" ? event.title : "";
+  const ariaLabel = titleText
+    ? `${titleText}, ${formatYear(event.year)}`
+    : undefined;
+  return (
+    <div
+      aria-label={ariaLabel}
+      className="absolute top-1/2 z-10 -translate-x-1/2 -translate-y-1/2"
+      data-event-id={event.id}
+      data-event-year={event.year}
+      style={{ left: `${left.toString()}%` }}
+    >
+      <div
+        aria-hidden="true"
+        className={cn(
+          "h-3 w-3 rounded-full border-2 ring-2 ring-background",
+          palette.marker,
+        )}
+      />
+      <div className="absolute left-1/2 top-4 w-40 -translate-x-1/2 text-center">
+        <p className="truncate text-xs font-medium text-foreground">
+          {event.title}
+        </p>
+        <p className="truncate text-[10px] text-muted-foreground">
+          {formatYear(event.year)}
+          {event.meta ? <span> · {event.meta}</span> : null}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+type TrackRowProps = {
+  endYear: number;
+  startYear: number;
+  track: ParallelTimelineTrack;
+};
+
+function TrackRow({ endYear, startYear, track }: TrackRowProps): ReactNode {
+  const color = track.color ?? "neutral";
+  const palette = COLOR_CLASSES[color];
+  return (
+    <div className="relative flex items-stretch gap-3 border-t border-border first:border-t-0">
+      <div className="flex w-32 shrink-0 flex-col gap-1 border-r border-border bg-muted/20 px-3 py-3">
+        <span
+          aria-hidden="true"
+          className={cn("h-1 w-8 rounded-full", palette.accent)}
+        />
+        <p className="text-sm font-semibold tracking-tight text-foreground">
+          {track.name}
+        </p>
+        {track.region ? (
+          <p className="text-xs text-muted-foreground">{track.region}</p>
+        ) : null}
+      </div>
+      <div
+        aria-label={typeof track.name === "string" ? track.name : undefined}
+        className="relative h-16 min-w-0 flex-1"
+        data-track-id={track.id}
+      >
+        <div className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-border" />
+        {track.events.map((event) => (
+          <EventMarker
+            color={color}
+            endYear={endYear}
+            event={event}
+            key={event.id}
+            startYear={startYear}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Multi-track timeline with a shared time axis. Renders each track as a
+ * horizontal lane with event markers positioned by year. Negative years
+ * render as `BCE`, positive as `CE`. Background era bands span every
+ * track when the consumer passes `eras`.
+ *
+ * Cross-track connectors, synchronized pan/zoom, collapsible tracks,
+ * and click-to-compare are intentionally **out of scope** — drive them
+ * from consumer code via the data slots.
+ *
+ * @example
+ * ```tsx
+ * <ParallelTimeline
+ *   startYear={-500}
+ *   endYear={500}
+ *   eras={[{ id: "antiquity", name: "Antiquity", start: -500, end: 500, color: "neutral" }]}
+ *   tracks={[
+ *     {
+ *       id: "rome",
+ *       name: "Rome",
+ *       color: "red",
+ *       events: [
+ *         { id: "augustus", year: -27, title: "Augustus becomes Emperor" },
+ *         { id: "fall", year: 476, title: "Fall of Western Rome" },
+ *       ],
+ *     },
+ *     {
+ *       id: "china",
+ *       name: "China",
+ *       color: "amber",
+ *       events: [
+ *         { id: "qin", year: -221, title: "Qin unifies China" },
+ *         { id: "han-end", year: 220, title: "End of Han Dynasty" },
+ *       ],
+ *     },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const ParallelTimeline = forwardRef<HTMLElement, ParallelTimelineProps>(
+  (props, ref) => {
+    const {
+      className,
+      endYear,
+      eras = [],
+      labels,
+      startYear,
+      tickCount = DEFAULT_TICK_COUNT,
+      tracks,
+      ...rest
+    } = props;
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const ticks = useMemo(
+      () => buildTicks(startYear, endYear, tickCount),
+      [endYear, startYear, tickCount],
+    );
+
+    return (
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "flex w-full flex-col overflow-x-auto rounded-2xl border bg-background text-foreground",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <div className="flex items-stretch gap-3 border-b border-border">
+          <div aria-hidden="true" className="w-32 shrink-0" />
+          <Axis ticks={ticks} />
+        </div>
+        <div className="relative">
+          <EraBands endYear={endYear} eras={eras} startYear={startYear} />
+          {tracks.map((track) => (
+            <TrackRow
+              endYear={endYear}
+              key={track.id}
+              startYear={startYear}
+              track={track}
+            />
+          ))}
+        </div>
+      </section>
+    );
+  },
+);
+ParallelTimeline.displayName = "ParallelTimeline";

--- a/apps/registry/registry/default/password-input/password-input.tsx
+++ b/apps/registry/registry/default/password-input/password-input.tsx
@@ -1,1 +1,60 @@
-export { PasswordInput } from '@vllnt/ui'
+"use client";
+
+import * as React from "react";
+
+import { Eye, EyeOff } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+export type PasswordInputProps = Omit<
+  React.ComponentPropsWithoutRef<"input">,
+  "type"
+> & {
+  hideLabel?: string;
+  showLabel?: string;
+};
+
+const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
+  (
+    {
+      className,
+      hideLabel = "Hide password",
+      showLabel = "Show password",
+      ...props
+    },
+    reference,
+  ) => {
+    const [visible, setVisible] = React.useState(false);
+
+    return (
+      <div className="relative">
+        <input
+          className={cn(
+            "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 pr-10 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+            className,
+          )}
+          ref={reference}
+          type={visible ? "text" : "password"}
+          {...props}
+        />
+        <button
+          aria-label={visible ? hideLabel : showLabel}
+          className="absolute inset-y-0 right-0 flex items-center justify-center px-3 text-muted-foreground transition-colors hover:text-foreground"
+          onClick={() => {
+            setVisible((previous) => !previous);
+          }}
+          type="button"
+        >
+          {visible ? (
+            <EyeOff className="h-4 w-4" />
+          ) : (
+            <Eye className="h-4 w-4" />
+          )}
+        </button>
+      </div>
+    );
+  },
+);
+PasswordInput.displayName = "PasswordInput";
+
+export { PasswordInput };

--- a/apps/registry/registry/default/plan-badge/plan-badge.tsx
+++ b/apps/registry/registry/default/plan-badge/plan-badge.tsx
@@ -1,2 +1,82 @@
-// Re-export from @vllnt/ui package
-export { PlanBadge } from '@vllnt/ui'
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+import { badgeVariants } from "@vllnt/ui";
+
+export type PlanBadgeTier = "enterprise" | "free" | "growth" | "starter";
+
+export type PlanBadgeState = "current" | "legacy" | "trial";
+
+export type PlanBadgeProps = Omit<
+  React.ComponentPropsWithoutRef<"span">,
+  "children"
+> & {
+  label?: string;
+  state?: PlanBadgeState;
+  tier: PlanBadgeTier;
+};
+
+function getPlanLabel(tier: PlanBadgeTier): string {
+  switch (tier) {
+    case "enterprise":
+      return "Enterprise";
+    case "free":
+      return "Free";
+    case "growth":
+      return "Growth";
+    case "starter":
+      return "Starter";
+  }
+}
+
+function getPlanClasses(tier: PlanBadgeTier, state: PlanBadgeState): string {
+  if (state === "legacy") {
+    return "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300";
+  }
+
+  if (state === "trial") {
+    return "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300";
+  }
+
+  switch (tier) {
+    case "enterprise":
+      return "border-primary/30 bg-primary/10 text-primary";
+    case "free":
+      return "border-border bg-muted text-muted-foreground";
+    case "growth":
+      return "border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-300";
+    case "starter":
+      return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+  }
+}
+
+export const PlanBadge = React.forwardRef<HTMLSpanElement, PlanBadgeProps>(
+  ({ className, label, state = "current", tier, ...props }, reference) => {
+    return (
+      <span
+        className={cn(
+          badgeVariants({ variant: "outline" }),
+          "gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium tracking-[0.02em] shadow-none",
+          getPlanClasses(tier, state),
+          className,
+        )}
+        ref={reference}
+        {...props}
+      >
+        <span
+          aria-hidden="true"
+          className="h-1.5 w-1.5 rounded-full bg-current"
+        />
+        <span>{label ?? getPlanLabel(tier)}</span>
+        {state === "trial" ? (
+          <span className="text-current/80">Trial</span>
+        ) : null}
+        {state === "legacy" ? (
+          <span className="text-current/80">Legacy</span>
+        ) : null}
+      </span>
+    );
+  },
+);
+
+PlanBadge.displayName = "PlanBadge";

--- a/apps/registry/registry/default/playback-ghost/playback-ghost.tsx
+++ b/apps/registry/registry/default/playback-ghost/playback-ghost.tsx
@@ -1,6 +1,161 @@
-export {
-  PlaybackGhost,
-  type PlaybackGhostKind,
-  type PlaybackGhostLabels,
-  type PlaybackGhostProps,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Object kind — drives the ghost glyph.
+ *
+ * @public
+ */
+export type PlaybackGhostKind =
+  | "agent"
+  | "artifact"
+  | "input"
+  | "output"
+  | "run"
+  | "task";
+
+const KIND_GLYPH: Record<PlaybackGhostKind, string> = {
+  agent: "◇",
+  artifact: "◌",
+  input: "↘",
+  output: "↗",
+  run: "▶",
+  task: "▢",
+};
+
+const KIND_LABEL: Record<PlaybackGhostKind, string> = {
+  agent: "Agent",
+  artifact: "Artifact",
+  input: "Input",
+  output: "Output",
+  run: "Run",
+  task: "Task",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type PlaybackGhostLabels = {
+  /** Aria-label override. Defaults to `"Playback ghost"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Playback ghost",
+} as const satisfies Required<PlaybackGhostLabels>;
+
+/**
+ * Props for {@link PlaybackGhost}.
+ *
+ * @public
+ */
+export type PlaybackGhostProps = {
+  /** Optional kind glyph + tooltip. */
+  kind?: PlaybackGhostKind;
+  /** Optional label rendered next to the glyph (e.g. id, run name). */
+  label?: ReactNode;
+  /** Localizable strings. */
+  labels?: PlaybackGhostLabels;
+  /** Ghost opacity `0..1`. Defaults to `0.4`. */
+  opacity?: number;
+  /** Ghost size in pixels. Defaults to `40`. */
+  size?: number;
+  /** Center X in canvas pixels. */
+  x: number;
+  /** Center Y in canvas pixels. */
+  y: number;
+} & ComponentPropsWithoutRef<"div">;
+
+const clamp01 = (v: number): number => {
+  if (v < 0) {
+    return 0;
+  }
+  if (v > 1) {
+    return 1;
+  }
+  return v;
+};
+
+/**
+ * Translucent overlay marking where a canvas object was at a previous
+ * timestamp during state playback. Renders a kind glyph (and optional
+ * label) at the historical position so the user can compare the
+ * present canvas against earlier state without losing context.
+ *
+ * Pure presentation; the host computes the historical position from the
+ * scrubbed timestamp. The wrapper is `pointer-events: none` so host
+ * gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <PlaybackGhost x={420} y={180} kind="run" label="research-2025" />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const PlaybackGhost = forwardRef<HTMLDivElement, PlaybackGhostProps>(
+  (props, ref) => {
+    const {
+      className,
+      kind,
+      label,
+      labels,
+      opacity = 0.4,
+      size = 40,
+      x,
+      y,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const safeOpacity = clamp01(opacity);
+    const safeSize = size < 16 ? 16 : size;
+    const ariaLabel = kind
+      ? `${resolvedLabels.region}: ${KIND_LABEL[kind]}`
+      : resolvedLabels.region;
+    return (
+      <div
+        aria-label={ariaLabel}
+        className={cn(
+          "pointer-events-none absolute z-10 inline-flex -translate-x-1/2 -translate-y-1/2 items-center justify-center gap-1.5 rounded-md border border-dashed border-border/70 bg-background/40 px-2 py-1 text-xs text-foreground backdrop-blur-sm",
+          className,
+        )}
+        data-playback-ghost
+        data-playback-kind={kind ?? "unknown"}
+        ref={ref}
+        role="img"
+        style={{
+          left: x,
+          minHeight: safeSize,
+          minWidth: safeSize,
+          opacity: safeOpacity,
+          top: y,
+        }}
+        {...rest}
+      >
+        {kind ? (
+          <span aria-hidden="true" className="text-muted-foreground">
+            {KIND_GLYPH[kind]}
+          </span>
+        ) : null}
+        {label ? (
+          <span className="truncate" data-playback-ghost-label>
+            {label}
+          </span>
+        ) : null}
+      </div>
+    );
+  },
+);
+PlaybackGhost.displayName = "PlaybackGhost";

--- a/apps/registry/registry/default/policy-delivery-panel/policy-delivery-panel.tsx
+++ b/apps/registry/registry/default/policy-delivery-panel/policy-delivery-panel.tsx
@@ -1,7 +1,197 @@
-export {
-  PolicyDeliveryPanel,
-  type PolicyDeliveryPanelLabels,
-  type PolicyDeliveryPanelProps,
-  type PolicyEntry,
-  type PolicyStatus,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Enforcement status for a policy.
+ *
+ * @public
+ */
+export type PolicyStatus = "advisory" | "disabled" | "enforced";
+
+const STATUS_LABEL: Record<PolicyStatus, string> = {
+  advisory: "Advisory",
+  disabled: "Disabled",
+  enforced: "Enforced",
+};
+
+const STATUS_TONE: Record<PolicyStatus, string> = {
+  advisory:
+    "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  disabled: "border-border bg-muted/40 text-muted-foreground",
+  enforced:
+    "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+};
+
+/**
+ * One policy row.
+ *
+ * @public
+ */
+export type PolicyEntry = {
+  /** Optional secondary line (rationale, owner, last-updated). */
+  description?: ReactNode;
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Display name (e.g. `"PII redaction"`). */
+  name: ReactNode;
+  /** Optional toggle handler — when provided, the row becomes a button. */
+  onToggle?: () => void;
+  /** Enforcement status. */
+  status: PolicyStatus;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type PolicyDeliveryPanelLabels = {
+  /** Empty-state copy. Defaults to `"No policies"`. */
+  empty?: string;
+  /** Aria-label for the panel. Defaults to `"Policy delivery"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No policies",
+  region: "Policy delivery",
+} as const satisfies Required<PolicyDeliveryPanelLabels>;
+
+/**
+ * Props for {@link PolicyDeliveryPanel}.
+ *
+ * @public
+ */
+export type PolicyDeliveryPanelProps = {
+  /** Localizable strings. */
+  labels?: PolicyDeliveryPanelLabels;
+  /** Policy entries in render order. */
+  policies: PolicyEntry[];
+  /** Panel title. Defaults to `"Policies"`. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const RowBody = (props: { policy: PolicyEntry }): React.ReactElement => {
+  const { policy } = props;
+  return (
+    <span className="flex flex-1 flex-col gap-0.5 text-left">
+      <span className="flex items-center justify-between gap-2">
+        <span className="truncate text-xs font-medium text-foreground">
+          {policy.name}
+        </span>
+        <span
+          className={cn(
+            "rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
+            STATUS_TONE[policy.status],
+          )}
+        >
+          {STATUS_LABEL[policy.status]}
+        </span>
+      </span>
+      {policy.description ? (
+        <span className="truncate text-[10px] text-muted-foreground">
+          {policy.description}
+        </span>
+      ) : null}
+    </span>
+  );
+};
+
+const Row = (props: { policy: PolicyEntry }): React.ReactElement => {
+  const { policy } = props;
+  if (policy.onToggle) {
+    const handleClick = (): void => {
+      policy.onToggle?.();
+    };
+    return (
+      <button
+        className="flex w-full items-center gap-2 rounded-md border border-transparent px-2 py-1.5 text-left transition-colors hover:border-border hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        data-policy-row={policy.id}
+        data-policy-status={policy.status}
+        onClick={handleClick}
+        type="button"
+      >
+        <RowBody policy={policy} />
+      </button>
+    );
+  }
+  return (
+    <div
+      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5"
+      data-policy-row={policy.id}
+      data-policy-status={policy.status}
+    >
+      <RowBody policy={policy} />
+    </div>
+  );
+};
+
+/**
+ * Right-dock panel listing the policies / guardrails that apply to the
+ * active route or run. Each row shows the policy name, enforcement
+ * status chip, and optional rationale. Pure presentation; the host
+ * computes the policy list from the live config and supplies an
+ * optional toggle handler for admin views.
+ *
+ * @example
+ * ```tsx
+ * <PolicyDeliveryPanel
+ *   policies={[
+ *     { id: "pii",  name: "PII redaction", status: "enforced" },
+ *     { id: "rate", name: "Rate limiting", status: "advisory", description: "60 / s soft cap" },
+ *     { id: "exp",  name: "Experiment B",  status: "disabled" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const PolicyDeliveryPanel = forwardRef<
+  HTMLElement,
+  PolicyDeliveryPanelProps
+>((props, ref) => {
+  const { className, labels, policies, title = "Policies", ...rest } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  return (
+    <section
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "flex w-full flex-col gap-2 rounded-lg border bg-background p-3 text-foreground",
+        className,
+      )}
+      data-policy-delivery-panel
+      ref={ref}
+      {...rest}
+    >
+      <header>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {title}
+        </h3>
+      </header>
+      {policies.length === 0 ? (
+        <p
+          className="px-2 py-3 text-center text-xs text-muted-foreground"
+          data-policy-state="empty"
+        >
+          {resolvedLabels.empty}
+        </p>
+      ) : (
+        <ul className="space-y-0.5">
+          {policies.map((policy) => (
+            <li key={policy.id}>
+              <Row policy={policy} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+});
+PolicyDeliveryPanel.displayName = "PolicyDeliveryPanel";

--- a/apps/registry/registry/default/popover/popover.tsx
+++ b/apps/registry/registry/default/popover/popover.tsx
@@ -1,1 +1,34 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+
+import { cn } from "@vllnt/ui";
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+const PopoverContent = forwardRef<
+  React.ComponentRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ align = "center", className, sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      align={align}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      ref={ref}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/apps/registry/registry/default/presence-stack/presence-stack.tsx
+++ b/apps/registry/registry/default/presence-stack/presence-stack.tsx
@@ -1,7 +1,198 @@
-export {
-  PresenceStack,
-  type PresenceStackLabels,
-  type PresenceStackProps,
-  type PresenceStatus,
-  type PresenceUser,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Presence status — drives the corner dot color.
+ *
+ * @public
+ */
+export type PresenceStatus = "active" | "away" | "idle" | "offline";
+
+const STATUS_DOT: Record<PresenceStatus, string> = {
+  active: "bg-emerald-500",
+  away: "bg-amber-500",
+  idle: "bg-muted-foreground",
+  offline: "bg-muted-foreground/40",
+};
+
+/**
+ * One user in the presence stack.
+ *
+ * @public
+ */
+export type PresenceUser = {
+  /** Optional accent color (hex / oklch / var). Drives the avatar fill. */
+  color?: string;
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Avatar initial / glyph. */
+  initial: ReactNode;
+  /** Display name shown on hover (`title` attribute). */
+  name?: string;
+  /** Optional status. Defaults to `"active"`. */
+  status?: PresenceStatus;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type PresenceStackLabels = {
+  /** Suffix for the overflow chip. Defaults to `"more"`. */
+  overflowSuffix?: string;
+  /** Aria-label override. Defaults to `"Live presence"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  overflowSuffix: "more",
+  region: "Live presence",
+} as const satisfies Required<PresenceStackLabels>;
+
+/**
+ * Props for {@link PresenceStack}.
+ *
+ * @public
+ */
+export type PresenceStackProps = {
+  /** Localizable strings. */
+  labels?: PresenceStackLabels;
+  /** Cap the rendered users; the rest collapse into a `+N` chip. Defaults to `5`. */
+  max?: number;
+  /** Optional click handler for the overflow chip. */
+  onOverflowActivate?: () => void;
+  /** Users sorted in render order (most-relevant first). */
+  users: PresenceUser[];
+} & ComponentPropsWithoutRef<"div">;
+
+const Avatar = (props: { user: PresenceUser }): React.ReactElement => {
+  const { user } = props;
+  const status = user.status ?? "active";
+  return (
+    <span
+      className="relative -ml-2 inline-flex h-7 w-7 items-center justify-center rounded-full border-2 border-background text-[11px] font-semibold text-white shadow-sm first:ml-0"
+      data-presence-stack-status={status}
+      data-presence-stack-user={user.id}
+      style={{ backgroundColor: user.color ?? "var(--foreground)" }}
+      title={user.name}
+    >
+      {user.initial}
+      <span
+        aria-hidden="true"
+        className={cn(
+          "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full border border-background",
+          STATUS_DOT[status],
+        )}
+        data-presence-stack-dot
+      />
+    </span>
+  );
+};
+
+/**
+ * Overlapping live-presence avatars showing who is in the canvas right
+ * now. Each avatar carries an accent color, an initial, and a status
+ * dot. Distinct from `AvatarGroup` (a static participant grouping):
+ * this primitive centers on live status, a sane overflow, and
+ * interactive expansion.
+ *
+ * Pure presentation; the host owns the websocket roster + maps user
+ * ids to colors.
+ *
+ * @example
+ * ```tsx
+ * <PresenceStack
+ *   max={4}
+ *   users={[
+ *     { id: "1", initial: "B", color: "#5b8def", name: "Bea" },
+ *     { id: "2", initial: "L", color: "#10b981", name: "Lior", status: "away" },
+ *     { id: "3", initial: "S", color: "#f59e0b", name: "Sam", status: "idle" },
+ *   ]}
+ *   onOverflowActivate={() => openRoster()}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const PresenceStack = forwardRef<HTMLDivElement, PresenceStackProps>(
+  (props, ref) => {
+    const {
+      className,
+      labels,
+      max = 5,
+      onOverflowActivate,
+      users,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const visible = max >= users.length ? users : users.slice(0, max);
+    const hidden = users.length - visible.length;
+    const handleOverflow = (): void => {
+      onOverflowActivate?.();
+    };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn("inline-flex items-center pl-2", className)}
+        data-presence-stack
+        ref={ref}
+        role="group"
+        {...rest}
+      >
+        {visible.map((user) => (
+          <Avatar key={user.id} user={user} />
+        ))}
+        {hidden > 0
+          ? renderOverflow({
+              count: hidden,
+              handleClick: handleOverflow,
+              handlerProvided: Boolean(onOverflowActivate),
+              labels: resolvedLabels,
+            })
+          : null}
+      </div>
+    );
+  },
+);
+PresenceStack.displayName = "PresenceStack";
+
+const renderOverflow = (input: {
+  count: number;
+  handleClick: () => void;
+  handlerProvided: boolean;
+  labels: Required<PresenceStackLabels>;
+}): React.ReactElement => {
+  const text = `+${input.count}`;
+  const aria = `${input.count} ${input.labels.overflowSuffix}`;
+  const className =
+    "relative -ml-2 inline-flex h-7 min-w-7 items-center justify-center rounded-full border-2 border-background bg-muted px-1.5 text-[10px] font-semibold text-muted-foreground shadow-sm";
+  if (input.handlerProvided) {
+    return (
+      <button
+        aria-label={aria}
+        className={cn(
+          className,
+          "transition-colors hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        )}
+        data-presence-stack-overflow
+        onClick={input.handleClick}
+        type="button"
+      >
+        {text}
+      </button>
+    );
+  }
+  return (
+    <span aria-label={aria} className={className} data-presence-stack-overflow>
+      {text}
+    </span>
+  );
+};

--- a/apps/registry/registry/default/presence-sync-indicator/presence-sync-indicator.tsx
+++ b/apps/registry/registry/default/presence-sync-indicator/presence-sync-indicator.tsx
@@ -1,6 +1,130 @@
-export {
-  PresenceSyncIndicator,
-  type PresenceSyncIndicatorLabels,
-  type PresenceSyncIndicatorProps,
-  type PresenceSyncState,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Connection / sync state — drives the dot color + animation.
+ *
+ * @public
+ */
+export type PresenceSyncState =
+  | "error"
+  | "live"
+  | "offline"
+  | "reconnecting"
+  | "syncing";
+
+const STATE_LABEL: Record<PresenceSyncState, string> = {
+  error: "Sync error",
+  live: "Live",
+  offline: "Offline",
+  reconnecting: "Reconnecting",
+  syncing: "Syncing",
+};
+
+const STATE_DOT: Record<PresenceSyncState, string> = {
+  error: "bg-red-500",
+  live: "bg-emerald-500",
+  offline: "bg-muted-foreground",
+  reconnecting: "bg-amber-500 animate-pulse",
+  syncing: "bg-blue-500 animate-pulse",
+};
+
+const STATE_TEXT: Record<PresenceSyncState, string> = {
+  error: "text-red-700 dark:text-red-300",
+  live: "text-emerald-700 dark:text-emerald-300",
+  offline: "text-muted-foreground",
+  reconnecting: "text-amber-700 dark:text-amber-300",
+  syncing: "text-blue-700 dark:text-blue-300",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type PresenceSyncIndicatorLabels = {
+  /** Aria-label override. Defaults to `"Presence sync"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Presence sync",
+} as const satisfies Required<PresenceSyncIndicatorLabels>;
+
+/**
+ * Props for {@link PresenceSyncIndicator}.
+ *
+ * @public
+ */
+export type PresenceSyncIndicatorProps = {
+  /** Optional override label (defaults to humanized state name). */
+  label?: ReactNode;
+  /** Localizable strings. */
+  labels?: PresenceSyncIndicatorLabels;
+  /** Connection state. */
+  state: PresenceSyncState;
+  /** Optional secondary line (peer count, latency). */
+  status?: ReactNode;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * Compact pill that surfaces live connection + sync health for the
+ * canvas. Stays calm: a single dot + one-line label, with a subtle
+ * pulse for transient `syncing` / `reconnecting` states.
+ *
+ * Pure presentation; the host owns the websocket / CRDT loop and maps
+ * its diagnostics into one of five canonical states.
+ *
+ * @example
+ * ```tsx
+ * <PresenceSyncIndicator state="live" status="3 peers" />
+ * <PresenceSyncIndicator state="reconnecting" status="retry 2/5" />
+ * ```
+ *
+ * @public
+ */
+export const PresenceSyncIndicator = forwardRef<
+  HTMLDivElement,
+  PresenceSyncIndicatorProps
+>((props, ref) => {
+  const { className, label, labels, state, status, ...rest } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const text = label ?? STATE_LABEL[state];
+  return (
+    <div
+      aria-label={`${resolvedLabels.region}: ${STATE_LABEL[state]}`}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-2 py-1 text-[11px] shadow-sm",
+        className,
+      )}
+      data-presence-state={state}
+      data-presence-sync
+      ref={ref}
+      role="status"
+      {...rest}
+    >
+      <span
+        aria-hidden="true"
+        className={cn("h-1.5 w-1.5 rounded-full", STATE_DOT[state])}
+        data-presence-sync-dot
+      />
+      <span className={cn("font-medium", STATE_TEXT[state])}>{text}</span>
+      {status ? (
+        <span
+          className="text-[10px] text-muted-foreground"
+          data-presence-sync-status
+        >
+          {status}
+        </span>
+      ) : null}
+    </div>
+  );
+});
+PresenceSyncIndicator.displayName = "PresenceSyncIndicator";

--- a/apps/registry/registry/default/pricing-table/pricing-table.tsx
+++ b/apps/registry/registry/default/pricing-table/pricing-table.tsx
@@ -1,2 +1,426 @@
-// Re-export from @vllnt/ui package
-export { PricingPlan, PricingTable } from '@vllnt/ui'
+"use client";
+
+import {
+  type ButtonHTMLAttributes,
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useState,
+} from "react";
+
+import { Check, X } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Button, type ButtonProps } from "@vllnt/ui";
+
+/**
+ * One row in a {@link PricingPlan}'s feature checklist.
+ *
+ * @public
+ */
+export type PricingFeature = {
+  /**
+   * When `true`, the row renders a check; when `false`, an X. Pass a string
+   * (e.g. `"5 users"`) to render the value as the limit indicator instead.
+   */
+  included: boolean | string;
+  /** Human-readable feature description. */
+  label: ReactNode;
+};
+
+/**
+ * Call-to-action descriptor for a {@link PricingPlan}.
+ *
+ * @public
+ */
+export type PricingPlanCta = {
+  /** Button label. */
+  label: ReactNode;
+  /** Click handler. */
+  onClick?: ButtonHTMLAttributes<HTMLButtonElement>["onClick"];
+  /** Underlying {@link Button} variant. Defaults to `"default"`. */
+  variant?: ButtonProps["variant"];
+};
+
+/**
+ * Props for {@link PricingPlan}.
+ *
+ * @public
+ */
+export type PricingPlanProps = {
+  /** Optional badge text shown on highlighted plans (e.g. "Most Popular"). */
+  badge?: ReactNode;
+  /** Bottom-row call-to-action descriptor. */
+  cta?: PricingPlanCta;
+  /** Sub-headline shown under the plan name. */
+  description?: ReactNode;
+  /** Feature checklist. */
+  features?: PricingFeature[];
+  /** When `true`, the plan renders with emphasis styling. */
+  highlighted?: boolean;
+  /** Plan name (e.g. "Free", "Pro"). */
+  name: ReactNode;
+  /** Suffix shown next to the price (e.g. "/month"). */
+  period?: ReactNode;
+  /** Headline price. */
+  price: ReactNode;
+} & Omit<ComponentPropsWithoutRef<"div">, "children">;
+
+function FeatureIndicator({
+  included,
+}: {
+  included: boolean | string;
+}): ReactNode {
+  if (typeof included === "string") {
+    return (
+      <span
+        aria-hidden="true"
+        className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-primary/15 text-[10px] font-semibold text-primary"
+      >
+        ✓
+      </span>
+    );
+  }
+  if (included) {
+    return (
+      <Check
+        aria-hidden="true"
+        className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+      />
+    );
+  }
+  return (
+    <X
+      aria-hidden="true"
+      className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground/60"
+    />
+  );
+}
+
+function FeatureRow({ feature }: { feature: PricingFeature }): ReactNode {
+  const { included, label } = feature;
+  const isLimit = typeof included === "string";
+  return (
+    <li className="flex items-start gap-2 text-sm">
+      <FeatureIndicator included={included} />
+      <span
+        className={cn(
+          "flex-1",
+          included === false && "text-muted-foreground line-through",
+        )}
+      >
+        {label}
+        {isLimit ? (
+          <span className="ml-1 text-muted-foreground">({included})</span>
+        ) : null}
+      </span>
+    </li>
+  );
+}
+
+function PlanBadgePill({
+  badge,
+  highlighted,
+}: {
+  badge: ReactNode;
+  highlighted: boolean;
+}): ReactNode {
+  return (
+    <span
+      className={cn(
+        "absolute -top-3 left-1/2 -translate-x-1/2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide",
+        highlighted
+          ? "bg-primary text-primary-foreground"
+          : "bg-muted text-muted-foreground",
+      )}
+    >
+      {badge}
+    </span>
+  );
+}
+
+function PlanHeader({
+  description,
+  name,
+}: {
+  description: ReactNode;
+  name: ReactNode;
+}): ReactNode {
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="text-lg font-semibold tracking-tight text-foreground">
+        {name}
+      </h3>
+      {description ? (
+        <p className="text-sm text-muted-foreground">{description}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function PlanPrice({
+  period,
+  price,
+}: {
+  period: ReactNode;
+  price: ReactNode;
+}): ReactNode {
+  return (
+    <div className="flex items-baseline gap-1">
+      <span className="text-3xl font-bold tracking-tight text-foreground">
+        {price}
+      </span>
+      {period ? (
+        <span className="text-sm text-muted-foreground">{period}</span>
+      ) : null}
+    </div>
+  );
+}
+
+function PlanFeatures({ features }: { features: PricingFeature[] }): ReactNode {
+  return (
+    <ul className="flex flex-col gap-2">
+      {features.map((feature, index) => (
+        <FeatureRow
+          feature={feature}
+          key={`${typeof feature.label === "string" ? feature.label : index.toString()}-${index.toString()}`}
+        />
+      ))}
+    </ul>
+  );
+}
+
+type PlanCtaProps = {
+  cta: PricingPlanCta;
+  highlighted: boolean;
+};
+
+function PlanCta({ cta, highlighted }: PlanCtaProps): ReactNode {
+  const { label, onClick: handleCtaClick, variant } = cta;
+  return (
+    <Button
+      className="mt-auto w-full"
+      onClick={handleCtaClick}
+      type="button"
+      variant={variant ?? (highlighted ? "default" : "outline")}
+    >
+      {label}
+    </Button>
+  );
+}
+
+/**
+ * Single plan column inside a {@link PricingTable}.
+ *
+ * @example
+ * ```tsx
+ * <PricingPlan
+ *   name="Pro"
+ *   price="$29"
+ *   period="/month"
+ *   highlighted
+ *   badge="Most Popular"
+ *   features={[
+ *     { label: "Unlimited projects", included: true },
+ *     { label: "Storage", included: "100 GB" },
+ *   ]}
+ *   cta={{ label: "Start trial", onClick: startTrial }}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const PricingPlan = forwardRef<HTMLDivElement, PricingPlanProps>(
+  (props, ref) => {
+    const {
+      badge,
+      className,
+      cta,
+      description,
+      features,
+      highlighted = false,
+      name,
+      period,
+      price,
+      ...rest
+    } = props;
+    return (
+      <div
+        className={cn(
+          "relative flex flex-col gap-6 rounded-2xl border bg-background p-6 shadow-sm transition-colors",
+          highlighted
+            ? "border-primary shadow-md ring-1 ring-primary/20"
+            : "border-border",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        {badge ? (
+          <PlanBadgePill badge={badge} highlighted={highlighted} />
+        ) : null}
+        <PlanHeader description={description} name={name} />
+        <PlanPrice period={period} price={price} />
+        {features && features.length > 0 ? (
+          <PlanFeatures features={features} />
+        ) : null}
+        {cta ? <PlanCta cta={cta} highlighted={highlighted} /> : null}
+      </div>
+    );
+  },
+);
+PricingPlan.displayName = "PricingPlan";
+
+/**
+ * Billing period for {@link PricingTable}'s built-in toggle.
+ *
+ * @public
+ */
+export type PricingPeriod = "annual" | "monthly";
+
+type PeriodLabels = {
+  annual?: ReactNode;
+  monthly?: ReactNode;
+  /** Optional caption shown next to the annual option (e.g. "Save 20%"). */
+  savings?: ReactNode;
+};
+
+/**
+ * Props for {@link PricingTable}.
+ *
+ * @public
+ */
+export type PricingTableProps = {
+  /** Period selected when uncontrolled. Defaults to `"monthly"`. */
+  defaultPeriod?: PricingPeriod;
+  /** Fires when the user changes the period (controlled or uncontrolled). */
+  onPeriodChange?: (period: PricingPeriod) => void;
+  /** Controlled value for the period toggle. */
+  period?: PricingPeriod;
+  /** Captions for the toggle. Defaults to `Monthly` / `Annual`. */
+  periodLabels?: PeriodLabels;
+  /** Set to `true` to render the built-in monthly/annual toggle. */
+  showPeriodToggle?: boolean;
+} & ComponentPropsWithoutRef<"div">;
+
+type PeriodToggleProps = {
+  labels: PeriodLabels;
+  onChange: (period: PricingPeriod) => void;
+  period: PricingPeriod;
+};
+
+function PeriodToggle({
+  labels,
+  onChange,
+  period,
+}: PeriodToggleProps): ReactNode {
+  const handleSelectMonthly = useCallback(() => {
+    onChange("monthly");
+  }, [onChange]);
+  const handleSelectAnnual = useCallback(() => {
+    onChange("annual");
+  }, [onChange]);
+
+  return (
+    <div
+      aria-label="Billing period"
+      className="mx-auto inline-flex items-center gap-2 rounded-full border bg-muted/40 p-1 text-sm"
+      role="radiogroup"
+    >
+      <button
+        aria-checked={period === "monthly"}
+        className={cn(
+          "rounded-full px-3 py-1 transition-colors",
+          period === "monthly"
+            ? "bg-background text-foreground shadow-sm"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+        onClick={handleSelectMonthly}
+        role="radio"
+        type="button"
+      >
+        {labels.monthly ?? "Monthly"}
+      </button>
+      <button
+        aria-checked={period === "annual"}
+        className={cn(
+          "inline-flex items-center gap-2 rounded-full px-3 py-1 transition-colors",
+          period === "annual"
+            ? "bg-background text-foreground shadow-sm"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+        onClick={handleSelectAnnual}
+        role="radio"
+        type="button"
+      >
+        {labels.annual ?? "Annual"}
+        {labels.savings ? (
+          <span className="rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+            {labels.savings}
+          </span>
+        ) : null}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Plan comparison container. Lays out child {@link PricingPlan} columns
+ * side-by-side on desktop and stacks them on mobile. Optionally renders a
+ * monthly/annual period toggle whose value flows through `onPeriodChange`.
+ *
+ * @example
+ * ```tsx
+ * const [period, setPeriod] = useState<PricingPeriod>("monthly")
+ *
+ * <PricingTable showPeriodToggle period={period} onPeriodChange={setPeriod}>
+ *   <PricingPlan name="Free" price="$0" period="/mo" cta={{ label: "Start" }} />
+ *   <PricingPlan name="Pro" price={period === "monthly" ? "$29" : "$24"} highlighted />
+ * </PricingTable>
+ * ```
+ *
+ * @public
+ */
+export const PricingTable = forwardRef<HTMLDivElement, PricingTableProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      defaultPeriod = "monthly",
+      onPeriodChange,
+      period: controlledPeriod,
+      periodLabels,
+      showPeriodToggle = false,
+      ...rest
+    } = props;
+
+    const [uncontrolledPeriod, setUncontrolledPeriod] =
+      useState<PricingPeriod>(defaultPeriod);
+    const period = controlledPeriod ?? uncontrolledPeriod;
+
+    const handlePeriodChange = useCallback(
+      (next: PricingPeriod) => {
+        if (controlledPeriod === undefined) setUncontrolledPeriod(next);
+        onPeriodChange?.(next);
+      },
+      [controlledPeriod, onPeriodChange],
+    );
+
+    return (
+      <div className={cn("flex flex-col gap-6", className)} ref={ref} {...rest}>
+        {showPeriodToggle ? (
+          <PeriodToggle
+            labels={periodLabels ?? {}}
+            onChange={handlePeriodChange}
+            period={period}
+          />
+        ) : null}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {children}
+        </div>
+      </div>
+    );
+  },
+);
+PricingTable.displayName = "PricingTable";

--- a/apps/registry/registry/default/primary-source-viewer/primary-source-viewer.tsx
+++ b/apps/registry/registry/default/primary-source-viewer/primary-source-viewer.tsx
@@ -1,19 +1,701 @@
-export {
-  type AnnotationColor,
-  type AnnotationRegion,
-  type PrimarySource,
-  PrimarySourceAnnotation,
-  type PrimarySourceAnnotationProps,
-  PrimarySourceAnnotations,
-  PrimarySourceContext,
-  PrimarySourceMetadata,
-  PrimarySourceQuestions,
-  PrimarySourceRotate,
-  PrimarySourceToolbar,
-  PrimarySourceTranscription,
-  PrimarySourceViewer,
-  type PrimarySourceViewerLabels,
-  type PrimarySourceViewerProps,
-  PrimarySourceZoomIn,
-  PrimarySourceZoomOut,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+const MIN_ZOOM = 0.25;
+const MAX_ZOOM = 8;
+const ZOOM_STEP = 1.25;
+const ROTATE_STEP = 90;
+
+/**
+ * Image source for {@link PrimarySourceViewer}.
+ *
+ * @public
+ */
+export type PrimarySource = {
+  /** Required alt text for assistive tech. */
+  alt: string;
+  /** Image URL. */
+  src: string;
+  /** Source kind. Image is the supported value today. */
+  type: "image";
+};
+
+/**
+ * Color theme for {@link PrimarySourceAnnotation}.
+ *
+ * @public
+ */
+export type AnnotationColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "purple"
+  | "red"
+  | "rose";
+
+const ANNOTATION_PALETTE: Record<
+  AnnotationColor,
+  { border: string; chip: string; fill: string }
+> = {
+  amber: {
+    border: "border-amber-500",
+    chip: "bg-amber-500/15 text-amber-700 dark:text-amber-300",
+    fill: "bg-amber-500/15",
+  },
+  blue: {
+    border: "border-blue-500",
+    chip: "bg-blue-500/15 text-blue-700 dark:text-blue-300",
+    fill: "bg-blue-500/15",
+  },
+  emerald: {
+    border: "border-emerald-500",
+    chip: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+    fill: "bg-emerald-500/15",
+  },
+  purple: {
+    border: "border-purple-500",
+    chip: "bg-purple-500/15 text-purple-700 dark:text-purple-300",
+    fill: "bg-purple-500/15",
+  },
+  red: {
+    border: "border-red-500",
+    chip: "bg-red-500/15 text-red-700 dark:text-red-300",
+    fill: "bg-red-500/15",
+  },
+  rose: {
+    border: "border-rose-500",
+    chip: "bg-rose-500/15 text-rose-700 dark:text-rose-300",
+    fill: "bg-rose-500/15",
+  },
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type PrimarySourceViewerLabels = {
+  /** Aria-label for the viewer region. Defaults to `"Primary source viewer"`. */
+  region?: string;
+  /** Aria-label for the rotate button. Defaults to `"Rotate"`. */
+  rotate?: string;
+  /** Aria-label for the zoom-in button. Defaults to `"Zoom in"`. */
+  zoomIn?: string;
+  /** Aria-label for the zoom-out button. Defaults to `"Zoom out"`. */
+  zoomOut?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Primary source viewer",
+  rotate: "Rotate",
+  zoomIn: "Zoom in",
+  zoomOut: "Zoom out",
+} as const satisfies Required<PrimarySourceViewerLabels>;
+
+type ViewerCtx = {
+  labels: Required<PrimarySourceViewerLabels>;
+  rotate: () => void;
+  rotation: number;
+  zoom: number;
+  zoomIn: () => void;
+  zoomOut: () => void;
+};
+
+const ViewerContext = createContext<null | ViewerCtx>(null);
+
+function useViewerContext(): ViewerCtx {
+  const ctx = useContext(ViewerContext);
+  if (!ctx) {
+    throw new Error("PrimarySourceViewer subcomponent used outside its root.");
+  }
+  return ctx;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function useViewerState(
+  resolvedLabels: Required<PrimarySourceViewerLabels>,
+): ViewerCtx {
+  const [zoom, setZoom] = useState(1);
+  const [rotation, setRotation] = useState(0);
+
+  const zoomIn = useCallback(() => {
+    setZoom((current) => clamp(current * ZOOM_STEP, MIN_ZOOM, MAX_ZOOM));
+  }, []);
+  const zoomOut = useCallback(() => {
+    setZoom((current) => clamp(current / ZOOM_STEP, MIN_ZOOM, MAX_ZOOM));
+  }, []);
+  const rotate = useCallback(() => {
+    setRotation((current) => (current + ROTATE_STEP) % 360);
+  }, []);
+
+  return useMemo(
+    () => ({
+      labels: resolvedLabels,
+      rotate,
+      rotation,
+      zoom,
+      zoomIn,
+      zoomOut,
+    }),
+    [resolvedLabels, rotate, rotation, zoom, zoomIn, zoomOut],
+  );
+}
+
+/**
+ * Toolbar slot. Render the zoom / rotate buttons as children.
+ *
+ * @public
+ */
+export const PrimarySourceToolbar = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ children, className, ...rest }, ref) => (
+  <div
+    className={cn(
+      "flex flex-wrap items-center gap-2 border-b border-border bg-muted/40 px-4 py-2",
+      className,
+    )}
+    ref={ref}
+    role="toolbar"
+    {...rest}
+  >
+    {children}
+  </div>
+));
+PrimarySourceToolbar.displayName = "PrimarySourceToolbar";
+
+type ToolbarButtonProps = {
+  ariaLabel: string;
+  glyph: ReactNode;
+  onActivate: () => void;
+} & Omit<ComponentPropsWithoutRef<"button">, "aria-label" | "onClick" | "type">;
+
+const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
+  ({ ariaLabel, className, glyph, onActivate, ...rest }, ref) => (
+    <button
+      aria-label={ariaLabel}
+      className={cn(
+        "inline-flex h-8 min-w-8 items-center justify-center rounded-md border border-border bg-background px-2 text-sm font-medium hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+      onClick={onActivate}
+      ref={ref}
+      type="button"
+      {...rest}
+    >
+      {glyph}
+    </button>
+  ),
+);
+ToolbarButton.displayName = "ToolbarButton";
+
+/**
+ * Zoom-in button.
+ *
+ * @public
+ */
+export const PrimarySourceZoomIn = forwardRef<
+  HTMLButtonElement,
+  Omit<ComponentPropsWithoutRef<"button">, "aria-label" | "onClick" | "type">
+>(({ ...rest }, ref) => {
+  const { labels, zoomIn } = useViewerContext();
+  return (
+    <ToolbarButton
+      ariaLabel={labels.zoomIn}
+      glyph="+"
+      onActivate={zoomIn}
+      ref={ref}
+      {...rest}
+    />
+  );
+});
+PrimarySourceZoomIn.displayName = "PrimarySourceZoomIn";
+
+/**
+ * Zoom-out button.
+ *
+ * @public
+ */
+export const PrimarySourceZoomOut = forwardRef<
+  HTMLButtonElement,
+  Omit<ComponentPropsWithoutRef<"button">, "aria-label" | "onClick" | "type">
+>(({ ...rest }, ref) => {
+  const { labels, zoomOut } = useViewerContext();
+  return (
+    <ToolbarButton
+      ariaLabel={labels.zoomOut}
+      glyph="−"
+      onActivate={zoomOut}
+      ref={ref}
+      {...rest}
+    />
+  );
+});
+PrimarySourceZoomOut.displayName = "PrimarySourceZoomOut";
+
+/**
+ * Rotate-90-degrees button.
+ *
+ * @public
+ */
+export const PrimarySourceRotate = forwardRef<
+  HTMLButtonElement,
+  Omit<ComponentPropsWithoutRef<"button">, "aria-label" | "onClick" | "type">
+>(({ ...rest }, ref) => {
+  const { labels, rotate } = useViewerContext();
+  return (
+    <ToolbarButton
+      ariaLabel={labels.rotate}
+      glyph="⟳"
+      onActivate={rotate}
+      ref={ref}
+      {...rest}
+    />
+  );
+});
+PrimarySourceRotate.displayName = "PrimarySourceRotate";
+
+/**
+ * Region in the source image, expressed as percentages of width / height.
+ *
+ * @public
+ */
+export type AnnotationRegion = {
+  /** Height as a percentage of the source height (0–100). */
+  height: number;
+  /** Width as a percentage of the source width (0–100). */
+  width: number;
+  /** X offset as a percentage of the source width (0–100). */
+  x: number;
+  /** Y offset as a percentage of the source height (0–100). */
+  y: number;
+};
+
+/**
+ * Props for {@link PrimarySourceAnnotation}.
+ *
+ * @public
+ */
+export type PrimarySourceAnnotationProps = {
+  /** Optional category label rendered as a chip in the tooltip. */
+  category?: ReactNode;
+  /** Color theme. Defaults to `"amber"`. */
+  color?: AnnotationColor;
+  /** Stable id. Defaults to a generated id. */
+  id?: string;
+  /** Note text rendered in the tooltip. */
+  note: ReactNode;
+  /** Highlighted region (percentages 0–100). */
+  region: AnnotationRegion;
+} & Omit<ComponentPropsWithoutRef<"button">, "id" | "type">;
+
+/**
+ * Container slot for the annotation overlay.
+ *
+ * @public
+ */
+export const PrimarySourceAnnotations = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ children, className, ...rest }, ref) => (
+  <div
+    aria-label="Annotations"
+    className={cn("pointer-events-none absolute inset-0 z-10", className)}
+    ref={ref}
+    {...rest}
+  >
+    {children}
+  </div>
+));
+PrimarySourceAnnotations.displayName = "PrimarySourceAnnotations";
+
+type AnnotationTooltipProps = {
+  category?: ReactNode;
+  color: AnnotationColor;
+  note: ReactNode;
+  tooltipId: string;
+};
+
+function AnnotationTooltip({
+  category,
+  color,
+  note,
+  tooltipId,
+}: AnnotationTooltipProps): ReactNode {
+  const palette = ANNOTATION_PALETTE[color];
+  return (
+    <span
+      className="pointer-events-none absolute left-0 top-full z-10 mt-1 hidden min-w-44 max-w-sm rounded-md border bg-popover px-2 py-1 text-left text-xs text-popover-foreground shadow-md group-hover:block group-focus-visible:block"
+      id={tooltipId}
+      role="tooltip"
+    >
+      {category ? (
+        <span
+          className={cn(
+            "mb-1 inline-block rounded px-1 text-[10px] font-medium uppercase tracking-wide",
+            palette.chip,
+          )}
+        >
+          {category}
+        </span>
+      ) : null}
+      <span className="block">{note}</span>
+    </span>
+  );
+}
+
+/**
+ * A single annotated region.
+ *
+ * @public
+ */
+export const PrimarySourceAnnotation = forwardRef<
+  HTMLButtonElement,
+  PrimarySourceAnnotationProps
+>((props, ref) => {
+  const {
+    category,
+    className,
+    color = "amber",
+    id,
+    note,
+    region,
+    ...rest
+  } = props;
+  const generatedId = useId();
+  const annotationId = id ?? generatedId;
+  const palette = ANNOTATION_PALETTE[color];
+  const tooltipId = `${annotationId}-tooltip`;
+  const noteText = typeof note === "string" ? note : "Annotation";
+  return (
+    <button
+      aria-describedby={tooltipId}
+      aria-label={noteText}
+      className={cn(
+        "group pointer-events-auto absolute rounded-md border-2 outline-none transition-colors hover:bg-foreground/10 focus-visible:bg-foreground/10",
+        palette.border,
+        palette.fill,
+        className,
+      )}
+      data-annotation-id={annotationId}
+      ref={ref}
+      style={{
+        height: `${region.height.toString()}%`,
+        left: `${region.x.toString()}%`,
+        top: `${region.y.toString()}%`,
+        width: `${region.width.toString()}%`,
+      }}
+      type="button"
+      {...rest}
+    >
+      <AnnotationTooltip
+        category={category}
+        color={color}
+        note={note}
+        tooltipId={tooltipId}
+      />
+    </button>
+  );
+});
+PrimarySourceAnnotation.displayName = "PrimarySourceAnnotation";
+
+/**
+ * Side panel for transcription text.
+ *
+ * @public
+ */
+export const PrimarySourceTranscription = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"aside">
+>(({ children, className, ...rest }, ref) => (
+  <aside
+    aria-label="Transcription"
+    className={cn(
+      "flex h-full flex-col gap-2 border-l border-border bg-background p-4 text-sm leading-relaxed",
+      className,
+    )}
+    ref={ref}
+    {...rest}
+  >
+    <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+      Transcription
+    </h3>
+    <div className="space-y-2 text-foreground">{children}</div>
+  </aside>
+));
+PrimarySourceTranscription.displayName = "PrimarySourceTranscription";
+
+/**
+ * Wrapper for metadata + discussion-questions slots beneath the viewer.
+ *
+ * @public
+ */
+export const PrimarySourceContext = forwardRef<
+  HTMLElement,
+  ComponentPropsWithoutRef<"footer">
+>(({ children, className, ...rest }, ref) => (
+  <footer
+    className={cn(
+      "grid gap-6 border-t border-border bg-muted/30 p-4 md:grid-cols-2",
+      className,
+    )}
+    ref={ref}
+    {...rest}
+  >
+    {children}
+  </footer>
+));
+PrimarySourceContext.displayName = "PrimarySourceContext";
+
+/**
+ * Metadata block. Wrap any markup; pair `<dt>` and `<dd>` for traditional
+ * key/value rows.
+ *
+ * @public
+ */
+export const PrimarySourceMetadata = forwardRef<
+  HTMLDListElement,
+  ComponentPropsWithoutRef<"dl">
+>(({ children, className, ...rest }, ref) => (
+  <dl
+    aria-label="Metadata"
+    className={cn(
+      "grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-sm",
+      className,
+    )}
+    ref={ref}
+    {...rest}
+  >
+    {children}
+  </dl>
+));
+PrimarySourceMetadata.displayName = "PrimarySourceMetadata";
+
+/**
+ * Discussion-questions block.
+ *
+ * @public
+ */
+export const PrimarySourceQuestions = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ children, className, ...rest }, ref) => (
+  <div
+    aria-label="Discussion questions"
+    className={cn("space-y-2 text-sm", className)}
+    ref={ref}
+    {...rest}
+  >
+    <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+      Discussion questions
+    </h3>
+    <div className="space-y-1 text-foreground">{children}</div>
+  </div>
+));
+PrimarySourceQuestions.displayName = "PrimarySourceQuestions";
+
+type ChildBuckets = {
+  annotations: ReactNode;
+  context: ReactNode;
+  toolbar: ReactNode;
+  transcription: ReactNode;
+};
+
+const SLOT_DISPLAY_NAMES = {
+  annotations: PrimarySourceAnnotations.displayName,
+  context: PrimarySourceContext.displayName,
+  toolbar: PrimarySourceToolbar.displayName,
+  transcription: PrimarySourceTranscription.displayName,
+} as const;
+
+type SlotKey = keyof ChildBuckets;
+
+const SLOT_KEY_BY_NAME: Record<string, SlotKey> = {
+  [SLOT_DISPLAY_NAMES.annotations]: "annotations",
+  [SLOT_DISPLAY_NAMES.context]: "context",
+  [SLOT_DISPLAY_NAMES.toolbar]: "toolbar",
+  [SLOT_DISPLAY_NAMES.transcription]: "transcription",
+};
+
+function bucketChildren(children: ReactNode): ChildBuckets {
+  const list: ReactNode[] = Array.isArray(children) ? children : [children];
+  return list.reduce<ChildBuckets>(
+    (accumulator, child) => {
+      const name = displayName(child);
+      if (!name) return accumulator;
+      const key = SLOT_KEY_BY_NAME[name];
+      if (!key) return accumulator;
+      accumulator[key] = child;
+      return accumulator;
+    },
+    { annotations: null, context: null, toolbar: null, transcription: null },
+  );
+}
+
+function displayName(child: ReactNode): string | undefined {
+  if (typeof child !== "object" || child === null) return undefined;
+  if (!("type" in child)) return undefined;
+  const type = (child as { type: unknown }).type;
+  if (typeof type !== "object" && typeof type !== "function") return undefined;
+  const name = (type as { displayName?: unknown }).displayName;
+  return typeof name === "string" ? name : undefined;
+}
+
+type StageProps = {
+  annotations: ReactNode;
+  source: PrimarySource;
+};
+
+function Stage({ annotations, source }: StageProps): ReactNode {
+  const { rotation, zoom } = useViewerContext();
+  return (
+    <div
+      className="relative h-full w-full overflow-auto bg-muted"
+      data-rotation={rotation}
+      data-zoom={zoom}
+    >
+      <div
+        className="relative inline-block"
+        style={{
+          transform: `rotate(${rotation.toString()}deg) scale(${zoom.toString()})`,
+          transformOrigin: "top left",
+        }}
+      >
+        <img
+          alt={source.alt}
+          className="block h-auto max-w-none select-none"
+          draggable={false}
+          loading="lazy"
+          src={source.src}
+        />
+        {annotations}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Props for {@link PrimarySourceViewer}.
+ *
+ * @public
+ */
+export type PrimarySourceViewerProps = {
+  /** Localizable strings. */
+  labels?: PrimarySourceViewerLabels;
+  /** Geographic origin (e.g. `"England"`). */
+  origin?: ReactNode;
+  /** Historical period (e.g. `"Medieval"`). */
+  period?: ReactNode;
+  /** Image source. */
+  source: PrimarySource;
+  /** Document title. */
+  title: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+/**
+ * Document viewer for historical primary sources. Renders an image
+ * viewer with button-driven zoom + rotate, region-based annotation
+ * overlay, an optional transcription side panel, and a footer slot for
+ * metadata and discussion questions.
+ *
+ * @example
+ * ```tsx
+ * <PrimarySourceViewer
+ *   title="Magna Carta (1215)"
+ *   period="Medieval"
+ *   origin="England"
+ *   source={{ type: "image", src: "/magna-carta.jpg", alt: "Magna Carta manuscript" }}
+ * >
+ *   <PrimarySourceToolbar>
+ *     <PrimarySourceZoomIn />
+ *     <PrimarySourceZoomOut />
+ *     <PrimarySourceRotate />
+ *   </PrimarySourceToolbar>
+ *   <PrimarySourceAnnotations>
+ *     <PrimarySourceAnnotation
+ *       region={{ x: 12, y: 8, width: 22, height: 6 }}
+ *       category="Artifact"
+ *       note="Royal seal of King John"
+ *     />
+ *   </PrimarySourceAnnotations>
+ * </PrimarySourceViewer>
+ * ```
+ *
+ * @public
+ */
+export const PrimarySourceViewer = forwardRef<
+  HTMLElement,
+  PrimarySourceViewerProps
+>((props, ref) => {
+  const {
+    children,
+    className,
+    labels,
+    origin,
+    period,
+    source,
+    title,
+    ...rest
+  } = props;
+  const titleId = useId();
+
+  const resolvedLabels = useMemo(
+    () => ({ ...DEFAULT_LABELS, ...labels }),
+    [labels],
+  );
+
+  const ctx = useViewerState(resolvedLabels);
+  const buckets = useMemo(() => bucketChildren(children), [children]);
+
+  return (
+    <ViewerContext.Provider value={ctx}>
+      <section
+        aria-labelledby={titleId}
+        className={cn(
+          "flex w-full flex-col overflow-hidden rounded-2xl border bg-background text-foreground",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <header className="flex flex-col gap-1 border-b border-border px-4 py-3">
+          <h2 className="text-lg font-semibold tracking-tight" id={titleId}>
+            {title}
+          </h2>
+          {period || origin ? (
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+              {period}
+              {period && origin ? " · " : null}
+              {origin}
+            </p>
+          ) : null}
+        </header>
+        {buckets.toolbar}
+        <div className="grid gap-0 md:grid-cols-[2fr_1fr]">
+          <div className="relative h-[420px] md:h-[520px]">
+            <Stage annotations={buckets.annotations} source={source} />
+          </div>
+          {buckets.transcription}
+        </div>
+        {buckets.context}
+      </section>
+    </ViewerContext.Provider>
+  );
+});
+PrimarySourceViewer.displayName = "PrimarySourceViewer";

--- a/apps/registry/registry/default/pro-tip/pro-tip.tsx
+++ b/apps/registry/registry/default/pro-tip/pro-tip.tsx
@@ -1,61 +1,81 @@
-import type { ReactNode } from 'react'
+import type { ReactNode } from "react";
 
-import { cn } from '../../../lib/utils'
+import { cn } from "@vllnt/ui";
 
-export type ProTipVariant = 'advanced' | 'best-practice' | 'expert' | 'gotcha' | 'performance' | 'tip'
+export type ProTipVariant =
+  | "advanced"
+  | "best-practice"
+  | "expert"
+  | "gotcha"
+  | "performance"
+  | "tip";
 
 export type ProTipProps = {
-  children: ReactNode
-  className?: string
-  icon?: ReactNode
-  title?: string
-  variant?: ProTipVariant
-}
+  children: ReactNode;
+  className?: string;
+  icon?: ReactNode;
+  title?: string;
+  variant?: ProTipVariant;
+};
 
-const variantStyles: Record<ProTipVariant, { className: string; defaultTitle: string }> = {
+const variantStyles: Record<
+  ProTipVariant,
+  { className: string; defaultTitle: string }
+> = {
   advanced: {
-    className: 'border-purple-500/50 bg-purple-500/10 text-purple-700 dark:text-purple-300',
-    defaultTitle: 'Advanced',
+    className:
+      "border-purple-500/50 bg-purple-500/10 text-purple-700 dark:text-purple-300",
+    defaultTitle: "Advanced",
   },
-  'best-practice': {
-    className: 'border-blue-500/50 bg-blue-500/10 text-blue-700 dark:text-blue-300',
-    defaultTitle: 'Best Practice',
+  "best-practice": {
+    className:
+      "border-blue-500/50 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+    defaultTitle: "Best Practice",
   },
   expert: {
-    className: 'border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-300',
-    defaultTitle: 'Expert Tip',
+    className:
+      "border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+    defaultTitle: "Expert Tip",
   },
   gotcha: {
-    className: 'border-red-500/50 bg-red-500/10 text-red-700 dark:text-red-300',
-    defaultTitle: 'Common Gotcha',
+    className: "border-red-500/50 bg-red-500/10 text-red-700 dark:text-red-300",
+    defaultTitle: "Common Gotcha",
   },
   performance: {
-    className: 'border-green-500/50 bg-green-500/10 text-green-700 dark:text-green-300',
-    defaultTitle: 'Performance',
+    className:
+      "border-green-500/50 bg-green-500/10 text-green-700 dark:text-green-300",
+    defaultTitle: "Performance",
   },
   tip: {
-    className: 'border-primary/50 bg-primary/10 text-primary',
-    defaultTitle: 'Pro Tip',
+    className: "border-primary/50 bg-primary/10 text-primary",
+    defaultTitle: "Pro Tip",
   },
-}
+};
 
 export function ProTip({
   children,
   className,
   icon,
   title,
-  variant = 'tip',
+  variant = "tip",
 }: ProTipProps): React.ReactNode {
-  const config = variantStyles[variant]
+  const config = variantStyles[variant];
 
   return (
-    <div className={cn('my-6 rounded-lg border p-4', config.className, className)}>
+    <div
+      className={cn("my-6 rounded-lg border p-4", config.className, className)}
+    >
       <div className="flex items-start gap-3">
         <div className="flex h-8 w-8 items-center justify-center rounded-full bg-current/10 flex-shrink-0">
           {icon ? (
             <span className="h-4 w-4">{icon}</span>
           ) : (
-            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
               <path
                 d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
                 strokeLinecap="round"
@@ -66,37 +86,47 @@ export function ProTip({
           )}
         </div>
         <div className="flex-1 min-w-0">
-          <p className="font-semibold text-sm mb-1">{title || config.defaultTitle}</p>
+          <p className="font-semibold text-sm mb-1">
+            {title || config.defaultTitle}
+          </p>
           <div className="text-sm [&>p]:mb-0 opacity-90">{children}</div>
         </div>
       </div>
     </div>
-  )
+  );
 }
 
 export type CommonMistakeProps = {
-  children: ReactNode
-  className?: string
-  fix?: ReactNode
-  fixIcon?: ReactNode
-  icon?: ReactNode
-  title?: string
-}
+  children: ReactNode;
+  className?: string;
+  fix?: ReactNode;
+  fixIcon?: ReactNode;
+  icon?: ReactNode;
+  title?: string;
+};
 
+// eslint-disable-next-line max-lines-per-function -- Complex component with conditional fix section
 export function CommonMistake({
   children,
   className,
   fix,
   fixIcon,
   icon,
-  title = 'Common Mistake',
+  title = "Common Mistake",
 }: CommonMistakeProps): React.ReactNode {
   return (
-    <div className={cn('my-6 rounded-lg border border-red-500/50 bg-red-500/5 overflow-hidden', className)}>
+    <div
+      className={cn(
+        "my-6 rounded-lg border border-red-500/50 bg-red-500/5 overflow-hidden",
+        className,
+      )}
+    >
       <div className="p-4">
         <div className="flex items-start gap-3">
           {icon ? (
-            <span className="h-5 w-5 text-red-500 flex-shrink-0 mt-0.5">{icon}</span>
+            <span className="h-5 w-5 text-red-500 flex-shrink-0 mt-0.5">
+              {icon}
+            </span>
           ) : (
             <svg
               className="h-5 w-5 text-red-500 flex-shrink-0 mt-0.5"
@@ -113,8 +143,12 @@ export function CommonMistake({
             </svg>
           )}
           <div className="flex-1 min-w-0">
-            <p className="font-semibold text-sm text-red-700 dark:text-red-300 mb-1">{title}</p>
-            <div className="text-sm text-muted-foreground [&>p]:mb-0">{children}</div>
+            <p className="font-semibold text-sm text-red-700 dark:text-red-300 mb-1">
+              {title}
+            </p>
+            <div className="text-sm text-muted-foreground [&>p]:mb-0">
+              {children}
+            </div>
           </div>
         </div>
       </div>
@@ -122,7 +156,9 @@ export function CommonMistake({
         <div className="border-t border-red-500/30 bg-green-500/5 p-4">
           <div className="flex items-start gap-3">
             {fixIcon ? (
-              <span className="h-5 w-5 text-green-500 flex-shrink-0 mt-0.5">{fixIcon}</span>
+              <span className="h-5 w-5 text-green-500 flex-shrink-0 mt-0.5">
+                {fixIcon}
+              </span>
             ) : (
               <svg
                 className="h-5 w-5 text-green-500 flex-shrink-0 mt-0.5"
@@ -139,12 +175,16 @@ export function CommonMistake({
               </svg>
             )}
             <div className="flex-1 min-w-0">
-              <p className="font-semibold text-sm text-green-700 dark:text-green-300 mb-1">The Fix</p>
-              <div className="text-sm text-muted-foreground [&>p]:mb-0">{fix}</div>
+              <p className="font-semibold text-sm text-green-700 dark:text-green-300 mb-1">
+                The Fix
+              </p>
+              <div className="text-sm text-muted-foreground [&>p]:mb-0">
+                {fix}
+              </div>
             </div>
           </div>
         </div>
       ) : null}
     </div>
-  )
+  );
 }

--- a/apps/registry/registry/default/profile-section/profile-section.tsx
+++ b/apps/registry/registry/default/profile-section/profile-section.tsx
@@ -1,4 +1,80 @@
-// Re-export from @vllnt/ui package
-export { ProfileSection } from '@vllnt/ui'
+import Image from "next/image";
+import Link from "next/link";
 
+import { Button } from "@vllnt/ui";
 
+type ProfileDict = {
+  profile: {
+    name: string;
+    tagline: string;
+  };
+};
+
+type SocialLink = {
+  href: string;
+  label: string;
+};
+
+type ProfileSectionProps = {
+  compact?: boolean;
+  dict: ProfileDict;
+  imageAlt?: string;
+  imageSource?: string;
+  socialLinks?: SocialLink[];
+};
+
+export function ProfileSection({
+  compact = false,
+  dict,
+  imageAlt,
+  imageSource = "/profile.png",
+  socialLinks,
+}: ProfileSectionProps) {
+  const displayImageAlt = imageAlt ?? `${dict.profile.name} Profile`;
+  const showImage = !compact && Boolean(imageSource);
+  const showSocialLinks =
+    !compact && Boolean(socialLinks && socialLinks.length > 0);
+
+  return (
+    <div className="text-center space-y-4">
+      {showImage ? (
+        <div className="relative w-24 h-24 mx-auto overflow-hidden rounded-md">
+          <Image
+            alt={displayImageAlt}
+            className="w-full h-full object-cover rounded-md"
+            height={96}
+            priority={true}
+            src={imageSource}
+            width={96}
+          />
+        </div>
+      ) : null}
+
+      <div className="space-y-2">
+        <h3 className={`font-semibold ${compact ? "text-lg" : "text-xl"}`}>
+          {dict.profile.name}
+        </h3>
+        <p className="text-sm text-muted-foreground">
+          {compact ? dict.profile.tagline : `> ${dict.profile.tagline}`}
+        </p>
+      </div>
+
+      {showSocialLinks ? (
+        <div className="flex flex-wrap justify-center items-center gap-2">
+          {socialLinks?.map((link) => (
+            <Link
+              href={link.href}
+              key={link.href}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <Button className="w-32" size="sm" variant="outline">
+                {link.label}
+              </Button>
+            </Link>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/registry/registry/default/progress-bar/progress-bar.tsx
+++ b/apps/registry/registry/default/progress-bar/progress-bar.tsx
@@ -1,15 +1,15 @@
-import { cn } from '../../../lib/utils'
+import { cn } from "@vllnt/ui";
 
 export type ProgressBarProps = {
-  className?: string
-  completedLabel?: string
-  currentLabel?: string
-  isComplete?: boolean
-  isLoading?: boolean
-  max: number
-  showLabels?: boolean
-  value: number
-}
+  className?: string;
+  completedLabel?: string;
+  currentLabel?: string;
+  isComplete?: boolean;
+  isLoading?: boolean;
+  max: number;
+  showLabels?: boolean;
+  value: number;
+};
 
 export function ProgressBar({
   className,
@@ -21,15 +21,15 @@ export function ProgressBar({
   showLabels = true,
   value,
 }: ProgressBarProps): React.ReactNode {
-  const percent = max > 0 ? Math.round((value / max) * 100) : 0
+  const percent = max > 0 ? Math.round((value / max) * 100) : 0;
 
   return (
     <div
       className={cn(
-        'border rounded-lg p-4 transition-colors',
-        isLoading && 'border-border bg-muted/30',
-        !isLoading && isComplete && 'border-green-500/50 bg-green-500/5',
-        !isLoading && !isComplete && 'border-border bg-muted/30',
+        "border rounded-lg p-4 transition-colors",
+        isLoading && "border-border bg-muted/30",
+        !isLoading && isComplete && "border-green-500/50 bg-green-500/5",
+        !isLoading && !isComplete && "border-border bg-muted/30",
         className,
       )}
     >
@@ -43,10 +43,10 @@ export function ProgressBar({
           ) : (
             <>
               <span className="text-sm font-medium leading-5">
-                {currentLabel ?? (isComplete ? 'Complete' : 'Progress')}
+                {currentLabel ?? (isComplete ? "Complete" : "Progress")}
               </span>
               <span className="text-sm text-muted-foreground leading-5">
-                {value} / {max} {completedLabel ?? ''}
+                {value} / {max} {completedLabel ?? ""}
               </span>
             </>
           )}
@@ -55,14 +55,14 @@ export function ProgressBar({
       <div className="h-2 bg-muted rounded-full overflow-hidden">
         <div
           className={cn(
-            'h-full transition-all duration-300',
-            isLoading && 'w-0',
-            !isLoading && isComplete && 'bg-green-500',
-            !isLoading && !isComplete && 'bg-primary',
+            "h-full transition-all duration-300",
+            isLoading && "w-0",
+            !isLoading && isComplete && "bg-green-500",
+            !isLoading && !isComplete && "bg-primary",
           )}
           style={isLoading ? undefined : { width: `${percent}%` }}
         />
       </div>
     </div>
-  )
+  );
 }

--- a/apps/registry/registry/default/progress-card/progress-card.tsx
+++ b/apps/registry/registry/default/progress-card/progress-card.tsx
@@ -1,2 +1,145 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { memo, useEffect, useState } from "react";
+
+import type { ReactNode } from "react";
+
+import { useMounted } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@vllnt/ui";
+
+export type ContentCardProgress = {
+  completedCount: number;
+  totalSections: number;
+};
+
+export type ContentCardProps = {
+  /** Badge label for difficulty/category */
+  badgeLabel: string;
+  /** Badge variant */
+  badgeVariant?: "default" | "destructive" | "outline" | "secondary";
+  /** Card description */
+  description: string;
+  /** Function to get progress from storage */
+  getProgress?: () => ContentCardProgress | null;
+  /** Href for the card link */
+  href: string;
+  /** Link component to use (e.g., Next.js Link) */
+  linkComponent?: React.ComponentType<{
+    children: ReactNode;
+    className?: string;
+    href: string;
+  }>;
+  /** Metadata items (e.g., "30 min", "10 sections") */
+  metadata?: string[];
+  /** Progress completed label (e.g., "completed") */
+  progressLabel?: string;
+  /** Tags to display */
+  tags?: string[];
+  /** Card title */
+  title: string;
+};
+
+function DefaultLink({
+  children,
+  className,
+  href,
+}: {
+  children: ReactNode;
+  className?: string;
+  href: string;
+}): React.ReactNode {
+  return (
+    <a className={className} href={href}>
+      {children}
+    </a>
+  );
+}
+
+function ContentCardImpl({
+  badgeLabel,
+  badgeVariant = "default",
+  description,
+  getProgress,
+  href,
+  linkComponent: LinkComponent = DefaultLink,
+  metadata = [],
+  progressLabel = "completed",
+  tags = [],
+  title,
+}: ContentCardProps): React.ReactNode {
+  const [progress, setProgress] = useState<ContentCardProgress | null>(null);
+  const isHydrated = useMounted();
+
+  // Load progress after hydration
+  useEffect(() => {
+    if (getProgress) {
+      const result = getProgress();
+      requestAnimationFrame(() => {
+        setProgress(result);
+      });
+    }
+  }, [getProgress]);
+
+  const showProgress = isHydrated && progress && progress.completedCount > 0;
+
+  return (
+    <LinkComponent className="block h-full" href={href}>
+      <Card className="h-full flex flex-col hover:shadow-lg transition-shadow cursor-pointer">
+        <CardHeader>
+          {/* Badge and progress */}
+          <div className="flex items-center gap-2 mb-2">
+            <Badge className="text-xs capitalize" variant={badgeVariant}>
+              {badgeLabel}
+            </Badge>
+            {showProgress ? (
+              <span className="text-xs text-muted-foreground">
+                {progress.completedCount}/{progress.totalSections}{" "}
+                {progressLabel}
+              </span>
+            ) : null}
+          </div>
+
+          <CardTitle className="line-clamp-2 text-lg">{title}</CardTitle>
+          <CardDescription className="line-clamp-3">
+            {description}
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent className="mt-auto space-y-2">
+          {/* Metadata */}
+          {metadata.length > 0 ? (
+            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+              {metadata.map((item, index) => (
+                <span key={index}>
+                  {index > 0 ? <span className="mr-2">•</span> : null}
+                  {item}
+                </span>
+              ))}
+            </div>
+          ) : null}
+
+          {/* Tags */}
+          {tags.length > 0 ? (
+            <div className="flex flex-wrap gap-1">
+              {tags.map((tag) => (
+                <Badge className="text-xs" key={tag} variant="outline">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+    </LinkComponent>
+  );
+}
+
+export const ContentCard = memo(ContentCardImpl);
+ContentCard.displayName = "ContentCard";

--- a/apps/registry/registry/default/prompt-templates/prompt-templates.tsx
+++ b/apps/registry/registry/default/prompt-templates/prompt-templates.tsx
@@ -1,2 +1,631 @@
-// Re-export from @vllnt/ui package
-export { PromptTemplates } from '@vllnt/ui'
+"use client";
+
+import {
+  type ChangeEvent,
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useCallback,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+
+import { Search, Sparkles } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import { Input } from "@vllnt/ui";
+
+const VARIABLE_PATTERN = /{{\s*([\w-]+)\s*}}/g;
+const ALL_CATEGORY_VALUE = "__all__";
+
+/**
+ * One prompt template entry.
+ *
+ * @public
+ */
+export type PromptTemplate = {
+  /** Optional category (matched against {@link PromptTemplateCategory.name}). */
+  category?: string;
+  /** Sub-headline shown under the title. */
+  description?: ReactNode;
+  /** Stable identifier. */
+  id: string;
+  /**
+   * Raw template body with `{{variable}}` placeholders. Placeholders are
+   * detected automatically; the explicit `variables` array overrides
+   * detection (useful when the same placeholder appears more than once).
+   */
+  template: string;
+  /** Display title. */
+  title: ReactNode;
+  /** Override for detected variable names. */
+  variables?: string[];
+};
+
+/**
+ * Category chip for filtering.
+ *
+ * @public
+ */
+export type PromptTemplateCategory = {
+  /** Optional icon rendered next to the name. */
+  icon?: ReactNode;
+  /** Category display name (matched against {@link PromptTemplate.category}). */
+  name: string;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type PromptTemplatesLabels = {
+  /** Caption for the all-categories chip. Defaults to `"All"`. */
+  allCategory?: string;
+  /** Caption for the cancel button on the variable form. Defaults to `"Cancel"`. */
+  cancel?: string;
+  /** Empty-state heading when no templates match. Defaults to `"No prompts found."`. */
+  empty?: string;
+  /** Caption for the use button when filling in variables. Defaults to `"Insert"`. */
+  insert?: string;
+  /** Search input placeholder. Defaults to `"Search prompts…"`. */
+  searchPlaceholder?: string;
+  /** Caption for the use button on a card. Defaults to `"Use template"`. */
+  use?: string;
+  /** Caption above the variable form. Defaults to `"Fill in the placeholders"`. */
+  variablesHeading?: string;
+};
+
+const DEFAULT_LABELS = {
+  allCategory: "All",
+  cancel: "Cancel",
+  empty: "No prompts found.",
+  insert: "Insert",
+  searchPlaceholder: "Search prompts…",
+  use: "Use template",
+  variablesHeading: "Fill in the placeholders",
+} as const satisfies Required<PromptTemplatesLabels>;
+
+/**
+ * Props for {@link PromptTemplates}.
+ *
+ * @public
+ */
+export type PromptTemplatesProps = {
+  /** Optional list of categories to render as filter chips. */
+  categories?: PromptTemplateCategory[];
+  /** Localizable strings. */
+  labels?: PromptTemplatesLabels;
+  /**
+   * Fires with the resolved template body. When the template has variables,
+   * the user fills them in first; otherwise this fires on click.
+   */
+  onSelect?: (resolved: string, template: PromptTemplate) => void;
+  /** The template list. */
+  templates: PromptTemplate[];
+} & ComponentPropsWithoutRef<"section">;
+
+function detectVariables(template: PromptTemplate): string[] {
+  if (template.variables) return template.variables;
+  const matches = [...template.template.matchAll(VARIABLE_PATTERN)];
+  const seen = new Set<string>();
+  return matches.reduce<string[]>((accumulator, match) => {
+    const name = match[1];
+    if (name && !seen.has(name)) {
+      seen.add(name);
+      accumulator.push(name);
+    }
+    return accumulator;
+  }, []);
+}
+
+function fillTemplate(
+  template: string,
+  values: Record<string, string>,
+): string {
+  return template.replaceAll(
+    VARIABLE_PATTERN,
+    (_match: string, name: string) => values[name] ?? `{{${name}}}`,
+  );
+}
+
+function matchesCategory(template: PromptTemplate, selected: string): boolean {
+  if (selected === ALL_CATEGORY_VALUE) return true;
+  return template.category === selected;
+}
+
+function matchesQuery(template: PromptTemplate, query: string): boolean {
+  if (!query) return true;
+  const lowered = query.toLowerCase();
+  const title =
+    typeof template.title === "string" ? template.title.toLowerCase() : "";
+  const description =
+    typeof template.description === "string"
+      ? template.description.toLowerCase()
+      : "";
+  return title.includes(lowered) || description.includes(lowered);
+}
+
+type FilterBarProps = {
+  categories: PromptTemplateCategory[];
+  labels: Required<PromptTemplatesLabels>;
+  onCategoryChange: (value: string) => void;
+  onQueryChange: (value: string) => void;
+  query: string;
+  searchId: string;
+  selectedCategory: string;
+};
+
+function FilterBar({
+  categories,
+  labels,
+  onCategoryChange,
+  onQueryChange,
+  query,
+  searchId,
+  selectedCategory,
+}: FilterBarProps): ReactNode {
+  const handleSearch = (event: ChangeEvent<HTMLInputElement>): void => {
+    onQueryChange(event.target.value);
+  };
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="relative">
+        <Search
+          aria-hidden="true"
+          className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          aria-label={labels.searchPlaceholder}
+          className="pl-9"
+          id={searchId}
+          onChange={handleSearch}
+          placeholder={labels.searchPlaceholder}
+          type="search"
+          value={query}
+        />
+      </div>
+      {categories.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5" role="tablist">
+          <CategoryChip
+            active={selectedCategory === ALL_CATEGORY_VALUE}
+            label={labels.allCategory}
+            onClick={() => {
+              onCategoryChange(ALL_CATEGORY_VALUE);
+            }}
+            value={ALL_CATEGORY_VALUE}
+          />
+          {categories.map((category) => (
+            <CategoryChip
+              active={selectedCategory === category.name}
+              icon={category.icon}
+              key={category.name}
+              label={category.name}
+              onClick={() => {
+                onCategoryChange(category.name);
+              }}
+              value={category.name}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+type CategoryChipProps = {
+  active: boolean;
+  icon?: ReactNode;
+  label: string;
+  onClick: () => void;
+  value: string;
+};
+
+function CategoryChip({
+  active,
+  icon,
+  label,
+  onClick,
+  value,
+}: CategoryChipProps): ReactNode {
+  return (
+    <button
+      aria-selected={active}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        active
+          ? "border-primary bg-primary text-primary-foreground"
+          : "border-border bg-background text-foreground hover:bg-accent",
+      )}
+      data-value={value}
+      onClick={onClick}
+      role="tab"
+      type="button"
+    >
+      {icon ? (
+        <span aria-hidden="true" className="[&>svg]:h-3.5 [&>svg]:w-3.5">
+          {icon}
+        </span>
+      ) : null}
+      {label}
+    </button>
+  );
+}
+
+type CardProps = {
+  active: boolean;
+  labels: Required<PromptTemplatesLabels>;
+  onActivate: (template: PromptTemplate) => void;
+  onCancel: () => void;
+  onResolve: (resolved: string, template: PromptTemplate) => void;
+  onValueChange: (name: string, value: string) => void;
+  template: PromptTemplate;
+  values: Record<string, string>;
+};
+
+type CardHeaderProps = {
+  category?: string;
+  description?: ReactNode;
+  title: ReactNode;
+};
+
+function CardHeader({
+  category,
+  description,
+  title,
+}: CardHeaderProps): ReactNode {
+  return (
+    <header className="flex flex-col gap-1">
+      <h4 className="text-sm font-semibold tracking-tight text-foreground">
+        {title}
+      </h4>
+      {description ? (
+        <p className="text-xs text-muted-foreground">{description}</p>
+      ) : null}
+      {category ? (
+        <Badge className="self-start" variant="outline">
+          {category}
+        </Badge>
+      ) : null}
+    </header>
+  );
+}
+
+type CardActionsProps = {
+  onUse: () => void;
+  useLabel: string;
+  variableCount: number;
+};
+
+function CardActions({
+  onUse,
+  useLabel,
+  variableCount,
+}: CardActionsProps): ReactNode {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      {variableCount > 0 ? (
+        <span className="text-xs text-muted-foreground">
+          {variableCount.toString()} variable{variableCount === 1 ? "" : "s"}
+        </span>
+      ) : (
+        <span aria-hidden="true" />
+      )}
+      <Button
+        onClick={onUse}
+        size="sm"
+        type="button"
+        variant={variableCount > 0 ? "outline" : "default"}
+      >
+        <Sparkles aria-hidden="true" className="mr-2 h-3.5 w-3.5" />
+        {useLabel}
+      </Button>
+    </div>
+  );
+}
+
+function PromptTemplateCard({
+  active,
+  labels,
+  onActivate,
+  onCancel,
+  onResolve,
+  onValueChange,
+  template,
+  values,
+}: CardProps): ReactNode {
+  const variables = detectVariables(template);
+  const handleUse = useCallback(() => {
+    if (variables.length === 0) {
+      onResolve(template.template, template);
+      return;
+    }
+    if (active) {
+      onResolve(fillTemplate(template.template, values), template);
+      return;
+    }
+    onActivate(template);
+  }, [active, onActivate, onResolve, template, values, variables.length]);
+
+  return (
+    <article
+      className="flex flex-col gap-3 rounded-xl border border-border bg-background p-4 shadow-sm"
+      data-template-id={template.id}
+    >
+      <CardHeader
+        category={template.category}
+        description={template.description}
+        title={template.title}
+      />
+      {active && variables.length > 0 ? (
+        <VariableForm
+          fieldIdPrefix={template.id}
+          labels={labels}
+          onCancel={onCancel}
+          onSubmit={handleUse}
+          onValueChange={onValueChange}
+          values={values}
+          variables={variables}
+        />
+      ) : (
+        <CardActions
+          onUse={handleUse}
+          useLabel={labels.use}
+          variableCount={variables.length}
+        />
+      )}
+    </article>
+  );
+}
+
+type VariableFormProps = {
+  fieldIdPrefix: string;
+  labels: Required<PromptTemplatesLabels>;
+  onCancel: () => void;
+  onSubmit: () => void;
+  onValueChange: (name: string, value: string) => void;
+  values: Record<string, string>;
+  variables: string[];
+};
+
+type VariableFieldProps = {
+  fieldId: string;
+  name: string;
+  onValueChange: (name: string, value: string) => void;
+  value: string;
+};
+
+function VariableField({
+  fieldId,
+  name,
+  onValueChange,
+  value,
+}: VariableFieldProps): ReactNode {
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onValueChange(name, event.target.value);
+    },
+    [name, onValueChange],
+  );
+  return (
+    <div className="flex flex-col gap-1 text-xs">
+      <label className="font-medium text-foreground" htmlFor={fieldId}>
+        {name}
+      </label>
+      <Input
+        id={fieldId}
+        onChange={handleChange}
+        placeholder={`Value for ${name}`}
+        value={value}
+      />
+    </div>
+  );
+}
+
+function VariableForm({
+  fieldIdPrefix,
+  labels,
+  onCancel,
+  onSubmit,
+  onValueChange,
+  values,
+  variables,
+}: VariableFormProps): ReactNode {
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-dashed border-border bg-muted/30 p-3">
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {labels.variablesHeading}
+      </p>
+      <div className="flex flex-col gap-2">
+        {variables.map((name) => (
+          <VariableField
+            fieldId={`${fieldIdPrefix}-${name}`}
+            key={name}
+            name={name}
+            onValueChange={onValueChange}
+            value={values[name] ?? ""}
+          />
+        ))}
+      </div>
+      <div className="mt-1 flex justify-end gap-2">
+        <Button onClick={onCancel} size="sm" type="button" variant="ghost">
+          {labels.cancel}
+        </Button>
+        <Button onClick={onSubmit} size="sm" type="button">
+          {labels.insert}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Library / gallery of saved prompt templates with search, category filter,
+ * and a built-in fill-in form for `{{variable}}` placeholders. Composes
+ * existing {@link Input}, {@link Button}, and {@link Badge} primitives.
+ *
+ * @example
+ * ```tsx
+ * <PromptTemplates
+ *   templates={[
+ *     {
+ *       id: "code-review",
+ *       title: "Code Review",
+ *       description: "Review code for bugs and improvements",
+ *       template: "Review this {{language}} code:\n\n{{code}}",
+ *       category: "Code",
+ *     },
+ *   ]}
+ *   categories={[{ name: "Code" }, { name: "Writing" }]}
+ *   onSelect={(resolved) => insertIntoComposer(resolved)}
+ * />
+ * ```
+ *
+ * @public
+ */
+type ControllerState = {
+  activeId: null | string;
+  filtered: PromptTemplate[];
+  handleActivate: (template: PromptTemplate) => void;
+  handleCancel: () => void;
+  handleCategoryChange: (value: string) => void;
+  handleQueryChange: (value: string) => void;
+  handleResolve: (resolved: string, template: PromptTemplate) => void;
+  handleValueChange: (name: string, value: string) => void;
+  query: string;
+  searchId: string;
+  selectedCategory: string;
+  values: Record<string, string>;
+};
+
+function usePromptTemplatesController(
+  templates: PromptTemplate[],
+  onSelect: PromptTemplatesProps["onSelect"],
+): ControllerState {
+  const searchId = useId();
+  const [query, setQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState(ALL_CATEGORY_VALUE);
+  const [activeId, setActiveId] = useState<null | string>(null);
+  const [values, setValues] = useState<Record<string, string>>({});
+
+  const filtered = useMemo(
+    () =>
+      templates.filter(
+        (template) =>
+          matchesCategory(template, selectedCategory) &&
+          matchesQuery(template, query),
+      ),
+    [query, selectedCategory, templates],
+  );
+
+  const handleActivate = useCallback((template: PromptTemplate) => {
+    setActiveId(template.id);
+    setValues({});
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    setActiveId(null);
+    setValues({});
+  }, []);
+
+  const handleResolve = useCallback(
+    (resolved: string, template: PromptTemplate) => {
+      onSelect?.(resolved, template);
+      setActiveId(null);
+      setValues({});
+    },
+    [onSelect],
+  );
+
+  const handleValueChange = useCallback((name: string, value: string) => {
+    setValues((current) => ({ ...current, [name]: value }));
+  }, []);
+
+  return {
+    activeId,
+    filtered,
+    handleActivate,
+    handleCancel,
+    handleCategoryChange: setSelectedCategory,
+    handleQueryChange: setQuery,
+    handleResolve,
+    handleValueChange,
+    query,
+    searchId,
+    selectedCategory,
+    values,
+  };
+}
+
+type GridProps = {
+  controller: ControllerState;
+  labels: Required<PromptTemplatesLabels>;
+};
+
+function TemplateGrid({ controller, labels }: GridProps): ReactNode {
+  if (controller.filtered.length === 0) {
+    return (
+      <p className="rounded-lg border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+        {labels.empty}
+      </p>
+    );
+  }
+  return (
+    <div
+      className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3"
+      role="tabpanel"
+    >
+      {controller.filtered.map((template) => (
+        <PromptTemplateCard
+          active={controller.activeId === template.id}
+          key={template.id}
+          labels={labels}
+          onActivate={controller.handleActivate}
+          onCancel={controller.handleCancel}
+          onResolve={controller.handleResolve}
+          onValueChange={controller.handleValueChange}
+          template={template}
+          values={controller.values}
+        />
+      ))}
+    </div>
+  );
+}
+
+export const PromptTemplates = forwardRef<HTMLElement, PromptTemplatesProps>(
+  (props, ref) => {
+    const { categories, className, labels, onSelect, templates, ...rest } =
+      props;
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+    const controller = usePromptTemplatesController(templates, onSelect);
+
+    return (
+      <section
+        className={cn(
+          "flex flex-col gap-4 rounded-2xl border bg-background p-4",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        <FilterBar
+          categories={categories ?? []}
+          labels={resolvedLabels}
+          onCategoryChange={controller.handleCategoryChange}
+          onQueryChange={controller.handleQueryChange}
+          query={controller.query}
+          searchId={controller.searchId}
+          selectedCategory={controller.selectedCategory}
+        />
+        <TemplateGrid controller={controller} labels={resolvedLabels} />
+      </section>
+    );
+  },
+);
+PromptTemplates.displayName = "PromptTemplates";

--- a/apps/registry/registry/default/property-section/property-section.tsx
+++ b/apps/registry/registry/default/property-section/property-section.tsx
@@ -1,6 +1,169 @@
-export {
-  type PropertyEntry,
-  PropertySection,
-  type PropertySectionLabels,
-  type PropertySectionProps,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * One row in the property grid.
+ *
+ * @public
+ */
+export type PropertyEntry = {
+  /** Stable id (used as React key + analytics hook). */
+  id: string;
+  /** Property label (left column). */
+  label: ReactNode;
+  /** Optional sublabel rendered beneath the label. */
+  sublabel?: ReactNode;
+  /** Property value (right column). */
+  value: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type PropertySectionLabels = {
+  /** Aria-label for the section. Defaults to `"Properties"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Properties",
+} as const satisfies Required<PropertySectionLabels>;
+
+/**
+ * Props for {@link PropertySection}.
+ *
+ * @public
+ */
+export type PropertySectionProps = {
+  /** Optional collapsible affordance. Pass `false` to render the body inline (default). */
+  collapsible?: boolean;
+  /** Property entries in render order. */
+  entries: PropertyEntry[];
+  /** Localizable strings. */
+  labels?: PropertySectionLabels;
+  /** Optional title rendered as a small uppercase heading above the grid. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const Grid = (props: { entries: PropertyEntry[] }): React.ReactElement => (
+  <dl
+    className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1.5 px-3 pb-3 pt-1 text-xs"
+    data-property-grid
+  >
+    {props.entries.map((entry) => (
+      <div className="contents" key={entry.id}>
+        <dt
+          className="flex flex-col text-muted-foreground"
+          data-property-id={entry.id}
+        >
+          <span>{entry.label}</span>
+          {entry.sublabel ? (
+            <span className="text-[10px] uppercase tracking-wide text-muted-foreground/70">
+              {entry.sublabel}
+            </span>
+          ) : null}
+        </dt>
+        <dd className="text-right text-foreground">{entry.value}</dd>
+      </div>
+    ))}
+  </dl>
+);
+
+const Body = (props: {
+  collapsible: boolean;
+  entries: PropertyEntry[];
+  title?: ReactNode;
+}): React.ReactElement => {
+  const grid = <Grid entries={props.entries} />;
+  if (!props.title) {
+    return grid;
+  }
+  if (props.collapsible) {
+    return (
+      <details className="group" open>
+        <summary
+          className="flex cursor-pointer items-center justify-between gap-2 px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+          data-property-summary
+        >
+          <span>{props.title}</span>
+          <span
+            aria-hidden="true"
+            className="text-muted-foreground/70 group-open:rotate-90"
+          >
+            ›
+          </span>
+        </summary>
+        {grid}
+      </details>
+    );
+  }
+  return (
+    <>
+      <header
+        className="flex items-center justify-between gap-2 border-b border-border px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+        data-property-header
+      >
+        {props.title}
+      </header>
+      {grid}
+    </>
+  );
+};
+
+/**
+ * Compact key / value grid for an inspector panel. Use one
+ * `PropertySection` per logical group (Identity, Layout, State, etc.)
+ * so the right dock stays scannable. Pure presentation — the host
+ * computes the entries from the current selection.
+ *
+ * @example
+ * ```tsx
+ * <PropertySection
+ *   title="Layout"
+ *   entries={[
+ *     { id: "x", label: "X", value: "120" },
+ *     { id: "y", label: "Y", value: "80" },
+ *     { id: "size", label: "Size", value: "240 × 120" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const PropertySection = forwardRef<HTMLElement, PropertySectionProps>(
+  (props, ref) => {
+    const {
+      className,
+      collapsible = false,
+      entries,
+      labels,
+      title,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "rounded-lg border bg-background text-foreground",
+          className,
+        )}
+        data-property-section
+        ref={ref}
+        {...rest}
+      >
+        <Body collapsible={collapsible} entries={entries} title={title} />
+      </section>
+    );
+  },
+);
+PropertySection.displayName = "PropertySection";

--- a/apps/registry/registry/default/quiz/quiz.tsx
+++ b/apps/registry/registry/default/quiz/quiz.tsx
@@ -1,23 +1,24 @@
-'use client'
+"use client";
 
-import { type ReactNode, useState } from 'react'
+import { type ReactNode, useState } from "react";
 
-import { cn } from '../../../lib/utils'
+import { cn } from "@vllnt/ui";
 
 export type QuizOption = {
-  correct?: boolean
-  explanation?: string
-  label: string
-}
+  correct?: boolean;
+  explanation?: string;
+  label: string;
+};
 
 type QuizOptionButtonProps = {
-  index: number
-  onSelect: (index: number) => void
-  option: QuizOption
-  selectedIndex: null | number
-  submitted: boolean
-}
+  index: number;
+  onSelect: (index: number) => void;
+  option: QuizOption;
+  selectedIndex: null | number;
+  submitted: boolean;
+};
 
+// eslint-disable-next-line max-lines-per-function -- Option button showing selected, correct, incorrect states
 function QuizOptionButton({
   index,
   onSelect,
@@ -25,20 +26,23 @@ function QuizOptionButton({
   selectedIndex,
   submitted,
 }: QuizOptionButtonProps): React.ReactNode {
-  const isSelected = selectedIndex === index
-  const showResult = submitted && isSelected
+  const isSelected = selectedIndex === index;
+  const showResult = submitted && isSelected;
   return (
     <button
       className={cn(
-        'w-full text-left p-3 rounded-md border transition-colors hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-primary',
-        isSelected && !submitted && 'border-primary bg-primary/10',
-        showResult && option.correct && 'border-green-500 bg-green-500/10',
-        showResult && !option.correct && 'border-red-500 bg-red-500/10',
-        submitted && !isSelected && option.correct && 'border-green-500/50 bg-green-500/5',
+        "w-full text-left p-3 rounded-md border transition-colors hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-primary",
+        isSelected && !submitted && "border-primary bg-primary/10",
+        showResult && option.correct && "border-green-500 bg-green-500/10",
+        showResult && !option.correct && "border-red-500 bg-red-500/10",
+        submitted &&
+          !isSelected &&
+          option.correct &&
+          "border-green-500/50 bg-green-500/5",
       )}
       disabled={submitted}
       onClick={() => {
-        onSelect(index)
+        onSelect(index);
       }}
       type="button"
     >
@@ -46,76 +50,122 @@ function QuizOptionButton({
         <span className="text-sm">{option.label}</span>
         {showResult ? (
           option.correct ? (
-            <svg className="h-4 w-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path d="M5 13l4 4L19 7" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+            <svg
+              className="h-4 w-4 text-green-500"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M5 13l4 4L19 7"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+              />
             </svg>
           ) : (
-            <svg className="h-4 w-4 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path d="M6 18L18 6M6 6l12 12" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+            <svg
+              className="h-4 w-4 text-red-500"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M6 18L18 6M6 6l12 12"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+              />
             </svg>
           )
         ) : null}
         {submitted && !isSelected && option.correct ? (
-          <svg className="h-4 w-4 text-green-500/50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path d="M5 13l4 4L19 7" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+          <svg
+            className="h-4 w-4 text-green-500/50"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M5 13l4 4L19 7"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+            />
           </svg>
         ) : null}
       </div>
       {submitted && option.explanation ? (
-        <p className="text-xs text-muted-foreground mt-2">{option.explanation}</p>
+        <p className="text-xs text-muted-foreground mt-2">
+          {option.explanation}
+        </p>
       ) : null}
     </button>
-  )
+  );
 }
 
 type QuizHintProps = {
-  hint: string
-  onShow: () => void
-  showHint: boolean
-}
+  hint: string;
+  onShow: () => void;
+  showHint: boolean;
+};
 
 function QuizHint({ hint, onShow, showHint }: QuizHintProps): React.ReactNode {
   return (
     <div className="mb-4">
       {showHint ? (
-        <p className="text-sm text-muted-foreground italic bg-muted/50 p-2 rounded">{hint}</p>
+        <p className="text-sm text-muted-foreground italic bg-muted/50 p-2 rounded">
+          {hint}
+        </p>
       ) : (
-        <button className="text-sm text-primary hover:underline" onClick={onShow} type="button">
+        <button
+          className="text-sm text-primary hover:underline"
+          onClick={onShow}
+          type="button"
+        >
           Show hint
         </button>
       )}
     </div>
-  )
+  );
 }
 
 type QuizResultProps = {
-  explanation: ReactNode
-  isCorrect: boolean
-}
+  explanation: ReactNode;
+  isCorrect: boolean;
+};
 
-function QuizResult({ explanation, isCorrect }: QuizResultProps): React.ReactNode {
+function QuizResult({
+  explanation,
+  isCorrect,
+}: QuizResultProps): React.ReactNode {
   return (
     <div
       className={cn(
-        'p-3 rounded-md text-sm mb-4',
-        isCorrect ? 'bg-green-500/10 text-green-700 dark:text-green-300' : 'bg-muted',
+        "p-3 rounded-md text-sm mb-4",
+        isCorrect
+          ? "bg-green-500/10 text-green-700 dark:text-green-300"
+          : "bg-muted",
       )}
     >
-      <p className="font-medium mb-1">{isCorrect ? 'Correct!' : 'Not quite right.'}</p>
+      <p className="font-medium mb-1">
+        {isCorrect ? "Correct!" : "Not quite right."}
+      </p>
       <div className="[&>p]:mb-0">{explanation}</div>
     </div>
-  )
+  );
 }
 
 export type QuizProps = {
-  className?: string
-  explanation?: ReactNode
-  hint?: string
-  onAnswer?: (correct: boolean) => void
-  options: QuizOption[]
-  question: string
-}
+  className?: string;
+  explanation?: ReactNode;
+  hint?: string;
+  onAnswer?: (correct: boolean) => void;
+  options: QuizOption[];
+  question: string;
+};
 
+// eslint-disable-next-line max-lines-per-function -- Interactive quiz with state management
 export function Quiz({
   className,
   explanation,
@@ -124,29 +174,39 @@ export function Quiz({
   options,
   question,
 }: QuizProps): React.ReactNode {
-  const [selectedIndex, setSelectedIndex] = useState<null | number>(null)
-  const [showHint, setShowHint] = useState(false)
-  const [submitted, setSubmitted] = useState(false)
+  const [selectedIndex, setSelectedIndex] = useState<null | number>(null);
+  const [showHint, setShowHint] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
 
   const handleReset = (): void => {
-    setSelectedIndex(null)
-    setSubmitted(false)
-    setShowHint(false)
-  }
+    setSelectedIndex(null);
+    setSubmitted(false);
+    setShowHint(false);
+  };
 
   const handleSubmit = (): void => {
-    setSubmitted(true)
-    const isCorrect = selectedIndex !== null && options[selectedIndex]?.correct
-    onAnswer?.(Boolean(isCorrect))
-  }
+    setSubmitted(true);
+    const isCorrect = selectedIndex !== null && options[selectedIndex]?.correct;
+    onAnswer?.(Boolean(isCorrect));
+  };
 
-  const isCorrect = selectedIndex !== null && options[selectedIndex]?.correct
+  const isCorrect = selectedIndex !== null && options[selectedIndex]?.correct;
 
   return (
-    <div className={cn('my-6 rounded-lg border bg-card p-6', className)}>
+    <div className={cn("my-6 rounded-lg border bg-card p-6", className)}>
       <div className="flex items-start gap-3 mb-4">
-        <svg className="h-5 w-5 text-primary flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+        <svg
+          className="h-5 w-5 text-primary flex-shrink-0 mt-0.5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+          />
         </svg>
         <h4 className="font-semibold text-foreground">{question}</h4>
       </div>
@@ -155,8 +215,8 @@ export function Quiz({
           <QuizOptionButton
             index={index}
             key={index}
-            onSelect={(i) => {
-              if (!submitted) setSelectedIndex(i)
+            onSelect={(index_) => {
+              if (!submitted) setSelectedIndex(index_);
             }}
             option={opt}
             selectedIndex={selectedIndex}
@@ -168,7 +228,7 @@ export function Quiz({
         <QuizHint
           hint={hint}
           onShow={() => {
-            setShowHint(true)
+            setShowHint(true);
           }}
           showHint={showHint}
         />
@@ -197,5 +257,5 @@ export function Quiz({
         )}
       </div>
     </div>
-  )
+  );
 }

--- a/apps/registry/registry/default/radio-group/radio-group.tsx
+++ b/apps/registry/registry/default/radio-group/radio-group.tsx
@@ -1,1 +1,45 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { Circle } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+const RadioGroup = forwardRef<
+  React.ComponentRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn("grid gap-2", className)}
+      {...props}
+      ref={ref}
+    />
+  );
+});
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+
+const RadioGroupItem = forwardRef<
+  React.ComponentRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Item
+      className={cn(
+        "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+        <Circle className="h-2.5 w-2.5 fill-current text-current" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+});
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };

--- a/apps/registry/registry/default/rating/rating.tsx
+++ b/apps/registry/registry/default/rating/rating.tsx
@@ -1,2 +1,153 @@
-// Re-export from @vllnt/ui package
-export { Rating } from '@vllnt/ui'
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { Star } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+
+const sizeClasses = {
+  lg: "h-6 w-6",
+  md: "h-5 w-5",
+  sm: "h-4 w-4",
+};
+
+export type RatingProps = {
+  allowClear?: boolean;
+  className?: string;
+  defaultValue?: number;
+  label?: string;
+  max?: number;
+  onValueChange?: (value: number) => void;
+  readOnly?: boolean;
+  showValue?: boolean;
+  size?: keyof typeof sizeClasses;
+  value?: number;
+};
+
+type RatingStarsProps = {
+  activeValue: number;
+  hoveredValue: number;
+  label: string;
+  max: number;
+  onHoverChange: (value: number) => void;
+  onSelect: (value: number) => void;
+  readOnly: boolean;
+  size: keyof typeof sizeClasses;
+};
+
+function RatingStars({
+  activeValue,
+  hoveredValue,
+  label,
+  max,
+  onHoverChange,
+  onSelect,
+  readOnly,
+  size,
+}: RatingStarsProps): ReactNode {
+  const stars = useMemo(
+    () => Array.from({ length: max }, (_, index) => index + 1),
+    [max],
+  );
+  const displayValue = hoveredValue || activeValue;
+
+  return (
+    <div
+      aria-label={label}
+      className="inline-flex items-center gap-1"
+      role="radiogroup"
+    >
+      {stars.map((starValue) => {
+        const isFilled = starValue <= displayValue;
+
+        return (
+          <button
+            aria-checked={activeValue === starValue}
+            aria-label={`${starValue} ${starValue === 1 ? "star" : "stars"}`}
+            className={cn(
+              "rounded-sm text-muted-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              !readOnly && "hover:text-amber-500",
+              isFilled && "text-amber-500",
+            )}
+            disabled={readOnly}
+            key={starValue}
+            onBlur={() => {
+              onHoverChange(0);
+            }}
+            onClick={() => {
+              onSelect(starValue);
+            }}
+            onMouseEnter={() => {
+              if (!readOnly) {
+                onHoverChange(starValue);
+              }
+            }}
+            onMouseLeave={() => {
+              onHoverChange(0);
+            }}
+            role="radio"
+            type="button"
+          >
+            <Star
+              className={cn(sizeClasses[size], isFilled && "fill-current")}
+              strokeWidth={1.75}
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function Rating({
+  allowClear = false,
+  className,
+  defaultValue = 0,
+  label = "Rating",
+  max = 5,
+  onValueChange,
+  readOnly = false,
+  showValue = false,
+  size = "md",
+  value,
+}: RatingProps): ReactNode {
+  const isControlled = value !== undefined;
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const [hoveredValue, setHoveredValue] = useState(0);
+  const activeValue = isControlled ? (value ?? 0) : internalValue;
+
+  const handleSelect = (nextValue: number): void => {
+    const resolvedValue =
+      allowClear && activeValue === nextValue ? 0 : nextValue;
+
+    if (!isControlled) {
+      setInternalValue(resolvedValue);
+    }
+
+    onValueChange?.(resolvedValue);
+  };
+
+  return (
+    <div className={cn("inline-flex flex-col gap-2", className)}>
+      <div className="inline-flex items-center gap-3">
+        <RatingStars
+          activeValue={activeValue}
+          hoveredValue={hoveredValue}
+          label={label}
+          max={max}
+          onHoverChange={setHoveredValue}
+          onSelect={handleSelect}
+          readOnly={readOnly}
+          size={size}
+        />
+        {showValue ? (
+          <span className="text-sm text-muted-foreground">
+            {activeValue}/{max}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/registry/registry/default/relationship-inspector/relationship-inspector.tsx
+++ b/apps/registry/registry/default/relationship-inspector/relationship-inspector.tsx
@@ -1,7 +1,214 @@
-export {
-  type RelationshipDirection,
-  type RelationshipEdge,
-  RelationshipInspector,
-  type RelationshipInspectorLabels,
-  type RelationshipInspectorProps,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Direction of an edge relative to the focused object.
+ *
+ * @public
+ */
+export type RelationshipDirection = "inbound" | "outbound";
+
+/**
+ * One edge in the relationship list.
+ *
+ * @public
+ */
+export type RelationshipEdge = {
+  /** Direction of the edge relative to the focused object. */
+  direction: RelationshipDirection;
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Optional click handler — when provided, the row becomes a button. */
+  onActivate?: () => void;
+  /** Relation kind (e.g. `"calls"`, `"emits"`, `"depends-on"`). */
+  relation: string;
+  /** Target id (when outbound) or source id (when inbound). */
+  target: ReactNode;
+  /** Optional secondary line beneath the row. */
+  targetSublabel?: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type RelationshipInspectorLabels = {
+  /** Empty-state copy. Defaults to `"No relationships"`. */
+  empty?: string;
+  /** Header for inbound edges. Defaults to `"Inbound"`. */
+  inbound?: string;
+  /** Header for outbound edges. Defaults to `"Outbound"`. */
+  outbound?: string;
+  /** Aria-label for the inspector. Defaults to `"Relationship inspector"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No relationships",
+  inbound: "Inbound",
+  outbound: "Outbound",
+  region: "Relationship inspector",
+} as const satisfies Required<RelationshipInspectorLabels>;
+
+/**
+ * Props for {@link RelationshipInspector}.
+ *
+ * @public
+ */
+export type RelationshipInspectorProps = {
+  /** Edges to render. Empty list shows the empty state. */
+  edges: RelationshipEdge[];
+  /** Localizable strings. */
+  labels?: RelationshipInspectorLabels;
+  /** Optional inspector title. Defaults to `"Relationships"`. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const ARROW_GLYPH: Record<RelationshipDirection, string> = {
+  inbound: "←",
+  outbound: "→",
+};
+
+const RowBody = (props: { edge: RelationshipEdge }): React.ReactElement => {
+  const { edge } = props;
+  return (
+    <span className="flex flex-1 items-center gap-2">
+      <span aria-hidden="true" className="text-muted-foreground">
+        {ARROW_GLYPH[edge.direction]}
+      </span>
+      <span className="flex flex-1 flex-col text-left">
+        <span className="truncate text-xs text-foreground">{edge.target}</span>
+        {edge.targetSublabel ? (
+          <span className="truncate text-[10px] text-muted-foreground">
+            {edge.targetSublabel}
+          </span>
+        ) : null}
+      </span>
+      <span className="rounded-full border border-border bg-background px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+        {edge.relation}
+      </span>
+    </span>
+  );
+};
+
+const Row = (props: { edge: RelationshipEdge }): React.ReactElement => {
+  const { edge } = props;
+  if (edge.onActivate) {
+    const handleClick = (): void => {
+      edge.onActivate?.();
+    };
+    return (
+      <button
+        className="flex w-full items-center gap-2 rounded-md border border-transparent px-2 py-1.5 text-left transition-colors hover:border-border hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        data-relationship-direction={edge.direction}
+        data-relationship-row
+        onClick={handleClick}
+        type="button"
+      >
+        <RowBody edge={edge} />
+      </button>
+    );
+  }
+  return (
+    <div
+      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5"
+      data-relationship-direction={edge.direction}
+      data-relationship-row
+    >
+      <RowBody edge={edge} />
+    </div>
+  );
+};
+
+const Group = (props: {
+  edges: RelationshipEdge[];
+  heading: string;
+}): null | React.ReactElement => {
+  const { edges, heading } = props;
+  if (edges.length === 0) {
+    return null;
+  }
+  return (
+    <div className="space-y-1" data-relationship-group={heading.toLowerCase()}>
+      <h4 className="px-2 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        {heading}
+      </h4>
+      <ul className="space-y-0.5">
+        {edges.map((edge) => (
+          <li key={edge.id}>
+            <Row edge={edge} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+/**
+ * Inspector panel listing inbound + outbound edges of the focused
+ * object. Each row shows direction arrow, target id, optional sublabel,
+ * and the relation kind chip. Pure presentation; the host computes
+ * edges from the runtime graph and supplies an optional click handler
+ * to jump to the related object.
+ *
+ * @example
+ * ```tsx
+ * <RelationshipInspector
+ *   edges={[
+ *     { id: "1", direction: "inbound",  target: "research-2025", relation: "spawned-by" },
+ *     { id: "2", direction: "outbound", target: "summary.md",    relation: "emits" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const RelationshipInspector = forwardRef<
+  HTMLElement,
+  RelationshipInspectorProps
+>((props, ref) => {
+  const { className, edges, labels, title = "Relationships", ...rest } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const inbound = edges.filter((edge) => edge.direction === "inbound");
+  const outbound = edges.filter((edge) => edge.direction === "outbound");
+  return (
+    <section
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "flex w-full flex-col gap-2 rounded-lg border bg-background p-3 text-foreground",
+        className,
+      )}
+      data-relationship-inspector
+      ref={ref}
+      {...rest}
+    >
+      <header>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {title}
+        </h3>
+      </header>
+      {edges.length === 0 ? (
+        <p
+          className="px-2 py-3 text-center text-xs text-muted-foreground"
+          data-relationship-state="empty"
+        >
+          {resolvedLabels.empty}
+        </p>
+      ) : (
+        <div className="space-y-2">
+          <Group edges={inbound} heading={resolvedLabels.inbound} />
+          <Group edges={outbound} heading={resolvedLabels.outbound} />
+        </div>
+      )}
+    </section>
+  );
+});
+RelationshipInspector.displayName = "RelationshipInspector";

--- a/apps/registry/registry/default/resizable/resizable.tsx
+++ b/apps/registry/registry/default/resizable/resizable.tsx
@@ -1,1 +1,45 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { GripVertical } from "lucide-react";
+import { Group, Panel, Separator } from "react-resizable-panels";
+
+import { cn } from "@vllnt/ui";
+
+const ResizablePanelGroup = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof Group>) => (
+  <Group
+    className={cn(
+      "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
+      className,
+    )}
+    {...props}
+  />
+);
+
+const ResizablePanel = Panel;
+
+const ResizableHandle = ({
+  className,
+  withHandle,
+  ...props
+}: React.ComponentProps<typeof Separator> & {
+  withHandle?: boolean;
+}) => (
+  <Separator
+    className={cn(
+      "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+      className,
+    )}
+    {...props}
+  >
+    {withHandle ? (
+      <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-border">
+        <GripVertical className="h-2.5 w-2.5" />
+      </div>
+    ) : null}
+  </Separator>
+);
+
+export { ResizableHandle, ResizablePanel, ResizablePanelGroup };

--- a/apps/registry/registry/default/right-dock/right-dock.tsx
+++ b/apps/registry/registry/default/right-dock/right-dock.tsx
@@ -1,1 +1,41 @@
-export { RightDock, type RightDockProps } from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type RightDockProps = React.ComponentPropsWithoutRef<"aside"> & {
+  footer?: ReactNode;
+  header?: ReactNode;
+  title?: ReactNode;
+};
+
+const RightDock = forwardRef<HTMLElement, RightDockProps>(
+  ({ children, className, footer, header, title, ...props }, ref) => (
+    <aside
+      className={cn(
+        "flex h-full min-w-[18rem] max-w-[24rem] shrink-0 flex-col border-l border-border bg-background",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    >
+      {header || title ? (
+        <div className="border-b border-border/60 px-4 py-3">
+          {title ? (
+            <div className="text-sm font-medium text-foreground">{title}</div>
+          ) : null}
+          {header ? <div className="mt-2">{header}</div> : null}
+        </div>
+      ) : null}
+      <div className="flex-1 overflow-auto p-4">{children}</div>
+      {footer ? (
+        <div className="border-t border-border/60 p-4">{footer}</div>
+      ) : null}
+    </aside>
+  ),
+);
+
+RightDock.displayName = "RightDock";
+
+export { RightDock };

--- a/apps/registry/registry/default/role-badge/role-badge.tsx
+++ b/apps/registry/registry/default/role-badge/role-badge.tsx
@@ -1,2 +1,61 @@
-// Re-export from @vllnt/ui package
-export { RoleBadge } from '@vllnt/ui'
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+import { badgeVariants } from "@vllnt/ui";
+
+export type RoleBadgeRole = "admin" | "billing" | "member" | "owner";
+
+export type RoleBadgeProps = Omit<
+  React.ComponentPropsWithoutRef<"span">,
+  "children"
+> & {
+  accountRole: RoleBadgeRole;
+  label?: string;
+};
+
+function getRoleLabel(accountRole: RoleBadgeRole): string {
+  switch (accountRole) {
+    case "admin":
+      return "Admin";
+    case "billing":
+      return "Billing";
+    case "member":
+      return "Member";
+    case "owner":
+      return "Owner";
+  }
+}
+
+function getRoleClasses(accountRole: RoleBadgeRole): string {
+  switch (accountRole) {
+    case "admin":
+      return "border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-300";
+    case "billing":
+      return "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300";
+    case "member":
+      return "border-border bg-muted text-muted-foreground";
+    case "owner":
+      return "border-primary/30 bg-primary/10 text-primary";
+  }
+}
+
+export const RoleBadge = React.forwardRef<HTMLSpanElement, RoleBadgeProps>(
+  ({ accountRole, className, label, ...props }, reference) => {
+    return (
+      <span
+        className={cn(
+          badgeVariants({ variant: "outline" }),
+          "rounded-full px-2.5 py-1 text-[11px] font-medium shadow-none",
+          getRoleClasses(accountRole),
+          className,
+        )}
+        ref={reference}
+        {...props}
+      >
+        {label ?? getRoleLabel(accountRole)}
+      </span>
+    );
+  },
+);
+
+RoleBadge.displayName = "RoleBadge";

--- a/apps/registry/registry/default/route-map/route-map.tsx
+++ b/apps/registry/registry/default/route-map/route-map.tsx
@@ -1,8 +1,512 @@
-export {
-  type RouteColor,
-  type RouteLineStyle,
-  RouteMap,
-  type RouteMapLabels,
-  type RouteMapProps,
-  type RouteWaypoint,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useId,
+  useMemo,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+const VIEWBOX_WIDTH = 1000;
+const VIEWBOX_HEIGHT = 500;
+
+/**
+ * Geographic coordinate `[longitude, latitude]`.
+ *
+ * @public
+ */
+export type GeoPosition = [number, number];
+
+/**
+ * A single waypoint along the route.
+ *
+ * @public
+ */
+export type RouteWaypoint = {
+  /** Stable identifier. */
+  id: string;
+  /** Human-readable label rendered next to the marker. */
+  label: ReactNode;
+  /** Optional 1-based ordinal. Defaults to the array index + 1. */
+  order?: number;
+  /** Geographic position. */
+  position: GeoPosition;
+};
+
+/**
+ * Color theme for the route line + waypoint markers.
+ *
+ * @public
+ */
+export type RouteColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "purple"
+  | "red"
+  | "rose";
+
+const ROUTE_PALETTE: Record<
+  RouteColor,
+  { dot: string; line: string; text: string }
+> = {
+  amber: {
+    dot: "fill-amber-500",
+    line: "stroke-amber-500",
+    text: "text-amber-600",
+  },
+  blue: {
+    dot: "fill-blue-500",
+    line: "stroke-blue-500",
+    text: "text-blue-600",
+  },
+  emerald: {
+    dot: "fill-emerald-500",
+    line: "stroke-emerald-500",
+    text: "text-emerald-600",
+  },
+  purple: {
+    dot: "fill-purple-500",
+    line: "stroke-purple-500",
+    text: "text-purple-600",
+  },
+  red: { dot: "fill-red-500", line: "stroke-red-500", text: "text-red-600" },
+  rose: {
+    dot: "fill-rose-500",
+    line: "stroke-rose-500",
+    text: "text-rose-600",
+  },
+};
+
+/**
+ * Line drawing style.
+ *
+ * @public
+ */
+export type RouteLineStyle = "dashed" | "dotted" | "solid";
+
+const LINE_DASH: Record<RouteLineStyle, string> = {
+  dashed: "10,8",
+  dotted: "2,6",
+  solid: "0",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type RouteMapLabels = {
+  /** Aria-label for the route region. Defaults to `"Route map"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Route map",
+} as const satisfies Required<RouteMapLabels>;
+
+function projectEquirectangular(position: GeoPosition): {
+  x: number;
+  y: number;
+} {
+  const [lng, lat] = position;
+  const x = ((lng + 180) / 360) * VIEWBOX_WIDTH;
+  const y = ((90 - lat) / 180) * VIEWBOX_HEIGHT;
+  return { x, y };
+}
+
+/**
+ * Props for {@link RouteMap}.
+ *
+ * @public
+ */
+export type RouteMapProps = {
+  /** When `true`, the route line draws progressively from start to end. */
+  animated?: boolean;
+  /** Animation duration in seconds. Defaults to `4`. */
+  animationDurationSeconds?: number;
+  /** Optional URL of a backdrop image (world map, terrain). */
+  backdrop?: string;
+  /** Aria-label for the backdrop image when set. */
+  backdropAlt?: string;
+  /** Color theme. Defaults to `"red"`. */
+  color?: RouteColor;
+  /** Localizable strings. */
+  labels?: RouteMapLabels;
+  /** Line drawing style. Defaults to `"solid"`. */
+  lineStyle?: RouteLineStyle;
+  /** When `true`, renders a moving indicator that travels along the route. */
+  showProgressIndicator?: boolean;
+  /** Ordered list of waypoints along the route. */
+  waypoints: RouteWaypoint[];
+} & ComponentPropsWithoutRef<"section">;
+
+type ProjectedWaypoint = {
+  ordinal: number;
+  raw: RouteWaypoint;
+  x: number;
+  y: number;
+};
+
+function projectWaypoints(waypoints: RouteWaypoint[]): ProjectedWaypoint[] {
+  return waypoints.map((waypoint, index) => {
+    const point = projectEquirectangular(waypoint.position);
+    return {
+      ordinal: waypoint.order ?? index + 1,
+      raw: waypoint,
+      x: point.x,
+      y: point.y,
+    };
+  });
+}
+
+function pathFor(points: ProjectedWaypoint[]): string {
+  if (points.length === 0) return "";
+  return points
+    .map(
+      (point, index) =>
+        `${index === 0 ? "M" : "L"}${point.x.toString()},${point.y.toString()}`,
+    )
+    .join(" ");
+}
+
+function pathLength(points: ProjectedWaypoint[]): number {
+  if (points.length < 2) return 0;
+  const total = points.reduce<{ length: number; previous?: ProjectedWaypoint }>(
+    (accumulator, point) => {
+      if (!accumulator.previous) return { length: 0, previous: point };
+      const dx = point.x - accumulator.previous.x;
+      const dy = point.y - accumulator.previous.y;
+      return {
+        length: accumulator.length + Math.hypot(dx, dy),
+        previous: point,
+      };
+    },
+    { length: 0 },
+  );
+  return total.length;
+}
+
+type RouteLineProps = {
+  animated: boolean;
+  animationDurationSeconds: number;
+  color: RouteColor;
+  lineStyle: RouteLineStyle;
+  pathDefinition: string;
+  pathId: string;
+  totalLength: number;
+};
+
+function RouteLine({
+  animated,
+  animationDurationSeconds,
+  color,
+  lineStyle,
+  pathDefinition,
+  pathId,
+  totalLength,
+}: RouteLineProps): ReactNode {
+  if (!pathDefinition) return null;
+  const palette = ROUTE_PALETTE[color];
+  const dashArray = animated
+    ? totalLength > 0
+      ? `${totalLength.toString()} ${totalLength.toString()}`
+      : LINE_DASH[lineStyle]
+    : LINE_DASH[lineStyle];
+
+  return (
+    <g data-route-line>
+      <path
+        className={cn("fill-none stroke-[3]", palette.line)}
+        d={pathDefinition}
+        id={pathId}
+        strokeDasharray={dashArray}
+        strokeDashoffset={animated ? totalLength : 0}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        {animated ? (
+          <animate
+            attributeName="stroke-dashoffset"
+            dur={`${animationDurationSeconds.toString()}s`}
+            fill="freeze"
+            from={totalLength}
+            to="0"
+          />
+        ) : null}
+      </path>
+    </g>
+  );
+}
+
+type ProgressIndicatorProps = {
+  animationDurationSeconds: number;
+  color: RouteColor;
+  pathId: string;
+  visible: boolean;
+};
+
+function ProgressIndicator({
+  animationDurationSeconds,
+  color,
+  pathId,
+  visible,
+}: ProgressIndicatorProps): ReactNode {
+  if (!visible) return null;
+  const palette = ROUTE_PALETTE[color];
+  return (
+    <g data-route-progress>
+      <circle
+        className={cn("stroke-background", palette.dot)}
+        r="6"
+        strokeWidth="2"
+      >
+        <animateMotion
+          dur={`${animationDurationSeconds.toString()}s`}
+          repeatCount="indefinite"
+          rotate="auto"
+        >
+          <mpath href={`#${pathId}`} />
+        </animateMotion>
+      </circle>
+    </g>
+  );
+}
+
+type WaypointDotsProps = {
+  color: RouteColor;
+  waypoints: ProjectedWaypoint[];
+};
+
+function WaypointDots({ color, waypoints }: WaypointDotsProps): ReactNode {
+  const palette = ROUTE_PALETTE[color];
+  return (
+    <g data-route-waypoints>
+      {waypoints.map((point) => {
+        const labelText =
+          typeof point.raw.label === "string" ? point.raw.label : undefined;
+        return (
+          <g
+            data-waypoint-id={point.raw.id}
+            data-waypoint-ordinal={point.ordinal}
+            key={point.raw.id}
+            transform={`translate(${point.x.toString()}, ${point.y.toString()})`}
+          >
+            <circle
+              className={cn(
+                "stroke-background outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                palette.dot,
+              )}
+              r="6"
+              strokeWidth="2"
+            >
+              {labelText ? <title>{labelText}</title> : null}
+            </circle>
+            <text
+              className={cn(
+                "select-none text-[10px] font-semibold",
+                palette.text,
+              )}
+              dominantBaseline="middle"
+              textAnchor="middle"
+              y="-12"
+            >
+              {point.raw.label}
+            </text>
+            <text
+              className="select-none fill-background text-[8px] font-bold"
+              dominantBaseline="central"
+              textAnchor="middle"
+              y="0"
+            >
+              {point.ordinal}
+            </text>
+          </g>
+        );
+      })}
+    </g>
+  );
+}
+
+type DataSummaryProps = {
+  titleId: string;
+  waypoints: RouteWaypoint[];
+};
+
+function DataSummary({ titleId, waypoints }: DataSummaryProps): ReactNode {
+  return (
+    <div aria-labelledby={titleId} className="sr-only" role="region">
+      <h3 id={titleId}>Route waypoint summary</h3>
+      <ol>
+        {waypoints.map((waypoint) => (
+          <li key={waypoint.id}>
+            {typeof waypoint.label === "string"
+              ? waypoint.label
+              : `Waypoint ${waypoint.id}`}
+            {`: ${waypoint.position[0].toString()}, ${waypoint.position[1].toString()}`}
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+type StageProps = {
+  animated: boolean;
+  animationDurationSeconds: number;
+  backdrop?: string;
+  backdropAlt?: string;
+  color: RouteColor;
+  lineStyle: RouteLineStyle;
+  pathDefinition: string;
+  pathId: string;
+  showProgressIndicator: boolean;
+  totalLength: number;
+  waypoints: ProjectedWaypoint[];
+};
+
+function Stage(props: StageProps): ReactNode {
+  const {
+    animated,
+    animationDurationSeconds,
+    backdrop,
+    backdropAlt,
+    color,
+    lineStyle,
+    pathDefinition,
+    pathId,
+    showProgressIndicator,
+    totalLength,
+    waypoints,
+  } = props;
+  const showProgress: boolean = showProgressIndicator && totalLength > 0;
+  return (
+    <svg
+      aria-hidden="true"
+      className="block h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+      viewBox={`0 0 ${VIEWBOX_WIDTH.toString()} ${VIEWBOX_HEIGHT.toString()}`}
+    >
+      <rect
+        className="fill-muted"
+        height={VIEWBOX_HEIGHT}
+        width={VIEWBOX_WIDTH}
+        x="0"
+        y="0"
+      />
+      {backdrop ? (
+        <image
+          aria-label={backdropAlt}
+          height={VIEWBOX_HEIGHT}
+          href={backdrop}
+          preserveAspectRatio="xMidYMid slice"
+          width={VIEWBOX_WIDTH}
+          x="0"
+          y="0"
+        />
+      ) : null}
+      <RouteLine
+        animated={animated}
+        animationDurationSeconds={animationDurationSeconds}
+        color={color}
+        lineStyle={lineStyle}
+        pathDefinition={pathDefinition}
+        pathId={pathId}
+        totalLength={totalLength}
+      />
+      <WaypointDots color={color} waypoints={waypoints} />
+      <ProgressIndicator
+        animationDurationSeconds={animationDurationSeconds}
+        color={color}
+        pathId={pathId}
+        visible={showProgress}
+      />
+    </svg>
+  );
+}
+
+/**
+ * Map for animated route paths, waypoints, and journey progression.
+ * Use for trade routes, military campaigns, exploration voyages,
+ * migration paths, and delivery tracking. Standalone SVG primitive —
+ * no external map library or tile provider required. Drop in a backdrop
+ * image (Natural Earth SVG, terrain raster) to add geographic context.
+ *
+ * @example
+ * ```tsx
+ * <RouteMap
+ *   animated
+ *   showProgressIndicator
+ *   color="red"
+ *   waypoints={[
+ *     { id: "chang", label: "Chang'an", position: [108.94, 34.34] },
+ *     { id: "kashgar", label: "Kashgar", position: [75.99, 39.47] },
+ *     { id: "samarkand", label: "Samarkand", position: [66.97, 39.65] },
+ *     { id: "constantinople", label: "Constantinople", position: [28.98, 41.01] },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const RouteMap = forwardRef<HTMLElement, RouteMapProps>((props, ref) => {
+  const {
+    animated = false,
+    animationDurationSeconds = 4,
+    backdrop,
+    backdropAlt,
+    children,
+    className,
+    color = "red",
+    labels,
+    lineStyle = "solid",
+    showProgressIndicator = false,
+    waypoints,
+    ...rest
+  } = props;
+  const titleId = useId();
+  const pathId = useId();
+  const resolvedLabels = useMemo(
+    () => ({ ...DEFAULT_LABELS, ...labels }),
+    [labels],
+  );
+  const projected = useMemo(() => projectWaypoints(waypoints), [waypoints]);
+  const pathDefinition = useMemo(() => pathFor(projected), [projected]);
+  const totalLength = useMemo(() => pathLength(projected), [projected]);
+
+  return (
+    <section
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "relative aspect-[2/1] w-full overflow-hidden rounded-2xl border bg-background text-foreground",
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    >
+      <Stage
+        animated={animated}
+        animationDurationSeconds={animationDurationSeconds}
+        backdrop={backdrop}
+        backdropAlt={backdropAlt}
+        color={color}
+        lineStyle={lineStyle}
+        pathDefinition={pathDefinition}
+        pathId={pathId}
+        showProgressIndicator={showProgressIndicator}
+        totalLength={totalLength}
+        waypoints={projected}
+      />
+      {children ? (
+        <div className="absolute bottom-3 left-3 z-10 max-w-xs rounded-md border bg-background/95 px-3 py-2 text-xs text-foreground shadow-sm backdrop-blur">
+          {children}
+        </div>
+      ) : null}
+      <DataSummary titleId={titleId} waypoints={waypoints} />
+    </section>
+  );
+});
+RouteMap.displayName = "RouteMap";

--- a/apps/registry/registry/default/routing-assignment-panel/routing-assignment-panel.tsx
+++ b/apps/registry/registry/default/routing-assignment-panel/routing-assignment-panel.tsx
@@ -1,7 +1,217 @@
-export {
-  type RoutingAssignment,
-  RoutingAssignmentPanel,
-  type RoutingAssignmentPanelLabels,
-  type RoutingAssignmentPanelProps,
-  type RoutingRole,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Role of an agent in the routing graph.
+ *
+ * @public
+ */
+export type RoutingRole = "fallback" | "primary" | "shadow";
+
+const ROLE_LABEL: Record<RoutingRole, string> = {
+  fallback: "Fallback",
+  primary: "Primary",
+  shadow: "Shadow",
+};
+
+const ROLE_TONE: Record<RoutingRole, string> = {
+  fallback:
+    "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  primary:
+    "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  shadow: "border-border bg-muted/40 text-muted-foreground",
+};
+
+/**
+ * One row in the routing assignment list.
+ *
+ * @public
+ */
+export type RoutingAssignment = {
+  /** Display name (e.g. `"researcher"`, `"ranker"`). */
+  agent: ReactNode;
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Optional load fraction `0..1` rendered as a thin progress bar. */
+  load?: number;
+  /** Optional click handler — when provided, the row becomes a button. */
+  onActivate?: () => void;
+  /** Role of the agent for this slot. */
+  role: RoutingRole;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type RoutingAssignmentPanelLabels = {
+  /** Empty-state copy. Defaults to `"No assignments"`. */
+  empty?: string;
+  /** Aria-label for the panel. Defaults to `"Routing assignments"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No assignments",
+  region: "Routing assignments",
+} as const satisfies Required<RoutingAssignmentPanelLabels>;
+
+/**
+ * Props for {@link RoutingAssignmentPanel}.
+ *
+ * @public
+ */
+export type RoutingAssignmentPanelProps = {
+  /** Assignments in render order. */
+  assignments: RoutingAssignment[];
+  /** Localizable strings. */
+  labels?: RoutingAssignmentPanelLabels;
+  /** Panel title. Defaults to `"Routing"`. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const clampLoad = (value: number): number => {
+  if (value < 0) {
+    return 0;
+  }
+  if (value > 1) {
+    return 1;
+  }
+  return value;
+};
+
+const RowBody = (props: {
+  assignment: RoutingAssignment;
+}): React.ReactElement => {
+  const { assignment } = props;
+  const load =
+    assignment.load === undefined ? null : clampLoad(assignment.load);
+  return (
+    <span className="flex flex-1 flex-col gap-1">
+      <span className="flex items-center justify-between gap-2">
+        <span className="truncate text-xs text-foreground">
+          {assignment.agent}
+        </span>
+        <span
+          className={cn(
+            "rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
+            ROLE_TONE[assignment.role],
+          )}
+        >
+          {ROLE_LABEL[assignment.role]}
+        </span>
+      </span>
+      {load === null ? null : (
+        <span
+          aria-hidden="true"
+          className="h-1 w-full overflow-hidden rounded-full bg-muted/40"
+        >
+          <span
+            className="block h-full rounded-full bg-foreground/50"
+            style={{ width: `${load * 100}%` }}
+          />
+        </span>
+      )}
+    </span>
+  );
+};
+
+const Row = (props: { assignment: RoutingAssignment }): React.ReactElement => {
+  const { assignment } = props;
+  if (assignment.onActivate) {
+    const handleClick = (): void => {
+      assignment.onActivate?.();
+    };
+    return (
+      <button
+        className="flex w-full items-center gap-2 rounded-md border border-transparent px-2 py-1.5 text-left transition-colors hover:border-border hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        data-routing-assignment={assignment.id}
+        data-routing-role={assignment.role}
+        onClick={handleClick}
+        type="button"
+      >
+        <RowBody assignment={assignment} />
+      </button>
+    );
+  }
+  return (
+    <div
+      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5"
+      data-routing-assignment={assignment.id}
+      data-routing-role={assignment.role}
+    >
+      <RowBody assignment={assignment} />
+    </div>
+  );
+};
+
+/**
+ * Right-dock panel listing the agent slots that the active route
+ * dispatches to: primary handler + fallbacks + shadow probes. Each row
+ * shows the agent name, role chip, and optional load bar. Pure
+ * presentation; the host computes the assignments from the routing
+ * config + observed traffic.
+ *
+ * @example
+ * ```tsx
+ * <RoutingAssignmentPanel
+ *   assignments={[
+ *     { id: "1", agent: "researcher",     role: "primary",  load: 0.82 },
+ *     { id: "2", agent: "researcher-mini", role: "fallback", load: 0.04 },
+ *     { id: "3", agent: "shadow-eval",    role: "shadow" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const RoutingAssignmentPanel = forwardRef<
+  HTMLElement,
+  RoutingAssignmentPanelProps
+>((props, ref) => {
+  const { assignments, className, labels, title = "Routing", ...rest } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  return (
+    <section
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "flex w-full flex-col gap-2 rounded-lg border bg-background p-3 text-foreground",
+        className,
+      )}
+      data-routing-assignment-panel
+      ref={ref}
+      {...rest}
+    >
+      <header>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {title}
+        </h3>
+      </header>
+      {assignments.length === 0 ? (
+        <p
+          className="px-2 py-3 text-center text-xs text-muted-foreground"
+          data-routing-state="empty"
+        >
+          {resolvedLabels.empty}
+        </p>
+      ) : (
+        <ul className="space-y-0.5">
+          {assignments.map((assignment) => (
+            <li key={assignment.id}>
+              <Row assignment={assignment} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+});
+RoutingAssignmentPanel.displayName = "RoutingAssignmentPanel";

--- a/apps/registry/registry/default/run-timeline/run-timeline.tsx
+++ b/apps/registry/registry/default/run-timeline/run-timeline.tsx
@@ -1,8 +1,360 @@
-export {
-  type RunPhaseState,
-  RunTimeline,
-  type RunTimelineLabels,
-  type RunTimelineLane,
-  type RunTimelinePhase,
-  type RunTimelineProps,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Phase state — drives the bar tone.
+ *
+ * @public
+ */
+export type RunPhaseState =
+  | "complete"
+  | "failed"
+  | "queued"
+  | "running"
+  | "stopped";
+
+const STATE_FILL: Record<RunPhaseState, string> = {
+  complete: "bg-emerald-500/70",
+  failed: "bg-red-500/70",
+  queued: "bg-amber-500/70",
+  running: "bg-blue-500/70",
+  stopped: "bg-muted-foreground/40",
+};
+
+const STATE_LABEL: Record<RunPhaseState, string> = {
+  complete: "Complete",
+  failed: "Failed",
+  queued: "Queued",
+  running: "Running",
+  stopped: "Stopped",
+};
+
+/**
+ * One lane in a multi-lane run timeline.
+ *
+ * @public
+ */
+export type RunTimelineLane = {
+  /** Stable identifier — used as the React key + phase routing. */
+  id: string;
+  /** Display label rendered to the left of the lane. */
+  label: ReactNode;
+};
+
+/**
+ * One phase block in the run timeline.
+ *
+ * @public
+ */
+export type RunTimelinePhase = {
+  /** End timestamp in the same units as `start` / `end`. */
+  end: number;
+  /** Stable identifier — used as the React key + analytics hook. */
+  id: string;
+  /** Optional label rendered inside the phase bar. */
+  label?: ReactNode;
+  /** Lane id this phase belongs to. Defaults to `"default"` (single-lane mode). */
+  laneId?: string;
+  /** Optional click handler — when provided, the phase becomes a button. */
+  onActivate?: () => void;
+  /** Start timestamp `>= timeline start`. */
+  start: number;
+  /** Phase state. Defaults to `"running"`. */
+  state?: RunPhaseState;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type RunTimelineLabels = {
+  /** Empty-state copy. Defaults to `"No phases"`. */
+  empty?: string;
+  /** Aria-label override. Defaults to `"Run timeline"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No phases",
+  region: "Run timeline",
+} as const satisfies Required<RunTimelineLabels>;
+
+/**
+ * Props for {@link RunTimeline}.
+ *
+ * @public
+ */
+export type RunTimelineProps = {
+  /** Optional cursor position in the same units as the range. Renders a vertical line. */
+  cursor?: number;
+  /** End of the time range. Must be `> start`. */
+  end: number;
+  /** Optional formatter for the start / cursor / end labels. */
+  formatValue?: (value: number) => ReactNode;
+  /** Localizable strings. */
+  labels?: RunTimelineLabels;
+  /** Optional explicit lane definitions in render order. Required for multi-lane mode. */
+  lanes?: RunTimelineLane[];
+  /** Phase blocks — order is irrelevant; routed to lanes by `laneId`. */
+  phases: RunTimelinePhase[];
+  /** Start of the time range. */
+  start: number;
+} & ComponentPropsWithoutRef<"section">;
+
+const clamp = (v: number, min: number, max: number): number => {
+  if (v < min) {
+    return min;
+  }
+  if (v > max) {
+    return max;
+  }
+  return v;
+};
+
+const Endpoints = (props: {
+  cursor?: number;
+  end: number;
+  format?: (v: number) => ReactNode;
+  start: number;
+}): React.ReactElement => {
+  const fmt = props.format;
+  const showCursor = typeof props.cursor === "number";
+  return (
+    <div className="flex items-baseline justify-between gap-2 text-[11px] text-muted-foreground">
+      <span data-run-timeline-start>
+        {fmt ? fmt(props.start) : props.start}
+      </span>
+      {showCursor ? (
+        <span
+          className="font-semibold text-foreground"
+          data-run-timeline-cursor-label
+        >
+          {fmt ? fmt(props.cursor ?? 0) : props.cursor}
+        </span>
+      ) : null}
+      <span data-run-timeline-end>{fmt ? fmt(props.end) : props.end}</span>
+    </div>
+  );
+};
+
+const PhaseBar = (props: {
+  laneIndex: number;
+  laneTotal: number;
+  phase: RunTimelinePhase;
+  span: number;
+  start: number;
+}): React.ReactElement => {
+  const { laneIndex, laneTotal, phase, span, start } = props;
+  const left = clamp((phase.start - start) / span, 0, 1) * 100;
+  const right = clamp((phase.end - start) / span, 0, 1) * 100;
+  const width = Math.max(right - left, 0.5);
+  const top = (laneIndex / laneTotal) * 100;
+  const height = 100 / laneTotal;
+  const state = phase.state ?? "running";
+  const sharedStyle = {
+    height: `${height}%`,
+    left: `${left}%`,
+    top: `${top}%`,
+    width: `${width}%`,
+  };
+  const ariaLabel = `${STATE_LABEL[state]} ${phase.start} → ${phase.end}`;
+  if (phase.onActivate) {
+    const handleClick = (): void => {
+      phase.onActivate?.();
+    };
+    return (
+      <button
+        aria-label={ariaLabel}
+        className={cn(
+          "absolute flex items-center justify-start overflow-hidden truncate rounded-sm border border-border/50 px-1 text-left text-[10px] text-foreground transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          STATE_FILL[state],
+        )}
+        data-run-phase={phase.id}
+        data-run-phase-state={state}
+        onClick={handleClick}
+        style={sharedStyle}
+        type="button"
+      >
+        {phase.label}
+      </button>
+    );
+  }
+  return (
+    <span
+      aria-label={ariaLabel}
+      className={cn(
+        "absolute flex items-center justify-start overflow-hidden truncate rounded-sm border border-border/50 px-1 text-[10px] text-foreground",
+        STATE_FILL[state],
+      )}
+      data-run-phase={phase.id}
+      data-run-phase-state={state}
+      role="img"
+      style={sharedStyle}
+    >
+      {phase.label}
+    </span>
+  );
+};
+
+type LaneViewInput = {
+  cursor?: number;
+  end: number;
+  lanes: RunTimelineLane[];
+  phases: RunTimelinePhase[];
+  start: number;
+};
+
+const TrackBody = (props: LaneViewInput): React.ReactElement => {
+  const { cursor, end, lanes, phases, start } = props;
+  const span = end - start;
+  const cursorRatio =
+    typeof cursor === "number" ? clamp((cursor - start) / span, 0, 1) : null;
+  return (
+    <div className="flex items-stretch">
+      <div className="flex w-24 flex-col gap-px text-[10px] uppercase tracking-wide text-muted-foreground">
+        {lanes.map((lane) => (
+          <div
+            className="flex h-7 items-center px-2"
+            data-run-timeline-lane={lane.id}
+            key={lane.id}
+          >
+            {lane.label}
+          </div>
+        ))}
+      </div>
+      <div
+        className="relative flex-1 overflow-hidden rounded-md border border-border bg-muted/20"
+        data-run-timeline-track
+        style={{ height: `${lanes.length * 28}px` }}
+      >
+        {phases.map((phase) => {
+          const index = lanes.findIndex(
+            (lane) => lane.id === (phase.laneId ?? "default"),
+          );
+          if (index === -1) {
+            return null;
+          }
+          return (
+            <PhaseBar
+              key={phase.id}
+              laneIndex={index}
+              laneTotal={lanes.length}
+              phase={phase}
+              span={span}
+              start={start}
+            />
+          );
+        })}
+        {cursorRatio === null ? null : (
+          <span
+            aria-hidden="true"
+            className="absolute top-0 bottom-0 w-px bg-foreground"
+            data-run-timeline-cursor
+            style={{ left: `${cursorRatio * 100}%` }}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+const resolveLanes = (
+  explicit: RunTimelineLane[] | undefined,
+): RunTimelineLane[] => {
+  if (explicit && explicit.length > 0) {
+    return explicit;
+  }
+  return [{ id: "default", label: "Run" }];
+};
+
+/**
+ * Multi-lane execution timeline showing run phases over time. Each
+ * phase renders as a colored bar positioned by its start / end and
+ * routed to a lane by `laneId`. Optional cursor draws a thin vertical
+ * line for the current playback position.
+ *
+ * Pure presentation; the host computes the phase list from the run's
+ * execution history. Pair with {@link "../timeline-scrubber/timeline-scrubber".TimelineScrubber}
+ * to drive the cursor.
+ *
+ * Distinct from `MapTimeline` (geo-aware), `Stepper` (sequential
+ * steps), and the timeline family `#32`–`#35`: this primitive is
+ * specifically the run history surface inside the canvas.
+ *
+ * @example
+ * ```tsx
+ * <RunTimeline
+ *   start={0} end={3600}
+ *   cursor={1800}
+ *   lanes={[
+ *     { id: "ingest", label: "Ingest" },
+ *     { id: "rank",   label: "Rank" },
+ *   ]}
+ *   phases={[
+ *     { id: "1", laneId: "ingest", start: 0,    end: 600,  state: "complete", label: "load" },
+ *     { id: "2", laneId: "rank",   start: 600,  end: 2400, state: "running",  label: "score" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const RunTimeline = forwardRef<HTMLElement, RunTimelineProps>(
+  (props, ref) => {
+    const {
+      className,
+      cursor,
+      end,
+      formatValue,
+      labels,
+      lanes,
+      phases,
+      start,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const safeEnd = end <= start ? start + 1 : end;
+    const resolvedLanes = resolveLanes(lanes);
+    return (
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn("flex w-full flex-col gap-2", className)}
+        data-run-timeline
+        ref={ref}
+        {...rest}
+      >
+        <Endpoints
+          cursor={cursor}
+          end={safeEnd}
+          format={formatValue}
+          start={start}
+        />
+        {phases.length === 0 ? (
+          <p
+            className="rounded-md border border-border bg-muted/20 px-2 py-3 text-center text-[11px] text-muted-foreground"
+            data-run-timeline-state="empty"
+          >
+            {resolvedLabels.empty}
+          </p>
+        ) : (
+          <TrackBody
+            cursor={cursor}
+            end={safeEnd}
+            lanes={resolvedLanes}
+            phases={phases}
+            start={start}
+          />
+        )}
+      </section>
+    );
+  },
+);
+RunTimeline.displayName = "RunTimeline";

--- a/apps/registry/registry/default/runtime-overview-panel/runtime-overview-panel.tsx
+++ b/apps/registry/registry/default/runtime-overview-panel/runtime-overview-panel.tsx
@@ -1,8 +1,183 @@
-export {
-  type RuntimeMetric,
-  type RuntimeMetricTone,
-  type RuntimeMetricTrend,
-  RuntimeOverviewPanel,
-  type RuntimeOverviewPanelLabels,
-  type RuntimeOverviewPanelProps,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Trend direction for a runtime metric.
+ *
+ * @public
+ */
+export type RuntimeMetricTrend = "down" | "flat" | "up";
+
+/**
+ * Tone of the metric value — drives the dot color.
+ *
+ * @public
+ */
+export type RuntimeMetricTone = "danger" | "neutral" | "success" | "warn";
+
+/**
+ * One metric tile in the runtime overview.
+ *
+ * @public
+ */
+export type RuntimeMetric = {
+  /** Optional secondary line (delta, target, owner). */
+  detail?: ReactNode;
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Short label (e.g. `"Active runs"`). */
+  label: ReactNode;
+  /** Optional tone for the dot. Defaults to `"neutral"`. */
+  tone?: RuntimeMetricTone;
+  /** Optional trend arrow next to the value. */
+  trend?: RuntimeMetricTrend;
+  /** Display value (already formatted by the host). */
+  value: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type RuntimeOverviewPanelLabels = {
+  /** Empty-state copy. Defaults to `"No runtime metrics"`. */
+  empty?: string;
+  /** Aria-label for the panel. Defaults to `"Runtime overview"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No runtime metrics",
+  region: "Runtime overview",
+} as const satisfies Required<RuntimeOverviewPanelLabels>;
+
+const TONE_DOT: Record<RuntimeMetricTone, string> = {
+  danger: "bg-red-500",
+  neutral: "bg-muted-foreground",
+  success: "bg-emerald-500",
+  warn: "bg-amber-500",
+};
+
+const TREND_GLYPH: Record<RuntimeMetricTrend, string> = {
+  down: "↓",
+  flat: "·",
+  up: "↑",
+};
+
+/**
+ * Props for {@link RuntimeOverviewPanel}.
+ *
+ * @public
+ */
+export type RuntimeOverviewPanelProps = {
+  /** Localizable strings. */
+  labels?: RuntimeOverviewPanelLabels;
+  /** Metric tiles in render order. */
+  metrics: RuntimeMetric[];
+  /** Panel title. Defaults to `"Runtime"`. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const Tile = (props: { metric: RuntimeMetric }): React.ReactElement => {
+  const { metric } = props;
+  const tone = metric.tone ?? "neutral";
+  return (
+    <li
+      className="flex flex-col gap-1 rounded-md border border-border/60 bg-muted/20 px-2.5 py-2"
+      data-runtime-metric={metric.id}
+      data-runtime-tone={tone}
+    >
+      <span className="flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+        <span
+          aria-hidden="true"
+          className={cn("h-1.5 w-1.5 rounded-full", TONE_DOT[tone])}
+        />
+        {metric.label}
+      </span>
+      <span className="flex items-baseline gap-1.5 text-sm font-semibold text-foreground">
+        <span>{metric.value}</span>
+        {metric.trend ? (
+          <span
+            aria-hidden="true"
+            className="text-[10px] text-muted-foreground"
+          >
+            {TREND_GLYPH[metric.trend]}
+          </span>
+        ) : null}
+      </span>
+      {metric.detail ? (
+        <span className="text-[10px] text-muted-foreground">
+          {metric.detail}
+        </span>
+      ) : null}
+    </li>
+  );
+};
+
+/**
+ * Top-of-dock summary for the runtime when nothing on the canvas is
+ * selected. Renders a compact grid of metric tiles (active runs,
+ * throughput, error rate, etc.). Pure presentation; the host computes
+ * the metric list from the runtime stream.
+ *
+ * @example
+ * ```tsx
+ * <RuntimeOverviewPanel
+ *   metrics={[
+ *     { id: "runs",  label: "Active runs", value: 3, tone: "success" },
+ *     { id: "errs",  label: "Errors / hr", value: 0, tone: "neutral", trend: "flat" },
+ *     { id: "tps",   label: "Throughput", value: "120 / s", tone: "success", trend: "up" },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const RuntimeOverviewPanel = forwardRef<
+  HTMLElement,
+  RuntimeOverviewPanelProps
+>((props, ref) => {
+  const { className, labels, metrics, title = "Runtime", ...rest } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  return (
+    <section
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "flex w-full flex-col gap-2 rounded-2xl border bg-background p-3 text-foreground",
+        className,
+      )}
+      data-runtime-overview-panel
+      ref={ref}
+      {...rest}
+    >
+      <header>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {title}
+        </h3>
+      </header>
+      {metrics.length === 0 ? (
+        <p
+          className="px-2 py-3 text-center text-xs text-muted-foreground"
+          data-runtime-state="empty"
+        >
+          {resolvedLabels.empty}
+        </p>
+      ) : (
+        <ul className="grid grid-cols-2 gap-1.5" data-runtime-grid>
+          {metrics.map((metric) => (
+            <Tile key={metric.id} metric={metric} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+});
+RuntimeOverviewPanel.displayName = "RuntimeOverviewPanel";

--- a/apps/registry/registry/default/scope-selector/scope-selector.tsx
+++ b/apps/registry/registry/default/scope-selector/scope-selector.tsx
@@ -1,6 +1,497 @@
-export {
-  ScopeSelector,
-  type ScopeSelectorNode,
-  type ScopeSelectorProps,
-  type ScopeSelectorSelection,
-} from "@vllnt/ui";
+"use client";
+
+import { forwardRef, useMemo, useState } from "react";
+
+import { Check, ChevronRight, Search } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import { Input } from "@vllnt/ui";
+import { Popover, PopoverContent, PopoverTrigger } from "@vllnt/ui";
+import { ScrollArea } from "@vllnt/ui";
+import { Separator } from "@vllnt/ui";
+
+export type ScopeSelectorNode = {
+  badge?: string;
+  children?: ScopeSelectorNode[];
+  description?: string;
+  disabled?: boolean;
+  id: string;
+  label: string;
+  selectable?: boolean;
+};
+
+export type ScopeSelectorSelection = {
+  node: ScopeSelectorNode;
+  path: ScopeSelectorNode[];
+};
+
+export type ScopeSelectorProps = {
+  className?: string;
+  defaultValue?: string;
+  disabled?: boolean;
+  emptyMessage?: string;
+  nodes: ScopeSelectorNode[];
+  onValueChange?: (selection: ScopeSelectorSelection) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  value?: string;
+};
+
+type FlattenedScopeNode = {
+  node: ScopeSelectorNode;
+  path: ScopeSelectorNode[];
+};
+
+type ScopeOptionButtonProps = {
+  node: ScopeSelectorNode;
+  onBrowse: (node: ScopeSelectorNode) => void;
+  onSelect: (selection: ScopeSelectorSelection) => void;
+  path: ScopeSelectorNode[];
+  selectedValue?: string;
+  showPathLabel?: boolean;
+};
+
+type ScopePanelProps = {
+  currentPath: ScopeSelectorNode[];
+  emptyMessage: string;
+  nodes: ScopeSelectorNode[];
+  onBrowse: (node: ScopeSelectorNode) => void;
+  onSelect: (selection: ScopeSelectorSelection) => void;
+  query: string;
+  searchResults: FlattenedScopeNode[];
+  selectedValue?: string;
+};
+
+type ScopeSelectorState = {
+  currentLevelNodes: ScopeSelectorNode[];
+  currentPath: ScopeSelectorNode[];
+  currentPathLabel: string;
+  handleBrowse: (node: ScopeSelectorNode) => void;
+  handleOpenChange: (nextOpen: boolean) => void;
+  handleSelect: (selection: ScopeSelectorSelection) => void;
+  open: boolean;
+  query: string;
+  searchResults: FlattenedScopeNode[];
+  selectedPathLabel?: string;
+  selectedSelection?: ScopeSelectorSelection;
+  selectedValue?: string;
+  setCurrentPath: (path: ScopeSelectorNode[]) => void;
+  setQuery: (value: string) => void;
+};
+
+type ScopeSelectorPopoverBodyProps = {
+  emptyMessage: string;
+  searchPlaceholder: string;
+  state: ScopeSelectorState;
+};
+
+function flattenNodes(
+  nodes: ScopeSelectorNode[],
+  parentPath: ScopeSelectorNode[] = [],
+): FlattenedScopeNode[] {
+  return nodes.flatMap((node) => {
+    const path = [...parentPath, node];
+    const current = [{ node, path }];
+    const descendants = node.children ? flattenNodes(node.children, path) : [];
+    return [...current, ...descendants];
+  });
+}
+
+function findSelection(
+  nodes: ScopeSelectorNode[],
+  value?: string,
+): ScopeSelectorSelection | undefined {
+  if (!value) return undefined;
+
+  const flattened = flattenNodes(nodes);
+  const match = flattened.find((entry) => entry.node.id === value);
+  return match ? { node: match.node, path: match.path } : undefined;
+}
+
+function getVisibleNodes(
+  tree: ScopeSelectorNode[],
+  currentPath: ScopeSelectorNode[],
+): ScopeSelectorNode[] {
+  const currentNode = currentPath.at(-1);
+  return currentNode?.children ?? tree;
+}
+
+function isSelectableNode(node: ScopeSelectorNode): boolean {
+  if (node.disabled) return false;
+  if (node.selectable !== undefined) return node.selectable;
+  return !node.children || node.children.length === 0;
+}
+
+function getPathLabel(path: ScopeSelectorNode[]): string {
+  return path.map((node) => node.label).join(" / ");
+}
+
+function filterScopeResults(
+  flattenedNodes: FlattenedScopeNode[],
+  query: string,
+): FlattenedScopeNode[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return [];
+
+  return flattenedNodes.filter(({ node, path }) => {
+    const pathLabel = getPathLabel(path).toLowerCase();
+    const description = node.description?.toLowerCase() ?? "";
+    return (
+      node.label.toLowerCase().includes(normalizedQuery) ||
+      description.includes(normalizedQuery) ||
+      pathLabel.includes(normalizedQuery)
+    );
+  });
+}
+
+function ScopeOptionButton({
+  node,
+  onBrowse,
+  onSelect,
+  path,
+  selectedValue,
+  showPathLabel,
+}: ScopeOptionButtonProps) {
+  const selectable = isSelectableNode(node);
+
+  return (
+    <button
+      className={cn(
+        "flex w-full items-start justify-between rounded-md border px-3 py-3 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
+        selectedValue === node.id && "border-primary bg-accent",
+        node.disabled && "cursor-not-allowed opacity-50",
+      )}
+      disabled={node.disabled}
+      key={node.id}
+      onClick={() => {
+        if (selectable) {
+          onSelect({ node, path });
+          return;
+        }
+        onBrowse(node);
+      }}
+      type="button"
+    >
+      <div className="min-w-0 space-y-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium">{node.label}</span>
+          {node.badge ? <Badge variant="outline">{node.badge}</Badge> : null}
+        </div>
+        {showPathLabel ? (
+          <div className="text-xs text-muted-foreground">
+            {getPathLabel(path)}
+          </div>
+        ) : null}
+        {node.description ? (
+          <p className="text-sm text-muted-foreground">{node.description}</p>
+        ) : null}
+      </div>
+      {selectedValue === node.id ? (
+        <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+      ) : node.children && node.children.length > 0 ? (
+        <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+      ) : null}
+    </button>
+  );
+}
+
+function ScopeSearchResults({
+  onBrowse,
+  onSelect,
+  results,
+  selectedValue,
+}: {
+  onBrowse: (node: ScopeSelectorNode) => void;
+  onSelect: (selection: ScopeSelectorSelection) => void;
+  results: FlattenedScopeNode[];
+  selectedValue?: string;
+}) {
+  return (
+    <div className="space-y-2 px-1 py-1">
+      {results.map(({ node, path }) => (
+        <ScopeOptionButton
+          key={getPathLabel(path)}
+          node={node}
+          onBrowse={onBrowse}
+          onSelect={onSelect}
+          path={path}
+          selectedValue={selectedValue}
+          showPathLabel
+        />
+      ))}
+    </div>
+  );
+}
+
+function ScopeCurrentLevel({
+  currentPath,
+  nodes,
+  onBrowse,
+  onSelect,
+  selectedValue,
+}: {
+  currentPath: ScopeSelectorNode[];
+  nodes: ScopeSelectorNode[];
+  onBrowse: (node: ScopeSelectorNode) => void;
+  onSelect: (selection: ScopeSelectorSelection) => void;
+  selectedValue?: string;
+}) {
+  return (
+    <div className="space-y-2 px-1 py-1">
+      {nodes.map((node) => (
+        <ScopeOptionButton
+          key={node.id}
+          node={node}
+          onBrowse={onBrowse}
+          onSelect={onSelect}
+          path={[...currentPath, node]}
+          selectedValue={selectedValue}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ScopePanel({
+  currentPath,
+  emptyMessage,
+  nodes,
+  onBrowse,
+  onSelect,
+  query,
+  searchResults,
+  selectedValue,
+}: ScopePanelProps) {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  if (normalizedQuery) {
+    if (searchResults.length === 0) {
+      return (
+        <div className="px-3 py-8 text-center text-sm text-muted-foreground">
+          No scopes match your search.
+        </div>
+      );
+    }
+
+    return (
+      <ScopeSearchResults
+        onBrowse={onBrowse}
+        onSelect={onSelect}
+        results={searchResults}
+        selectedValue={selectedValue}
+      />
+    );
+  }
+
+  if (nodes.length === 0) {
+    return (
+      <div className="px-3 py-8 text-center text-sm text-muted-foreground">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return (
+    <ScopeCurrentLevel
+      currentPath={currentPath}
+      nodes={nodes}
+      onBrowse={onBrowse}
+      onSelect={onSelect}
+      selectedValue={selectedValue}
+    />
+  );
+}
+
+function ScopeSelectorBreadcrumb({
+  currentPath,
+  onBack,
+}: {
+  currentPath: ScopeSelectorNode[];
+  onBack: () => void;
+}) {
+  if (currentPath.length === 0) return null;
+
+  return (
+    <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
+      <Button className="h-7 px-2" onClick={onBack} size="sm" variant="ghost">
+        <ChevronRight className="h-3.5 w-3.5 rotate-180" />
+        Back
+      </Button>
+      <span className="truncate">{getPathLabel(currentPath)}</span>
+    </div>
+  );
+}
+
+function ScopeSelectorPopoverBody({
+  emptyMessage,
+  searchPlaceholder,
+  state,
+}: ScopeSelectorPopoverBodyProps) {
+  return (
+    <PopoverContent align="start" className="w-[380px] p-0" sideOffset={8}>
+      <div className="border-b p-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            className="pl-9"
+            onChange={(event) => {
+              state.setQuery(event.target.value);
+            }}
+            placeholder={searchPlaceholder}
+            value={state.query}
+          />
+        </div>
+        {state.query.trim() ? null : (
+          <ScopeSelectorBreadcrumb
+            currentPath={state.currentPath}
+            onBack={() => {
+              state.setCurrentPath(state.currentPath.slice(0, -1));
+            }}
+          />
+        )}
+      </div>
+      <ScrollArea className="max-h-[320px]">
+        <ScopePanel
+          currentPath={state.currentPath}
+          emptyMessage={emptyMessage}
+          nodes={state.currentLevelNodes}
+          onBrowse={state.handleBrowse}
+          onSelect={state.handleSelect}
+          query={state.query}
+          searchResults={state.searchResults}
+          selectedValue={state.selectedValue}
+        />
+      </ScrollArea>
+      {state.selectedSelection ? (
+        <>
+          <Separator />
+          <div className="px-3 py-2 text-xs text-muted-foreground">
+            Selected: {state.selectedPathLabel}
+          </div>
+        </>
+      ) : null}
+    </PopoverContent>
+  );
+}
+
+function useScopeSelectorState({
+  defaultValue,
+  nodes,
+  onValueChange,
+  value,
+}: Pick<
+  ScopeSelectorProps,
+  "defaultValue" | "nodes" | "onValueChange" | "value"
+>): ScopeSelectorState {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue);
+  const [currentPath, setCurrentPath] = useState<ScopeSelectorNode[]>([]);
+  const selectedValue = value ?? uncontrolledValue;
+  const selectedSelection = useMemo(
+    () => findSelection(nodes, selectedValue),
+    [nodes, selectedValue],
+  );
+  const flattenedNodes = useMemo(() => flattenNodes(nodes), [nodes]);
+  const searchResults = useMemo(
+    () => filterScopeResults(flattenedNodes, query),
+    [flattenedNodes, query],
+  );
+  const currentLevelNodes = getVisibleNodes(nodes, currentPath);
+
+  function handleSelect(selection: ScopeSelectorSelection) {
+    if (value === undefined) {
+      setUncontrolledValue(selection.node.id);
+    }
+    setCurrentPath(selection.path.slice(0, -1));
+    setQuery("");
+    setOpen(false);
+    onValueChange?.(selection);
+  }
+
+  function handleBrowse(node: ScopeSelectorNode) {
+    const nextPath = findSelection(nodes, node.id)?.path ?? [];
+    setCurrentPath(nextPath);
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      setCurrentPath(selectedSelection?.path.slice(0, -1) ?? []);
+      return;
+    }
+    setQuery("");
+  }
+
+  return {
+    currentLevelNodes,
+    currentPath,
+    currentPathLabel: getPathLabel(currentPath),
+    handleBrowse,
+    handleOpenChange,
+    handleSelect,
+    open,
+    query,
+    searchResults,
+    selectedPathLabel: selectedSelection
+      ? getPathLabel(selectedSelection.path)
+      : undefined,
+    selectedSelection,
+    selectedValue,
+    setCurrentPath,
+    setQuery,
+  };
+}
+
+const ScopeSelector = forwardRef<HTMLButtonElement, ScopeSelectorProps>(
+  (
+    {
+      className,
+      defaultValue,
+      disabled,
+      emptyMessage = "No scopes available.",
+      nodes,
+      onValueChange,
+      placeholder = "Select scope",
+      searchPlaceholder = "Search scopes...",
+      value,
+    },
+    ref,
+  ) => {
+    const state = useScopeSelectorState({
+      defaultValue,
+      nodes,
+      onValueChange,
+      value,
+    });
+
+    return (
+      <Popover onOpenChange={state.handleOpenChange} open={state.open}>
+        <PopoverTrigger asChild>
+          <Button
+            className={cn("w-full justify-between", className)}
+            disabled={disabled}
+            ref={ref}
+            variant="outline"
+          >
+            <span className="truncate text-left">
+              {state.selectedPathLabel ?? placeholder}
+            </span>
+            <ChevronRight className="h-4 w-4 shrink-0 rotate-90 text-muted-foreground" />
+          </Button>
+        </PopoverTrigger>
+        <ScopeSelectorPopoverBody
+          emptyMessage={emptyMessage}
+          searchPlaceholder={searchPlaceholder}
+          state={state}
+        />
+      </Popover>
+    );
+  },
+);
+
+ScopeSelector.displayName = "ScopeSelector";
+
+export { ScopeSelector };

--- a/apps/registry/registry/default/scroll-area/scroll-area.tsx
+++ b/apps/registry/registry/default/scroll-area/scroll-area.tsx
@@ -1,1 +1,49 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+
+import { cn } from "@vllnt/ui";
+
+const ScrollArea = forwardRef<
+  React.ComponentRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ children, className, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    className={cn("relative overflow-hidden", className)}
+    ref={ref}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+));
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
+
+const ScrollBar = forwardRef<
+  React.ComponentRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className,
+    )}
+    orientation={orientation}
+    ref={ref}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+));
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+
+export { ScrollArea, ScrollBar };

--- a/apps/registry/registry/default/search-bar/search-bar.tsx
+++ b/apps/registry/registry/default/search-bar/search-bar.tsx
@@ -1,2 +1,162 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { useDebounce } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import { Input } from "@vllnt/ui";
+
+type SearchBarProps = {
+  className?: string;
+  onSearch?: (query: string) => void;
+  placeholder?: string;
+};
+
+export function SearchBar({
+  className,
+  onSearch,
+  placeholder = "Search posts...",
+}: SearchBarProps) {
+  const router = useRouter();
+  const searchParameters = useSearchParams();
+  const initialQuery = searchParameters.get("search") ?? "";
+  const [query, setQuery] = useState(initialQuery);
+  const debouncedQuery = useDebounce(query, 300);
+  const isInitialMount = useRef(true);
+  const isUserTyping = useRef(false);
+
+  const typingTimeoutReference = useRef<NodeJS.Timeout | undefined>(undefined);
+  const lastSetSearchParameterReference = useRef<string>("");
+  const lastDebouncedQueryReference = useRef<string>("");
+
+  // Sync query with URL search params (e.g., on browser back/forward)
+  // Sync when user is not actively typing and URL changed externally
+  useEffect(() => {
+    const searchParameter = searchParameters.get("search") ?? "";
+
+    // Skip if this is the search param we set ourselves
+    if (searchParameter === lastSetSearchParameterReference.current) {
+      return;
+    }
+
+    // Sync if user is not actively typing and values differ
+    if (!isUserTyping.current && query !== searchParameter) {
+      requestAnimationFrame(() => {
+        setQuery(searchParameter);
+        lastDebouncedQueryReference.current = searchParameter;
+      });
+    }
+  }, [searchParameters, query]); // Include query to properly sync state
+
+  // Update URL when debounced query changes
+  useEffect(() => {
+    // Skip initial mount to avoid unnecessary URL update
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      const initialTrimmed = debouncedQuery.trim();
+      lastDebouncedQueryReference.current = initialTrimmed;
+      lastSetSearchParameterReference.current = initialTrimmed;
+      return;
+    }
+
+    const trimmedQuery = debouncedQuery.trim();
+
+    // Skip if this is the same value we already processed
+    if (trimmedQuery === lastDebouncedQueryReference.current) {
+      return;
+    }
+
+    lastDebouncedQueryReference.current = trimmedQuery;
+
+    if (onSearch) {
+      onSearch(trimmedQuery);
+      return;
+    }
+
+    // Check current URL to avoid unnecessary updates
+    const currentUrlParameter = searchParameters.get("search") ?? "";
+
+    // Skip if URL already matches the debounced query
+    if (trimmedQuery === currentUrlParameter) {
+      lastSetSearchParameterReference.current = trimmedQuery;
+      return;
+    }
+
+    const parameters = new URLSearchParams(searchParameters);
+    if (trimmedQuery) {
+      parameters.set("search", trimmedQuery);
+    } else {
+      parameters.delete("search");
+    }
+    const newUrl = parameters.toString();
+    lastSetSearchParameterReference.current = trimmedQuery;
+    router.replace(`?${newUrl}`);
+  }, [debouncedQuery, router, onSearch, searchParameters]);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (typingTimeoutReference.current) {
+        clearTimeout(typingTimeoutReference.current);
+      }
+    };
+  }, []);
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    isUserTyping.current = true;
+    setQuery(event.target.value);
+
+    // Clear existing timeout
+    if (typingTimeoutReference.current) {
+      clearTimeout(typingTimeoutReference.current);
+    }
+
+    // Reset typing flag after debounce delay + buffer
+    typingTimeoutReference.current = setTimeout(() => {
+      isUserTyping.current = false;
+    }, 350);
+  };
+
+  const handleSubmit = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+    isUserTyping.current = false;
+
+    // Clear typing timeout
+    if (typingTimeoutReference.current) {
+      clearTimeout(typingTimeoutReference.current);
+    }
+
+    const trimmedQuery = query.trim();
+    if (onSearch) {
+      onSearch(trimmedQuery);
+    } else {
+      const parameters = new URLSearchParams(searchParameters);
+      if (trimmedQuery) {
+        parameters.set("search", trimmedQuery);
+      } else {
+        parameters.delete("search");
+      }
+      const newUrl = parameters.toString();
+      lastSetSearchParameterReference.current = trimmedQuery;
+      router.replace(`?${newUrl}`);
+    }
+  };
+
+  return (
+    <form className={`flex gap-2 ${className}`} onSubmit={handleSubmit}>
+      <Input
+        aria-label={placeholder}
+        className="flex-1"
+        onChange={handleInputChange}
+        placeholder={placeholder}
+        type="text"
+        value={query}
+      />
+      <Button type="submit" variant="outline">
+        Search
+      </Button>
+    </form>
+  );
+}

--- a/apps/registry/registry/default/search-dialog/search-dialog.tsx
+++ b/apps/registry/registry/default/search-dialog/search-dialog.tsx
@@ -1,2 +1,138 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Search } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@vllnt/ui";
+
+type SearchItem = {
+  description?: string;
+  id: string;
+  keywords?: string;
+  title: string;
+};
+
+function useKeyboardShortcut(callback: () => void) {
+  useEffect(() => {
+    const down = (event: KeyboardEvent) => {
+      if (
+        (event.key === "k" || event.key === "K") &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        const target = event.target as HTMLElement | null;
+        if (
+          target &&
+          (target.tagName === "INPUT" ||
+            target.tagName === "TEXTAREA" ||
+            target.isContentEditable)
+        ) {
+          return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        callback();
+      }
+    };
+
+    window.addEventListener("keydown", down, { capture: true, passive: false });
+    return () => {
+      window.removeEventListener("keydown", down, { capture: true });
+    };
+  }, [callback]);
+}
+
+type SearchDialogProps = {
+  buttonText?: string;
+  buttonTextMobile?: string;
+  emptyText?: string;
+  enableKeyboardShortcut?: boolean;
+  groupHeading?: string;
+  items: SearchItem[];
+  onSelect: (item: SearchItem) => void;
+  searchPlaceholder?: string;
+};
+
+export function SearchDialog({
+  buttonText = "Search...",
+  buttonTextMobile = "Search...",
+  emptyText = "No results found.",
+  enableKeyboardShortcut = true,
+  groupHeading,
+  items,
+  onSelect,
+  searchPlaceholder = "Search...",
+}: SearchDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  const sortedItems = [...items].sort((a, b) => a.title.localeCompare(b.title));
+
+  useKeyboardShortcut(() => {
+    if (enableKeyboardShortcut) {
+      setOpen((previous) => !previous);
+    }
+  });
+
+  const handleSelect = (item: SearchItem) => {
+    setOpen(false);
+    onSelect(item);
+  };
+
+  return (
+    <>
+      <Button
+        className={cn(
+          "relative h-9 w-full justify-start text-sm text-muted-foreground sm:pr-12 md:w-40 lg:w-64",
+        )}
+        onClick={() => {
+          setOpen(true);
+        }}
+        variant="outline"
+      >
+        <Search className="mr-2 h-4 w-4" />
+        <span className="hidden lg:inline-flex">{buttonText}</span>
+        <span className="inline-flex lg:hidden">{buttonTextMobile}</span>
+        <kbd className="pointer-events-none absolute right-1.5 top-1.5 hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex">
+          <span className="text-xs">⌘</span>K
+        </kbd>
+      </Button>
+      <CommandDialog onOpenChange={setOpen} open={open}>
+        <CommandInput placeholder={searchPlaceholder} />
+        <CommandList>
+          <CommandEmpty>{emptyText}</CommandEmpty>
+          <CommandGroup heading={groupHeading}>
+            {sortedItems.map((item) => (
+              <CommandItem
+                key={item.id}
+                onSelect={() => {
+                  handleSelect(item);
+                }}
+                value={`${item.title} ${item.description || ""} ${item.keywords || ""} ${item.id}`}
+              >
+                <div className="flex flex-col">
+                  <span className="font-medium">{item.title}</span>
+                  {item.description ? (
+                    <span className="text-xs text-muted-foreground">
+                      {item.description}
+                    </span>
+                  ) : null}
+                </div>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>
+    </>
+  );
+}

--- a/apps/registry/registry/default/segmented-control/segmented-control.tsx
+++ b/apps/registry/registry/default/segmented-control/segmented-control.tsx
@@ -1,8 +1,87 @@
+"use client";
+
+import * as React from "react";
+
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+
+const segmentedControlVariants = cva(
+  "inline-flex w-full items-center rounded-lg bg-muted p-1 text-muted-foreground",
+  {
+    defaultVariants: {
+      size: "default",
+    },
+    variants: {
+      size: {
+        default: "min-h-10",
+        lg: "min-h-11",
+        sm: "min-h-9",
+      },
+    },
+  },
+);
+
+const segmentedControlItemVariants = cva(
+  "inline-flex flex-1 items-center justify-center rounded-md px-3 text-sm font-medium whitespace-nowrap transition-all outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm",
+  {
+    defaultVariants: {
+      size: "default",
+    },
+    variants: {
+      size: {
+        default: "min-h-8",
+        lg: "min-h-9 px-4",
+        sm: "min-h-7 px-2.5 text-xs",
+      },
+    },
+  },
+);
+
+export type SegmentedControlProps = Omit<
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root>,
+  "defaultValue" | "onValueChange" | "type" | "value"
+> &
+  VariantProps<typeof segmentedControlVariants> & {
+    defaultValue?: string;
+    onValueChange?: (value: string) => void;
+    value?: string;
+  };
+
+export type SegmentedControlItemProps = React.ComponentPropsWithoutRef<
+  typeof ToggleGroupPrimitive.Item
+> &
+  VariantProps<typeof segmentedControlItemVariants>;
+
+const SegmentedControl = React.forwardRef<
+  React.ComponentRef<typeof ToggleGroupPrimitive.Root>,
+  SegmentedControlProps
+>(({ className, size, ...props }, ref) => (
+  <ToggleGroupPrimitive.Root
+    className={cn(segmentedControlVariants({ size }), className)}
+    ref={ref}
+    type="single"
+    {...props}
+  />
+));
+SegmentedControl.displayName = "SegmentedControl";
+
+const SegmentedControlItem = React.forwardRef<
+  React.ComponentRef<typeof ToggleGroupPrimitive.Item>,
+  SegmentedControlItemProps
+>(({ className, size, ...props }, ref) => (
+  <ToggleGroupPrimitive.Item
+    className={cn(segmentedControlItemVariants({ size }), className)}
+    ref={ref}
+    {...props}
+  />
+));
+SegmentedControlItem.displayName = "SegmentedControlItem";
+
 export {
   SegmentedControl,
   SegmentedControlItem,
-  type SegmentedControlItemProps,
   segmentedControlItemVariants,
-  type SegmentedControlProps,
   segmentedControlVariants,
-} from '@vllnt/ui'
+};

--- a/apps/registry/registry/default/select/select.tsx
+++ b/apps/registry/registry/default/select/select.tsx
@@ -1,1 +1,161 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ children, className, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ children, className, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      className={cn(
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className,
+      )}
+      position={position}
+      ref={ref}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    ref={ref}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ children, className, ...props }, ref) => (
+  <SelectPrimitive.Item
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    ref={ref}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/apps/registry/registry/default/selection-halo/selection-halo.tsx
+++ b/apps/registry/registry/default/selection-halo/selection-halo.tsx
@@ -1,6 +1,126 @@
-export {
-  type SelectionBounds,
-  SelectionHalo,
-  type SelectionHaloLabels,
-  type SelectionHaloProps,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Geometric bounds of the selection in container px.
+ *
+ * @public
+ */
+export type SelectionBounds = {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type SelectionHaloLabels = {
+  /** Aria-label for the halo. Defaults to `"Selection"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Selection",
+} as const satisfies Required<SelectionHaloLabels>;
+
+/**
+ * Props for {@link SelectionHalo}.
+ *
+ * @public
+ */
+export type SelectionHaloProps = {
+  /** Selection bounds in container pixels. */
+  bounds: SelectionBounds;
+  /** Optional label rendered above the top-left corner. */
+  label?: ReactNode;
+  /** Localizable strings. */
+  labels?: SelectionHaloLabels;
+  /** When `true`, the ring pulses (use during multi-step transitions). */
+  pulsing?: boolean;
+} & Omit<ComponentPropsWithoutRef<"div">, "style">;
+
+/**
+ * Local-user selection halo for a canvas. Outlines a rectangular
+ * region with a primary ring + handles at every corner. Pure
+ * presentation — the host computes bounds (single object, group
+ * bounding box, lasso result) and toggles the wrapper.
+ *
+ * Distinct from {@link SelectionPresence}: this halo represents the
+ * **local** user's selection (with corner handles + label slot), while
+ * `SelectionPresence` represents a remote participant's selection.
+ *
+ * @example
+ * ```tsx
+ * <SelectionHalo bounds={{ x: 80, y: 60, width: 200, height: 120 }} label="3 selected" />
+ * ```
+ *
+ * @public
+ */
+export const SelectionHalo = forwardRef<HTMLDivElement, SelectionHaloProps>(
+  (props, ref) => {
+    const {
+      bounds,
+      className,
+      label,
+      labels,
+      pulsing = false,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "pointer-events-none absolute z-20 rounded-md ring-2 ring-primary",
+          pulsing ? "animate-pulse" : "",
+          className,
+        )}
+        data-pulsing={pulsing ? "true" : undefined}
+        data-selection-halo
+        ref={ref}
+        style={{
+          height: `${bounds.height.toString()}px`,
+          left: `${bounds.x.toString()}px`,
+          top: `${bounds.y.toString()}px`,
+          width: `${bounds.width.toString()}px`,
+        }}
+        {...rest}
+      >
+        {(["nw", "ne", "se", "sw"] as const).map((corner) => (
+          <span
+            aria-hidden="true"
+            className={cn(
+              "absolute h-2 w-2 rounded-sm border-2 border-primary bg-background",
+              corner === "nw" && "-left-1 -top-1",
+              corner === "ne" && "-right-1 -top-1",
+              corner === "se" && "-bottom-1 -right-1",
+              corner === "sw" && "-bottom-1 -left-1",
+            )}
+            data-handle-corner={corner}
+            key={corner}
+          />
+        ))}
+        {label ? (
+          <span
+            className="absolute -top-6 left-0 inline-flex items-center rounded-md bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-primary-foreground shadow-sm"
+            data-selection-label
+          >
+            {label}
+          </span>
+        ) : null}
+      </div>
+    );
+  },
+);
+SelectionHalo.displayName = "SelectionHalo";

--- a/apps/registry/registry/default/selection-presence/selection-presence.tsx
+++ b/apps/registry/registry/default/selection-presence/selection-presence.tsx
@@ -1,5 +1,114 @@
-export {
-  SelectionPresence,
-  type SelectionPresenceLabels,
-  type SelectionPresenceProps,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type SelectionPresenceLabels = {
+  /** Aria-label override. Defaults to `"Selection presence"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Selection presence",
+} as const satisfies Required<SelectionPresenceLabels>;
+
+/**
+ * Props for {@link SelectionPresence}.
+ *
+ * @public
+ */
+export type SelectionPresenceProps = {
+  /** Tailwind / CSS color used for the border + chip. Defaults to `var(--foreground)`. */
+  color?: string;
+  /** Selection rectangle height in pixels. */
+  height: number;
+  /** Localizable strings. */
+  labels?: SelectionPresenceLabels;
+  /** Optional name shown in the corner chip (e.g. owner of the selection). */
+  name?: ReactNode;
+  /** Selection rectangle width in pixels. */
+  width: number;
+  /** Selection rectangle X (top-left) in canvas pixels. */
+  x: number;
+  /** Selection rectangle Y (top-left) in canvas pixels. */
+  y: number;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * Overlay marking what another user has selected on the canvas. The
+ * dashed border + soft fill stay calm so they communicate
+ * "someone-else's-selection" without blocking primary content. Pure
+ * presentation; the host computes the rect from the remote user's
+ * viewport and supplies an accent color per user.
+ *
+ * The wrapper is `pointer-events: none` so host gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <SelectionPresence
+ *     x={120} y={80} width={240} height={120}
+ *     color="#5b8def"
+ *     name="Bea"
+ *   />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const SelectionPresence = forwardRef<
+  HTMLDivElement,
+  SelectionPresenceProps
+>((props, ref) => {
+  const { className, color, height, labels, name, width, x, y, ...rest } =
+    props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const accent = color ?? "var(--foreground)";
+  const ariaLabel =
+    typeof name === "string"
+      ? `${resolvedLabels.region}: ${name}`
+      : resolvedLabels.region;
+  return (
+    <div
+      aria-label={ariaLabel}
+      className={cn(
+        "pointer-events-none absolute z-20 rounded-md border-2 border-dashed",
+        className,
+      )}
+      data-selection-presence
+      ref={ref}
+      role="img"
+      style={{
+        backgroundColor: `color-mix(in srgb, ${accent} 10%, transparent)`,
+        borderColor: accent,
+        height,
+        left: x,
+        top: y,
+        width,
+      }}
+      {...rest}
+    >
+      {name === null || name === undefined ? null : (
+        <span
+          className="absolute -top-5 left-0 inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-medium text-white shadow-sm"
+          data-selection-presence-chip
+          style={{ backgroundColor: accent }}
+        >
+          {name}
+        </span>
+      )}
+    </div>
+  );
+});
+SelectionPresence.displayName = "SelectionPresence";

--- a/apps/registry/registry/default/separator/separator.tsx
+++ b/apps/registry/registry/default/separator/separator.tsx
@@ -1,1 +1,32 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+
+import { cn } from "@vllnt/ui";
+
+const Separator = forwardRef<
+  React.ComponentRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, decorative = true, orientation = "horizontal", ...props },
+    ref,
+  ) => (
+    <SeparatorPrimitive.Root
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className,
+      )}
+      decorative={decorative}
+      orientation={orientation}
+      ref={ref}
+      {...props}
+    />
+  ),
+);
+Separator.displayName = SeparatorPrimitive.Root.displayName;
+
+export { Separator };

--- a/apps/registry/registry/default/severity-badge/severity-badge.tsx
+++ b/apps/registry/registry/default/severity-badge/severity-badge.tsx
@@ -1,1 +1,183 @@
-export * from "@vllnt/ui";
+import * as React from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+
+export type SeverityBadgeLevel =
+  | "critical"
+  | "high"
+  | "info"
+  | "low"
+  | "medium";
+
+const severityBadgeVariants = cva(
+  "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    compoundVariants: [
+      {
+        className:
+          "border-transparent bg-destructive text-destructive-foreground",
+        level: "critical",
+        tone: "solid",
+      },
+      {
+        className: "border-destructive/30 bg-destructive/10 text-destructive",
+        level: "critical",
+        tone: "soft",
+      },
+      {
+        className: "border-destructive/40 text-destructive",
+        level: "critical",
+        tone: "outline",
+      },
+      {
+        className: "border-transparent bg-orange-500 text-white",
+        level: "high",
+        tone: "solid",
+      },
+      {
+        className: "border-orange-500/30 bg-orange-500/10 text-orange-600",
+        level: "high",
+        tone: "soft",
+      },
+      {
+        className: "border-orange-500/40 text-orange-600",
+        level: "high",
+        tone: "outline",
+      },
+      {
+        className: "border-transparent bg-amber-500 text-white",
+        level: "medium",
+        tone: "solid",
+      },
+      {
+        className: "border-amber-500/30 bg-amber-500/10 text-amber-600",
+        level: "medium",
+        tone: "soft",
+      },
+      {
+        className: "border-amber-500/40 text-amber-600",
+        level: "medium",
+        tone: "outline",
+      },
+      {
+        className: "border-transparent bg-sky-500 text-white",
+        level: "low",
+        tone: "solid",
+      },
+      {
+        className: "border-sky-500/30 bg-sky-500/10 text-sky-600",
+        level: "low",
+        tone: "soft",
+      },
+      {
+        className: "border-sky-500/40 text-sky-600",
+        level: "low",
+        tone: "outline",
+      },
+      {
+        className: "border-transparent bg-muted text-muted-foreground",
+        level: "info",
+        tone: "solid",
+      },
+      {
+        className: "border-border bg-muted/50 text-muted-foreground",
+        level: "info",
+        tone: "soft",
+      },
+      {
+        className: "border-border text-muted-foreground",
+        level: "info",
+        tone: "outline",
+      },
+    ],
+    defaultVariants: {
+      level: "info",
+      tone: "soft",
+    },
+    variants: {
+      level: {
+        critical: "",
+        high: "",
+        info: "",
+        low: "",
+        medium: "",
+      },
+      tone: {
+        outline: "",
+        soft: "",
+        solid: "",
+      },
+    },
+  },
+);
+
+const DOT_COLOR: Record<SeverityBadgeLevel, string> = {
+  critical: "bg-destructive",
+  high: "bg-orange-500",
+  info: "bg-muted-foreground",
+  low: "bg-sky-500",
+  medium: "bg-amber-500",
+};
+
+const DEFAULT_LABEL: Record<SeverityBadgeLevel, string> = {
+  critical: "Critical",
+  high: "High",
+  info: "Info",
+  low: "Low",
+  medium: "Medium",
+};
+
+export type SeverityBadgeProps = Omit<
+  React.HTMLAttributes<HTMLSpanElement>,
+  "children"
+> &
+  VariantProps<typeof severityBadgeVariants> & {
+    children?: React.ReactNode;
+    level: SeverityBadgeLevel;
+    pulse?: boolean;
+    showDot?: boolean;
+  };
+
+function SeverityBadge({
+  children,
+  className,
+  level,
+  pulse = false,
+  showDot = true,
+  tone,
+  ...props
+}: SeverityBadgeProps) {
+  const label = children ?? DEFAULT_LABEL[level];
+
+  return (
+    <span
+      className={cn(severityBadgeVariants({ level, tone }), className)}
+      data-level={level}
+      {...props}
+    >
+      {showDot ? (
+        <span aria-hidden="true" className="relative flex h-2 w-2">
+          {pulse ? (
+            <span
+              className={cn(
+                "absolute inline-flex h-full w-full animate-ping rounded-full opacity-60",
+                DOT_COLOR[level],
+              )}
+            />
+          ) : null}
+          <span
+            className={cn(
+              "relative inline-flex h-2 w-2 rounded-full",
+              DOT_COLOR[level],
+            )}
+          />
+        </span>
+      ) : null}
+      <span>{label}</span>
+    </span>
+  );
+}
+
+export { SeverityBadge, severityBadgeVariants };

--- a/apps/registry/registry/default/share-section/share-section.tsx
+++ b/apps/registry/registry/default/share-section/share-section.tsx
@@ -1,2 +1,82 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+export type SharePlatform =
+  | "bluesky"
+  | "facebook"
+  | "linkedin"
+  | "mastodon"
+  | "threads"
+  | "x";
+
+export type PlatformConfig = {
+  key: SharePlatform;
+  label: string;
+};
+
+const defaultPlatforms: PlatformConfig[] = [
+  { key: "x", label: "X" },
+  { key: "linkedin", label: "LinkedIn" },
+  { key: "facebook", label: "Facebook" },
+  { key: "mastodon", label: "Mastodon" },
+  { key: "bluesky", label: "Bluesky" },
+  { key: "threads", label: "Threads" },
+];
+
+function buildShareUrl(
+  platform: SharePlatform,
+  url: string,
+  title: string,
+): string {
+  const encodedUrl = encodeURIComponent(url);
+  const encodedTitle = encodeURIComponent(title);
+
+  switch (platform) {
+    case "x":
+      return `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`;
+    case "linkedin":
+      return `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`;
+    case "facebook":
+      return `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`;
+    case "mastodon":
+      return `https://mastodon.social/share?text=${encodedTitle}%20${encodedUrl}`;
+    case "bluesky":
+      return `https://bsky.app/intent/compose?text=${encodedTitle}%20${encodedUrl}`;
+    case "threads":
+      return `https://www.threads.net/intent/post?text=${encodedTitle}%20${encodedUrl}`;
+  }
+}
+
+type ShareSectionProps = {
+  buildUrl?: (platform: SharePlatform, url: string, title: string) => string;
+  platforms?: PlatformConfig[];
+  shareOn: string;
+  shareTitle: string;
+  title: string;
+  url: string;
+};
+
+export function ShareSection({
+  buildUrl: buildUrlFunction = buildShareUrl,
+  platforms = defaultPlatforms,
+  shareOn,
+  shareTitle,
+  title,
+  url,
+}: ShareSectionProps) {
+  return (
+    <div className="border-t border-border pt-6 mt-8">
+      <h3 className="text-lg font-semibold mb-4">{shareTitle}</h3>
+      <div className="flex flex-wrap gap-3">
+        {platforms.map((platform) => (
+          <a
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors border border-border px-3 py-1.5 hover:bg-accent rounded-md"
+            href={buildUrlFunction(platform.key, url, title)}
+            key={platform.key}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {shareOn} {platform.label}
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/registry/registry/default/sheet/sheet.tsx
+++ b/apps/registry/registry/default/sheet/sheet.tsx
@@ -1,1 +1,142 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+const Sheet = SheetPrimitive.Root;
+
+const SheetTrigger = SheetPrimitive.Trigger;
+
+const SheetClose = SheetPrimitive.Close;
+
+const SheetPortal = SheetPrimitive.Portal;
+
+const SheetOverlay = forwardRef<
+  React.ComponentRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  {
+    defaultVariants: {
+      side: "right",
+    },
+    variants: {
+      side: {
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+      },
+    },
+  },
+);
+
+type SheetContentProps = {} & React.ComponentPropsWithoutRef<
+  typeof SheetPrimitive.Content
+> &
+  VariantProps<typeof sheetVariants>;
+
+const SheetContent = forwardRef<
+  React.ComponentRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ children, className, side = "right", ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      className={cn(sheetVariants({ side }), className)}
+      ref={ref}
+      {...props}
+    >
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+);
+SheetHeader.displayName = "SheetHeader";
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+SheetFooter.displayName = "SheetFooter";
+
+const SheetTitle = forwardRef<
+  React.ComponentRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    className={cn("text-lg font-semibold text-foreground", className)}
+    ref={ref}
+    {...props}
+  />
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
+
+const SheetDescription = forwardRef<
+  React.ComponentRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    className={cn("text-sm text-muted-foreground", className)}
+    ref={ref}
+    {...props}
+  />
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+};

--- a/apps/registry/registry/default/sidebar-provider/sidebar-provider.tsx
+++ b/apps/registry/registry/default/sidebar-provider/sidebar-provider.tsx
@@ -1,2 +1,34 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+type SidebarContextType = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+};
+
+const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
+
+export function useSidebar() {
+  const context = useContext(SidebarContext);
+  if (!context) {
+    throw new Error("useSidebar must be used within SidebarProvider");
+  }
+  return context;
+}
+
+export function SidebarProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+
+  const value = useMemo(() => ({ open, setOpen }), [open]);
+
+  return (
+    <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>
+  );
+}

--- a/apps/registry/registry/default/sidebar-toggle/sidebar-toggle.tsx
+++ b/apps/registry/registry/default/sidebar-toggle/sidebar-toggle.tsx
@@ -1,38 +1,44 @@
-'use client'
+"use client";
 
-import { Menu, X } from 'lucide-react'
+import { Menu, X } from "lucide-react";
 
-import { cn } from '../../../lib/utils'
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
 
 export type SidebarToggleProps = {
-  className?: string
-  /** Called when toggle is clicked. */
-  onToggle: () => void
-  /** Whether the sidebar is currently open. */
-  open: boolean
-}
+  className?: string;
+  /** Called when user clicks the toggle. */
+  onToggle: () => void;
+  /** Whether the sidebar is open. */
+  open: boolean;
+};
 
 /** Responsive sidebar toggle button that shows Menu/X icons based on state. */
-export function SidebarToggle({ className, onToggle, open }: SidebarToggleProps) {
-  const buttonClass = cn(
-    'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors',
-    'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
-    'disabled:pointer-events-none disabled:opacity-50',
-    'hover:bg-accent hover:text-accent-foreground',
-    'h-9 w-9',
-    className
-  )
-
+export function SidebarToggle({
+  className,
+  onToggle,
+  open,
+}: SidebarToggleProps) {
   return (
     <>
       {/* Mobile: shows X when open, Menu when closed */}
-      <button className={cn(buttonClass, 'lg:hidden')} onClick={onToggle} type="button">
+      <Button
+        className={cn("lg:hidden", className)}
+        onClick={onToggle}
+        size="icon"
+        variant="ghost"
+      >
         {open ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
-      </button>
+      </Button>
       {/* Desktop: always shows Menu icon */}
-      <button className={cn(buttonClass, 'hidden lg:flex')} onClick={onToggle} type="button">
+      <Button
+        className={cn("hidden lg:flex", className)}
+        onClick={onToggle}
+        size="icon"
+        variant="ghost"
+      >
         <Menu className="h-5 w-5" />
-      </button>
+      </Button>
     </>
-  )
+  );
 }

--- a/apps/registry/registry/default/sidebar/sidebar.tsx
+++ b/apps/registry/registry/default/sidebar/sidebar.tsx
@@ -1,2 +1,250 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { ChevronDown } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@vllnt/ui";
+import { useSidebar } from "@vllnt/ui";
+
+export type SidebarItem = {
+  href: string;
+  title: string;
+};
+
+export type SidebarSection = {
+  collapsible?: boolean;
+  defaultOpen?: boolean;
+  items: SidebarItem[];
+  title?: string;
+};
+
+type SidebarProps = {
+  sections: SidebarSection[];
+};
+
+function useMobile(setOpen: (open: boolean) => void) {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkMobile = () => {
+      const mobile = window.innerWidth < 1024;
+      setIsMobile(mobile);
+      if (mobile) {
+        setOpen(false);
+      } else {
+        setOpen(true);
+      }
+    };
+
+    checkMobile();
+    window.addEventListener("resize", checkMobile);
+    return () => {
+      window.removeEventListener("resize", checkMobile);
+    };
+  }, [setOpen]);
+
+  return isMobile;
+}
+
+function useScrollFade(
+  containerReference: React.RefObject<HTMLDivElement | null>,
+) {
+  const [showTopFade, setShowTopFade] = useState(false);
+  const [showBottomFade, setShowBottomFade] = useState(false);
+
+  useEffect(() => {
+    const container = containerReference.current;
+    if (!container) return;
+
+    const checkScroll = () => {
+      const { clientHeight, scrollHeight, scrollTop } = container;
+      setShowTopFade(scrollTop > 0);
+      setShowBottomFade(scrollTop < scrollHeight - clientHeight - 1);
+    };
+
+    checkScroll();
+    container.addEventListener("scroll", checkScroll);
+    return () => {
+      container.removeEventListener("scroll", checkScroll);
+    };
+  }, [containerReference]);
+
+  return { showBottomFade, showTopFade };
+}
+
+type CollapsibleSectionProps = {
+  children: React.ReactNode;
+  collapsible?: boolean;
+  defaultOpen?: boolean;
+  title: string;
+};
+
+function CollapsibleSection({
+  children,
+  collapsible = false,
+  defaultOpen = true,
+  title,
+}: CollapsibleSectionProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  if (!collapsible) {
+    return (
+      <>
+        <div className="px-3 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          {title}
+        </div>
+        {children}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <button
+        className="flex w-full items-center justify-between px-3 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider hover:text-foreground transition-colors"
+        onClick={() => {
+          setIsOpen(!isOpen);
+        }}
+        type="button"
+      >
+        <span>{title}</span>
+        <ChevronDown
+          className={cn(
+            "h-3 w-3 transition-transform duration-200",
+            isOpen && "rotate-180",
+          )}
+        />
+      </button>
+      <div
+        className={cn(
+          "grid transition-all duration-200 ease-in-out",
+          isOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+        )}
+      >
+        <div className="overflow-hidden">{children}</div>
+      </div>
+    </>
+  );
+}
+
+// eslint-disable-next-line max-lines-per-function
+export function Sidebar({ sections }: SidebarProps) {
+  const pathname = usePathname();
+  const { open, setOpen } = useSidebar();
+  const isMobile = useMobile(setOpen);
+  const scrollContainerReference = useRef<HTMLDivElement>(null);
+  const { showBottomFade, showTopFade } = useScrollFade(
+    scrollContainerReference,
+  );
+
+  return (
+    <>
+      {/* Mobile overlay */}
+      {isMobile && open ? (
+        <div
+          className="fixed inset-0 bg-black/50 z-40 lg:hidden"
+          onClick={() => {
+            setOpen(false);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              setOpen(false);
+            }
+          }}
+          role="button"
+          tabIndex={0}
+        />
+      ) : null}
+
+      {/* Sidebar */}
+      <aside
+        className={cn(
+          "fixed lg:relative top-16 lg:top-0 bottom-0 lg:bottom-auto left-0 z-40 lg:h-full border-r bg-background transition-transform duration-300 ease-in-out",
+          "flex flex-col",
+          "overflow-hidden",
+          "shrink-0",
+          isMobile ? "w-full" : "w-64",
+          isMobile && !open && "-translate-x-full",
+          isMobile && open && "translate-x-0",
+          !isMobile && !open && "-translate-x-full lg:translate-x-0",
+          !isMobile && "lg:translate-x-0",
+        )}
+      >
+        <div className="relative flex-1 overflow-hidden">
+          {/* Top fade */}
+          {showTopFade ? (
+            <div className="absolute top-0 left-0 right-0 h-8 bg-gradient-to-b from-background to-transparent pointer-events-none z-20" />
+          ) : null}
+
+          {/* Bottom fade */}
+          {showBottomFade ? (
+            <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-background to-transparent pointer-events-none z-20" />
+          ) : null}
+
+          <nav
+            className="flex-1 p-4 overflow-y-auto h-full"
+            ref={scrollContainerReference}
+          >
+            <div className="space-y-4">
+              {sections.map((section, sectionIndex) => {
+                const sectionItems = (
+                  <div className={section.title ? "space-y-0.5" : "space-y-1"}>
+                    {section.items.map((item) => (
+                      <Link
+                        className={cn(
+                          section.title
+                            ? "block px-3 py-1.5 rounded-md text-sm transition-colors"
+                            : "flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                          pathname === item.href ||
+                            (item.href === "/" && pathname === "/")
+                            ? "bg-accent text-accent-foreground"
+                            : section.title
+                              ? "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                              : "hover:bg-accent hover:text-accent-foreground",
+                          section.title &&
+                            pathname === item.href &&
+                            "font-medium",
+                        )}
+                        href={item.href}
+                        key={item.href}
+                        onClick={() => {
+                          if (isMobile) {
+                            setOpen(false);
+                          }
+                        }}
+                      >
+                        {item.title}
+                      </Link>
+                    ))}
+                  </div>
+                );
+
+                return (
+                  <div
+                    className="space-y-1"
+                    key={section.title || sectionIndex}
+                  >
+                    {section.title ? (
+                      <CollapsibleSection
+                        collapsible={section.collapsible}
+                        defaultOpen={section.defaultOpen ?? true}
+                        title={section.title}
+                      >
+                        {sectionItems}
+                      </CollapsibleSection>
+                    ) : (
+                      sectionItems
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </nav>
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/apps/registry/registry/default/skeleton/skeleton.tsx
+++ b/apps/registry/registry/default/skeleton/skeleton.tsx
@@ -1,1 +1,15 @@
-export * from '@vllnt/ui'
+import { cn } from "@vllnt/ui";
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/apps/registry/registry/default/slider/slider.tsx
+++ b/apps/registry/registry/default/slider/slider.tsx
@@ -1,1 +1,29 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import * as SliderPrimitive from "@radix-ui/react-slider";
+
+import { cn } from "@vllnt/ui";
+
+const Slider = forwardRef<
+  React.ComponentRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    className={cn(
+      "relative flex w-full touch-none select-none items-center",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+));
+Slider.displayName = SliderPrimitive.Root.displayName;
+
+export { Slider };

--- a/apps/registry/registry/default/slideshow/slideshow.tsx
+++ b/apps/registry/registry/default/slideshow/slideshow.tsx
@@ -1,2 +1,462 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { memo, useCallback, useEffect, useState } from "react";
+
+import type { ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+import { useMounted } from "@vllnt/ui";
+import { cn } from "@vllnt/ui";
+import { CompletionDialog } from "@vllnt/ui";
+
+export type SlideshowSection = {
+  id: string;
+  title: string;
+};
+
+export type SlideshowLabels = {
+  closeLabel?: string;
+  closeTocLabel?: string;
+  exitLabel?: string;
+  finishLabel?: string;
+  nextLabel?: string;
+  openTocLabel?: string;
+  prevLabel?: string;
+  sectionsLabel?: string;
+};
+
+export type SlideshowProps = {
+  /** Completed section IDs */
+  completedSections: Set<string>;
+  /** Dialog labels */
+  completionDialogTitle?: string;
+  /** Current section index */
+  currentIndex: number;
+  /** Labels for i18n */
+  labels?: SlideshowLabels;
+  /** Callback when tutorial completes */
+  onComplete: () => void;
+  /** Callback to exit slideshow */
+  onExit: () => void;
+  /** Callback to navigate to section */
+  onNavigate: (index: number) => void;
+  /** Callback to toggle section completion */
+  onToggleSection: (sectionId: string) => void;
+  /** Render function for section content */
+  renderContent: (section: SlideshowSection) => ReactNode;
+  /** Sections to display */
+  sections: SlideshowSection[];
+  /** Tutorial title */
+  title: string;
+};
+
+const DEFAULT_LABELS: Required<SlideshowLabels> = {
+  closeLabel: "Close",
+  closeTocLabel: "Close table of contents",
+  exitLabel: "Exit",
+  finishLabel: "Finish",
+  nextLabel: "Next",
+  openTocLabel: "Open table of contents",
+  prevLabel: "Prev",
+  sectionsLabel: "Sections",
+};
+
+function SlideshowImpl({
+  completedSections,
+  completionDialogTitle = "Mark section as complete?",
+  currentIndex,
+  labels = {},
+  onComplete,
+  onExit,
+  onNavigate,
+  onToggleSection,
+  renderContent,
+  sections,
+  title,
+}: SlideshowProps): React.ReactNode {
+  const mergedLabels = { ...DEFAULT_LABELS, ...labels };
+  const [animationDirection, setAnimationDirection] = useState<
+    "left" | "right" | null
+  >(null);
+  const [isCompletionDialogOpen, setIsCompletionDialogOpen] = useState(false);
+  const [isTocOpen, setIsTocOpen] = useState(false);
+  const mounted = useMounted();
+
+  const currentSection = sections[currentIndex];
+  const isCurrentCompleted = currentSection
+    ? completedSections.has(currentSection.id)
+    : false;
+  const isLastSection = currentIndex === sections.length - 1;
+  const canGoNext = currentIndex < sections.length - 1;
+  const canGoPrevious = currentIndex > 0;
+  const progress = ((currentIndex + 1) / sections.length) * 100;
+
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, []);
+
+  const goToSection = useCallback(
+    (index: number, direction: "left" | "right") => {
+      setAnimationDirection(direction);
+      setTimeout(() => {
+        onNavigate(index);
+        setAnimationDirection(null);
+      }, 150);
+    },
+    [onNavigate],
+  );
+
+  const handlePrevious = useCallback(() => {
+    if (canGoPrevious) goToSection(currentIndex - 1, "right");
+  }, [canGoPrevious, currentIndex, goToSection]);
+
+  const handleNext = useCallback(() => {
+    if (!canGoNext) {
+      if (isCurrentCompleted) onComplete();
+      else setIsCompletionDialogOpen(true);
+      return;
+    }
+    if (isCurrentCompleted) goToSection(currentIndex + 1, "left");
+    else setIsCompletionDialogOpen(true);
+  }, [canGoNext, currentIndex, goToSection, isCurrentCompleted, onComplete]);
+
+  const handleMarkComplete = useCallback(() => {
+    if (currentSection) onToggleSection(currentSection.id);
+    setIsCompletionDialogOpen(false);
+    if (isLastSection) onComplete();
+    else goToSection(currentIndex + 1, "left");
+  }, [
+    currentSection,
+    onToggleSection,
+    isLastSection,
+    onComplete,
+    goToSection,
+    currentIndex,
+  ]);
+
+  const handleSkip = useCallback(() => {
+    setIsCompletionDialogOpen(false);
+    if (isLastSection) onComplete();
+    else goToSection(currentIndex + 1, "left");
+  }, [isLastSection, onComplete, goToSection, currentIndex]);
+
+  const handleTocNavigate = useCallback(
+    (index: number) => {
+      setIsTocOpen(false);
+      goToSection(index, index > currentIndex ? "left" : "right");
+    },
+    [currentIndex, goToSection],
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (isCompletionDialogOpen) return;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        if (isTocOpen) setIsTocOpen(false);
+        else onExit();
+        return;
+      }
+      if (event.key === "t" || event.key === "T") {
+        event.preventDefault();
+        setIsTocOpen((p) => !p);
+        return;
+      }
+      if (event.key === "ArrowRight" || event.key === "j") {
+        event.preventDefault();
+        handleNext();
+        return;
+      }
+      if (event.key === "ArrowLeft" || event.key === "k") {
+        event.preventDefault();
+        handlePrevious();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [handleNext, handlePrevious, onExit, isTocOpen, isCompletionDialogOpen]);
+
+  if (!currentSection || !mounted) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[9999] bg-background flex flex-col">
+      {/* Progress Bar */}
+      <div className="absolute top-0 left-0 right-0 h-1 bg-muted z-10">
+        <div
+          className="h-full bg-foreground transition-all duration-300 ease-out"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 mt-1 border-b border-border bg-background">
+        <div className="flex items-center gap-3 min-w-0 flex-1">
+          <button
+            aria-label={
+              isTocOpen ? mergedLabels.closeTocLabel : mergedLabels.openTocLabel
+            }
+            className="flex-shrink-0 p-2 rounded-lg hover:bg-muted transition-colors"
+            onClick={() => {
+              setIsTocOpen((p) => !p);
+            }}
+            type="button"
+          >
+            {isTocOpen ? (
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M6 18L18 6M6 6l12 12"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                />
+              </svg>
+            ) : (
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M4 6h16M4 12h16M4 18h16"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                />
+              </svg>
+            )}
+          </button>
+          <div className="min-w-0 flex-1">
+            <p className="text-xs text-muted-foreground truncate">{title}</p>
+            <p className="text-sm font-medium truncate">
+              {currentSection.title}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <span className="text-xs text-muted-foreground tabular-nums hidden sm:inline">
+            {currentIndex + 1}/{sections.length}
+          </span>
+          <button
+            aria-label={mergedLabels.exitLabel}
+            className="p-2 rounded-lg hover:bg-muted transition-colors"
+            onClick={onExit}
+            type="button"
+          >
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M6 18L18 6M6 6l12 12"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="relative flex-1 overflow-hidden">
+        {isTocOpen ? (
+          <div
+            className="absolute inset-0 z-20 flex animate-in fade-in-0 duration-200"
+            onClick={() => {
+              setIsTocOpen(false);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ")
+                setIsTocOpen(false);
+            }}
+            role="button"
+            tabIndex={0}
+          >
+            <div className="absolute inset-0 bg-background/40" />
+            {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+            <div
+              className="relative w-full sm:max-w-sm bg-background border-r border-border h-full overflow-auto shadow-2xl"
+              onClick={(event) => {
+                event.stopPropagation();
+              }}
+              onKeyDown={(event) => {
+                event.stopPropagation();
+              }}
+              role="dialog"
+            >
+              <div className="sticky top-0 flex items-center justify-between px-4 py-3 border-b border-border bg-background">
+                <h3 className="font-semibold">{mergedLabels.sectionsLabel}</h3>
+                <button
+                  aria-label={mergedLabels.closeLabel}
+                  className="p-2 rounded-lg hover:bg-muted transition-colors"
+                  onClick={() => {
+                    setIsTocOpen(false);
+                  }}
+                  type="button"
+                >
+                  <svg
+                    className="h-4 w-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 18L18 6M6 6l12 12"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                    />
+                  </svg>
+                </button>
+              </div>
+              <div className="p-2">
+                {sections.map((section, index) => {
+                  const isCompleted = completedSections.has(section.id);
+                  const isCurrent = index === currentIndex;
+                  return (
+                    <button
+                      className={cn(
+                        "w-full flex items-center gap-3 p-3 rounded-lg text-left transition-colors",
+                        isCurrent ? "bg-muted" : "hover:bg-muted/50",
+                      )}
+                      key={`${section.id}-${index}`}
+                      onClick={() => {
+                        handleTocNavigate(index);
+                      }}
+                      type="button"
+                    >
+                      <div
+                        className={cn(
+                          "flex-shrink-0 w-5 h-5 rounded-full border-2 flex items-center justify-center",
+                          isCompleted
+                            ? "bg-foreground border-foreground"
+                            : "border-muted-foreground",
+                        )}
+                      >
+                        {isCompleted ? (
+                          <svg
+                            className="h-3 w-3 text-background"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M5 13l4 4L19 7"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                            />
+                          </svg>
+                        ) : null}
+                      </div>
+                      <span
+                        className={cn(
+                          "flex-1 text-sm truncate",
+                          isCompleted && "line-through opacity-60",
+                        )}
+                      >
+                        {section.title}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="h-full overflow-auto px-4 py-8 md:px-8 lg:px-16">
+          <div className="mx-auto max-w-3xl">
+            <div
+              className={cn(
+                "transition-all duration-150 ease-out",
+                animationDirection === "left" && "opacity-0 -translate-x-4",
+                animationDirection === "right" && "opacity-0 translate-x-4",
+                !animationDirection && "opacity-100 translate-x-0",
+              )}
+            >
+              {renderContent(currentSection)}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom Nav */}
+      <div className="relative z-20 flex items-center justify-between px-4 py-4 border-t border-border bg-background">
+        <button
+          className="min-w-[100px] gap-1 inline-flex items-center justify-center px-4 py-2 rounded-md hover:bg-muted transition-colors disabled:opacity-50 disabled:pointer-events-none"
+          disabled={!canGoPrevious}
+          onClick={handlePrevious}
+          type="button"
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m15 19-7-7 7-7"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+            />
+          </svg>
+          <span>{mergedLabels.prevLabel}</span>
+        </button>
+        <button
+          className="min-w-[100px] gap-1 inline-flex items-center justify-center px-4 py-2 rounded-md bg-foreground text-background hover:bg-foreground/90 transition-colors"
+          onClick={handleNext}
+          type="button"
+        >
+          <span>
+            {isLastSection ? mergedLabels.finishLabel : mergedLabels.nextLabel}
+          </span>
+          {!isLastSection && (
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m9 5 7 7-7 7"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+              />
+            </svg>
+          )}
+        </button>
+      </div>
+
+      <CompletionDialog
+        description={`You're about to ${isLastSection ? "finish" : "move to the next section from"}: ${currentSection.title}`}
+        isOpen={isCompletionDialogOpen}
+        onCancel={handleSkip}
+        onClose={() => {
+          setIsCompletionDialogOpen(false);
+        }}
+        onConfirm={handleMarkComplete}
+        title={completionDialogTitle}
+      />
+    </div>,
+    document.body,
+  );
+}
+
+export const Slideshow = memo(SlideshowImpl);
+Slideshow.displayName = "Slideshow";

--- a/apps/registry/registry/default/snap-guides/snap-guides.tsx
+++ b/apps/registry/registry/default/snap-guides/snap-guides.tsx
@@ -1,6 +1,111 @@
-export {
-  type SnapGuide,
-  SnapGuides,
-  type SnapGuidesLabels,
-  type SnapGuidesProps,
-} from "@vllnt/ui";
+"use client";
+
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * One alignment line.
+ *
+ * @public
+ */
+export type SnapGuide =
+  | {
+      /** Stable id (used as React key). */
+      id: string;
+      /** Horizontal guide — runs left to right at this `y` in container px. */
+      orientation: "horizontal";
+      y: number;
+    }
+  | {
+      /** Stable id (used as React key). */
+      id: string;
+      /** Vertical guide — runs top to bottom at this `x` in container px. */
+      orientation: "vertical";
+      x: number;
+    };
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type SnapGuidesLabels = {
+  /** Aria-label for the layer. Defaults to `"Snap guides"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Snap guides",
+} as const satisfies Required<SnapGuidesLabels>;
+
+/**
+ * Props for {@link SnapGuides}.
+ *
+ * @public
+ */
+export type SnapGuidesProps = {
+  /** Active alignment lines. Pass an empty array to hide all. */
+  guides: SnapGuide[];
+  /** Localizable strings. */
+  labels?: SnapGuidesLabels;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * Alignment guide overlay for a canvas. Renders dashed lines at the
+ * `x` / `y` coordinates supplied by the host snapper. Pure
+ * presentation — the host computes which guides are active during a
+ * drag and unmounts them on release.
+ *
+ * @example
+ * ```tsx
+ * <SnapGuides
+ *   guides={[
+ *     { id: "x-200", orientation: "vertical", x: 200 },
+ *     { id: "y-160", orientation: "horizontal", y: 160 },
+ *   ]}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const SnapGuides = forwardRef<HTMLDivElement, SnapGuidesProps>(
+  (props, ref) => {
+    const { className, guides, labels, ...rest } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn("pointer-events-none absolute inset-0 z-30", className)}
+        data-snap-guide-count={guides.length}
+        ref={ref}
+        {...rest}
+      >
+        {guides.map((guide) => {
+          const isVertical = guide.orientation === "vertical";
+          const offset = isVertical ? guide.x : guide.y;
+          return (
+            <span
+              aria-hidden="true"
+              className={cn(
+                "absolute border-primary/70",
+                isVertical
+                  ? "inset-y-0 w-px border-l border-dashed"
+                  : "inset-x-0 h-px border-t border-dashed",
+              )}
+              data-snap-guide-id={guide.id}
+              data-snap-orientation={guide.orientation}
+              key={guide.id}
+              style={
+                isVertical
+                  ? { left: `${offset.toString()}px` }
+                  : { top: `${offset.toString()}px` }
+              }
+            />
+          );
+        })}
+      </div>
+    );
+  },
+);
+SnapGuides.displayName = "SnapGuides";

--- a/apps/registry/registry/default/sparkline-grid/sparkline-grid.tsx
+++ b/apps/registry/registry/default/sparkline-grid/sparkline-grid.tsx
@@ -1,1 +1,111 @@
-export { SparklineGrid } from "@vllnt/ui";
+import * as React from "react";
+
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+export type SparklineGridItem = {
+  change: number;
+  data: number[];
+  label: string;
+  value: string;
+};
+
+export type SparklineGridProps = {
+  columns?: 2 | 3 | 4;
+  items: SparklineGridItem[];
+} & React.HTMLAttributes<HTMLDivElement>;
+
+function buildSparklinePath(data: number[], width: number, height: number) {
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+
+  return data
+    .map((value, index) => {
+      const x =
+        data.length === 1 ? width / 2 : (index / (data.length - 1)) * width;
+      const y = height - ((value - min) / range) * height;
+      return `${index === 0 ? "M" : "L"}${x},${y}`;
+    })
+    .join(" ");
+}
+
+const gridColumns = {
+  2: "md:grid-cols-2",
+  3: "md:grid-cols-2 xl:grid-cols-3",
+  4: "md:grid-cols-2 xl:grid-cols-4",
+};
+
+export const SparklineGrid = React.forwardRef<
+  HTMLDivElement,
+  SparklineGridProps
+>(({ className, columns = 2, items, ...props }, reference) => {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn("grid grid-cols-1 gap-4", gridColumns[columns], className)}
+      ref={reference}
+      {...props}
+    >
+      {items.map((item) => {
+        const isPositive = item.change >= 0;
+        const TrendIcon = isPositive ? ArrowUpRight : ArrowDownRight;
+        const stroke = isPositive ? "hsl(142 71% 45%)" : "hsl(348 83% 47%)";
+
+        return (
+          <section
+            className="rounded-2xl border border-border bg-card/80 p-4 shadow-sm"
+            key={item.label}
+          >
+            <div className="mb-4 flex items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  {item.label}
+                </p>
+                <p className="mt-1 text-2xl font-semibold tracking-tight text-foreground">
+                  {item.value}
+                </p>
+              </div>
+              <div
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium tabular-nums",
+                  isPositive
+                    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                    : "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400",
+                )}
+              >
+                <TrendIcon className="h-3.5 w-3.5" />
+                {item.change > 0 ? "+" : ""}
+                {item.change.toFixed(2)}%
+              </div>
+            </div>
+            <div className="rounded-xl border border-border/60 bg-muted/20 p-3">
+              <svg
+                aria-label={`${item.label} sparkline`}
+                className="h-16 w-full"
+                role="img"
+                viewBox="0 0 120 48"
+              >
+                <path
+                  d={buildSparklinePath(item.data, 120, 48)}
+                  fill="none"
+                  stroke={stroke}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2.5"
+                  vectorEffect="non-scaling-stroke"
+                />
+              </svg>
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+});
+
+SparklineGrid.displayName = "SparklineGrid";

--- a/apps/registry/registry/default/spinner/spinner.tsx
+++ b/apps/registry/registry/default/spinner/spinner.tsx
@@ -1,1 +1,26 @@
-export * from '@vllnt/ui'
+import { cn } from "@vllnt/ui";
+
+export type SpinnerProps = {
+  size?: "lg" | "md" | "sm";
+} & React.HTMLAttributes<HTMLDivElement>;
+
+function Spinner({ className, size = "md", ...props }: SpinnerProps) {
+  return (
+    <div
+      className={cn(
+        "animate-spin rounded-full border-2 border-current border-t-transparent",
+        {
+          "h-4 w-4": size === "sm",
+          "h-6 w-6": size === "md",
+          "h-8 w-8": size === "lg",
+        },
+        className,
+      )}
+      {...props}
+    >
+      <span className="sr-only">Loading...</span>
+    </div>
+  );
+}
+
+export { Spinner };

--- a/apps/registry/registry/default/stat-card/stat-card.tsx
+++ b/apps/registry/registry/default/stat-card/stat-card.tsx
@@ -1,1 +1,139 @@
-export * from '@vllnt/ui'
+import * as React from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import { ArrowDownRight, ArrowRight, ArrowUpRight } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Card, CardContent, CardDescription, CardHeader } from "@vllnt/ui";
+
+const statCardVariants = cva("overflow-hidden border shadow-sm", {
+  defaultVariants: {
+    tone: "neutral",
+  },
+  variants: {
+    tone: {
+      danger: "border-red-200/70 dark:border-red-950/70",
+      neutral: "",
+      success: "border-emerald-200/70 dark:border-emerald-950/70",
+      warning: "border-amber-200/70 dark:border-amber-950/70",
+    },
+  },
+});
+
+const accentVariants = cva("h-1 w-full", {
+  defaultVariants: {
+    tone: "neutral",
+  },
+  variants: {
+    tone: {
+      danger: "bg-red-500/80",
+      neutral: "bg-primary/70",
+      success: "bg-emerald-500/80",
+      warning: "bg-amber-500/80",
+    },
+  },
+});
+
+const changeVariants = cva(
+  "inline-flex items-center gap-1 text-xs font-medium",
+  {
+    defaultVariants: {
+      trend: "neutral",
+    },
+    variants: {
+      trend: {
+        down: "text-red-600 dark:text-red-400",
+        neutral: "text-muted-foreground",
+        up: "text-emerald-600 dark:text-emerald-400",
+      },
+    },
+  },
+);
+
+type StatCardTrend = "down" | "neutral" | "up";
+
+export type StatCardProps = React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof statCardVariants> & {
+    change?: React.ReactNode;
+    description?: React.ReactNode;
+    icon?: React.ReactNode;
+    label: React.ReactNode;
+    meta?: React.ReactNode;
+    trend?: StatCardTrend;
+    value: React.ReactNode;
+  };
+
+function TrendIcon({ trend }: { trend: StatCardTrend }) {
+  if (trend === "up") {
+    return <ArrowUpRight className="h-3.5 w-3.5" />;
+  }
+
+  if (trend === "down") {
+    return <ArrowDownRight className="h-3.5 w-3.5" />;
+  }
+
+  return <ArrowRight className="h-3.5 w-3.5" />;
+}
+
+const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
+  (
+    {
+      change,
+      className,
+      description,
+      icon,
+      label,
+      meta,
+      tone,
+      trend = "neutral",
+      value,
+      ...props
+    },
+    reference,
+  ) => (
+    <Card
+      className={cn(statCardVariants({ tone }), className)}
+      ref={reference}
+      {...props}
+    >
+      <div className={accentVariants({ tone })} />
+      <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0 pb-3">
+        <div className="space-y-1">
+          <CardDescription className="text-xs font-medium uppercase tracking-[0.14em]">
+            {label}
+          </CardDescription>
+          <div className="text-3xl font-semibold tracking-tight">{value}</div>
+        </div>
+        {icon ? (
+          <div className="rounded-lg border bg-muted/50 p-2 text-muted-foreground">
+            {icon}
+          </div>
+        ) : null}
+      </CardHeader>
+      {description || change || meta ? (
+        <CardContent className="space-y-3">
+          {description ? (
+            <p className="text-sm text-muted-foreground">{description}</p>
+          ) : null}
+          {change || meta ? (
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              {change ? (
+                <div className={changeVariants({ trend })}>
+                  <TrendIcon trend={trend} />
+                  <span>{change}</span>
+                </div>
+              ) : null}
+              {meta ? (
+                <div className="text-xs text-muted-foreground">{meta}</div>
+              ) : null}
+            </div>
+          ) : null}
+        </CardContent>
+      ) : null}
+    </Card>
+  ),
+);
+
+StatCard.displayName = "StatCard";
+
+export { StatCard, statCardVariants };

--- a/apps/registry/registry/default/state-badge-overlay/state-badge-overlay.tsx
+++ b/apps/registry/registry/default/state-badge-overlay/state-badge-overlay.tsx
@@ -1,7 +1,169 @@
-export {
-  type StateBadgeAnchor,
-  StateBadgeOverlay,
-  type StateBadgeOverlayLabels,
-  type StateBadgeOverlayProps,
-  type StateBadgeState,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * State name — drives the badge tone.
+ *
+ * @public
+ */
+export type StateBadgeState =
+  | "complete"
+  | "failed"
+  | "idle"
+  | "queued"
+  | "running"
+  | "stopped";
+
+const STATE_LABEL: Record<StateBadgeState, string> = {
+  complete: "Complete",
+  failed: "Failed",
+  idle: "Idle",
+  queued: "Queued",
+  running: "Running",
+  stopped: "Stopped",
+};
+
+const STATE_TONE: Record<StateBadgeState, string> = {
+  complete:
+    "border-emerald-500/40 bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+  failed: "border-red-500/40 bg-red-500/15 text-red-700 dark:text-red-300",
+  idle: "border-border bg-muted/40 text-muted-foreground",
+  queued:
+    "border-amber-500/40 bg-amber-500/15 text-amber-700 dark:text-amber-300",
+  running: "border-blue-500/40 bg-blue-500/15 text-blue-700 dark:text-blue-300",
+  stopped: "border-border bg-background text-foreground",
+};
+
+const STATE_DOT: Record<StateBadgeState, string> = {
+  complete: "bg-emerald-500",
+  failed: "bg-red-500",
+  idle: "bg-muted-foreground",
+  queued: "bg-amber-500",
+  running: "bg-blue-500 animate-pulse",
+  stopped: "bg-muted-foreground",
+};
+
+/**
+ * Anchor corner relative to the canvas object the badge attaches to.
+ *
+ * @public
+ */
+export type StateBadgeAnchor =
+  | "bottom-left"
+  | "bottom-right"
+  | "top-left"
+  | "top-right";
+
+const ANCHOR_TRANSFORM: Record<StateBadgeAnchor, string> = {
+  "bottom-left": "translate(-100%, 100%)",
+  "bottom-right": "translate(0%, 100%)",
+  "top-left": "translate(-100%, -100%)",
+  "top-right": "translate(0%, -100%)",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type StateBadgeOverlayLabels = {
+  /** Aria-label override. Defaults to `"State"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "State",
+} as const satisfies Required<StateBadgeOverlayLabels>;
+
+/**
+ * Props for {@link StateBadgeOverlay}.
+ *
+ * @public
+ */
+export type StateBadgeOverlayProps = {
+  /** Anchor corner. Defaults to `"top-right"`. */
+  anchor?: StateBadgeAnchor;
+  /** Optional override label (defaults to humanized state name). */
+  label?: ReactNode;
+  /** Localizable strings. */
+  labels?: StateBadgeOverlayLabels;
+  /** State to display. */
+  state: StateBadgeState;
+  /** Anchor X in canvas pixels. */
+  x: number;
+  /** Anchor Y in canvas pixels. */
+  y: number;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * State chip pinned to a canvas object's corner. Use when a single-
+ * letter glyph in `ObjectCard` doesn't carry enough signal — for
+ * runs that have transitioned, jobs that failed, agents idling. Pure
+ * presentation; the host computes the anchor from the object's
+ * bounding box.
+ *
+ * The wrapper is `pointer-events: none` — host gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <StateBadgeOverlay state="running" x={420} y={180} anchor="top-right" />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const StateBadgeOverlay = forwardRef<
+  HTMLDivElement,
+  StateBadgeOverlayProps
+>((props, ref) => {
+  const {
+    anchor = "top-right",
+    className,
+    label,
+    labels,
+    state,
+    x,
+    y,
+    ...rest
+  } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const text = label ?? STATE_LABEL[state];
+  return (
+    <div
+      aria-label={`${resolvedLabels.region}: ${STATE_LABEL[state]}`}
+      className={cn(
+        "pointer-events-none absolute z-20 inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide shadow-sm backdrop-blur",
+        STATE_TONE[state],
+        className,
+      )}
+      data-state-anchor={anchor}
+      data-state-badge-overlay
+      data-state-name={state}
+      ref={ref}
+      role="status"
+      style={{
+        left: x,
+        top: y,
+        transform: ANCHOR_TRANSFORM[anchor],
+      }}
+      {...rest}
+    >
+      <span
+        aria-hidden="true"
+        className={cn("h-1.5 w-1.5 rounded-full", STATE_DOT[state])}
+        data-state-badge-dot
+      />
+      {text}
+    </div>
+  );
+});
+StateBadgeOverlay.displayName = "StateBadgeOverlay";

--- a/apps/registry/registry/default/status-board/status-board.tsx
+++ b/apps/registry/registry/default/status-board/status-board.tsx
@@ -1,1 +1,210 @@
-export * from "@vllnt/ui";
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@vllnt/ui";
+
+export type StatusBoardStatus =
+  | "critical"
+  | "healthy"
+  | "maintenance"
+  | "offline"
+  | "warning";
+
+export type StatusBoardItem = {
+  description?: string;
+  label: string;
+  meta?: string;
+  status: StatusBoardStatus;
+  value?: string;
+};
+
+export type StatusBoardProps = React.ComponentPropsWithoutRef<"div"> & {
+  columns?: 2 | 3 | 4;
+  description?: string;
+  items: StatusBoardItem[];
+  title?: string;
+};
+
+type StatusMeta = {
+  badgeVariant: "default" | "destructive" | "outline" | "secondary";
+  dotClassName: string;
+  label: string;
+  panelClassName: string;
+};
+
+const STATUS_META: Record<StatusBoardStatus, StatusMeta> = {
+  critical: {
+    badgeVariant: "destructive",
+    dotClassName: "bg-destructive",
+    label: "Critical",
+    panelClassName: "border-destructive/30 bg-destructive/5",
+  },
+  healthy: {
+    badgeVariant: "default",
+    dotClassName: "bg-emerald-500",
+    label: "Healthy",
+    panelClassName: "border-emerald-500/25 bg-emerald-500/5",
+  },
+  maintenance: {
+    badgeVariant: "secondary",
+    dotClassName: "bg-sky-500",
+    label: "Maintenance",
+    panelClassName: "border-sky-500/25 bg-sky-500/5",
+  },
+  offline: {
+    badgeVariant: "outline",
+    dotClassName: "bg-muted-foreground",
+    label: "Offline",
+    panelClassName: "border-border bg-muted/30",
+  },
+  warning: {
+    badgeVariant: "secondary",
+    dotClassName: "bg-amber-500",
+    label: "Warning",
+    panelClassName: "border-amber-500/25 bg-amber-500/5",
+  },
+};
+
+const STATUS_ORDER: StatusBoardStatus[] = [
+  "healthy",
+  "warning",
+  "critical",
+  "maintenance",
+  "offline",
+];
+
+function getColumnsClassName(columns: 2 | 3 | 4): string {
+  if (columns === 2) {
+    return "md:grid-cols-2";
+  }
+
+  if (columns === 4) {
+    return "md:grid-cols-2 xl:grid-cols-4";
+  }
+
+  return "md:grid-cols-2 xl:grid-cols-3";
+}
+
+function getSummary(items: StatusBoardItem[]) {
+  const counts = items.reduce<Record<StatusBoardStatus, number>>(
+    (summary, item) => ({
+      ...summary,
+      [item.status]: summary[item.status] + 1,
+    }),
+    {
+      critical: 0,
+      healthy: 0,
+      maintenance: 0,
+      offline: 0,
+      warning: 0,
+    },
+  );
+
+  return STATUS_ORDER.map((status) => ({
+    count: counts[status],
+    status,
+  })).filter((entry) => entry.count > 0);
+}
+
+function StatusBoardSummary({ items }: { items: StatusBoardItem[] }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {getSummary(items).map(({ count, status }) => {
+        const meta = STATUS_META[status];
+
+        return (
+          <Badge key={status} variant={meta.badgeVariant}>
+            {count} {meta.label}
+          </Badge>
+        );
+      })}
+    </div>
+  );
+}
+
+function StatusBoardCard({ item }: { item: StatusBoardItem }) {
+  const meta = STATUS_META[item.status];
+
+  return (
+    <Card className={cn("shadow-sm", meta.panelClassName)}>
+      <CardHeader className="gap-3 space-y-0">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <span
+                aria-hidden="true"
+                className={cn("h-2.5 w-2.5 rounded-full", meta.dotClassName)}
+              />
+              <CardTitle className="text-base leading-none">
+                {item.label}
+              </CardTitle>
+            </div>
+            {item.description ? (
+              <CardDescription>{item.description}</CardDescription>
+            ) : null}
+          </div>
+          <Badge variant={meta.badgeVariant}>{meta.label}</Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="flex items-end justify-between gap-3">
+        <div>
+          {item.value ? (
+            <div className="text-2xl font-semibold tracking-tight">
+              {item.value}
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">
+              No metric reported
+            </div>
+          )}
+        </div>
+        {item.meta ? (
+          <div className="text-xs text-muted-foreground">{item.meta}</div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+export const StatusBoard = React.forwardRef<HTMLDivElement, StatusBoardProps>(
+  (
+    {
+      className,
+      columns = 3,
+      description,
+      items,
+      title = "Status board",
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <div className={cn("space-y-4", className)} ref={ref} {...props}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
+            {description ? (
+              <p className="text-sm text-muted-foreground">{description}</p>
+            ) : null}
+          </div>
+          <StatusBoardSummary items={items} />
+        </div>
+
+        <div className={cn("grid gap-4", getColumnsClassName(columns))}>
+          {items.map((item) => (
+            <StatusBoardCard item={item} key={item.label} />
+          ))}
+        </div>
+      </div>
+    );
+  },
+);
+
+StatusBoard.displayName = "StatusBoard";

--- a/apps/registry/registry/default/status-indicator/status-indicator.tsx
+++ b/apps/registry/registry/default/status-indicator/status-indicator.tsx
@@ -1,1 +1,194 @@
-export * from '@vllnt/ui'
+import * as React from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+
+const statusIndicatorVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-full border font-medium transition-colors",
+  {
+    compoundVariants: [
+      {
+        className: "border-border text-foreground",
+        tone: "neutral",
+        variant: "outline",
+      },
+      {
+        className: "border-transparent bg-muted text-foreground",
+        tone: "neutral",
+        variant: "soft",
+      },
+      {
+        className: "bg-foreground text-background",
+        tone: "neutral",
+        variant: "solid",
+      },
+      {
+        className:
+          "border-emerald-200 text-emerald-700 dark:border-emerald-900 dark:text-emerald-300",
+        tone: "success",
+        variant: "outline",
+      },
+      {
+        className:
+          "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/60 dark:text-emerald-300",
+        tone: "success",
+        variant: "soft",
+      },
+      {
+        className: "bg-emerald-600 text-white dark:bg-emerald-500",
+        tone: "success",
+        variant: "solid",
+      },
+      {
+        className:
+          "border-amber-200 text-amber-700 dark:border-amber-900 dark:text-amber-300",
+        tone: "warning",
+        variant: "outline",
+      },
+      {
+        className:
+          "bg-amber-100 text-amber-800 dark:bg-amber-950/60 dark:text-amber-300",
+        tone: "warning",
+        variant: "soft",
+      },
+      {
+        className:
+          "bg-amber-500 text-amber-950 dark:bg-amber-400 dark:text-amber-950",
+        tone: "warning",
+        variant: "solid",
+      },
+      {
+        className:
+          "border-red-200 text-red-700 dark:border-red-900 dark:text-red-300",
+        tone: "danger",
+        variant: "outline",
+      },
+      {
+        className:
+          "bg-red-100 text-red-800 dark:bg-red-950/60 dark:text-red-300",
+        tone: "danger",
+        variant: "soft",
+      },
+      {
+        className: "bg-red-600 text-white dark:bg-red-500",
+        tone: "danger",
+        variant: "solid",
+      },
+      {
+        className:
+          "border-sky-200 text-sky-700 dark:border-sky-900 dark:text-sky-300",
+        tone: "info",
+        variant: "outline",
+      },
+      {
+        className:
+          "bg-sky-100 text-sky-800 dark:bg-sky-950/60 dark:text-sky-300",
+        tone: "info",
+        variant: "soft",
+      },
+      {
+        className: "bg-sky-600 text-white dark:bg-sky-500",
+        tone: "info",
+        variant: "solid",
+      },
+    ],
+    defaultVariants: {
+      size: "md",
+      tone: "neutral",
+      variant: "soft",
+    },
+    variants: {
+      size: {
+        lg: "min-h-8 px-3 text-sm",
+        md: "min-h-7 px-2.5 text-xs",
+        sm: "min-h-6 px-2 text-[11px]",
+      },
+      tone: {
+        danger: "",
+        info: "",
+        neutral: "",
+        success: "",
+        warning: "",
+      },
+      variant: {
+        outline: "bg-background",
+        soft: "border-transparent",
+        solid: "border-transparent text-primary-foreground",
+      },
+    },
+  },
+);
+
+const dotVariants = cva("rounded-full", {
+  defaultVariants: {
+    size: "md",
+    tone: "neutral",
+  },
+  variants: {
+    size: {
+      lg: "h-2.5 w-2.5",
+      md: "h-2 w-2",
+      sm: "h-1.5 w-1.5",
+    },
+    tone: {
+      danger: "bg-red-500",
+      info: "bg-sky-500",
+      neutral: "bg-muted-foreground",
+      success: "bg-emerald-500",
+      warning: "bg-amber-500",
+    },
+  },
+});
+
+export type StatusIndicatorProps = React.HTMLAttributes<HTMLSpanElement> &
+  VariantProps<typeof statusIndicatorVariants> & {
+    label?: string;
+    pulse?: boolean;
+    showDot?: boolean;
+  };
+
+const StatusIndicator = React.forwardRef<HTMLSpanElement, StatusIndicatorProps>(
+  (
+    {
+      children,
+      className,
+      label,
+      pulse = false,
+      showDot = true,
+      size,
+      tone,
+      variant,
+      ...props
+    },
+    reference,
+  ) => {
+    const content = children ?? label;
+
+    return (
+      <span
+        className={cn(
+          statusIndicatorVariants({ size, tone, variant }),
+          className,
+        )}
+        ref={reference}
+        {...props}
+      >
+        {showDot ? (
+          <span
+            aria-hidden="true"
+            className={cn(
+              dotVariants({ size, tone }),
+              pulse ? "animate-pulse" : undefined,
+            )}
+          />
+        ) : null}
+        {content}
+      </span>
+    );
+  },
+);
+
+StatusIndicator.displayName = "StatusIndicator";
+
+export { dotVariants, StatusIndicator, statusIndicatorVariants };

--- a/apps/registry/registry/default/step-by-step/step-by-step.tsx
+++ b/apps/registry/registry/default/step-by-step/step-by-step.tsx
@@ -1,21 +1,26 @@
-'use client'
+"use client";
 
-import { useState } from 'react'
+import { useState } from "react";
 
-import type { ReactNode } from 'react'
+import type { ReactNode } from "react";
 
-import { cn } from '../../../lib/utils'
+import { cn } from "@vllnt/ui";
 
 export type StepProps = {
-  children: ReactNode
-  className?: string
-  number?: number
-  title: string
-}
+  children: ReactNode;
+  className?: string;
+  number?: number;
+  title: string;
+};
 
-function Step({ children, className, number, title }: StepProps): React.ReactNode {
+function Step({
+  children,
+  className,
+  number,
+  title,
+}: StepProps): React.ReactNode {
   return (
-    <div className={cn('flex gap-4', className)}>
+    <div className={cn("flex gap-4", className)}>
       <div className="flex flex-col items-center">
         <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary text-primary-foreground text-sm font-bold">
           {number}
@@ -24,20 +29,22 @@ function Step({ children, className, number, title }: StepProps): React.ReactNod
       </div>
       <div className="flex-1 pb-8 last:pb-0">
         <h4 className="font-semibold text-foreground mb-2">{title}</h4>
-        <div className="text-sm text-muted-foreground [&>p]:mb-2 [&>pre]:my-2">{children}</div>
+        <div className="text-sm text-muted-foreground [&>p]:mb-2 [&>pre]:my-2">
+          {children}
+        </div>
       </div>
     </div>
-  )
+  );
 }
 
 type InteractiveStepProps = {
-  children: ReactNode
-  isCompleted: boolean
-  isLast: boolean
-  onToggle: () => void
-  stepNumber: number
-  title: string
-}
+  children: ReactNode;
+  isCompleted: boolean;
+  isLast: boolean;
+  onToggle: () => void;
+  stepNumber: number;
+  title: string;
+};
 
 function InteractiveStep({
   children,
@@ -52,88 +59,142 @@ function InteractiveStep({
       <div className="flex flex-col items-center">
         <button
           className={cn(
-            'flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold transition-colors',
-            isCompleted ? 'bg-green-500 text-white' : 'bg-primary text-primary-foreground',
+            "flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold transition-colors",
+            isCompleted
+              ? "bg-green-500 text-white"
+              : "bg-primary text-primary-foreground",
           )}
           onClick={onToggle}
           type="button"
         >
           {isCompleted ? (
-            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path d="M5 13l4 4L19 7" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M5 13l4 4L19 7"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+              />
             </svg>
           ) : (
             stepNumber
           )}
         </button>
         {!isLast && (
-          <div className={cn('w-px flex-1 mt-2', isCompleted ? 'bg-green-500' : 'bg-border')} />
+          <div
+            className={cn(
+              "w-px flex-1 mt-2",
+              isCompleted ? "bg-green-500" : "bg-border",
+            )}
+          />
         )}
       </div>
-      <div className={cn('flex-1 pb-8 transition-opacity', isCompleted && 'opacity-60')}>
-        <h4 className={cn('font-semibold text-foreground mb-2', isCompleted && 'line-through')}>
+      <div
+        className={cn(
+          "flex-1 pb-8 transition-opacity",
+          isCompleted && "opacity-60",
+        )}
+      >
+        <h4
+          className={cn(
+            "font-semibold text-foreground mb-2",
+            isCompleted && "line-through",
+          )}
+        >
           {title}
         </h4>
-        <div className="text-sm text-muted-foreground [&>p]:mb-2 [&>pre]:my-2">{children}</div>
+        <div className="text-sm text-muted-foreground [&>p]:mb-2 [&>pre]:my-2">
+          {children}
+        </div>
       </div>
     </div>
-  )
+  );
 }
 
 export type StepByStepProps = {
-  children: ReactNode
-  className?: string
-  interactive?: boolean
-  title?: string
-}
+  children: ReactNode;
+  className?: string;
+  interactive?: boolean;
+  title?: string;
+};
 
+// eslint-disable-next-line max-lines-per-function -- Complex component with interactive/non-interactive modes
 function StepByStep({
   children,
   className,
   interactive = false,
   title,
 }: StepByStepProps): React.ReactNode {
-  const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set())
-  const steps = Array.isArray(children) ? children : [children]
+  const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
+  const steps = Array.isArray(children) ? children : [children];
 
   const toggleStep = (index: number): void => {
-    const newCompleted = new Set(completedSteps)
-    if (newCompleted.has(index)) newCompleted.delete(index)
-    else newCompleted.add(index)
-    setCompletedSteps(newCompleted)
-  }
+    const newCompleted = new Set(completedSteps);
+    if (newCompleted.has(index)) newCompleted.delete(index);
+    else newCompleted.add(index);
+    setCompletedSteps(newCompleted);
+  };
 
   if (!interactive) {
     return (
-      <div className={cn('my-6', className)}>
+      <div className={cn("my-6", className)}>
         {title ? (
           <div className="flex items-center gap-2 mb-4">
-            <svg className="h-5 w-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path d="m9 18 6-6-6-6" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+            <svg
+              className="h-5 w-5 text-primary"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m9 18 6-6-6-6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+              />
             </svg>
             <h3 className="font-semibold text-lg">{title}</h3>
           </div>
         ) : null}
         <div className="space-y-0">
           {steps.map((step, index) => {
-            const stepElement = step as React.ReactElement<StepProps>
+            const stepElement = step as React.ReactElement<StepProps>;
             return (
-              <Step key={index} number={index + 1} title={stepElement.props.title}>
+              <Step
+                key={index}
+                number={index + 1}
+                title={stepElement.props.title}
+              >
                 {stepElement.props.children}
               </Step>
-            )
+            );
           })}
         </div>
       </div>
-    )
+    );
   }
 
   return (
-    <div className={cn('my-6', className)}>
+    <div className={cn("my-6", className)}>
       {title ? (
         <div className="flex items-center gap-2 mb-4">
-          <svg className="h-5 w-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path d="m9 18 6-6-6-6" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+          <svg
+            className="h-5 w-5 text-primary"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m9 18 6-6-6-6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+            />
           </svg>
           <h3 className="font-semibold text-lg">{title}</h3>
           <span className="text-xs text-muted-foreground ml-auto">
@@ -148,7 +209,7 @@ function StepByStep({
             isLast={index === steps.length - 1}
             key={index}
             onToggle={() => {
-              toggleStep(index)
+              toggleStep(index);
             }}
             stepNumber={index + 1}
             title={(step as React.ReactElement<StepProps>).props.title}
@@ -158,9 +219,9 @@ function StepByStep({
         ))}
       </div>
     </div>
-  )
+  );
 }
 
-StepByStep.Step = Step
+StepByStep.Step = Step;
 
-export { Step, StepByStep }
+export { Step, StepByStep };

--- a/apps/registry/registry/default/step-navigation/step-navigation.tsx
+++ b/apps/registry/registry/default/step-navigation/step-navigation.tsx
@@ -1,2 +1,124 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { memo } from "react";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type StepNavigationProps = {
+  canNext: boolean;
+  canPrev: boolean;
+  className?: string;
+  currentStep: number;
+  nextIcon?: ReactNode;
+  nextLabel?: string;
+  onNext: () => void;
+  onPrev: () => void;
+  previousIcon?: ReactNode;
+  previousLabel?: string;
+  stepLabel?: string;
+  totalSteps: number;
+};
+
+// eslint-disable-next-line max-lines-per-function -- Complex navigation with icons
+function StepNavigationImpl({
+  canNext,
+  canPrev,
+  className,
+  currentStep,
+  nextIcon,
+  nextLabel = "Next",
+  onNext,
+  onPrev,
+  previousIcon,
+  previousLabel = "Prev",
+  stepLabel = "Section",
+  totalSteps,
+}: StepNavigationProps): React.ReactNode {
+  return (
+    <nav
+      aria-label="Step navigation"
+      className={cn(
+        "fixed bottom-0 left-0 right-0 z-50",
+        "border-t border-neutral-200 bg-white",
+        "dark:border-neutral-800 dark:bg-black",
+        className,
+      )}
+    >
+      <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-3">
+        {/* Previous Button */}
+        <button
+          aria-label="Previous step"
+          className={cn(
+            "flex min-h-[44px] min-w-[44px] items-center justify-center",
+            "rounded-md px-3 py-2 text-sm font-medium transition-colors",
+            "hover:bg-neutral-100 dark:hover:bg-neutral-900",
+            "disabled:pointer-events-none disabled:opacity-40",
+          )}
+          disabled={!canPrev}
+          onClick={onPrev}
+          type="button"
+        >
+          {previousIcon ?? (
+            <svg
+              aria-hidden="true"
+              className="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m15 19-7-7 7-7"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+              />
+            </svg>
+          )}
+          <span className="ml-1">{previousLabel}</span>
+        </button>
+
+        {/* Center: Step Counter */}
+        <div className="text-sm tabular-nums text-neutral-600 dark:text-neutral-400">
+          {stepLabel} {currentStep} / {totalSteps}
+        </div>
+
+        {/* Next Button */}
+        <button
+          aria-label="Next step"
+          className={cn(
+            "flex min-h-[44px] min-w-[44px] items-center justify-center",
+            "rounded-md px-3 py-2 text-sm font-medium transition-colors",
+            "hover:bg-neutral-100 dark:hover:bg-neutral-900",
+            "disabled:pointer-events-none disabled:opacity-40",
+          )}
+          disabled={!canNext}
+          onClick={onNext}
+          type="button"
+        >
+          <span className="mr-1">{nextLabel}</span>
+          {nextIcon ?? (
+            <svg
+              aria-hidden="true"
+              className="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m9 5 7 7-7 7"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+              />
+            </svg>
+          )}
+        </button>
+      </div>
+    </nav>
+  );
+}
+
+export const StepNavigation = memo(StepNavigationImpl);
+StepNavigation.displayName = "StepNavigation";

--- a/apps/registry/registry/default/stepper/stepper.tsx
+++ b/apps/registry/registry/default/stepper/stepper.tsx
@@ -1,2 +1,173 @@
-// Re-export from @vllnt/ui package
-export { Stepper } from '@vllnt/ui'
+import { Check, Circle } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type StepperStep = {
+  description?: string;
+  id: string;
+  meta?: string;
+  title: string;
+};
+
+export type StepperProps = {
+  className?: string;
+  currentStep: number;
+  onStepClick?: (step: StepperStep, stepIndex: number) => void;
+  orientation?: "horizontal" | "vertical";
+  showNumbers?: boolean;
+  steps: StepperStep[];
+};
+
+type StepperItemProps = {
+  index: number;
+  isVertical: boolean;
+  onStepClick?: (step: StepperStep, stepIndex: number) => void;
+  showNumbers: boolean;
+  step: StepperStep;
+  stepState: "complete" | "current" | "upcoming";
+  totalSteps: number;
+};
+
+function getStepState(
+  index: number,
+  currentStep: number,
+): "complete" | "current" | "upcoming" {
+  const stepNumber = index + 1;
+
+  if (stepNumber < currentStep) return "complete";
+  if (stepNumber === currentStep) return "current";
+  return "upcoming";
+}
+
+function StepIcon({
+  showNumbers,
+  state,
+  stepNumber,
+}: {
+  showNumbers: boolean;
+  state: "complete" | "current" | "upcoming";
+  stepNumber: number;
+}): ReactNode {
+  if (state === "complete") {
+    return <Check className="h-4 w-4" />;
+  }
+
+  if (!showNumbers) {
+    return <Circle className="h-3.5 w-3.5 fill-current stroke-none" />;
+  }
+
+  return <span className="text-xs font-semibold">{stepNumber}</span>;
+}
+
+function StepperItem({
+  index,
+  isVertical,
+  onStepClick,
+  showNumbers,
+  step,
+  stepState,
+  totalSteps,
+}: StepperItemProps): ReactNode {
+  const clickable = Boolean(onStepClick);
+  const stepNumber = index + 1;
+
+  return (
+    <li className={cn("relative", !isVertical && "min-w-0")}>
+      {!isVertical && index < totalSteps - 1 ? (
+        <div className="absolute left-[calc(50%+1rem)] right-[calc(-50%+1rem)] top-4 hidden h-px bg-border md:block" />
+      ) : null}
+      <button
+        className={cn(
+          "flex w-full items-start gap-3 rounded-lg text-left transition-colors",
+          clickable
+            ? "hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            : "cursor-default",
+          isVertical ? "p-2" : "flex-col items-start p-2 md:p-0",
+        )}
+        disabled={!clickable}
+        onClick={() => {
+          onStepClick?.(step, index);
+        }}
+        type="button"
+      >
+        <span
+          aria-current={stepState === "current" ? "step" : undefined}
+          className={cn(
+            "relative z-10 flex h-8 w-8 items-center justify-center rounded-full border text-sm transition-colors",
+            stepState === "complete" &&
+              "border-primary bg-primary text-primary-foreground",
+            stepState === "current" &&
+              "border-primary bg-primary/10 text-primary shadow-sm",
+            stepState === "upcoming" &&
+              "border-border bg-background text-muted-foreground",
+          )}
+        >
+          <StepIcon
+            showNumbers={showNumbers}
+            state={stepState}
+            stepNumber={stepNumber}
+          />
+        </span>
+        <span className="min-w-0 space-y-1">
+          <span className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium text-foreground">
+              {step.title}
+            </span>
+            {step.meta ? (
+              <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                {step.meta}
+              </span>
+            ) : null}
+          </span>
+          {step.description ? (
+            <span className="block text-sm text-muted-foreground">
+              {step.description}
+            </span>
+          ) : null}
+        </span>
+      </button>
+    </li>
+  );
+}
+
+export function Stepper({
+  className,
+  currentStep,
+  onStepClick,
+  orientation = "horizontal",
+  showNumbers = true,
+  steps,
+}: StepperProps): ReactNode {
+  const isVertical = orientation === "vertical";
+
+  if (steps.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn("my-6 rounded-xl border bg-card p-4", className)}>
+      <ol
+        className={cn("gap-3", isVertical ? "flex flex-col" : "grid gap-4")}
+        style={
+          isVertical
+            ? undefined
+            : { gridTemplateColumns: `repeat(${steps.length}, minmax(0, 1fr))` }
+        }
+      >
+        {steps.map((step, index) => (
+          <StepperItem
+            index={index}
+            isVertical={isVertical}
+            key={step.id}
+            onStepClick={onStepClick}
+            showNumbers={showNumbers}
+            step={step}
+            stepState={getStepState(index, currentStep)}
+            totalSteps={steps.length}
+          />
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/apps/registry/registry/default/sticky-metric/sticky-metric.tsx
+++ b/apps/registry/registry/default/sticky-metric/sticky-metric.tsx
@@ -1,7 +1,159 @@
-export {
-  StickyMetric,
-  type StickyMetricAnchor,
-  type StickyMetricLabels,
-  type StickyMetricProps,
-  type StickyMetricTone,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Tone of the metric — drives the dot color.
+ *
+ * @public
+ */
+export type StickyMetricTone = "danger" | "neutral" | "success" | "warn";
+
+/**
+ * Anchor corner relative to the canvas object the metric sticks to.
+ *
+ * @public
+ */
+export type StickyMetricAnchor =
+  | "bottom-left"
+  | "bottom-right"
+  | "top-left"
+  | "top-right";
+
+const TONE_DOT: Record<StickyMetricTone, string> = {
+  danger: "bg-red-500",
+  neutral: "bg-muted-foreground",
+  success: "bg-emerald-500",
+  warn: "bg-amber-500",
+};
+
+const ANCHOR_OFFSET: Record<StickyMetricAnchor, { transform: string }> = {
+  "bottom-left": { transform: "translate(-100%, 100%)" },
+  "bottom-right": { transform: "translate(0%, 100%)" },
+  "top-left": { transform: "translate(-100%, -100%)" },
+  "top-right": { transform: "translate(0%, -100%)" },
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type StickyMetricLabels = {
+  /** Aria-label override. Defaults to `"Sticky metric"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Sticky metric",
+} as const satisfies Required<StickyMetricLabels>;
+
+/**
+ * Props for {@link StickyMetric}.
+ *
+ * @public
+ */
+export type StickyMetricProps = {
+  /** Anchor corner. Defaults to `"top-right"`. */
+  anchor?: StickyMetricAnchor;
+  /** Optional secondary slot rendered after the value (delta, unit). */
+  detail?: ReactNode;
+  /** Short metric label (e.g. `"errs/min"`). */
+  label: ReactNode;
+  /** Localizable strings. */
+  labels?: StickyMetricLabels;
+  /** Tone for the leading dot. Defaults to `"neutral"`. */
+  tone?: StickyMetricTone;
+  /** Display value (already formatted by host). */
+  value: ReactNode;
+  /** Anchor X in canvas pixels. */
+  x: number;
+  /** Anchor Y in canvas pixels. */
+  y: number;
+} & ComponentPropsWithoutRef<"div">;
+
+/**
+ * Pinned metric pill that sticks to a canvas object's corner. Use to
+ * overlay a single live value (errors / min, p95 latency, queue depth)
+ * on a runtime object without consuming card real-estate. Pure
+ * presentation; the host computes the anchor coords from the object's
+ * bounding box and the value from the runtime stream.
+ *
+ * The wrapper is `pointer-events: none` — host gestures pass through.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative h-screen w-screen">
+ *   <Canvas />
+ *   <StickyMetric
+ *     x={420} y={180}
+ *     anchor="top-right"
+ *     label="errs / min"
+ *     value="14"
+ *     tone="danger"
+ *   />
+ * </div>
+ * ```
+ *
+ * @public
+ */
+export const StickyMetric = forwardRef<HTMLDivElement, StickyMetricProps>(
+  (props, ref) => {
+    const {
+      anchor = "top-right",
+      className,
+      detail,
+      label,
+      labels,
+      tone = "neutral",
+      value,
+      x,
+      y,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    return (
+      <div
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "pointer-events-none absolute z-20 inline-flex items-center gap-1.5 rounded-full border border-border bg-background/90 px-2 py-1 text-[11px] shadow-sm backdrop-blur",
+          className,
+        )}
+        data-sticky-anchor={anchor}
+        data-sticky-metric
+        data-sticky-tone={tone}
+        ref={ref}
+        role="status"
+        style={{
+          left: x,
+          top: y,
+          transform: ANCHOR_OFFSET[anchor].transform,
+        }}
+        {...rest}
+      >
+        <span
+          aria-hidden="true"
+          className={cn("h-1.5 w-1.5 rounded-full", TONE_DOT[tone])}
+          data-sticky-metric-dot
+        />
+        <span className="font-medium text-muted-foreground">{label}</span>
+        <span className="font-semibold text-foreground">{value}</span>
+        {detail ? (
+          <span
+            className="text-[10px] text-muted-foreground"
+            data-sticky-metric-detail
+          >
+            {detail}
+          </span>
+        ) : null}
+      </div>
+    );
+  },
+);
+StickyMetric.displayName = "StickyMetric";

--- a/apps/registry/registry/default/story-map/story-map.tsx
+++ b/apps/registry/registry/default/story-map/story-map.tsx
@@ -1,9 +1,609 @@
-export {
-  StoryMap,
-  StoryMapChapter,
-  type StoryMapChapterProps,
-  type StoryMapColor,
-  type StoryMapLabels,
-  type StoryMapMedia,
-  type StoryMapProps,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  Children,
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+const VIEWBOX_WIDTH = 1000;
+const VIEWBOX_HEIGHT = 500;
+
+/**
+ * Geographic coordinate `[longitude, latitude]`.
+ *
+ * @public
+ */
+export type GeoPosition = [number, number];
+
+/**
+ * Color theme for the chapter marker.
+ *
+ * @public
+ */
+export type StoryMapColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "purple"
+  | "red"
+  | "rose";
+
+const PALETTE: Record<StoryMapColor, string> = {
+  amber: "fill-amber-500",
+  blue: "fill-blue-500",
+  emerald: "fill-emerald-500",
+  purple: "fill-purple-500",
+  red: "fill-red-500",
+  rose: "fill-rose-500",
+};
+
+/**
+ * Optional image media rendered inside the chapter card.
+ *
+ * @public
+ */
+export type StoryMapMedia = {
+  /** Required alt text. */
+  alt: string;
+  /** Optional caption rendered beneath the image. */
+  caption?: ReactNode;
+  /** Image URL. */
+  src: string;
+  /** Media kind. Image is the supported value today. */
+  type: "image";
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type StoryMapLabels = {
+  /** Aria-label for the narrative column. Defaults to `"Narrative"`. */
+  narrative?: string;
+  /** Aria-label for the progress strip. Defaults to `"Story progress"`. */
+  progress?: string;
+  /** Aria-label for the map region. Defaults to `"Story map"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  narrative: "Narrative",
+  progress: "Story progress",
+  region: "Story map",
+} as const satisfies Required<StoryMapLabels>;
+
+type RegisterArguments = {
+  center: GeoPosition;
+  color: StoryMapColor;
+  id: string;
+  zoom: number;
+};
+
+type Ctx = {
+  activeId?: string;
+  registerChapter: (id: string, node: HTMLElement | null) => void;
+  registerMarker: (entry: RegisterArguments) => void;
+  setActiveId: (id: string) => void;
+  unregisterMarker: (id: string) => void;
+};
+
+const StoryMapContext = createContext<Ctx | null>(null);
+
+function useStoryMapContext(): Ctx {
+  const ctx = useContext(StoryMapContext);
+  if (!ctx) {
+    throw new Error("StoryMap subcomponent used outside its root.");
+  }
+  return ctx;
+}
+
+function projectEquirectangular(position: GeoPosition): {
+  x: number;
+  y: number;
+} {
+  const [lng, lat] = position;
+  return {
+    x: ((lng + 180) / 360) * VIEWBOX_WIDTH,
+    y: ((90 - lat) / 180) * VIEWBOX_HEIGHT,
+  };
+}
+
+/**
+ * Props for {@link StoryMapChapter}.
+ *
+ * @public
+ */
+export type StoryMapChapterProps = {
+  /** Center the map on this position when the chapter is active. */
+  center: GeoPosition;
+  /** Color theme for the chapter marker. Defaults to `"red"`. */
+  color?: StoryMapColor;
+  /** Stable id. Defaults to a generated id. */
+  id?: string;
+  /** Optional image media. */
+  media?: StoryMapMedia;
+  /** Optional subtitle. */
+  subtitle?: ReactNode;
+  /** Chapter title. */
+  title: ReactNode;
+  /** Map zoom factor when the chapter is active. `1` shows the full world; `8` zooms in tight. Defaults to `2`. */
+  zoom?: number;
+} & Omit<ComponentPropsWithoutRef<"article">, "id" | "title">;
+
+type ChapterMediaProps = {
+  media: StoryMapMedia;
+};
+
+function ChapterMedia({ media }: ChapterMediaProps): ReactNode {
+  return (
+    <figure className="overflow-hidden rounded-xl border bg-muted">
+      <img
+        alt={media.alt}
+        className="aspect-video w-full object-cover"
+        loading="lazy"
+        src={media.src}
+      />
+      {media.caption ? (
+        <figcaption className="border-t bg-background px-3 py-2 text-xs text-muted-foreground">
+          {media.caption}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}
+
+type ChapterHeaderProps = {
+  subtitle?: ReactNode;
+  title: ReactNode;
+};
+
+function ChapterHeader({ subtitle, title }: ChapterHeaderProps): ReactNode {
+  return (
+    <header className="space-y-1">
+      <h3 className="text-xl font-semibold tracking-tight text-foreground">
+        {title}
+      </h3>
+      {subtitle ? (
+        <p className="text-sm text-muted-foreground">{subtitle}</p>
+      ) : null}
+    </header>
+  );
+}
+
+/**
+ * Single chapter section. Place narrative paragraphs as children.
+ *
+ * @public
+ */
+export const StoryMapChapter = forwardRef<HTMLElement, StoryMapChapterProps>(
+  (props, forwardedRef) => {
+    const {
+      center,
+      children,
+      className,
+      color = "red",
+      id,
+      media,
+      subtitle,
+      title,
+      zoom = 2,
+      ...rest
+    } = props;
+    const generatedId = useId();
+    const chapterId = id ?? generatedId;
+    const localRef = useRef<HTMLElement | null>(null);
+    const { registerChapter, registerMarker, unregisterMarker } =
+      useStoryMapContext();
+
+    useEffect(() => {
+      registerMarker({ center, color, id: chapterId, zoom });
+      return () => {
+        unregisterMarker(chapterId);
+      };
+    }, [center, chapterId, color, registerMarker, unregisterMarker, zoom]);
+
+    const refCallback = useCallback(
+      (node: HTMLElement | null) => {
+        localRef.current = node;
+        registerChapter(chapterId, node);
+        if (typeof forwardedRef === "function") forwardedRef(node);
+        else if (forwardedRef) forwardedRef.current = node;
+      },
+      [chapterId, forwardedRef, registerChapter],
+    );
+
+    return (
+      <article
+        className={cn(
+          "flex min-h-screen flex-col justify-center gap-3 py-12",
+          className,
+        )}
+        data-chapter-id={chapterId}
+        id={chapterId}
+        ref={refCallback}
+        {...rest}
+      >
+        <ChapterHeader subtitle={subtitle} title={title} />
+        {media ? <ChapterMedia media={media} /> : null}
+        {children ? (
+          <div className="space-y-2 text-sm leading-relaxed text-foreground [&_blockquote]:my-3 [&_blockquote]:border-l-2 [&_blockquote]:border-primary [&_blockquote]:pl-3 [&_blockquote]:italic [&_blockquote]:text-muted-foreground">
+            {children}
+          </div>
+        ) : null}
+      </article>
+    );
+  },
+);
+StoryMapChapter.displayName = "StoryMapChapter";
+
+type Marker = RegisterArguments;
+
+type StageProps = {
+  activeId?: string;
+  backdrop?: string;
+  backdropAlt?: string;
+  markers: Marker[];
+};
+
+function Stage({
+  activeId,
+  backdrop,
+  backdropAlt,
+  markers,
+}: StageProps): ReactNode {
+  const active = markers.find((marker) => marker.id === activeId);
+  const zoom = active?.zoom ?? 1;
+  const innerWidth = VIEWBOX_WIDTH / zoom;
+  const innerHeight = VIEWBOX_HEIGHT / zoom;
+  const center = active
+    ? projectEquirectangular(active.center)
+    : { x: VIEWBOX_WIDTH / 2, y: VIEWBOX_HEIGHT / 2 };
+  const viewX = center.x - innerWidth / 2;
+  const viewY = center.y - innerHeight / 2;
+  return (
+    <svg
+      aria-hidden="true"
+      className="block h-full w-full transition-[viewBox] duration-500"
+      data-active-chapter-id={activeId ?? ""}
+      data-active-zoom={zoom}
+      preserveAspectRatio="xMidYMid slice"
+      viewBox={`${viewX.toString()} ${viewY.toString()} ${innerWidth.toString()} ${innerHeight.toString()}`}
+    >
+      <rect
+        className="fill-muted"
+        height={VIEWBOX_HEIGHT}
+        width={VIEWBOX_WIDTH}
+        x="0"
+        y="0"
+      />
+      {backdrop ? (
+        <image
+          aria-label={backdropAlt}
+          height={VIEWBOX_HEIGHT}
+          href={backdrop}
+          preserveAspectRatio="xMidYMid slice"
+          width={VIEWBOX_WIDTH}
+          x="0"
+          y="0"
+        />
+      ) : null}
+      {markers.map((marker) => {
+        const point = projectEquirectangular(marker.center);
+        const isActive = marker.id === activeId;
+        return (
+          <g
+            data-marker-active={isActive ? "true" : undefined}
+            data-marker-id={marker.id}
+            key={marker.id}
+            transform={`translate(${point.x.toString()}, ${point.y.toString()})`}
+          >
+            <circle
+              className={cn("stroke-background", PALETTE[marker.color])}
+              r={isActive ? 12 : 6}
+              strokeWidth={2}
+            />
+            {isActive ? (
+              <circle
+                className={cn("opacity-30", PALETTE[marker.color])}
+                r={24}
+              />
+            ) : null}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+function chapterIdsFromChildren(children: ReactNode): string[] {
+  const ids: string[] = [];
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    const element = child as ReactElement<{ id?: string }>;
+    if (typeof element.props.id === "string") ids.push(element.props.id);
+  });
+  return ids;
+}
+
+type ProgressStripProps = {
+  activeId?: string;
+  ids: string[];
+  label: string;
+};
+
+function ProgressStrip({
+  activeId,
+  ids,
+  label,
+}: ProgressStripProps): ReactNode {
+  if (ids.length === 0) return null;
+  const activeIndex = activeId ? ids.indexOf(activeId) : -1;
+  const ratio = activeIndex < 0 ? 0 : (activeIndex + 1) / ids.length;
+  return (
+    <div
+      aria-label={label}
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={Math.round(ratio * 100)}
+      className="sticky top-0 z-20 h-1 w-full bg-border"
+      role="progressbar"
+    >
+      <span
+        className="block h-full bg-primary transition-[width] duration-200"
+        style={{ width: `${(ratio * 100).toString()}%` }}
+      />
+    </div>
+  );
+}
+
+function useChapterRegistry(): {
+  activeId?: string;
+  markerEntries: Marker[];
+  registerChapter: (id: string, node: HTMLElement | null) => void;
+  registerMarker: (entry: RegisterArguments) => void;
+  setActiveId: (id: string) => void;
+  unregisterMarker: (id: string) => void;
+} {
+  const chapterMapRef = useRef<Map<string, HTMLElement>>(new Map());
+  const markersRef = useRef<Map<string, Marker>>(new Map());
+  const [chapterIds, setChapterIds] = useState<string[]>([]);
+  const [markerEntries, setMarkerEntries] = useState<Marker[]>([]);
+  const [activeId, setActiveId] = useState<string | undefined>();
+
+  const registerChapter = useCallback(
+    (id: string, node: HTMLElement | null) => {
+      const map = chapterMapRef.current;
+      if (node) map.set(id, node);
+      else map.delete(id);
+      setChapterIds([...map.keys()]);
+    },
+    [],
+  );
+
+  const registerMarker = useCallback((entry: RegisterArguments) => {
+    markersRef.current.set(entry.id, entry);
+    setMarkerEntries([...markersRef.current.values()]);
+  }, []);
+
+  const unregisterMarker = useCallback((id: string) => {
+    markersRef.current.delete(id);
+    setMarkerEntries([...markersRef.current.values()]);
+  }, []);
+
+  useEffect(() => {
+    if (typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        const first = visible[0];
+        if (first?.target instanceof HTMLElement) {
+          const id = first.target.dataset.chapterId;
+          if (id) setActiveId(id);
+        }
+      },
+      { rootMargin: "-30% 0px -50% 0px", threshold: 0.1 },
+    );
+    [...chapterMapRef.current.values()].forEach((node) => {
+      observer.observe(node);
+    });
+    return () => {
+      observer.disconnect();
+    };
+  }, [chapterIds]);
+
+  return {
+    activeId,
+    markerEntries,
+    registerChapter,
+    registerMarker,
+    setActiveId,
+    unregisterMarker,
+  };
+}
+
+/**
+ * Props for {@link StoryMap}.
+ *
+ * @public
+ */
+export type StoryMapProps = {
+  /** Optional URL of a backdrop image (world map, terrain). */
+  backdrop?: string;
+  /** Aria-label for the backdrop image. */
+  backdropAlt?: string;
+  /** Localizable strings. */
+  labels?: StoryMapLabels;
+} & ComponentPropsWithoutRef<"section">;
+
+type ShellProps = {
+  activeId?: string;
+  backdrop?: string;
+  backdropAlt?: string;
+  children: ReactNode;
+  className?: string;
+  labels: Required<StoryMapLabels>;
+  markers: Marker[];
+  orderedIds: string[];
+  titleId: string;
+};
+
+const Shell = forwardRef<HTMLElement, ShellProps>(function Shell(props, ref) {
+  const {
+    activeId,
+    backdrop,
+    backdropAlt,
+    children,
+    className,
+    labels,
+    markers,
+    orderedIds,
+    titleId,
+  } = props;
+  return (
+    <section
+      aria-labelledby={titleId}
+      className={cn(
+        "relative flex w-full flex-col overflow-hidden rounded-2xl border bg-background text-foreground md:flex-row",
+        className,
+      )}
+      ref={ref}
+    >
+      <span className="sr-only" id={titleId}>
+        {labels.region}
+      </span>
+      <ProgressStrip
+        activeId={activeId}
+        ids={orderedIds}
+        label={labels.progress}
+      />
+      <div
+        className="sticky top-0 hidden h-[80vh] flex-1 self-start md:block"
+        data-story-map-stage
+      >
+        <Stage
+          activeId={activeId}
+          backdrop={backdrop}
+          backdropAlt={backdropAlt}
+          markers={markers}
+        />
+      </div>
+      <div
+        aria-label={labels.narrative}
+        className="flex-1 px-6 md:max-w-xl"
+        role="region"
+      >
+        {children}
+      </div>
+      <div
+        className="block aspect-[2/1] w-full border-t border-border md:hidden"
+        data-story-map-stage-mobile
+      >
+        <Stage
+          activeId={activeId}
+          backdrop={backdrop}
+          backdropAlt={backdropAlt}
+          markers={markers}
+        />
+      </div>
+    </section>
+  );
+});
+
+/**
+ * Scroll-driven narrative map. Place {@link StoryMapChapter} children
+ * in the narrative column; an `IntersectionObserver` tracks the active
+ * chapter and the SVG map shifts to center on its `[lng, lat]` and
+ * `zoom`. Standalone SVG primitive — no external map library required.
+ *
+ * @example
+ * ```tsx
+ * <StoryMap>
+ *   <StoryMapChapter
+ *     center={[12.49, 41.89]}
+ *     zoom={4}
+ *     title="The Fall of Rome"
+ *   >
+ *     <p>In 476 AD...</p>
+ *   </StoryMapChapter>
+ *   <StoryMapChapter
+ *     center={[28.98, 41.01]}
+ *     zoom={4}
+ *     title="Constantinople Endures"
+ *   >
+ *     <p>While Rome fell, Constantinople thrived...</p>
+ *   </StoryMapChapter>
+ * </StoryMap>
+ * ```
+ *
+ * @public
+ */
+export const StoryMap = forwardRef<HTMLElement, StoryMapProps>((props, ref) => {
+  const { backdrop, backdropAlt, children, className, labels, ...rest } = props;
+  const titleId = useId();
+  const resolvedLabels = useMemo(
+    () => ({ ...DEFAULT_LABELS, ...labels }),
+    [labels],
+  );
+
+  const {
+    activeId,
+    markerEntries,
+    registerChapter,
+    registerMarker,
+    setActiveId,
+    unregisterMarker,
+  } = useChapterRegistry();
+
+  const ctx = useMemo<Ctx>(
+    () => ({
+      activeId,
+      registerChapter,
+      registerMarker,
+      setActiveId,
+      unregisterMarker,
+    }),
+    [activeId, registerChapter, registerMarker, setActiveId, unregisterMarker],
+  );
+
+  const orderedIds = useMemo(
+    () => chapterIdsFromChildren(children),
+    [children],
+  );
+
+  return (
+    <StoryMapContext.Provider value={ctx}>
+      <Shell
+        activeId={activeId}
+        backdrop={backdrop}
+        backdropAlt={backdropAlt}
+        className={className}
+        labels={resolvedLabels}
+        markers={markerEntries}
+        orderedIds={orderedIds}
+        ref={ref}
+        titleId={titleId}
+        {...rest}
+      >
+        {children}
+      </Shell>
+    </StoryMapContext.Provider>
+  );
+});
+StoryMap.displayName = "StoryMap";

--- a/apps/registry/registry/default/subscription-card/subscription-card.tsx
+++ b/apps/registry/registry/default/subscription-card/subscription-card.tsx
@@ -1,2 +1,220 @@
-// Re-export from @vllnt/ui package
-export { SubscriptionCard } from '@vllnt/ui'
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@vllnt/ui";
+import { PlanBadge, type PlanBadgeTier } from "@vllnt/ui";
+
+export type SubscriptionCardStatus =
+  | "active"
+  | "canceled"
+  | "past-due"
+  | "trialing";
+
+export type SubscriptionCardProps = React.ComponentPropsWithoutRef<
+  typeof Card
+> & {
+  note?: string;
+  plan: PlanBadgeTier;
+  priceLabel: string;
+  primaryActionLabel?: string;
+  renewalLabel: string;
+  seatsLabel?: string;
+  secondaryActionLabel?: string;
+  status: SubscriptionCardStatus;
+  usageLabel?: string;
+};
+
+type SubscriptionActionsProps = {
+  primaryActionLabel?: string;
+  secondaryActionLabel?: string;
+};
+
+type SubscriptionDetailsProps = {
+  note?: string;
+  priceLabel: string;
+  renewalLabel: string;
+  seatsLabel?: string;
+  usageLabel?: string;
+};
+
+function getStatusLabel(status: SubscriptionCardStatus): string {
+  switch (status) {
+    case "active":
+      return "Active";
+    case "canceled":
+      return "Canceled";
+    case "past-due":
+      return "Past due";
+    case "trialing":
+      return "Trialing";
+  }
+}
+
+function getStatusClasses(status: SubscriptionCardStatus): string {
+  switch (status) {
+    case "active":
+      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+    case "canceled":
+      return "bg-muted text-muted-foreground";
+    case "past-due":
+      return "bg-amber-500/10 text-amber-700 dark:text-amber-300";
+    case "trialing":
+      return "bg-sky-500/10 text-sky-700 dark:text-sky-300";
+  }
+}
+
+function getPlanState(
+  status: SubscriptionCardStatus,
+): "current" | "legacy" | "trial" {
+  switch (status) {
+    case "active":
+    case "past-due":
+      return "current";
+    case "canceled":
+      return "legacy";
+    case "trialing":
+      return "trial";
+  }
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-4 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="text-right font-medium">{value}</span>
+    </div>
+  );
+}
+
+function SubscriptionDetails({
+  note,
+  priceLabel,
+  renewalLabel,
+  seatsLabel,
+  usageLabel,
+}: SubscriptionDetailsProps) {
+  return (
+    <CardContent className="space-y-4">
+      <div className="rounded-lg border border-border/70 bg-background px-4 py-3">
+        <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+          Monthly total
+        </p>
+        <p className="mt-2 text-3xl font-semibold tracking-tight">
+          {priceLabel}
+        </p>
+      </div>
+      <div className="space-y-3 rounded-lg border border-border/70 bg-muted/20 px-4 py-4">
+        <DetailRow label="Renewal" value={renewalLabel} />
+        {seatsLabel ? <DetailRow label="Seats" value={seatsLabel} /> : null}
+        {usageLabel ? <DetailRow label="Usage" value={usageLabel} /> : null}
+      </div>
+      {note ? (
+        <p className="rounded-lg bg-muted px-4 py-3 text-sm text-muted-foreground">
+          {note}
+        </p>
+      ) : null}
+    </CardContent>
+  );
+}
+
+function SubscriptionActions({
+  primaryActionLabel,
+  secondaryActionLabel,
+}: SubscriptionActionsProps) {
+  if (!primaryActionLabel && !secondaryActionLabel) {
+    return null;
+  }
+
+  return (
+    <CardFooter className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+      {secondaryActionLabel ? (
+        <Button className="w-full sm:w-auto" variant="outline">
+          {secondaryActionLabel}
+        </Button>
+      ) : null}
+      {primaryActionLabel ? (
+        <Button className="w-full sm:w-auto">{primaryActionLabel}</Button>
+      ) : null}
+    </CardFooter>
+  );
+}
+
+export const SubscriptionCard = React.forwardRef<
+  React.ComponentRef<typeof Card>,
+  SubscriptionCardProps
+>(
+  (
+    {
+      className,
+      note,
+      plan,
+      priceLabel,
+      primaryActionLabel,
+      renewalLabel,
+      seatsLabel,
+      secondaryActionLabel,
+      status,
+      usageLabel,
+      ...props
+    },
+    reference,
+  ) => {
+    return (
+      <Card
+        className={cn(
+          "w-full max-w-md border-border/70 bg-card shadow-sm",
+          className,
+        )}
+        ref={reference}
+        {...props}
+      >
+        <CardHeader className="space-y-4 pb-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1">
+              <CardTitle className="text-lg">Subscription</CardTitle>
+              <CardDescription>
+                Billing overview for the current workspace plan.
+              </CardDescription>
+            </div>
+            <span
+              className={cn(
+                "inline-flex rounded-full px-2.5 py-1 text-xs font-medium",
+                getStatusClasses(status),
+              )}
+            >
+              {getStatusLabel(status)}
+            </span>
+          </div>
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-border/70 bg-muted/30 px-4 py-3">
+            <div>
+              <p className="text-sm font-medium">Current plan</p>
+              <p className="text-xs text-muted-foreground">{renewalLabel}</p>
+            </div>
+            <PlanBadge state={getPlanState(status)} tier={plan} />
+          </div>
+        </CardHeader>
+        <SubscriptionDetails
+          note={note}
+          priceLabel={priceLabel}
+          renewalLabel={renewalLabel}
+          seatsLabel={seatsLabel}
+          usageLabel={usageLabel}
+        />
+        <SubscriptionActions
+          primaryActionLabel={primaryActionLabel}
+          secondaryActionLabel={secondaryActionLabel}
+        />
+      </Card>
+    );
+  },
+);
+
+SubscriptionCard.displayName = "SubscriptionCard";

--- a/apps/registry/registry/default/table-of-contents-panel/table-of-contents-panel.tsx
+++ b/apps/registry/registry/default/table-of-contents-panel/table-of-contents-panel.tsx
@@ -1,2 +1,234 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { memo, useEffect, useRef } from "react";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type TOCSection = {
+  id: string;
+  title: string;
+};
+
+export type TableOfContentsPanelProps = {
+  className?: string;
+  closeIcon?: ReactNode;
+  completedSections: Set<string>;
+  completionCount: number;
+  currentSectionIndex: number;
+  isOpen: boolean;
+  onClose: () => void;
+  onReset?: () => void;
+  onSelectSection: (index: number) => void;
+  progressLabel?: string;
+  resetLabel?: string;
+  sections: TOCSection[];
+  title?: string;
+  totalSections: number;
+};
+
+// eslint-disable-next-line max-lines-per-function -- Complex panel with progress and section list
+function TableOfContentsPanelImpl({
+  className,
+  closeIcon,
+  completedSections,
+  completionCount,
+  currentSectionIndex,
+  isOpen,
+  onClose,
+  onReset,
+  onSelectSection,
+  progressLabel = "Progress",
+  resetLabel = "Reset Progress",
+  sections,
+  title = "Table of Contents",
+  totalSections,
+}: TableOfContentsPanelProps): React.ReactNode {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Focus trap and close on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+
+    closeButtonRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  // Prevent body scroll when open
+  useEffect(() => {
+    document.body.style.overflow = isOpen ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const completionPercent =
+    totalSections > 0 ? Math.round((completionCount / totalSections) * 100) : 0;
+
+  return (
+    <div
+      aria-labelledby="toc-title"
+      aria-modal="true"
+      className="fixed inset-0 z-50"
+      role="dialog"
+    >
+      {/* Backdrop */}
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Panel */}
+      <div
+        className={cn(
+          "absolute right-0 top-0 h-full w-full max-w-md bg-background shadow-xl",
+          className,
+        )}
+        ref={panelRef}
+      >
+        <div className="flex h-full flex-col">
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-border px-4 py-3">
+            <h2 className="text-lg font-semibold" id="toc-title">
+              {title}
+            </h2>
+            <button
+              aria-label="Close table of contents"
+              className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
+              onClick={onClose}
+              ref={closeButtonRef}
+              type="button"
+            >
+              {closeIcon ?? (
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M6 18L18 6M6 6l12 12"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                  />
+                </svg>
+              )}
+            </button>
+          </div>
+
+          {/* Progress */}
+          <div className="border-b border-border px-4 py-3">
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">{progressLabel}</span>
+              <span className="font-medium">
+                {completionCount} / {totalSections} ({completionPercent}%)
+              </span>
+            </div>
+            <div className="mt-2 h-2 rounded-full bg-muted">
+              <div
+                className="h-full rounded-full bg-primary transition-all duration-300"
+                style={{ width: `${completionPercent}%` }}
+              />
+            </div>
+          </div>
+
+          {/* Sections List */}
+          <nav
+            aria-label="Sections"
+            className="flex-1 overflow-y-auto px-4 py-3"
+          >
+            <ol className="space-y-1">
+              {sections.map((section, index) => {
+                const isCompleted = completedSections.has(section.id);
+                const isCurrent = index === currentSectionIndex;
+
+                return (
+                  <li key={`${section.id}-${index}`}>
+                    <button
+                      className={cn(
+                        "flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition-colors",
+                        isCurrent
+                          ? "bg-primary/10 text-primary font-medium"
+                          : "hover:bg-muted text-foreground",
+                      )}
+                      onClick={() => {
+                        onSelectSection(index);
+                        onClose();
+                      }}
+                      type="button"
+                    >
+                      <span
+                        className={cn(
+                          "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border",
+                          isCompleted
+                            ? "border-primary bg-primary text-primary-foreground"
+                            : "border-muted-foreground",
+                        )}
+                      >
+                        {isCompleted ? (
+                          <svg
+                            className="h-3 w-3"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M5 13l4 4L19 7"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                            />
+                          </svg>
+                        ) : (
+                          <span className="text-xs">{index + 1}</span>
+                        )}
+                      </span>
+                      <span
+                        className={isCompleted ? "line-through opacity-60" : ""}
+                      >
+                        {section.title}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ol>
+          </nav>
+
+          {/* Footer */}
+          {completionCount > 0 && onReset ? (
+            <div className="border-t border-border px-4 py-3">
+              <button
+                className="w-full rounded-md border border-border px-3 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+                onClick={onReset}
+                type="button"
+              >
+                {resetLabel}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const TableOfContentsPanel = memo(TableOfContentsPanelImpl);
+TableOfContentsPanel.displayName = "TableOfContentsPanel";

--- a/apps/registry/registry/default/table-of-contents/table-of-contents.tsx
+++ b/apps/registry/registry/default/table-of-contents/table-of-contents.tsx
@@ -1,2 +1,94 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { cn } from "@vllnt/ui";
+
+type TableOfContentsProps = {
+  sections: { id: string; title: string }[];
+};
+
+function handleClick(id: string) {
+  const element = document.querySelector(`#${id}`);
+  if (element) {
+    element.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+}
+
+function useActiveSection(sections: { id: string; title: string }[]) {
+  const [activeSection, setActiveSection] = useState<null | string>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveSection(entry.target.id);
+          }
+        });
+      },
+      {
+        rootMargin: "-100px 0px -66% 0px",
+        threshold: 0,
+      },
+    );
+
+    sections.forEach((section) => {
+      const element = document.querySelector(`#${section.id}`);
+      if (element) {
+        observer.observe(element);
+      }
+    });
+
+    return () => {
+      sections.forEach((section) => {
+        const element = document.querySelector(`#${section.id}`);
+        if (element) {
+          observer.unobserve(element);
+        }
+      });
+    };
+  }, [sections]);
+
+  return activeSection;
+}
+
+export function TableOfContents({ sections }: TableOfContentsProps) {
+  const activeSection = useActiveSection(sections);
+
+  if (sections.length === 0) {
+    return null;
+  }
+
+  return (
+    <aside className="hidden xl:block">
+      <div className="sticky top-8">
+        <div className="border-l-2 border-border pl-4">
+          <h3 className="text-sm font-semibold mb-4 text-muted-foreground uppercase tracking-wider">
+            On This Page
+          </h3>
+          <nav className="space-y-2">
+            {sections.map((section) => (
+              <button
+                className={cn(
+                  "block text-left text-sm transition-colors",
+                  "hover:text-foreground",
+                  activeSection === section.id
+                    ? "text-foreground font-medium"
+                    : "text-muted-foreground",
+                )}
+                key={section.id}
+                onClick={() => {
+                  handleClick(section.id);
+                }}
+                type="button"
+              >
+                {section.title}
+              </button>
+            ))}
+          </nav>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/apps/registry/registry/default/table/table.tsx
+++ b/apps/registry/registry/default/table/table.tsx
@@ -1,1 +1,117 @@
-export * from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import { cn } from "@vllnt/ui";
+
+const Table = forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      className={cn("w-full caption-bottom text-sm", className)}
+      ref={ref}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = "Table";
+
+const TableHeader = forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead className={cn("[&_tr]:border-b", className)} ref={ref} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    className={cn("[&_tr:last-child]:border-0", className)}
+    ref={ref}
+    {...props}
+  />
+));
+TableBody.displayName = "TableBody";
+
+const TableFooter = forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+TableFooter.displayName = "TableFooter";
+
+const TableRow = forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+TableRow.displayName = "TableRow";
+
+const TableHead = forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    className={cn(
+      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    ref={ref}
+    {...props}
+  />
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    ref={ref}
+    {...props}
+  />
+));
+TableCaption.displayName = "TableCaption";
+
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+};

--- a/apps/registry/registry/default/tabs/tabs.tsx
+++ b/apps/registry/registry/default/tabs/tabs.tsx
@@ -1,124 +1,137 @@
-'use client'
+"use client";
 
-import { createContext, useContext, useMemo, useState } from 'react'
+import { createContext, useContext, useMemo, useState } from "react";
 
-import type { ReactNode } from 'react'
+import type { ReactNode } from "react";
 
-import { cn } from '../../../lib/utils'
+import { cn } from "@vllnt/ui";
 
 // Context for tabs state
 type TabsContextValue = {
-  activeTab: string
-  setActiveTab: (value: string) => void
-}
+  activeTab: string;
+  setActiveTab: (value: string) => void;
+};
 
-const TabsContext = createContext<null | TabsContextValue>(null)
+const TabsContext = createContext<null | TabsContextValue>(null);
 
 function useTabsContext(): TabsContextValue {
-  const context = useContext(TabsContext)
+  const context = useContext(TabsContext);
   if (!context) {
-    throw new Error('Tab components must be used within a Tabs component')
+    throw new Error("Tab components must be used within a Tabs component");
   }
-  return context
+  return context;
 }
 
 export type TabsProps = {
-  children: ReactNode
-  className?: string
-  defaultValue: string
-  onValueChange?: (value: string) => void
-}
+  children: ReactNode;
+  className?: string;
+  defaultValue: string;
+  onValueChange?: (value: string) => void;
+};
 
-function Tabs({ children, className, defaultValue, onValueChange }: TabsProps): React.ReactNode {
-  const [activeTab, setActiveTab] = useState(defaultValue)
+function Tabs({
+  children,
+  className,
+  defaultValue,
+  onValueChange,
+}: TabsProps): React.ReactNode {
+  const [activeTab, setActiveTab] = useState(defaultValue);
 
   const handleSetActiveTab = (value: string): void => {
-    setActiveTab(value)
-    onValueChange?.(value)
-  }
+    setActiveTab(value);
+    onValueChange?.(value);
+  };
 
   const contextValue = useMemo(
     () => ({ activeTab, setActiveTab: handleSetActiveTab }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [activeTab],
-  )
+  );
 
   return (
     <TabsContext.Provider value={contextValue}>
-      <div className={cn('my-6', className)}>{children}</div>
+      <div className={cn("my-6", className)}>{children}</div>
     </TabsContext.Provider>
-  )
+  );
 }
 
 export type TabsListProps = {
-  children: ReactNode
-  className?: string
-}
+  children: ReactNode;
+  className?: string;
+};
 
 function TabsList({ children, className }: TabsListProps): React.ReactNode {
   return (
     <div
-      className={cn('flex border-b border-border overflow-x-auto', className)}
+      className={cn("flex border-b border-border overflow-x-auto", className)}
       role="tablist"
     >
       {children}
     </div>
-  )
+  );
 }
 
 export type TabsTriggerProps = {
-  children: ReactNode
-  className?: string
-  value: string
-}
+  children: ReactNode;
+  className?: string;
+  value: string;
+};
 
-function TabsTrigger({ children, className, value }: TabsTriggerProps): React.ReactNode {
-  const { activeTab, setActiveTab } = useTabsContext()
-  const isActive = activeTab === value
+function TabsTrigger({
+  children,
+  className,
+  value,
+}: TabsTriggerProps): React.ReactNode {
+  const { activeTab, setActiveTab } = useTabsContext();
+  const isActive = activeTab === value;
 
   return (
     <button
       aria-selected={isActive}
       className={cn(
-        'px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors',
-        'border-b-2 -mb-px',
+        "px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors",
+        "border-b-2 -mb-px",
         isActive
-          ? 'border-primary text-primary'
-          : 'border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/50',
+          ? "border-primary text-primary"
+          : "border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/50",
         className,
       )}
       onClick={() => {
-        setActiveTab(value)
+        setActiveTab(value);
       }}
       role="tab"
       type="button"
     >
       {children}
     </button>
-  )
+  );
 }
 
 export type TabsContentProps = {
-  children: ReactNode
-  className?: string
-  value: string
-}
+  children: ReactNode;
+  className?: string;
+  value: string;
+};
 
-function TabsContent({ children, className, value }: TabsContentProps): React.ReactNode {
-  const { activeTab } = useTabsContext()
+function TabsContent({
+  children,
+  className,
+  value,
+}: TabsContentProps): React.ReactNode {
+  const { activeTab } = useTabsContext();
 
-  if (activeTab !== value) return null
+  if (activeTab !== value) return null;
 
   return (
-    <div className={cn('pt-4', className)} role="tabpanel">
+    <div className={cn("pt-4", className)} role="tabpanel">
       {children}
     </div>
-  )
+  );
 }
 
 // Attach sub-components
-Tabs.List = TabsList
-Tabs.Trigger = TabsTrigger
-Tabs.Content = TabsContent
+Tabs.List = TabsList;
+Tabs.Trigger = TabsTrigger;
+Tabs.Content = TabsContent;
 
-export { Tabs, TabsContent, TabsList, TabsTrigger }
+export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/apps/registry/registry/default/tags-input/tags-input.tsx
+++ b/apps/registry/registry/default/tags-input/tags-input.tsx
@@ -1,2 +1,233 @@
-// Re-export from @vllnt/ui package
-export { TagsInput } from "@vllnt/ui";
+"use client";
+
+import * as React from "react";
+
+import { X } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+function normalizeTag(tag: string) {
+  return tag.trim();
+}
+
+function getNormalizedTags(tags: string[]) {
+  return tags
+    .map(normalizeTag)
+    .filter(
+      (tag, index, values) => tag.length > 0 && values.indexOf(tag) === index,
+    );
+}
+
+function shouldAddTagFromKey(key: string) {
+  return key === "Enter" || key === ",";
+}
+
+type TagsInputStateOptions = {
+  defaultValue: string[];
+  onValueChange?: (value: string[]) => void;
+  value?: string[];
+};
+
+type TagsInputHandlersOptions = {
+  disabled: boolean;
+  inputValue: string;
+  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
+  setInputValue: React.Dispatch<React.SetStateAction<string>>;
+  tags: string[];
+  updateTags: (nextTags: string[]) => void;
+};
+
+type TagListProps = {
+  disabled: boolean;
+  onRemove: (tag: string) => void;
+  tags: string[];
+};
+
+function useTagsInputState({
+  defaultValue,
+  onValueChange,
+  value,
+}: TagsInputStateOptions) {
+  const [uncontrolledValue, setUncontrolledValue] = React.useState(() =>
+    getNormalizedTags(defaultValue),
+  );
+  const isControlled = value !== undefined;
+  const tags = React.useMemo(
+    () => getNormalizedTags(value ?? uncontrolledValue),
+    [uncontrolledValue, value],
+  );
+
+  const updateTags = React.useCallback(
+    (nextTags: string[]) => {
+      const normalizedTags = getNormalizedTags(nextTags);
+
+      if (!isControlled) {
+        setUncontrolledValue(normalizedTags);
+      }
+
+      onValueChange?.(normalizedTags);
+    },
+    [isControlled, onValueChange],
+  );
+
+  return { tags, updateTags };
+}
+
+function useTagsInputHandlers({
+  disabled,
+  inputValue,
+  onKeyDown,
+  setInputValue,
+  tags,
+  updateTags,
+}: TagsInputHandlersOptions) {
+  const removeTag = React.useCallback(
+    (tagToRemove: string) => {
+      updateTags(tags.filter((tag) => tag !== tagToRemove));
+    },
+    [tags, updateTags],
+  );
+
+  const commitTag = React.useCallback(() => {
+    const nextTag = normalizeTag(inputValue);
+
+    if (nextTag.length === 0 || tags.includes(nextTag)) {
+      setInputValue("");
+      return;
+    }
+
+    updateTags([...tags, nextTag]);
+    setInputValue("");
+  }, [inputValue, setInputValue, tags, updateTags]);
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      onKeyDown?.(event);
+
+      if (event.defaultPrevented || disabled) {
+        return;
+      }
+
+      if (shouldAddTagFromKey(event.key)) {
+        event.preventDefault();
+        commitTag();
+        return;
+      }
+
+      if (
+        (event.key === "Backspace" || event.key === "Delete") &&
+        inputValue.length === 0
+      ) {
+        const lastTag = tags.at(-1);
+
+        if (lastTag) {
+          event.preventDefault();
+          removeTag(lastTag);
+        }
+      }
+    },
+    [commitTag, disabled, inputValue.length, onKeyDown, removeTag, tags],
+  );
+
+  return { handleKeyDown, removeTag };
+}
+
+function TagList({ disabled, onRemove, tags }: TagListProps) {
+  return (
+    <ul className="flex flex-wrap items-center gap-2">
+      {tags.map((tag) => (
+        <li
+          className="flex items-center gap-1 rounded-md border bg-muted px-2 py-1 text-sm text-foreground"
+          key={tag}
+        >
+          <span>{tag}</span>
+          <button
+            aria-label={`Remove ${tag}`}
+            className="rounded-sm text-muted-foreground outline-none ring-offset-background transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            disabled={disabled}
+            onClick={(event) => {
+              event.stopPropagation();
+              onRemove(tag);
+            }}
+            type="button"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export type TagsInputProps = Omit<
+  React.ComponentPropsWithoutRef<"input">,
+  "defaultValue" | "onChange" | "value"
+> & {
+  defaultValue?: string[];
+  onValueChange?: (value: string[]) => void;
+  value?: string[];
+};
+
+const TagsInput = React.forwardRef<HTMLInputElement, TagsInputProps>(
+  (
+    {
+      className,
+      defaultValue = [],
+      disabled = false,
+      onBlur,
+      onKeyDown,
+      onValueChange,
+      placeholder = "Add a tag",
+      value,
+      ...props
+    },
+    ref,
+  ) => {
+    const [inputValue, setInputValue] = React.useState("");
+    const { tags, updateTags } = useTagsInputState({
+      defaultValue,
+      onValueChange,
+      value,
+    });
+    const { handleKeyDown, removeTag } = useTagsInputHandlers({
+      disabled,
+      inputValue,
+      onKeyDown,
+      setInputValue,
+      tags,
+      updateTags,
+    });
+
+    return (
+      <div
+        aria-disabled={disabled || undefined}
+        className={cn(
+          "flex min-h-10 w-full flex-wrap items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background transition-colors focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
+          disabled && "cursor-not-allowed opacity-50",
+          className,
+        )}
+        data-disabled={disabled ? "true" : undefined}
+        role="group"
+      >
+        <TagList disabled={disabled} onRemove={removeTag} tags={tags} />
+        <input
+          {...props}
+          className="min-w-[8rem] flex-1 border-0 bg-transparent p-0 text-sm placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed"
+          disabled={disabled}
+          onBlur={onBlur}
+          onChange={(event) => {
+            setInputValue(event.target.value);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          ref={ref}
+          type="text"
+          value={inputValue}
+        />
+      </div>
+    );
+  },
+);
+TagsInput.displayName = "TagsInput";
+
+export { TagsInput };

--- a/apps/registry/registry/default/terminal/terminal.tsx
+++ b/apps/registry/registry/default/terminal/terminal.tsx
@@ -1,2 +1,175 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { useState } from "react";
+
+import { Check, Copy, Terminal as TerminalIcon } from "lucide-react";
+
+import { Button } from "@vllnt/ui";
+
+export type TerminalLine = {
+  content: string;
+  type: "command" | "comment" | "output";
+};
+
+export type TerminalProps = {
+  copyable?: boolean;
+  lines: TerminalLine[];
+  title?: string;
+};
+
+export function Terminal({
+  copyable = true,
+  lines,
+  title = "Terminal",
+}: TerminalProps) {
+  const [copied, setCopied] = useState(false);
+
+  const commands = lines
+    .filter((l) => l.type === "command")
+    .map((l) => l.content);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(commands.join("\n"));
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+
+  return (
+    <div className="my-6 rounded-lg border bg-zinc-950 dark:bg-zinc-900 overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-2 bg-zinc-900 dark:bg-zinc-800 border-b border-zinc-800">
+        <div className="flex items-center gap-2">
+          <TerminalIcon className="h-4 w-4 text-zinc-400" />
+          <span className="text-sm font-medium text-zinc-300">{title}</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="h-3 w-3 rounded-full bg-red-500" />
+          <div className="h-3 w-3 rounded-full bg-yellow-500" />
+          <div className="h-3 w-3 rounded-full bg-green-500" />
+        </div>
+      </div>
+      <div className="relative">
+        <div className="p-4 font-mono text-sm space-y-1 overflow-x-auto">
+          {lines.map((line, index) => (
+            <div className="flex items-start" key={index}>
+              {line.type === "command" && (
+                <>
+                  <span className="text-green-400 mr-2 select-none">$</span>
+                  <span className="text-zinc-100">{line.content}</span>
+                </>
+              )}
+              {line.type === "output" && (
+                <span className="text-zinc-400">{line.content}</span>
+              )}
+              {line.type === "comment" && (
+                <span className="text-zinc-600 italic"># {line.content}</span>
+              )}
+            </div>
+          ))}
+        </div>
+        {copyable && commands.length > 0 ? (
+          <Button
+            className="absolute top-2 right-2 h-8 w-8 bg-zinc-800 hover:bg-zinc-700 text-zinc-300"
+            onClick={handleCopy}
+            size="icon"
+            variant="ghost"
+          >
+            {copied ? (
+              <Check className="h-3 w-3" />
+            ) : (
+              <Copy className="h-3 w-3" />
+            )}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export type SimpleTerminalProps = {
+  children: string;
+  title?: string;
+};
+
+export function SimpleTerminal({
+  children,
+  title = "Terminal",
+}: SimpleTerminalProps) {
+  const [copied, setCopied] = useState(false);
+
+  const lines = children
+    .trim()
+    .split("\n")
+    .map((line): TerminalLine => {
+      if (line.startsWith("$ ")) {
+        return { content: line.slice(2), type: "command" };
+      }
+      if (line.startsWith("# ")) {
+        return { content: line.slice(2), type: "comment" };
+      }
+      return { content: line, type: "output" };
+    });
+
+  const commands = lines
+    .filter((l) => l.type === "command")
+    .map((l) => l.content);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(commands.join("\n"));
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+
+  return (
+    <div className="my-6 rounded-lg border bg-zinc-950 dark:bg-zinc-900 overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-2 bg-zinc-900 dark:bg-zinc-800 border-b border-zinc-800">
+        <div className="flex items-center gap-2">
+          <TerminalIcon className="h-4 w-4 text-zinc-400" />
+          <span className="text-sm font-medium text-zinc-300">{title}</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="h-3 w-3 rounded-full bg-red-500" />
+          <div className="h-3 w-3 rounded-full bg-yellow-500" />
+          <div className="h-3 w-3 rounded-full bg-green-500" />
+        </div>
+      </div>
+      <div className="relative">
+        <div className="p-4 font-mono text-sm space-y-1 overflow-x-auto">
+          {lines.map((line, index) => (
+            <div className="flex items-start" key={index}>
+              {line.type === "command" && (
+                <>
+                  <span className="text-green-400 mr-2 select-none">$</span>
+                  <span className="text-zinc-100">{line.content}</span>
+                </>
+              )}
+              {line.type === "output" && (
+                <span className="text-zinc-400">{line.content}</span>
+              )}
+              {line.type === "comment" && (
+                <span className="text-zinc-600 italic"># {line.content}</span>
+              )}
+            </div>
+          ))}
+        </div>
+        {commands.length > 0 && (
+          <Button
+            className="absolute top-2 right-2 h-8 w-8 bg-zinc-800 hover:bg-zinc-700 text-zinc-300"
+            onClick={handleCopy}
+            size="icon"
+            variant="ghost"
+          >
+            {copied ? (
+              <Check className="h-3 w-3" />
+            ) : (
+              <Copy className="h-3 w-3" />
+            )}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/registry/registry/default/textarea/textarea.tsx
+++ b/apps/registry/registry/default/textarea/textarea.tsx
@@ -1,1 +1,23 @@
-export * from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/apps/registry/registry/default/theme-provider/theme-provider.tsx
+++ b/apps/registry/registry/default/theme-provider/theme-provider.tsx
@@ -1,3 +1,10 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
 
+import {
+  ThemeProvider as NextThemesProvider,
+  type ThemeProviderProps,
+} from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/apps/registry/registry/default/theme-toggle/theme-toggle.tsx
+++ b/apps/registry/registry/default/theme-toggle/theme-toggle.tsx
@@ -1,4 +1,185 @@
-// Re-export from @vllnt/ui package
-export { ThemeToggle } from '@vllnt/ui'
+"use client";
 
+import { useCallback, useRef, useState } from "react";
 
+import { useTheme } from "next-themes";
+
+import { useMounted } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@vllnt/ui";
+
+type ThemeToggleProps = {
+  dict: {
+    theme: {
+      dark: string;
+      light: string;
+      system: string;
+      toggle_theme: string;
+    };
+  };
+};
+
+type ThemeButtonProps = {
+  ariaLabel: string;
+  children?: React.ReactNode;
+  icon: string;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+function ThemeButton({
+  ariaLabel,
+  children,
+  icon,
+  ...props
+}: ThemeButtonProps) {
+  return (
+    <Button
+      aria-label={ariaLabel}
+      className="bg-background text-foreground border border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 transition-colors"
+      size="icon"
+      variant="outline"
+      {...props}
+    >
+      <span className="text-sm font-mono">{icon}</span>
+      <span className="sr-only">{ariaLabel}</span>
+      {children}
+    </Button>
+  );
+}
+
+function ThemeMenuItem({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: string;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <DropdownMenuItem
+      className="hover:bg-accent cursor-pointer"
+      onClick={onClick}
+    >
+      {icon} {label}
+    </DropdownMenuItem>
+  );
+}
+
+export function ThemeToggle({ dict }: ThemeToggleProps) {
+  const { setTheme, theme } = useTheme();
+  const mounted = useMounted();
+  const [open, setOpen] = useState(false);
+  const closeTimerReference = useRef<null | number>(null);
+  const isHoveringOverMenuAreaReference = useRef(false);
+
+  const clearCloseTimer = useCallback(() => {
+    if (closeTimerReference.current !== null) {
+      window.clearTimeout(closeTimerReference.current);
+      closeTimerReference.current = null;
+    }
+  }, []);
+
+  const scheduleClose = useCallback(() => {
+    clearCloseTimer();
+    closeTimerReference.current = window.setTimeout(() => {
+      setOpen(false);
+    }, 250);
+  }, [clearCloseTimer]);
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    if (!nextOpen && isHoveringOverMenuAreaReference.current) {
+      return;
+    }
+    setOpen(nextOpen);
+  }, []);
+
+  const getThemeIcon = useCallback(() => {
+    if (!mounted) return "☀";
+
+    switch (theme) {
+      case "light":
+        return "☀";
+      case "dark":
+        return "☾";
+      case "system":
+        return "⚙";
+      case undefined:
+        return "⚙";
+      default:
+        return "⚙";
+    }
+  }, [theme, mounted]);
+
+  const themeIcon = getThemeIcon();
+
+  const handleThemeChange = useCallback(
+    (newTheme: string) => {
+      setTheme(newTheme);
+    },
+    [setTheme],
+  );
+
+  // Prevent hydration mismatch by not rendering until mounted
+  if (!mounted) {
+    return <ThemeButton ariaLabel={dict.theme.toggle_theme} icon="☀" />;
+  }
+
+  return (
+    <DropdownMenu modal={false} onOpenChange={handleOpenChange} open={open}>
+      <DropdownMenuTrigger asChild>
+        <ThemeButton
+          ariaLabel={dict.theme.toggle_theme}
+          icon={themeIcon}
+          onMouseEnter={() => {
+            isHoveringOverMenuAreaReference.current = true;
+            clearCloseTimer();
+            setOpen(true);
+          }}
+          onMouseLeave={() => {
+            isHoveringOverMenuAreaReference.current = false;
+            scheduleClose();
+          }}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="bg-background border border-gray-300 dark:border-gray-600"
+        onMouseEnter={() => {
+          isHoveringOverMenuAreaReference.current = true;
+          clearCloseTimer();
+        }}
+        onMouseLeave={() => {
+          isHoveringOverMenuAreaReference.current = false;
+          scheduleClose();
+        }}
+      >
+        <ThemeMenuItem
+          icon="☀"
+          label={dict.theme.light}
+          onClick={() => {
+            handleThemeChange("light");
+          }}
+        />
+        <ThemeMenuItem
+          icon="☾"
+          label={dict.theme.dark}
+          onClick={() => {
+            handleThemeChange("dark");
+          }}
+        />
+        <ThemeMenuItem
+          icon="⚙"
+          label={dict.theme.system}
+          onClick={() => {
+            handleThemeChange("system");
+          }}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/registry/registry/default/thinking-block/thinking-block.tsx
+++ b/apps/registry/registry/default/thinking-block/thinking-block.tsx
@@ -1,35 +1,43 @@
-'use client'
+"use client";
 
-import { useCallback, useEffect, useId, useState } from 'react'
+import { useCallback, useEffect, useId, useState } from "react";
 
-import { ChevronDown, ChevronRight } from 'lucide-react'
+import { ChevronDown, ChevronRight } from "lucide-react";
 
-import { cn } from '../../../lib/utils'
+import { cn } from "@vllnt/ui";
 
 export type ThinkingBlockProps = {
-  className?: string
-  /** Whether the content is still being streamed. */
-  isStreaming?: boolean
+  className?: string;
+  /** Whether the content is still streaming. */
+  isStreaming?: boolean;
   /** The thinking text content to display. */
-  thinking: string
-}
+  thinking: string;
+};
 
 /** Collapsible thinking block with streaming support. */
-export function ThinkingBlock({ className, isStreaming = false, thinking }: ThinkingBlockProps) {
-  const [isExpanded, setIsExpanded] = useState(isStreaming)
-  const contentId = useId()
+export function ThinkingBlock({
+  className,
+  isStreaming = false,
+  thinking,
+}: ThinkingBlockProps) {
+  const [isExpanded, setIsExpanded] = useState(isStreaming);
+  const contentId = useId();
 
   // Auto-open when streaming starts
   useEffect(() => {
-    if (isStreaming) setIsExpanded(true)
-  }, [isStreaming])
+    if (isStreaming) {
+      requestAnimationFrame(() => {
+        setIsExpanded(true);
+      });
+    }
+  }, [isStreaming]);
 
   const toggleExpanded = useCallback(() => {
-    setIsExpanded((previous) => !previous)
-  }, [])
+    setIsExpanded((previous) => !previous);
+  }, []);
 
   return (
-    <div className={cn('mb-2', className)}>
+    <div className={cn("mb-2", className)}>
       <button
         aria-controls={contentId}
         aria-expanded={isExpanded}
@@ -37,7 +45,11 @@ export function ThinkingBlock({ className, isStreaming = false, thinking }: Thin
         onClick={toggleExpanded}
         type="button"
       >
-        {isExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        {isExpanded ? (
+          <ChevronDown className="h-3 w-3" />
+        ) : (
+          <ChevronRight className="h-3 w-3" />
+        )}
         <span>
           Thinking
           {isStreaming ? <span className="ml-1 animate-pulse">...</span> : null}
@@ -53,5 +65,5 @@ export function ThinkingBlock({ className, isStreaming = false, thinking }: Thin
         </div>
       ) : null}
     </div>
-  )
+  );
 }

--- a/apps/registry/registry/default/thread-bubble/thread-bubble.tsx
+++ b/apps/registry/registry/default/thread-bubble/thread-bubble.tsx
@@ -1,6 +1,181 @@
-export {
-  ThreadBubble,
-  type ThreadBubbleLabels,
-  type ThreadBubbleProps,
-  type ThreadMessage,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * One message in a thread bubble.
+ *
+ * @public
+ */
+export type ThreadMessage = {
+  /** Author display name. */
+  author: ReactNode;
+  /** Optional accent color for the author chip. */
+  authorColor?: string;
+  /** Message body — rendered as-is, can be plain text or a `ReactNode`. */
+  body: ReactNode;
+  /** Stable identifier — used as the React key + analytics hook. */
+  id: string;
+  /** Pre-formatted timestamp (host owns formatting). */
+  ts?: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type ThreadBubbleLabels = {
+  /** Empty-state copy. Defaults to `"No replies yet"`. */
+  empty?: string;
+  /** Aria-label override. Defaults to `"Comment thread"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No replies yet",
+  region: "Comment thread",
+} as const satisfies Required<ThreadBubbleLabels>;
+
+/**
+ * Props for {@link ThreadBubble}.
+ *
+ * @public
+ */
+export type ThreadBubbleProps = {
+  /** Optional footer slot — typically a reply input. */
+  footer?: ReactNode;
+  /** Localizable strings. */
+  labels?: ThreadBubbleLabels;
+  /** Messages newest-last. */
+  messages: ThreadMessage[];
+  /** Optional resolve handler. When provided, a "Resolve" button appears in the header. */
+  onResolve?: () => void;
+  /** Optional thread title (e.g. anchored object name). */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const Message = (props: { message: ThreadMessage }): React.ReactElement => {
+  const { message } = props;
+  return (
+    <li className="space-y-0.5" data-thread-bubble-message={message.id}>
+      <header className="flex items-baseline justify-between gap-2 text-[10px]">
+        <span
+          className="font-semibold"
+          data-thread-bubble-author
+          style={
+            message.authorColor ? { color: message.authorColor } : undefined
+          }
+        >
+          {message.author}
+        </span>
+        {message.ts ? (
+          <span className="text-muted-foreground" data-thread-bubble-ts>
+            {message.ts}
+          </span>
+        ) : null}
+      </header>
+      <p className="text-xs text-foreground" data-thread-bubble-body>
+        {message.body}
+      </p>
+    </li>
+  );
+};
+
+/**
+ * Expanded discussion bubble for an anchored canvas comment thread.
+ * Renders a stacked message list plus an optional reply slot via
+ * `footer`. Pair with {@link "../comment-pin/comment-pin".CommentPin}: pin marks the location,
+ * bubble holds the conversation.
+ *
+ * Pure presentation; the host owns the message store + supplies the
+ * resolve handler for hosts that allow threading.
+ *
+ * @example
+ * ```tsx
+ * <ThreadBubble
+ *   title="research-2025"
+ *   messages={[
+ *     { id: "1", author: "Bea", authorColor: "#5b8def", body: "Why fallback?", ts: "12s" },
+ *     { id: "2", author: "Lior", authorColor: "#10b981", body: "p95 spike — see graph", ts: "9s" },
+ *   ]}
+ *   footer={<ReplyInput onSubmit={post} />}
+ *   onResolve={resolve}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const ThreadBubble = forwardRef<HTMLElement, ThreadBubbleProps>(
+  (props, ref) => {
+    const { className, footer, labels, messages, onResolve, title, ...rest } =
+      props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const handleResolve = (): void => {
+      onResolve?.();
+    };
+    return (
+      <section
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "flex w-72 flex-col gap-2 rounded-lg border border-border bg-background p-3 text-foreground shadow-md",
+          className,
+        )}
+        data-thread-bubble
+        ref={ref}
+        {...rest}
+      >
+        {title || onResolve ? (
+          <header className="flex items-center justify-between gap-2 text-[11px] uppercase tracking-wide text-muted-foreground">
+            {title ? (
+              <span className="truncate font-semibold" data-thread-bubble-title>
+                {title}
+              </span>
+            ) : (
+              <span aria-hidden="true" />
+            )}
+            {onResolve ? (
+              <button
+                className="rounded-full border border-border px-2 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                data-thread-bubble-resolve
+                onClick={handleResolve}
+                type="button"
+              >
+                Resolve
+              </button>
+            ) : null}
+          </header>
+        ) : null}
+        {messages.length === 0 ? (
+          <p
+            className="px-1 py-2 text-center text-[11px] text-muted-foreground"
+            data-thread-bubble-state="empty"
+          >
+            {resolvedLabels.empty}
+          </p>
+        ) : (
+          <ul className="space-y-2 overflow-y-auto" data-thread-bubble-list>
+            {messages.map((message) => (
+              <Message key={message.id} message={message} />
+            ))}
+          </ul>
+        )}
+        {footer ? (
+          <footer
+            className="border-t border-border pt-2"
+            data-thread-bubble-footer
+          >
+            {footer}
+          </footer>
+        ) : null}
+      </section>
+    );
+  },
+);
+ThreadBubble.displayName = "ThreadBubble";

--- a/apps/registry/registry/default/threshold-ring/threshold-ring.tsx
+++ b/apps/registry/registry/default/threshold-ring/threshold-ring.tsx
@@ -1,6 +1,240 @@
-export {
-  ThresholdRing,
-  type ThresholdRingLabels,
-  type ThresholdRingProps,
-  type ThresholdRingTone,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Tone of the active arc — drives its stroke color.
+ *
+ * @public
+ */
+export type ThresholdRingTone = "danger" | "neutral" | "success" | "warn";
+
+const TONE_STROKE: Record<ThresholdRingTone, string> = {
+  danger: "stroke-red-500",
+  neutral: "stroke-foreground",
+  success: "stroke-emerald-500",
+  warn: "stroke-amber-500",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type ThresholdRingLabels = {
+  /** Aria-label override. Defaults to `"Threshold ring"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Threshold ring",
+} as const satisfies Required<ThresholdRingLabels>;
+
+/**
+ * Props for {@link ThresholdRing}.
+ *
+ * @public
+ */
+export type ThresholdRingProps = {
+  /** Optional center label (formatted by host — e.g. `"82%"`). */
+  centerLabel?: ReactNode;
+  /** Localizable strings. */
+  labels?: ThresholdRingLabels;
+  /** Upper bound of the ring's value range. Defaults to `1`. */
+  max?: number;
+  /** Outer diameter in pixels. Defaults to `64`. */
+  size?: number;
+  /** Stroke width in pixels. Defaults to `6`. */
+  stroke?: number;
+  /** Optional threshold marker `0..max` rendered as a small notch. */
+  threshold?: number;
+  /** Tone of the active arc. Defaults to `"neutral"`. */
+  tone?: ThresholdRingTone;
+  /** Current value `0..max`. */
+  value: number;
+} & ComponentPropsWithoutRef<"svg">;
+
+const clamp = (v: number, min: number, max: number): number => {
+  if (v < min) {
+    return min;
+  }
+  if (v > max) {
+    return max;
+  }
+  return v;
+};
+
+const polar = (input: {
+  angle: number;
+  cx: number;
+  cy: number;
+  r: number;
+}): { x: number; y: number } => {
+  const rad = (input.angle - 90) * (Math.PI / 180);
+  return {
+    x: input.cx + input.r * Math.cos(rad),
+    y: input.cy + input.r * Math.sin(rad),
+  };
+};
+
+type Geometry = {
+  circumference: number;
+  cx: number;
+  cy: number;
+  r: number;
+  ratio: number;
+  size: number;
+  stroke: number;
+  tickAngle: null | number;
+};
+
+const computeGeometry = (input: {
+  max: number;
+  size: number;
+  stroke: number;
+  threshold?: number;
+  value: number;
+}): Geometry => {
+  const safeMax = input.max <= 0 ? 1 : input.max;
+  const ratio = clamp(input.value / safeMax, 0, 1);
+  const cx = input.size / 2;
+  const cy = input.size / 2;
+  const r = (input.size - input.stroke) / 2;
+  const circumference = 2 * Math.PI * r;
+  const tickAngle =
+    input.threshold === undefined
+      ? null
+      : clamp(input.threshold / safeMax, 0, 1) * 360;
+  return {
+    circumference,
+    cx,
+    cy,
+    r,
+    ratio,
+    size: input.size,
+    stroke: input.stroke,
+    tickAngle,
+  };
+};
+
+const Tick = (props: { geom: Geometry }): null | React.ReactElement => {
+  const { geom } = props;
+  if (geom.tickAngle === null) {
+    return null;
+  }
+  const inner = polar({
+    angle: geom.tickAngle,
+    cx: geom.cx,
+    cy: geom.cy,
+    r: geom.r - geom.stroke / 2,
+  });
+  const outer = polar({
+    angle: geom.tickAngle,
+    cx: geom.cx,
+    cy: geom.cy,
+    r: geom.r + geom.stroke / 2,
+  });
+  return (
+    <line
+      className="stroke-foreground/80"
+      data-threshold-ring-tick
+      strokeLinecap="round"
+      strokeWidth={2}
+      x1={inner.x}
+      x2={outer.x}
+      y1={inner.y}
+      y2={outer.y}
+    />
+  );
+};
+
+/**
+ * Compact ring gauge expressing how close a value is to a threshold.
+ * Pure presentation; the host supplies the value, threshold, and tone.
+ * Use to overlay budget / quota / SLA indicators on canvas objects
+ * without consuming card real-estate.
+ *
+ * Distinct from `MetricGauge`: this primitive is small, headless, and
+ * meant to attach to a runtime object — not a dashboard tile.
+ *
+ * @example
+ * ```tsx
+ * <ThresholdRing value={0.82} threshold={0.7} tone="warn" centerLabel="82%" />
+ * ```
+ *
+ * @public
+ */
+export const ThresholdRing = forwardRef<SVGSVGElement, ThresholdRingProps>(
+  (props, ref) => {
+    const {
+      centerLabel,
+      className,
+      labels,
+      max = 1,
+      size = 64,
+      stroke = 6,
+      threshold,
+      tone = "neutral",
+      value,
+      ...rest
+    } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    const geom = computeGeometry({ max, size, stroke, threshold, value });
+    const dash = `${geom.ratio * geom.circumference} ${geom.circumference}`;
+    return (
+      <svg
+        aria-label={resolvedLabels.region}
+        className={cn("inline-block", className)}
+        data-threshold-ring
+        data-threshold-tone={tone}
+        height={geom.size}
+        ref={ref}
+        role="img"
+        viewBox={`0 0 ${geom.size} ${geom.size}`}
+        width={geom.size}
+        {...rest}
+      >
+        <circle
+          className="stroke-muted"
+          cx={geom.cx}
+          cy={geom.cy}
+          fill="none"
+          r={geom.r}
+          strokeWidth={geom.stroke}
+        />
+        <circle
+          className={cn("transition-all duration-300", TONE_STROKE[tone])}
+          cx={geom.cx}
+          cy={geom.cy}
+          data-threshold-ring-arc
+          fill="none"
+          r={geom.r}
+          strokeDasharray={dash}
+          strokeLinecap="round"
+          strokeWidth={geom.stroke}
+          transform={`rotate(-90 ${geom.cx} ${geom.cy})`}
+        />
+        <Tick geom={geom} />
+        {centerLabel ? (
+          <text
+            className="fill-foreground text-[10px] font-semibold"
+            data-threshold-ring-label
+            dominantBaseline="central"
+            textAnchor="middle"
+            x={geom.cx}
+            y={geom.cy}
+          >
+            {centerLabel}
+          </text>
+        ) : null}
+      </svg>
+    );
+  },
+);
+ThresholdRing.displayName = "ThresholdRing";

--- a/apps/registry/registry/default/ticker-tape/ticker-tape.tsx
+++ b/apps/registry/registry/default/ticker-tape/ticker-tape.tsx
@@ -1,1 +1,130 @@
-export { TickerTape } from "@vllnt/ui";
+import * as React from "react";
+
+import { ArrowDownRight, ArrowUpRight, Dot } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+
+export type TickerTapeItem = {
+  change: number;
+  price: number | string;
+  symbol: string;
+  volume?: string;
+};
+
+export type TickerTapeProps = {
+  items: TickerTapeItem[];
+  pauseOnHover?: boolean;
+  speedSeconds?: number;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+const tickerTapeKeyframes = `
+@keyframes ticker-tape-scroll {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(-50%);
+  }
+}
+`;
+
+function formatPrice(price: number | string) {
+  return typeof price === "number" ? price.toLocaleString() : price;
+}
+
+function formatChange(change: number) {
+  const sign = change > 0 ? "+" : "";
+  return `${sign}${change.toFixed(2)}%`;
+}
+
+function TickerTapeRow({ items }: { items: TickerTapeItem[] }) {
+  return (
+    <div className="flex min-w-max items-center gap-3 px-3 py-3">
+      {items.map((item) => {
+        const isPositive = item.change >= 0;
+        const TrendIcon = isPositive ? ArrowUpRight : ArrowDownRight;
+
+        return (
+          <div
+            className="flex min-w-[12rem] items-center gap-3 rounded-full border border-border/70 bg-background/80 px-3 py-2 shadow-sm"
+            key={`${item.symbol}-${item.price}-${item.change}`}
+          >
+            <div className="flex min-w-0 flex-col">
+              <span className="text-xs font-medium uppercase tracking-[0.24em] text-muted-foreground">
+                {item.symbol}
+              </span>
+              <span className="truncate text-sm font-semibold text-foreground">
+                {formatPrice(item.price)}
+              </span>
+            </div>
+            <Badge
+              className={cn(
+                "ml-auto gap-1 rounded-full border px-2 py-0.5 text-[11px] tabular-nums",
+                isPositive
+                  ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                  : "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400",
+              )}
+              variant="outline"
+            >
+              <TrendIcon className="h-3 w-3" />
+              {formatChange(item.change)}
+            </Badge>
+            {item.volume ? (
+              <span className="hidden items-center text-xs text-muted-foreground sm:inline-flex">
+                <Dot className="h-3.5 w-3.5" />
+                {item.volume}
+              </span>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export const TickerTape = React.forwardRef<HTMLDivElement, TickerTapeProps>(
+  (
+    { className, items, pauseOnHover = true, speedSeconds = 28, ...props },
+    reference,
+  ) => {
+    if (items.length === 0) {
+      return null;
+    }
+
+    return (
+      <div
+        aria-label="TickerTape"
+        className={cn(
+          "relative overflow-hidden rounded-2xl border border-border bg-card/70 backdrop-blur-sm",
+          className,
+        )}
+        ref={reference}
+        role="region"
+        {...props}
+      >
+        <style>{tickerTapeKeyframes}</style>
+        <div
+          className={cn(
+            "flex w-max items-stretch",
+            pauseOnHover && "hover:[animation-play-state:paused]",
+          )}
+          style={{
+            animationDuration: `${speedSeconds}s`,
+            animationIterationCount: "infinite",
+            animationName: "ticker-tape-scroll",
+            animationTimingFunction: "linear",
+          }}
+        >
+          <TickerTapeRow items={items} />
+          <div aria-hidden="true">
+            <TickerTapeRow items={items} />
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+
+TickerTape.displayName = "TickerTape";

--- a/apps/registry/registry/default/timeline-scrubber/timeline-scrubber.tsx
+++ b/apps/registry/registry/default/timeline-scrubber/timeline-scrubber.tsx
@@ -1,7 +1,290 @@
-export {
-  type TimelineScrubberLabels,
-  type TimelineScrubberProps,
-  type TimelineScrubberTone,
-  TimelineScrubber,
-  type TimelineTick,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ChangeEvent,
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+  useId,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * One milestone tick rendered along the scrubber track.
+ *
+ * @public
+ */
+export type TimelineTick = {
+  /** Stable identifier — used as the React key + analytics hook. */
+  id: string;
+  /** Optional accessible label (e.g. `"deploy"`, `"alert"`). */
+  label?: ReactNode;
+  /** Optional tone for the tick. Defaults to `"neutral"`. */
+  tone?: TimelineScrubberTone;
+  /** Time value of the tick. */
+  value: number;
+};
+
+/**
+ * Tone of the scrubber's filled track + handle.
+ *
+ * @public
+ */
+export type TimelineScrubberTone =
+  | "danger"
+  | "neutral"
+  | "primary"
+  | "success"
+  | "warn";
+
+const TONE_FILL: Record<TimelineScrubberTone, string> = {
+  danger: "bg-red-500",
+  neutral: "bg-foreground",
+  primary: "bg-blue-500",
+  success: "bg-emerald-500",
+  warn: "bg-amber-500",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type TimelineScrubberLabels = {
+  /** Aria-label for the slider. Defaults to `"Timeline scrubber"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Timeline scrubber",
+} as const satisfies Required<TimelineScrubberLabels>;
+
+/**
+ * Props for {@link TimelineScrubber}.
+ *
+ * @public
+ */
+export type TimelineScrubberProps = {
+  /** End of the time range. Must be `> start`. */
+  end: number;
+  /** Optional formatter for the cursor + endpoint labels. Receives the raw value. */
+  formatValue?: (value: number) => ReactNode;
+  /** Localizable strings. */
+  labels?: TimelineScrubberLabels;
+  /** Change handler — receives the new clamped value. */
+  onValueChange: (value: number) => void;
+  /** Start of the time range. */
+  start: number;
+  /** Step granularity for the underlying range input. Defaults to `1`. */
+  step?: number;
+  /** Optional milestone ticks rendered along the track. */
+  ticks?: TimelineTick[];
+  /** Tone of the filled track + handle. Defaults to `"primary"`. */
+  tone?: TimelineScrubberTone;
+  /** Current scrub value `start..end`. */
+  value: number;
+} & Omit<ComponentPropsWithoutRef<"div">, "onChange">;
+
+const clamp = (v: number, min: number, max: number): number => {
+  if (v < min) {
+    return min;
+  }
+  if (v > max) {
+    return max;
+  }
+  return v;
+};
+
+type LabelsRow = {
+  clamped: number;
+  end: number;
+  formatValue?: (value: number) => ReactNode;
+  start: number;
+};
+
+const Labels = (props: LabelsRow): React.ReactElement => {
+  const fmt = props.formatValue;
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <span data-timeline-scrubber-start>
+        {fmt ? fmt(props.start) : props.start}
+      </span>
+      <span
+        className="font-semibold text-foreground"
+        data-timeline-scrubber-cursor
+      >
+        {fmt ? fmt(props.clamped) : props.clamped}
+      </span>
+      <span data-timeline-scrubber-end>{fmt ? fmt(props.end) : props.end}</span>
+    </div>
+  );
+};
+
+type TrackInput = {
+  ariaLabel: string;
+  inputId: string;
+  max: number;
+  min: number;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  ratio: number;
+  scrubberId: string;
+  span: number;
+  start: number;
+  step: number;
+  ticks?: TimelineTick[];
+  tone: TimelineScrubberTone;
+  value: number;
+};
+
+const Track = (props: TrackInput): React.ReactElement => (
+  <div className="relative h-6">
+    <span
+      aria-hidden="true"
+      className="absolute left-0 right-0 top-1/2 h-1 -translate-y-1/2 rounded-full bg-muted"
+    />
+    <span
+      aria-hidden="true"
+      className={cn(
+        "absolute left-0 top-1/2 h-1 -translate-y-1/2 rounded-full",
+        TONE_FILL[props.tone],
+      )}
+      data-timeline-scrubber-fill
+      style={{ width: `${props.ratio * 100}%` }}
+    />
+    {props.ticks?.map((tick) => (
+      <TickMark
+        key={tick.id}
+        scrubberId={props.scrubberId}
+        span={props.span}
+        start={props.start}
+        tick={tick}
+      />
+    ))}
+    <input
+      aria-label={props.ariaLabel}
+      className="absolute inset-0 h-full w-full cursor-pointer appearance-none bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      data-timeline-scrubber-input
+      id={props.inputId}
+      max={props.max}
+      min={props.min}
+      onChange={props.onChange}
+      step={props.step}
+      type="range"
+      value={props.value}
+    />
+  </div>
+);
+
+const TickMark = (props: {
+  scrubberId: string;
+  span: number;
+  start: number;
+  tick: TimelineTick;
+}): React.ReactElement => {
+  const { scrubberId, span, start, tick } = props;
+  const ratio = clamp((tick.value - start) / span, 0, 1);
+  const tone = tick.tone ?? "neutral";
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "absolute top-1/2 h-2.5 w-px -translate-y-1/2 rounded-full",
+        TONE_FILL[tone],
+      )}
+      data-scrubber-tick={tick.id}
+      data-scrubber-tick-of={scrubberId}
+      data-scrubber-tick-tone={tone}
+      style={{ left: `${ratio * 100}%` }}
+      title={typeof tick.label === "string" ? tick.label : undefined}
+    />
+  );
+};
+
+/**
+ * Range slider for scrubbing through canvas state playback. Renders a
+ * thin track with optional milestone ticks plus the current value
+ * cursor; the underlying `<input type="range">` keeps keyboard +
+ * pointer + screen-reader semantics for free.
+ *
+ * Pure presentation; the host owns the value + drives playback in its
+ * own loop. Pair with {@link "../playback-ghost/playback-ghost".PlaybackGhost} to fade the canvas
+ * back to historical state as the user scrubs.
+ *
+ * @example
+ * ```tsx
+ * <TimelineScrubber
+ *   start={0} end={3600}
+ *   value={cursor}
+ *   onValueChange={setCursor}
+ *   ticks={milestones}
+ *   formatValue={(v) => formatDuration(v)}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const TimelineScrubber = forwardRef<
+  HTMLDivElement,
+  TimelineScrubberProps
+>((props, ref) => {
+  const {
+    className,
+    end,
+    formatValue,
+    labels,
+    onValueChange,
+    start,
+    step = 1,
+    ticks,
+    tone = "primary",
+    value,
+    ...rest
+  } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const inputId = useId();
+  const safeEnd = end <= start ? start + 1 : end;
+  const span = safeEnd - start;
+  const clamped = clamp(value, start, safeEnd);
+  const ratio = clamp((clamped - start) / span, 0, 1);
+  const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    onValueChange(clamp(Number(event.target.value), start, safeEnd));
+  };
+  return (
+    <div
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "flex w-full flex-col gap-1 text-[11px] text-muted-foreground",
+        className,
+      )}
+      data-timeline-scrubber
+      data-timeline-tone={tone}
+      ref={ref}
+      role="group"
+      {...rest}
+    >
+      <Labels
+        clamped={clamped}
+        end={safeEnd}
+        formatValue={formatValue}
+        start={start}
+      />
+      <Track
+        ariaLabel={resolvedLabels.region}
+        inputId={inputId}
+        max={safeEnd}
+        min={start}
+        onChange={handleChange}
+        ratio={ratio}
+        scrubberId={inputId}
+        span={span}
+        start={start}
+        step={step}
+        ticks={ticks}
+        tone={tone}
+        value={clamped}
+      />
+    </div>
+  );
+});
+TimelineScrubber.displayName = "TimelineScrubber";

--- a/apps/registry/registry/default/timeline/timeline.tsx
+++ b/apps/registry/registry/default/timeline/timeline.tsx
@@ -1,7 +1,369 @@
-// Re-export from @vllnt/ui package
-export {
-  Timeline,
-  TimelineItem,
-  timelineVariants,
-  useTimelineOrientation,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useContext,
+  useMemo,
+} from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Visual orientation for a {@link Timeline}.
+ *
+ * @public
+ */
+export type TimelineOrientation = "horizontal" | "vertical";
+
+/**
+ * Status for a {@link TimelineItem}.
+ *
+ * @public
+ */
+export type TimelineItemStatus = "active" | "completed" | "upcoming";
+
+/**
+ * Color theme for a {@link TimelineItem} marker.
+ *
+ * @public
+ */
+export type TimelineColor =
+  | "amber"
+  | "blue"
+  | "emerald"
+  | "neutral"
+  | "purple"
+  | "red"
+  | "rose";
+
+const STATUS_CLASSES: Record<
+  TimelineItemStatus,
+  { connector: string; markerBorder: string; markerFill: string }
+> = {
+  active: {
+    connector: "border-solid border-primary",
+    markerBorder: "border-primary",
+    markerFill: "bg-background ring-2 ring-primary",
+  },
+  completed: {
+    connector: "border-solid border-primary",
+    markerBorder: "border-primary",
+    markerFill: "bg-primary",
+  },
+  upcoming: {
+    connector: "border-dashed border-muted-foreground/40",
+    markerBorder: "border-muted-foreground/40",
+    markerFill: "bg-background",
+  },
+};
+
+const COLOR_OVERRIDES: Record<TimelineColor, { border: string; fill: string }> =
+  {
+    amber: {
+      border: "border-amber-500",
+      fill: "bg-amber-500",
+    },
+    blue: {
+      border: "border-blue-500",
+      fill: "bg-blue-500",
+    },
+    emerald: {
+      border: "border-emerald-500",
+      fill: "bg-emerald-500",
+    },
+    neutral: {
+      border: "border-muted-foreground",
+      fill: "bg-muted-foreground",
+    },
+    purple: {
+      border: "border-purple-500",
+      fill: "bg-purple-500",
+    },
+    red: {
+      border: "border-red-500",
+      fill: "bg-red-500",
+    },
+    rose: {
+      border: "border-rose-500",
+      fill: "bg-rose-500",
+    },
+  };
+
+type TimelineContextValue = {
+  orientation: TimelineOrientation;
+};
+
+const TimelineContext = createContext<TimelineContextValue>({
+  orientation: "vertical",
+});
+
+/**
+ * Hook for reading the surrounding {@link Timeline}'s orientation. Useful
+ * for custom children that need to adapt their layout.
+ *
+ * @public
+ */
+export function useTimelineOrientation(): TimelineOrientation {
+  return useContext(TimelineContext).orientation;
+}
+
+const timelineVariants = cva("flex", {
+  defaultVariants: {
+    orientation: "vertical",
+  },
+  variants: {
+    orientation: {
+      horizontal: "flex-row gap-0 overflow-x-auto",
+      vertical: "flex-col gap-0",
+    },
+  },
+});
+
+/**
+ * Props for {@link Timeline}.
+ *
+ * @public
+ */
+export type TimelineProps = ComponentPropsWithoutRef<"ol"> &
+  VariantProps<typeof timelineVariants>;
+
+/**
+ * Vertical or horizontal timeline of sequential events. Renders an
+ * ordered list (`<ol>`) so the order matters semantically. Children
+ * should be {@link TimelineItem}s.
+ *
+ * The component injects connector styling per child via context — the
+ * last item drops its trailing connector automatically.
+ *
+ * @example
+ * ```tsx
+ * <Timeline>
+ *   <TimelineItem title="Project started" date="Jan 2026" status="completed" />
+ *   <TimelineItem title="MVP launch" date="Mar 2026" status="completed" />
+ *   <TimelineItem title="V2" date="Jul 2026" status="active" />
+ *   <TimelineItem title="Public release" date="Q4 2026" status="upcoming" />
+ * </Timeline>
+ * ```
+ *
+ * @public
+ */
+export const Timeline = forwardRef<HTMLOListElement, TimelineProps>(
+  ({ children, className, orientation, ...rest }, ref) => {
+    const resolvedOrientation: TimelineOrientation = orientation ?? "vertical";
+    const contextValue = useMemo<TimelineContextValue>(
+      () => ({ orientation: resolvedOrientation }),
+      [resolvedOrientation],
+    );
+    return (
+      <TimelineContext.Provider value={contextValue}>
+        <ol
+          className={cn(timelineVariants({ orientation }), className)}
+          data-orientation={resolvedOrientation}
+          ref={ref}
+          {...rest}
+        >
+          {children}
+        </ol>
+      </TimelineContext.Provider>
+    );
+  },
+);
+Timeline.displayName = "Timeline";
+
+/**
+ * Props for {@link TimelineItem}.
+ *
+ * @public
+ */
+export type TimelineItemProps = {
+  /** Optional color override for the marker. Falls back to the status palette. */
+  color?: TimelineColor;
+  /** Optional date / time caption rendered alongside the title. */
+  date?: ReactNode;
+  /** Optional sub-headline rendered under the title. */
+  description?: ReactNode;
+  /** Optional icon rendered inside the marker. */
+  icon?: ReactNode;
+  /** When true, suppresses the trailing connector. Defaults to `false`. */
+  isLast?: boolean;
+  /** Status drives marker fill and connector style. Defaults to `"upcoming"`. */
+  status?: TimelineItemStatus;
+  /** Item title. */
+  title: ReactNode;
+} & ComponentPropsWithoutRef<"li">;
+
+type MarkerProps = {
+  color?: TimelineColor;
+  icon?: ReactNode;
+  status: TimelineItemStatus;
+};
+
+function Marker({ color, icon, status }: MarkerProps): ReactNode {
+  const palette = STATUS_CLASSES[status];
+  const override = color ? COLOR_OVERRIDES[color] : undefined;
+  const borderClass = override?.border ?? palette.markerBorder;
+  const fillClass = override?.fill ?? palette.markerFill;
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "relative z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 bg-background text-[10px]",
+        borderClass,
+      )}
+    >
+      {icon ? (
+        <span
+          className={cn(
+            "flex h-full w-full items-center justify-center text-foreground [&>svg]:h-3 [&>svg]:w-3",
+            status === "completed" ? "text-primary-foreground" : "",
+          )}
+        >
+          {icon}
+        </span>
+      ) : (
+        <span
+          className={cn(
+            "h-2.5 w-2.5 rounded-full",
+            override ? fillClass : palette.markerFill,
+          )}
+        />
+      )}
+    </span>
+  );
+}
+
+type ConnectorProps = {
+  orientation: TimelineOrientation;
+  status: TimelineItemStatus;
+};
+
+function Connector({ orientation, status }: ConnectorProps): ReactNode {
+  const palette = STATUS_CLASSES[status];
+  if (orientation === "horizontal") {
+    return (
+      <span
+        aria-hidden="true"
+        className={cn(
+          "absolute top-3 h-0 w-full border-t-2",
+          palette.connector,
+        )}
+        style={{ left: "calc(50% + 0.75rem)" }}
+      />
+    );
+  }
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "absolute left-3 top-6 h-full w-0 -translate-x-1/2 border-l-2",
+        palette.connector,
+      )}
+    />
+  );
+}
+
+type ItemBodyProps = {
+  children?: ReactNode;
+  date?: ReactNode;
+  description?: ReactNode;
+  orientation: TimelineOrientation;
+  title: ReactNode;
+};
+
+function ItemBody({
+  children,
+  date,
+  description,
+  orientation,
+  title,
+}: ItemBodyProps): ReactNode {
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 flex-col gap-0.5",
+        orientation === "horizontal" ? "items-center text-center" : "",
+      )}
+    >
+      <div
+        className={cn(
+          "flex flex-wrap items-baseline gap-x-2 gap-y-0.5",
+          orientation === "horizontal" ? "justify-center" : "",
+        )}
+      >
+        <p className="text-sm font-semibold tracking-tight text-foreground">
+          {title}
+        </p>
+        {date ? (
+          <span className="font-mono text-xs text-muted-foreground">
+            {date}
+          </span>
+        ) : null}
+      </div>
+      {description ? (
+        <p className="text-sm text-muted-foreground">{description}</p>
+      ) : null}
+      {children ? (
+        <div className="mt-1 text-sm text-foreground">{children}</div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * One row inside a {@link Timeline}. Renders the marker, connector, title,
+ * date, description, and any rich-content children.
+ *
+ * @public
+ */
+export const TimelineItem = forwardRef<HTMLLIElement, TimelineItemProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      color,
+      date,
+      description,
+      icon,
+      isLast = false,
+      status = "upcoming",
+      title,
+      ...rest
+    } = props;
+    const orientation = useTimelineOrientation();
+    return (
+      <li
+        className={cn(
+          "relative",
+          orientation === "horizontal"
+            ? "flex flex-1 flex-col items-center gap-2 px-3 pt-1"
+            : "flex items-start gap-3 pb-6 last:pb-0",
+          className,
+        )}
+        data-status={status}
+        ref={ref}
+        {...rest}
+      >
+        {isLast ? null : (
+          <Connector orientation={orientation} status={status} />
+        )}
+        <Marker color={color} icon={icon} status={status} />
+        <ItemBody
+          date={date}
+          description={description}
+          orientation={orientation}
+          title={title}
+        >
+          {children}
+        </ItemBody>
+      </li>
+    );
+  },
+);
+TimelineItem.displayName = "TimelineItem";
+
+export { timelineVariants };

--- a/apps/registry/registry/default/tldr-section/tldr-section.tsx
+++ b/apps/registry/registry/default/tldr-section/tldr-section.tsx
@@ -1,2 +1,118 @@
-// Re-export from @vllnt/ui package
-export { TLDRSection } from '@vllnt/ui'
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type TLDRSectionProps = {
+  children: React.ReactNode;
+  label: string;
+};
+
+export function TLDRSection({ children, label }: TLDRSectionProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasBeenOpened, setHasBeenOpened] = useState(false);
+  const timerReference = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (isExpanded && !hasBeenOpened) {
+      // Clear any existing timer
+      if (timerReference.current) {
+        clearTimeout(timerReference.current);
+      }
+
+      const rafId = requestAnimationFrame(() => {
+        setIsLoading(true);
+        setHasBeenOpened(true);
+      });
+
+      // Simulate loading with skeleton
+      timerReference.current = setTimeout(() => {
+        setIsLoading(false);
+        timerReference.current = null;
+      }, 800);
+
+      return () => {
+        cancelAnimationFrame(rafId);
+        if (timerReference.current) {
+          clearTimeout(timerReference.current);
+          timerReference.current = null;
+        }
+      };
+    }
+
+    return () => {
+      if (timerReference.current) {
+        clearTimeout(timerReference.current);
+        timerReference.current = null;
+      }
+    };
+  }, [isExpanded]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="my-8 rounded-lg border border-border bg-muted/30 overflow-hidden">
+      <button
+        className="flex items-center justify-between w-full px-4 py-3 hover:bg-muted/50 transition-colors"
+        onClick={() => {
+          setIsExpanded(!isExpanded);
+        }}
+        type="button"
+      >
+        <div className="flex items-center gap-3">
+          <svg
+            className="w-5 h-5 text-muted-foreground"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M4 6h16M4 12h16M4 18h16"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          <span className="text-sm font-medium text-foreground">{label}</span>
+        </div>
+        <svg
+          className={`w-4 h-4 text-muted-foreground transition-transform ${isExpanded ? "rotate-180" : ""}`}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M19 9l-7 7-7-7"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+      {isExpanded ? (
+        <div className="px-4 pb-4 pt-2 border-t border-border">
+          {isLoading ? (
+            <div className="space-y-3">
+              <div className="relative h-4 bg-muted/50 rounded overflow-hidden">
+                <div className="absolute inset-0 bg-gradient-to-r from-transparent via-amber-400/40 to-transparent animate-shimmer" />
+              </div>
+              <div className="relative h-4 bg-muted/50 rounded overflow-hidden w-5/6">
+                <div className="absolute inset-0 bg-gradient-to-r from-transparent via-amber-400/40 to-transparent animate-shimmer" />
+              </div>
+              <div className="relative h-4 bg-muted/50 rounded overflow-hidden w-4/5">
+                <div className="absolute inset-0 bg-gradient-to-r from-transparent via-amber-400/40 to-transparent animate-shimmer" />
+              </div>
+              <div className="relative h-4 bg-muted/50 rounded overflow-hidden w-3/4">
+                <div className="absolute inset-0 bg-gradient-to-r from-transparent via-amber-400/40 to-transparent animate-shimmer" />
+              </div>
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground leading-relaxed">
+              {children}
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/registry/registry/default/toast/toast.tsx
+++ b/apps/registry/registry/default/toast/toast.tsx
@@ -1,9 +1,102 @@
-// Re-export from @vllnt/ui package
-export {
-  Toast,
-  ToastAction,
-  ToastClose,
-  ToastDescription,
-  type ToastProps,
-  ToastTitle,
-} from '@vllnt/ui'
+"use client";
+
+import * as React from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+
+export type ToastProps = {
+  variant?: "default" | "destructive";
+} & React.HTMLAttributes<HTMLDivElement>;
+
+export type ToastActionElement = {} & React.ReactElement;
+
+const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  {
+    defaultVariants: {
+      variant: "default",
+    },
+    variants: {
+      variant: {
+        default: "border bg-background text-foreground",
+        destructive:
+          "destructive border-destructive bg-destructive text-destructive-foreground",
+      },
+    },
+  },
+);
+
+const Toast = React.forwardRef<
+  HTMLDivElement,
+  ToastProps & VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, reference) => (
+  <div
+    className={cn(toastVariants({ variant }), className)}
+    ref={reference}
+    {...props}
+  />
+));
+Toast.displayName = "Toast";
+
+const ToastAction = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<"button"> & { altText?: string }
+>(({ altText, className, ...props }, reference) => (
+  <button
+    className={cn(
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      className,
+    )}
+    ref={reference}
+    type="button"
+    {...props}
+  />
+));
+ToastAction.displayName = "ToastAction";
+
+const ToastClose = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<"button">
+>(({ className, ...props }, reference) => (
+  <button
+    className={cn(
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      className,
+    )}
+    data-toast-close="true"
+    ref={reference}
+    type="button"
+    {...props}
+  >
+    <span className="sr-only">Close</span>✕
+  </button>
+));
+ToastClose.displayName = "ToastClose";
+
+const ToastTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, reference) => (
+  <div
+    className={cn("text-sm font-semibold", className)}
+    ref={reference}
+    {...props}
+  />
+));
+ToastTitle.displayName = "ToastTitle";
+
+const ToastDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, reference) => (
+  <div
+    className={cn("text-sm opacity-90", className)}
+    ref={reference}
+    {...props}
+  />
+));
+ToastDescription.displayName = "ToastDescription";
+
+export { Toast, ToastAction, ToastClose, ToastDescription, ToastTitle };

--- a/apps/registry/registry/default/toggle-group/toggle-group.tsx
+++ b/apps/registry/registry/default/toggle-group/toggle-group.tsx
@@ -1,1 +1,64 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { createContext, forwardRef, useContext, useMemo } from "react";
+
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import type { VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+import { toggleVariants } from "@vllnt/ui";
+
+const ToggleGroupContext = createContext<VariantProps<typeof toggleVariants>>({
+  size: "default",
+  variant: "default",
+});
+
+const ToggleGroup = forwardRef<
+  React.ComponentRef<typeof ToggleGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ children, className, size, variant, ...props }, ref) => {
+  const contextValue = useMemo(() => ({ size, variant }), [size, variant]);
+
+  return (
+    <ToggleGroupPrimitive.Root
+      className={cn("flex items-center justify-center gap-1", className)}
+      ref={ref}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={contextValue}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  );
+});
+
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
+
+const ToggleGroupItem = forwardRef<
+  React.ComponentRef<typeof ToggleGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
+    VariantProps<typeof toggleVariants>
+>(({ children, className, size, variant, ...props }, ref) => {
+  const context = useContext(ToggleGroupContext);
+
+  return (
+    <ToggleGroupPrimitive.Item
+      className={cn(
+        toggleVariants({
+          size: context.size ?? size,
+          variant: context.variant ?? variant,
+        }),
+        className,
+      )}
+      ref={ref}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  );
+});
+
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName;
+
+export { ToggleGroup, ToggleGroupItem };

--- a/apps/registry/registry/default/toggle/toggle.tsx
+++ b/apps/registry/registry/default/toggle/toggle.tsx
@@ -1,1 +1,46 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@vllnt/ui";
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    defaultVariants: {
+      size: "default",
+      variant: "default",
+    },
+    variants: {
+      size: {
+        default: "h-10 px-3 min-w-10",
+        lg: "h-11 px-5 min-w-11",
+        sm: "h-9 px-2.5 min-w-9",
+      },
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
+      },
+    },
+  },
+);
+
+const Toggle = forwardRef<
+  React.ComponentRef<typeof TogglePrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, size, variant, ...props }, ref) => (
+  <TogglePrimitive.Root
+    className={cn(toggleVariants({ className, size, variant }))}
+    ref={ref}
+    {...props}
+  />
+));
+
+Toggle.displayName = TogglePrimitive.Root.displayName;
+
+export { Toggle, toggleVariants };

--- a/apps/registry/registry/default/tooltip/tooltip.tsx
+++ b/apps/registry/registry/default/tooltip/tooltip.tsx
@@ -1,1 +1,33 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { forwardRef } from "react";
+
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "@vllnt/ui";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = forwardRef<
+  React.ComponentRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      className={cn(
+        "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      ref={ref}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/apps/registry/registry/default/top-bar/top-bar.tsx
+++ b/apps/registry/registry/default/top-bar/top-bar.tsx
@@ -1,1 +1,60 @@
-export { TopBar, type TopBarProps } from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type TopBarProps = React.ComponentPropsWithoutRef<"header"> & {
+  leading?: ReactNode;
+  subtitle?: ReactNode;
+  title?: ReactNode;
+  trailing?: ReactNode;
+};
+
+const TopBar = forwardRef<HTMLElement, TopBarProps>(
+  (
+    { children, className, leading, subtitle, title, trailing, ...props },
+    ref,
+  ) => (
+    <header
+      className={cn(
+        "flex min-h-14 items-center justify-between gap-3 border-b border-border bg-background px-4 font-mono",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        {leading ? (
+          <div className="flex shrink-0 items-center gap-2">{leading}</div>
+        ) : null}
+        {title || subtitle ? (
+          <div className="min-w-0">
+            {title ? (
+              <div className="truncate text-sm font-medium uppercase tracking-[0.18em] text-foreground">
+                {title}
+              </div>
+            ) : null}
+            {subtitle ? (
+              <div className="truncate text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+                {subtitle}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+      {children ? (
+        <div className="flex flex-1 items-center justify-center">
+          {children}
+        </div>
+      ) : null}
+      <div className="flex min-w-0 flex-1 items-center justify-end gap-2">
+        {trailing}
+      </div>
+    </header>
+  ),
+);
+
+TopBar.displayName = "TopBar";
+
+export { TopBar };

--- a/apps/registry/registry/default/tour/tour.tsx
+++ b/apps/registry/registry/default/tour/tour.tsx
@@ -1,2 +1,202 @@
-// Re-export from @vllnt/ui package
-export { Tour } from '@vllnt/ui'
+"use client";
+
+import { useState } from "react";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@vllnt/ui";
+
+export type TourStep = {
+  badge?: string;
+  description: ReactNode;
+  hint?: ReactNode;
+  id: string;
+  media?: ReactNode;
+  title: string;
+};
+
+export type TourProps = {
+  className?: string;
+  defaultStep?: number;
+  onComplete?: () => void;
+  onStepChange?: (stepIndex: number, step: TourStep) => void;
+  steps: TourStep[];
+};
+
+type TourHeaderProps = {
+  progress: number;
+  step: TourStep;
+  stepIndex: number;
+  totalSteps: number;
+};
+
+function TourHeader({
+  progress,
+  step,
+  stepIndex,
+  totalSteps,
+}: TourHeaderProps): ReactNode {
+  return (
+    <CardHeader className="gap-4 border-b bg-background/70">
+      <div className="flex items-center justify-between gap-3">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <Badge variant="secondary">Tour</Badge>
+            {step.badge ? <Badge variant="outline">{step.badge}</Badge> : null}
+          </div>
+          <CardTitle>{step.title}</CardTitle>
+        </div>
+        <span className="text-sm text-muted-foreground">
+          {stepIndex + 1}/{totalSteps}
+        </span>
+      </div>
+      <div className="h-1 rounded-full bg-muted">
+        <div
+          className="h-full rounded-full bg-primary transition-all"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+    </CardHeader>
+  );
+}
+
+type TourFooterProps = {
+  currentStep: number;
+  isFirstStep: boolean;
+  isLastStep: boolean;
+  onComplete?: () => void;
+  onStepSelect: (stepIndex: number) => void;
+  steps: TourStep[];
+};
+
+function TourFooter({
+  currentStep,
+  isFirstStep,
+  isLastStep,
+  onComplete,
+  onStepSelect,
+  steps,
+}: TourFooterProps): ReactNode {
+  return (
+    <CardFooter className="flex items-center justify-between gap-3 border-t bg-background/70 px-6 py-4">
+      <Button
+        disabled={isFirstStep}
+        onClick={() => {
+          onStepSelect(currentStep - 1);
+        }}
+        variant="outline"
+      >
+        Previous
+      </Button>
+      <div className="flex gap-2">
+        {steps.map((step, index) => (
+          <button
+            aria-label={`Go to ${step.title}`}
+            className={cn(
+              "h-2.5 w-2.5 rounded-full transition-colors",
+              index === currentStep ? "bg-primary" : "bg-muted-foreground/30",
+            )}
+            key={step.id}
+            onClick={() => {
+              onStepSelect(index);
+            }}
+            type="button"
+          />
+        ))}
+      </div>
+      {isLastStep ? (
+        <Button
+          onClick={() => {
+            onComplete?.();
+          }}
+        >
+          Finish
+        </Button>
+      ) : (
+        <Button
+          onClick={() => {
+            onStepSelect(currentStep + 1);
+          }}
+        >
+          Next
+        </Button>
+      )}
+    </CardFooter>
+  );
+}
+
+export function Tour({
+  className,
+  defaultStep = 0,
+  onComplete,
+  onStepChange,
+  steps,
+}: TourProps): ReactNode {
+  const [currentStep, setCurrentStep] = useState(defaultStep);
+
+  if (steps.length === 0) {
+    return null;
+  }
+
+  const activeStep = steps[currentStep];
+  const isFirstStep = currentStep === 0;
+  const isLastStep = currentStep === steps.length - 1;
+  const progress = ((currentStep + 1) / steps.length) * 100;
+
+  if (!activeStep) {
+    return null;
+  }
+
+  const handleStepSelect = (stepIndex: number): void => {
+    const nextStep = steps[stepIndex];
+
+    if (!nextStep) {
+      return;
+    }
+
+    setCurrentStep(stepIndex);
+    onStepChange?.(stepIndex, nextStep);
+  };
+
+  return (
+    <Card
+      className={cn(
+        "my-6 overflow-hidden border-primary/20 bg-gradient-to-br from-background to-primary/5",
+        className,
+      )}
+    >
+      <TourHeader
+        progress={progress}
+        step={activeStep}
+        stepIndex={currentStep}
+        totalSteps={steps.length}
+      />
+      <CardContent className="space-y-4 p-6">
+        {activeStep.media ? (
+          <div className="rounded-lg border bg-card p-4">
+            {activeStep.media}
+          </div>
+        ) : null}
+        <div className="text-sm text-muted-foreground [&>p]:mb-3">
+          {activeStep.description}
+        </div>
+        {activeStep.hint ? (
+          <div className="rounded-lg border border-dashed bg-muted/50 p-3 text-sm text-muted-foreground">
+            {activeStep.hint}
+          </div>
+        ) : null}
+      </CardContent>
+      <TourFooter
+        currentStep={currentStep}
+        isFirstStep={isFirstStep}
+        isLastStep={isLastStep}
+        onComplete={onComplete}
+        onStepSelect={handleStepSelect}
+        steps={steps}
+      />
+    </Card>
+  );
+}

--- a/apps/registry/registry/default/transaction-list/transaction-list.tsx
+++ b/apps/registry/registry/default/transaction-list/transaction-list.tsx
@@ -1,8 +1,449 @@
-// Re-export from @vllnt/ui package
-export {
-  formatTransactionAmount,
-  formatTransactionDate,
-  TransactionList,
-  TransactionListPinned,
-  TransactionListSubscriptionRow,
-} from '@vllnt/ui'
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+
+const CENTS_PER_UNIT = 100;
+const DEFAULT_LOCALE = "en-US";
+const DEFAULT_CURRENCY = "USD";
+
+/**
+ * Transaction type for {@link TransactionListItem}.
+ *
+ * @public
+ */
+export type TransactionType = "credit" | "debit" | "initial" | "refund";
+
+/**
+ * Renewal interval for {@link TransactionListSubscriptionRow}.
+ *
+ * @public
+ */
+export type SubscriptionInterval = "day" | "month" | "week" | "year";
+
+/**
+ * Subscription status for {@link TransactionListSubscriptionRow}.
+ *
+ * @public
+ */
+export type SubscriptionStatus =
+  | "active"
+  | "canceled"
+  | "past_due"
+  | "trialing";
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type TransactionListLabels = {
+  /** Caption for the active subscription badge. Defaults to `"Active"`. */
+  active?: string;
+  /** Caption for the canceled subscription badge. Defaults to `"Canceled"`. */
+  canceled?: string;
+  /** Caption for the past-due subscription badge. Defaults to `"Past due"`. */
+  pastDue?: string;
+  /** Renewal label prefix. Defaults to `"Renews"`. */
+  renews?: string;
+  /** Caption for the trial subscription badge. Defaults to `"Trial"`. */
+  trialing?: string;
+};
+
+const DEFAULT_LABELS = {
+  active: "Active",
+  canceled: "Canceled",
+  pastDue: "Past due",
+  renews: "Renews",
+  trialing: "Trial",
+} as const satisfies Required<TransactionListLabels>;
+
+/**
+ * One transaction entry.
+ *
+ * @public
+ */
+export type Transaction = {
+  /** Amount in minor units (cents). Always positive — `type` decides the sign. */
+  amountCents: number;
+  /** Unix timestamp (ms) for the transaction. */
+  createdAt: number;
+  /** Free-form description. */
+  description: ReactNode;
+  /** Stable identifier. */
+  id: string;
+  /** Optional secondary line (e.g. `"VAT incl."`). */
+  meta?: ReactNode;
+  /** Transaction type. */
+  type: TransactionType;
+};
+
+const SIGN_BY_TYPE: Record<TransactionType, "negative" | "positive"> = {
+  credit: "positive",
+  debit: "negative",
+  initial: "positive",
+  refund: "positive",
+};
+
+const AMOUNT_CLASS: Record<"negative" | "positive", string> = {
+  negative: "text-destructive",
+  positive: "text-emerald-600 dark:text-emerald-400",
+};
+
+const STATUS_VARIANT: Record<
+  SubscriptionStatus,
+  "default" | "destructive" | "outline" | "secondary"
+> = {
+  active: "default",
+  canceled: "secondary",
+  past_due: "destructive",
+  trialing: "outline",
+};
+
+const STATUS_LABEL_KEY: Record<
+  SubscriptionStatus,
+  keyof Required<TransactionListLabels>
+> = {
+  active: "active",
+  canceled: "canceled",
+  past_due: "pastDue",
+  trialing: "trialing",
+};
+
+const INTERVAL_LABEL: Record<SubscriptionInterval, string> = {
+  day: "day",
+  month: "mo",
+  week: "wk",
+  year: "yr",
+};
+
+/**
+ * Format an amount in minor units as a localized currency string. Use the
+ * locale + currency from {@link TransactionListProps} to drive the output.
+ *
+ * @public
+ */
+export function formatTransactionAmount(
+  amountCents: number,
+  options: {
+    currency?: string;
+    locale?: string;
+  } = {},
+): string {
+  const { currency = DEFAULT_CURRENCY, locale = DEFAULT_LOCALE } = options;
+  return new Intl.NumberFormat(locale, {
+    currency,
+    style: "currency",
+  }).format(amountCents / CENTS_PER_UNIT);
+}
+
+/**
+ * Format a Unix timestamp (ms) as a short locale-aware date.
+ *
+ * @public
+ */
+export function formatTransactionDate(
+  timestamp: number,
+  locale: string = DEFAULT_LOCALE,
+): string {
+  return new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(new Date(timestamp));
+}
+
+/**
+ * Props for {@link TransactionList}.
+ *
+ * @public
+ */
+export type TransactionListProps = {
+  /** Currency code (ISO 4217). Defaults to `"USD"`. */
+  currency?: string;
+  /** Caption shown when the list is empty and no pinned children exist. */
+  emptyMessage?: ReactNode;
+  /** Localizable strings. */
+  labels?: TransactionListLabels;
+  /** BCP-47 locale tag. Defaults to `"en-US"`. */
+  locale?: string;
+  /** Transaction array (rendered after pinned children). */
+  transactions: Transaction[];
+} & ComponentPropsWithoutRef<"div">;
+
+type TransactionListComponent = ReturnType<
+  typeof forwardRef<HTMLDivElement, TransactionListProps>
+> & {
+  Pinned: typeof TransactionListPinned;
+  SubscriptionRow: typeof TransactionListSubscriptionRow;
+};
+
+const TransactionListBase = forwardRef<HTMLDivElement, TransactionListProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      currency,
+      emptyMessage,
+      labels,
+      locale,
+      transactions,
+      ...rest
+    } = props;
+    const isEmpty = transactions.length === 0;
+    const hasPinned = Boolean(children);
+    return (
+      <div
+        className={cn(
+          "flex w-full flex-col gap-2 rounded-2xl border bg-background p-3",
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+        {isEmpty && !hasPinned && emptyMessage ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            {emptyMessage}
+          </p>
+        ) : null}
+        {isEmpty ? null : (
+          <ul className="flex flex-col gap-1.5">
+            {transactions.map((transaction) => (
+              <TransactionListItem
+                currency={currency}
+                key={transaction.id}
+                labels={labels}
+                locale={locale}
+                transaction={transaction}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  },
+);
+TransactionListBase.displayName = "TransactionList";
+
+/**
+ * Props for {@link TransactionListPinned}.
+ *
+ * @public
+ */
+export type TransactionListPinnedProps = ComponentPropsWithoutRef<"div">;
+
+/**
+ * Wrapper that renders pinned content (typically the active subscription
+ * row) above the main transaction list.
+ *
+ * @public
+ */
+export const TransactionListPinned = forwardRef<
+  HTMLDivElement,
+  TransactionListPinnedProps
+>(({ children, className, ...rest }, ref) => (
+  <div className={cn("flex flex-col gap-1.5", className)} ref={ref} {...rest}>
+    {children}
+  </div>
+));
+TransactionListPinned.displayName = "TransactionList.Pinned";
+
+type TransactionListItemProps = {
+  currency?: string;
+  labels?: TransactionListLabels;
+  locale?: string;
+  transaction: Transaction;
+};
+
+function TransactionListItem({
+  currency,
+  locale,
+  transaction,
+}: TransactionListItemProps): ReactNode {
+  const sign = SIGN_BY_TYPE[transaction.type];
+  const formatted = formatTransactionAmount(transaction.amountCents, {
+    currency,
+    locale,
+  });
+  const display = sign === "negative" ? `-${formatted}` : `+${formatted}`;
+  const ariaLabel =
+    typeof transaction.description === "string"
+      ? `${sign === "negative" ? "Debit" : "Credit"} ${display} for ${transaction.description}`
+      : undefined;
+  return (
+    <li
+      className="flex items-start justify-between gap-3 rounded-lg border border-border bg-muted/20 px-3 py-2"
+      data-transaction-type={transaction.type}
+    >
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <p className="truncate text-sm font-medium text-foreground">
+          {transaction.description}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {formatTransactionDate(transaction.createdAt, locale)}
+          {transaction.meta ? <span> · {transaction.meta}</span> : null}
+        </p>
+      </div>
+      <span
+        aria-label={ariaLabel}
+        className={cn(
+          "shrink-0 font-mono text-sm font-semibold",
+          AMOUNT_CLASS[sign],
+        )}
+      >
+        {display}
+      </span>
+    </li>
+  );
+}
+
+/**
+ * Props for {@link TransactionListSubscriptionRow}.
+ *
+ * @public
+ */
+export type TransactionListSubscriptionRowProps = {
+  /** Subscription amount per interval, in minor units. */
+  amountCents: number;
+  /** Currency code (ISO 4217). Defaults to `"USD"`. */
+  currency?: string;
+  /** Renewal interval. */
+  interval: SubscriptionInterval;
+  /** Localizable strings. */
+  labels?: TransactionListLabels;
+  /** BCP-47 locale tag. Defaults to `"en-US"`. */
+  locale?: string;
+  /** Optional secondary metadata (e.g. `"VAT incl."`). */
+  meta?: ReactNode;
+  /** Plan display name. */
+  plan: ReactNode;
+  /** Optional renewal timestamp (ms). */
+  renewsAt?: number;
+  /** Subscription status. */
+  status: SubscriptionStatus;
+} & ComponentPropsWithoutRef<"div">;
+
+type SubscriptionMetaProps = {
+  locale?: string;
+  meta?: ReactNode;
+  renewsAt?: number;
+  renewsLabel: string;
+};
+
+function SubscriptionMeta({
+  locale,
+  meta,
+  renewsAt,
+  renewsLabel,
+}: SubscriptionMetaProps): ReactNode {
+  if (renewsAt === undefined && !meta) return null;
+  return (
+    <p className="text-xs text-muted-foreground">
+      {renewsAt === undefined
+        ? null
+        : `${renewsLabel} ${formatTransactionDate(renewsAt, locale)}`}
+      {renewsAt !== undefined && meta ? <span> · {meta}</span> : null}
+      {renewsAt === undefined && meta ? meta : null}
+    </p>
+  );
+}
+
+/**
+ * Active-subscription row for the pinned section. Renders a green-border
+ * card with plan name, status badge, amount/interval, and optional
+ * renewal date.
+ *
+ * @public
+ */
+export const TransactionListSubscriptionRow = forwardRef<
+  HTMLDivElement,
+  TransactionListSubscriptionRowProps
+>((props, ref) => {
+  const {
+    amountCents,
+    className,
+    currency,
+    interval,
+    labels,
+    locale,
+    meta,
+    plan,
+    renewsAt,
+    status,
+    ...rest
+  } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  const formatted = formatTransactionAmount(amountCents, { currency, locale });
+  const intervalSuffix = INTERVAL_LABEL[interval];
+  const isActive = status === "active";
+
+  return (
+    <div
+      className={cn(
+        "flex items-start justify-between gap-3 rounded-lg border px-3 py-2",
+        isActive
+          ? "border-emerald-500/40 bg-emerald-500/5"
+          : "border-border bg-muted/20",
+        className,
+      )}
+      data-status={status}
+      ref={ref}
+      {...rest}
+    >
+      <div className="flex min-w-0 flex-col gap-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="text-sm font-semibold text-foreground">{plan}</p>
+          <Badge variant={STATUS_VARIANT[status]}>
+            {resolvedLabels[STATUS_LABEL_KEY[status]]}
+          </Badge>
+        </div>
+        <SubscriptionMeta
+          locale={locale}
+          meta={meta}
+          renewsAt={renewsAt}
+          renewsLabel={resolvedLabels.renews}
+        />
+      </div>
+      <span className="shrink-0 font-mono text-sm font-semibold text-foreground">
+        {formatted}/{intervalSuffix}
+      </span>
+    </div>
+  );
+});
+TransactionListSubscriptionRow.displayName = "TransactionList.SubscriptionRow";
+
+/**
+ * Chronological list of financial transactions with credit/debit color
+ * coding, locale-aware currency / date formatting, and an optional pinned
+ * section for the active subscription.
+ *
+ * @example
+ * ```tsx
+ * <TransactionList
+ *   transactions={transactions}
+ *   currency="EUR"
+ *   locale="en-IE"
+ *   emptyMessage="No transactions yet"
+ * >
+ *   <TransactionList.Pinned>
+ *     <TransactionList.SubscriptionRow
+ *       plan="AI OS Pro"
+ *       status="active"
+ *       amountCents={1200}
+ *       renewsAt={1713139200000}
+ *       interval="month"
+ *     />
+ *   </TransactionList.Pinned>
+ * </TransactionList>
+ * ```
+ *
+ * @public
+ */
+export const TransactionList = TransactionListBase as TransactionListComponent;
+TransactionList.Pinned = TransactionListPinned;
+TransactionList.SubscriptionRow = TransactionListSubscriptionRow;

--- a/apps/registry/registry/default/tree-view/tree-view.tsx
+++ b/apps/registry/registry/default/tree-view/tree-view.tsx
@@ -1,7 +1,465 @@
-export {
-  type TreeNode,
-  TreeView,
-  type TreeViewLabels,
-  type TreeViewProps,
-  type TreeViewSelectionMode,
-} from "@vllnt/ui";
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * Selection mode for {@link TreeView}.
+ *
+ * @public
+ */
+export type TreeViewSelectionMode = "multiple" | "single";
+
+/**
+ * A node in the tree.
+ *
+ * @public
+ */
+export type TreeNode = {
+  /** When `true`, the node renders dimmed and ignores clicks. */
+  disabled?: boolean;
+  /** Optional leading icon. */
+  icon?: ReactNode;
+  /** Stable identifier. */
+  id: string;
+  /** Visible label. */
+  label: ReactNode;
+  /** Child nodes; the node renders as a branch when present. */
+  nodes?: TreeNode[];
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type TreeViewLabels = {
+  /** Aria-label for the tree. Defaults to `"Tree"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  region: "Tree",
+} as const satisfies Required<TreeViewLabels>;
+
+/**
+ * Props for {@link TreeView}.
+ *
+ * @public
+ */
+export type TreeViewProps = {
+  /** Default expanded ids (uncontrolled). */
+  defaultExpanded?: string[];
+  /** Default selected ids (uncontrolled). */
+  defaultSelected?: string[];
+  /** Controlled expanded ids. */
+  expanded?: string[];
+  /** Localizable strings. */
+  labels?: TreeViewLabels;
+  /** Tree data. */
+  nodes: TreeNode[];
+  /** Fires when expanded ids change. */
+  onExpandedChange?: (next: string[]) => void;
+  /** Fires when selection changes. */
+  onSelect?: (next: string[]) => void;
+  /** Controlled selected ids. */
+  selected?: string[];
+  /** Selection mode. Defaults to `"single"`. */
+  selectionMode?: TreeViewSelectionMode;
+} & Omit<ComponentPropsWithoutRef<"ul">, "onSelect">;
+
+type FlatNode = {
+  depth: number;
+  hasChildren: boolean;
+  node: TreeNode;
+  parentId?: string;
+};
+
+type FlattenArguments = {
+  depth?: number;
+  expanded: ReadonlySet<string>;
+  nodes: TreeNode[];
+  parentId?: string;
+};
+
+function flattenVisible(arguments_: FlattenArguments): FlatNode[] {
+  const { depth = 0, expanded, nodes, parentId } = arguments_;
+  return nodes.flatMap((node) => {
+    const hasChildren = (node.nodes?.length ?? 0) > 0;
+    const head: FlatNode = { depth, hasChildren, node, parentId };
+    if (!hasChildren || !expanded.has(node.id)) return [head];
+    return [
+      head,
+      ...flattenVisible({
+        depth: depth + 1,
+        expanded,
+        nodes: node.nodes ?? [],
+        parentId: node.id,
+      }),
+    ];
+  });
+}
+
+function useControlled<T>(
+  controlled: T | undefined,
+  defaultValue: T,
+): readonly [T, (next: T) => void, boolean] {
+  const [internal, setInternal] = useState<T>(defaultValue);
+  const isControlled = controlled !== undefined;
+  const value = isControlled ? controlled : internal;
+  const setValue = useCallback(
+    (next: T) => {
+      if (!isControlled) setInternal(next);
+    },
+    [isControlled],
+  );
+  return [value, setValue, isControlled];
+}
+
+function toggleSet(set: ReadonlySet<string>, id: string): string[] {
+  const next = new Set(set);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  return [...next];
+}
+
+type TreeRowProps = {
+  active: boolean;
+  expanded: boolean;
+  flat: FlatNode;
+  onActivate: (id: string) => void;
+  onExpand: (id: string) => void;
+  onSelect: (id: string) => void;
+  selected: boolean;
+};
+
+function TreeRow({
+  active,
+  expanded,
+  flat,
+  onActivate,
+  onExpand,
+  onSelect,
+  selected,
+}: TreeRowProps): ReactNode {
+  const { depth, hasChildren, node } = flat;
+  const activate = (): void => {
+    if (node.disabled) return;
+    onActivate(node.id);
+    if (hasChildren) onExpand(node.id);
+    else onSelect(node.id);
+  };
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLLIElement>): void => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    activate();
+  };
+  return (
+    <li
+      aria-disabled={node.disabled || undefined}
+      aria-expanded={hasChildren ? expanded : undefined}
+      aria-selected={selected || undefined}
+      className={cn(
+        "flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-sm focus:outline-none",
+        active ? "bg-accent text-accent-foreground" : "hover:bg-accent/60",
+        selected ? "ring-1 ring-primary" : "",
+        node.disabled ? "cursor-not-allowed opacity-50" : "",
+      )}
+      data-active={active ? "true" : undefined}
+      data-depth={depth}
+      data-node-id={node.id}
+      data-selected={selected ? "true" : undefined}
+      onClick={activate}
+      onKeyDown={handleKeyDown}
+      role="treeitem"
+      style={{ paddingLeft: `${(depth * 16 + 8).toString()}px` }}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "inline-flex h-4 w-4 shrink-0 items-center justify-center text-xs text-muted-foreground transition-transform",
+          hasChildren ? "" : "opacity-0",
+          expanded ? "rotate-90" : "",
+        )}
+      >
+        ▸
+      </span>
+      {node.icon ? (
+        <span aria-hidden="true" className="inline-flex h-4 w-4 shrink-0">
+          {node.icon}
+        </span>
+      ) : null}
+      <span className="truncate">{node.label}</span>
+    </li>
+  );
+}
+
+function nextActiveId(
+  flat: FlatNode[],
+  delta: number,
+  current?: string,
+): string | undefined {
+  if (flat.length === 0) return undefined;
+  if (!current) return flat[0]?.node.id;
+  const index = flat.findIndex((entry) => entry.node.id === current);
+  if (index < 0) return flat[0]?.node.id;
+  const nextIndex = Math.min(Math.max(index + delta, 0), flat.length - 1);
+  return flat[nextIndex]?.node.id;
+}
+
+function findFlat(flat: FlatNode[], id?: string): FlatNode | undefined {
+  if (!id) return undefined;
+  return flat.find((entry) => entry.node.id === id);
+}
+
+function useTreeState(arguments_: {
+  defaultExpanded?: string[];
+  defaultSelected?: string[];
+  expanded?: string[];
+  onExpandedChange?: (next: string[]) => void;
+  onSelect?: (next: string[]) => void;
+  selected?: string[];
+  selectionMode: TreeViewSelectionMode;
+}): {
+  applyExpand: (id: string) => void;
+  applySelect: (id: string) => void;
+  expandedSet: ReadonlySet<string>;
+  selectedSet: ReadonlySet<string>;
+} {
+  const {
+    defaultExpanded = [],
+    defaultSelected = [],
+    expanded,
+    onExpandedChange,
+    onSelect,
+    selected,
+    selectionMode,
+  } = arguments_;
+  const [expandedState, setExpandedState] = useControlled<string[]>(
+    expanded,
+    defaultExpanded,
+  );
+  const [selectedState, setSelectedState] = useControlled<string[]>(
+    selected,
+    defaultSelected,
+  );
+  const expandedSet = useMemo(() => new Set(expandedState), [expandedState]);
+  const selectedSet = useMemo(() => new Set(selectedState), [selectedState]);
+
+  const applyExpand = useCallback(
+    (id: string) => {
+      const next = toggleSet(expandedSet, id);
+      setExpandedState(next);
+      onExpandedChange?.(next);
+    },
+    [expandedSet, onExpandedChange, setExpandedState],
+  );
+
+  const applySelect = useCallback(
+    (id: string) => {
+      const next =
+        selectionMode === "single" ? [id] : toggleSet(selectedSet, id);
+      setSelectedState(next);
+      onSelect?.(next);
+    },
+    [onSelect, selectedSet, selectionMode, setSelectedState],
+  );
+
+  return { applyExpand, applySelect, expandedSet, selectedSet };
+}
+
+function useKeyboardHandler(arguments_: {
+  activeId?: string;
+  applyExpand: (id: string) => void;
+  applySelect: (id: string) => void;
+  expandedSet: ReadonlySet<string>;
+  flat: FlatNode[];
+  setActiveId: (id?: string) => void;
+}): (event: ReactKeyboardEvent<HTMLUListElement>) => void {
+  const { activeId, applyExpand, applySelect, expandedSet, flat, setActiveId } =
+    arguments_;
+  return useCallback(
+    (event) => {
+      const current = findFlat(flat, activeId);
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setActiveId(nextActiveId(flat, 1, activeId));
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setActiveId(nextActiveId(flat, -1, activeId));
+        return;
+      }
+      if (event.key === "ArrowRight" && current?.hasChildren) {
+        event.preventDefault();
+        if (!expandedSet.has(current.node.id)) applyExpand(current.node.id);
+        return;
+      }
+      if (event.key === "ArrowLeft" && current) {
+        event.preventDefault();
+        if (current.hasChildren && expandedSet.has(current.node.id)) {
+          applyExpand(current.node.id);
+        } else if (current.parentId) {
+          setActiveId(current.parentId);
+        }
+        return;
+      }
+      if (event.key === "Enter" || event.key === " ") {
+        if (!current || current.node.disabled) return;
+        event.preventDefault();
+        if (current.hasChildren) applyExpand(current.node.id);
+        else applySelect(current.node.id);
+      }
+    },
+    [activeId, applyExpand, applySelect, expandedSet, flat, setActiveId],
+  );
+}
+
+type TreeRowsProps = {
+  activeId?: string;
+  applyExpand: (id: string) => void;
+  applySelect: (id: string) => void;
+  expandedSet: ReadonlySet<string>;
+  flat: FlatNode[];
+  selectedSet: ReadonlySet<string>;
+  setActiveId: (id?: string) => void;
+};
+
+function TreeRows({
+  activeId,
+  applyExpand,
+  applySelect,
+  expandedSet,
+  flat,
+  selectedSet,
+  setActiveId,
+}: TreeRowsProps): ReactNode {
+  return (
+    <>
+      {flat.map((entry) => (
+        <TreeRow
+          active={entry.node.id === activeId}
+          expanded={expandedSet.has(entry.node.id)}
+          flat={entry}
+          key={entry.node.id}
+          onActivate={setActiveId}
+          onExpand={applyExpand}
+          onSelect={applySelect}
+          selected={selectedSet.has(entry.node.id)}
+        />
+      ))}
+    </>
+  );
+}
+
+/**
+ * Hierarchical tree component for nested data (file systems, categories,
+ * org charts). Pass {@link TreeNode} data via `nodes`. Supports controlled
+ * and uncontrolled expand/select state, single or multi-select, and full
+ * keyboard navigation (arrows expand/collapse and traverse, enter/space
+ * activates).
+ *
+ * @example
+ * ```tsx
+ * <TreeView
+ *   nodes={[
+ *     { id: "src", label: "src/", nodes: [
+ *       { id: "components", label: "components/" },
+ *       { id: "utils", label: "utils/" },
+ *     ]},
+ *   ]}
+ *   defaultExpanded={["src"]}
+ *   onSelect={(ids) => console.info(ids)}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const TreeView = forwardRef<HTMLUListElement, TreeViewProps>(
+  (props, ref) => {
+    const {
+      className,
+      defaultExpanded,
+      defaultSelected,
+      expanded,
+      labels,
+      nodes,
+      onExpandedChange,
+      onSelect,
+      selected,
+      selectionMode = "single",
+      ...rest
+    } = props;
+    const resolvedLabels = useMemo(
+      () => ({ ...DEFAULT_LABELS, ...labels }),
+      [labels],
+    );
+
+    const { applyExpand, applySelect, expandedSet, selectedSet } = useTreeState(
+      {
+        defaultExpanded,
+        defaultSelected,
+        expanded,
+        onExpandedChange,
+        onSelect,
+        selected,
+        selectionMode,
+      },
+    );
+
+    const flat = useMemo(
+      () => flattenVisible({ expanded: expandedSet, nodes }),
+      [expandedSet, nodes],
+    );
+
+    const [activeId, setActiveId] = useState<string | undefined>(
+      () => flat[0]?.node.id,
+    );
+
+    const handleKeyDown = useKeyboardHandler({
+      activeId,
+      applyExpand,
+      applySelect,
+      expandedSet,
+      flat,
+      setActiveId,
+    });
+
+    return (
+      <ul
+        aria-label={resolvedLabels.region}
+        aria-multiselectable={selectionMode === "multiple" || undefined}
+        className={cn(
+          "flex flex-col gap-0.5 rounded-2xl border bg-background p-2 text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          className,
+        )}
+        onKeyDown={handleKeyDown}
+        ref={ref}
+        role="tree"
+        tabIndex={0}
+        {...rest}
+      >
+        <TreeRows
+          activeId={activeId}
+          applyExpand={applyExpand}
+          applySelect={applySelect}
+          expandedSet={expandedSet}
+          flat={flat}
+          selectedSet={selectedSet}
+          setActiveId={setActiveId}
+        />
+      </ul>
+    );
+  },
+);
+TreeView.displayName = "TreeView";

--- a/apps/registry/registry/default/tutorial-card/tutorial-card.tsx
+++ b/apps/registry/registry/default/tutorial-card/tutorial-card.tsx
@@ -1,2 +1,151 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { memo, useEffect, useState } from "react";
+
+import type { ReactNode } from "react";
+
+import { useMounted } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@vllnt/ui";
+
+export type TutorialCardProgress = {
+  completedCount: number;
+  totalSections: number;
+};
+
+export type TutorialCardMeta = {
+  description: string;
+  difficulty: "advanced" | "beginner" | "intermediate";
+  estimatedTime: string;
+  id: string;
+  sectionCount: number;
+  tags: string[];
+  title: string;
+};
+
+export type TutorialCardLabels = {
+  completed: string;
+  difficulty: Record<string, string>;
+  sectionsCount: string;
+};
+
+export type TutorialCardProps = {
+  /** Function to get progress (for localStorage etc) */
+  getProgress?: (id: string) => null | TutorialCardProgress;
+  href: string;
+  labels: TutorialCardLabels;
+  /** Link component (e.g., Next.js Link) */
+  linkComponent?: React.ComponentType<{
+    children: ReactNode;
+    className?: string;
+    href: string;
+  }>;
+  tutorial: TutorialCardMeta;
+};
+
+const DIFFICULTY_VARIANTS = {
+  advanced: "destructive",
+  beginner: "secondary",
+  intermediate: "default",
+} satisfies Record<
+  TutorialCardMeta["difficulty"],
+  "default" | "destructive" | "secondary"
+>;
+
+function DefaultLink({
+  children,
+  className,
+  href,
+}: {
+  children: ReactNode;
+  className?: string;
+  href: string;
+}): React.ReactNode {
+  return (
+    <a className={className} href={href}>
+      {children}
+    </a>
+  );
+}
+
+function TutorialCardImpl({
+  getProgress,
+  href,
+  labels,
+  linkComponent: LinkComponent = DefaultLink,
+  tutorial,
+}: TutorialCardProps): React.ReactNode {
+  const [progress, setProgress] = useState<null | TutorialCardProgress>(null);
+  const isHydrated = useMounted();
+
+  useEffect(() => {
+    if (getProgress) {
+      const result = getProgress(tutorial.id);
+      requestAnimationFrame(() => {
+        setProgress(result);
+      });
+    }
+  }, [getProgress, tutorial.id]);
+
+  const difficultyVariant = DIFFICULTY_VARIANTS[tutorial.difficulty];
+  // Cap completedCount at sectionCount to handle stale localStorage data
+  const safeCompletedCount = progress
+    ? Math.min(progress.completedCount, tutorial.sectionCount)
+    : 0;
+  const showProgress = isHydrated && safeCompletedCount > 0;
+
+  return (
+    <LinkComponent className="block h-full" href={href}>
+      <Card className="h-full flex flex-col hover:shadow-lg transition-shadow cursor-pointer">
+        <CardHeader>
+          <div className="flex items-center gap-2 mb-2">
+            <Badge className="text-xs capitalize" variant={difficultyVariant}>
+              {labels.difficulty[tutorial.difficulty] || tutorial.difficulty}
+            </Badge>
+            {showProgress ? (
+              <span className="text-xs text-muted-foreground">
+                {safeCompletedCount}/{tutorial.sectionCount} {labels.completed}
+              </span>
+            ) : null}
+          </div>
+
+          <CardTitle className="line-clamp-2 text-lg">
+            {tutorial.title}
+          </CardTitle>
+          <CardDescription className="line-clamp-3">
+            {tutorial.description}
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent className="mt-auto space-y-2">
+          <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+            <span>{tutorial.estimatedTime}</span>
+            <span>•</span>
+            <span>
+              {tutorial.sectionCount} {labels.sectionsCount}
+            </span>
+          </div>
+
+          {tutorial.tags.length > 0 ? (
+            <div className="flex flex-wrap gap-1">
+              {tutorial.tags.map((tag) => (
+                <Badge className="text-xs" key={tag} variant="outline">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+    </LinkComponent>
+  );
+}
+
+export const TutorialCard = memo(TutorialCardImpl);
+TutorialCard.displayName = "TutorialCard";

--- a/apps/registry/registry/default/tutorial-complete/tutorial-complete.tsx
+++ b/apps/registry/registry/default/tutorial-complete/tutorial-complete.tsx
@@ -1,2 +1,225 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { memo } from "react";
+
+import { Check, ChevronRight, RotateCcw } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Button } from "@vllnt/ui";
+import { ProfileSection } from "@vllnt/ui";
+import { ShareSection } from "@vllnt/ui";
+
+export type TutorialCompleteSection = {
+  id: string;
+  title: string;
+};
+
+export type TutorialCompleteRelatedContent = {
+  href: string;
+  title: string;
+  type: string;
+};
+
+export type TutorialCompleteLabels = {
+  backToTutorials: string;
+  profileName: string;
+  profileTagline: string;
+  relatedContent: string;
+  reviewSections: string;
+  shareOn: string;
+  shareTitle: string;
+  startOver: string;
+  tutorialComplete: string;
+  tutorialFinished: string;
+  youveCompletedAll: string;
+  youveFinishedWith: string;
+};
+
+export type TutorialCompleteProps = {
+  backHref: string;
+  completedSections: Set<string>;
+  completionPercent: number;
+  labels: TutorialCompleteLabels;
+  /** Link component (e.g., Next.js Link) */
+  linkComponent?: React.ComponentType<{
+    children: ReactNode;
+    className?: string;
+    href: string;
+  }>;
+  onGoToSection: (index: number) => void;
+  onRestart: () => void;
+  /** Profile config */
+  profile?: {
+    imageSource: string;
+    socialLinks: { href: string; label: string }[];
+  };
+  relatedContent: TutorialCompleteRelatedContent[];
+  sections: TutorialCompleteSection[];
+  shareUrl: string;
+  title: string;
+};
+
+function DefaultLink({
+  children,
+  className,
+  href,
+}: {
+  children: ReactNode;
+  className?: string;
+  href: string;
+}): React.ReactNode {
+  return (
+    <a className={className} href={href}>
+      {children}
+    </a>
+  );
+}
+
+// eslint-disable-next-line max-lines-per-function -- Completion UI renders stats, achievements, and related content
+function TutorialCompleteImpl({
+  backHref,
+  completedSections,
+  completionPercent,
+  labels,
+  linkComponent: LinkComponent = DefaultLink,
+  onGoToSection,
+  onRestart,
+  profile,
+  relatedContent,
+  sections,
+  shareUrl,
+  title,
+}: TutorialCompleteProps): React.ReactNode {
+  const isFullyComplete = completionPercent === 100;
+
+  return (
+    <div>
+      {/* Completion Status */}
+      <div className="text-center py-12">
+        <div
+          className={`inline-flex items-center justify-center w-20 h-20 rounded-full mb-6 ${
+            isFullyComplete ? "bg-green-100 dark:bg-green-900/30" : "bg-muted"
+          }`}
+        >
+          <Check
+            className={`h-10 w-10 ${isFullyComplete ? "text-green-600 dark:text-green-400" : "text-muted-foreground"}`}
+          />
+        </div>
+
+        <h2 className="text-3xl font-bold mb-2">
+          {isFullyComplete ? labels.tutorialComplete : labels.tutorialFinished}
+        </h2>
+
+        <p className="text-muted-foreground mb-6">
+          {isFullyComplete
+            ? `${labels.youveCompletedAll} "${title}"`
+            : `${labels.youveFinishedWith} "${title}" (${completionPercent}%)`}
+        </p>
+
+        <Button className="gap-2" onClick={onRestart} variant="outline">
+          <RotateCcw className="h-4 w-4" />
+          {labels.startOver}
+        </Button>
+      </div>
+
+      {/* Review Sections */}
+      <div className="max-w-2xl mx-auto mt-8">
+        <h3 className="text-lg font-semibold mb-4">{labels.reviewSections}</h3>
+        <div className="space-y-2">
+          {sections.map((section, index) => {
+            const isCompleted = completedSections.has(section.id);
+            return (
+              <button
+                className="w-full flex items-center gap-3 p-3 rounded-lg border border-border hover:bg-muted/50 transition-colors text-left"
+                key={`${section.id}-${index}`}
+                onClick={() => {
+                  onGoToSection(index);
+                }}
+                type="button"
+              >
+                <div
+                  className={`flex-shrink-0 w-5 h-5 rounded-full border-2 flex items-center justify-center ${
+                    isCompleted
+                      ? "bg-foreground border-foreground"
+                      : "border-muted-foreground"
+                  }`}
+                >
+                  {isCompleted ? (
+                    <Check className="h-3 w-3 text-background" />
+                  ) : null}
+                </div>
+                <span className="flex-1 truncate">{section.title}</span>
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Related Content */}
+      {relatedContent.length > 0 ? (
+        <div className="max-w-2xl mx-auto mt-12">
+          <h3 className="text-lg font-semibold mb-4">
+            {labels.relatedContent}
+          </h3>
+          <div className="space-y-2">
+            {relatedContent.map((item) => (
+              <LinkComponent
+                className="flex items-center gap-3 p-3 rounded-lg border border-border hover:bg-muted/50 transition-colors"
+                href={item.href}
+                key={item.href}
+              >
+                <span className="text-xs uppercase text-muted-foreground font-medium">
+                  {item.type}
+                </span>
+                <span className="flex-1 truncate">{item.title}</span>
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+              </LinkComponent>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {/* Share Section */}
+      <div className="max-w-4xl mx-auto mt-12">
+        <ShareSection
+          shareOn={labels.shareOn}
+          shareTitle={labels.shareTitle}
+          title={title}
+          url={shareUrl}
+        />
+      </div>
+
+      {/* Profile Section */}
+      {profile ? (
+        <div className="border-t border-border pt-8 mt-12">
+          <div className="max-w-4xl mx-auto">
+            <ProfileSection
+              dict={{
+                profile: {
+                  name: labels.profileName,
+                  tagline: labels.profileTagline,
+                },
+              }}
+              imageSource={profile.imageSource}
+              socialLinks={profile.socialLinks}
+            />
+          </div>
+        </div>
+      ) : null}
+
+      {/* Back Link */}
+      <div className="text-center pt-8">
+        <LinkComponent
+          className="inline-flex items-center space-x-2 text-muted-foreground hover:text-foreground transition-colors"
+          href={backHref}
+        >
+          <span>← {labels.backToTutorials}</span>
+        </LinkComponent>
+      </div>
+    </div>
+  );
+}
+
+export const TutorialComplete = memo(TutorialCompleteImpl);
+TutorialComplete.displayName = "TutorialComplete";

--- a/apps/registry/registry/default/tutorial-filters/tutorial-filters.tsx
+++ b/apps/registry/registry/default/tutorial-filters/tutorial-filters.tsx
@@ -1,2 +1,291 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { memo } from "react";
+
+import { Badge } from "@vllnt/ui";
+
+export type TutorialFiltersLabels = {
+  activeFilters: string;
+  clear: string;
+  clearAll: string;
+  difficulty: Record<string, string>;
+  difficultyLabel: string;
+  searchFilter: string;
+  searchLabel: string;
+  searchPlaceholder: string;
+  tagsLabel: string;
+};
+
+export type FilterUpdates = {
+  difficulty?: string;
+  search?: string;
+  tags?: string[];
+};
+
+export type TutorialFiltersProps = {
+  currentDifficulty: string;
+  currentTags: string[];
+  difficultyOptions?: string[];
+  isPending?: boolean;
+  labels: TutorialFiltersLabels;
+  onFilterChange: (updates: FilterUpdates) => void;
+  searchQuery: string;
+  tags: string[];
+};
+
+function SearchInput({
+  isPending,
+  labels,
+  onSearchChange,
+  searchQuery,
+}: {
+  isPending: boolean;
+  labels: TutorialFiltersLabels;
+  onSearchChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  searchQuery: string;
+}): React.ReactNode {
+  return (
+    <div>
+      <label className="sr-only" htmlFor="tutorial-search">
+        {labels.searchLabel}
+      </label>
+      <input
+        className="w-full px-4 py-2 border border-border rounded-lg bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+        defaultValue={searchQuery}
+        disabled={isPending}
+        id="tutorial-search"
+        onChange={onSearchChange}
+        placeholder={labels.searchPlaceholder}
+        type="text"
+      />
+    </div>
+  );
+}
+
+function DifficultyFilter({
+  activeDifficulty,
+  difficultyOptions,
+  isPending,
+  labels,
+  onDifficultyChange,
+}: {
+  activeDifficulty: string;
+  difficultyOptions: string[];
+  isPending: boolean;
+  labels: TutorialFiltersLabels;
+  onDifficultyChange: (difficulty: string) => void;
+}): React.ReactNode {
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-sm font-medium">{labels.difficultyLabel}</span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {difficultyOptions.map((difficulty) => {
+          const isActive = difficulty === activeDifficulty;
+          return (
+            <button
+              className={`px-3 py-1 text-sm rounded-lg border transition-colors ${
+                isActive
+                  ? "bg-primary text-primary-foreground border-transparent"
+                  : "bg-background text-foreground border-border hover:bg-muted"
+              }`}
+              disabled={isPending}
+              key={difficulty}
+              onClick={() => {
+                onDifficultyChange(difficulty);
+              }}
+              type="button"
+            >
+              <span className="capitalize">
+                {labels.difficulty[difficulty] || difficulty}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function TagFilter({
+  currentTags,
+  labels,
+  onClearTags,
+  onTagToggle,
+  tags,
+}: {
+  currentTags: string[];
+  labels: TutorialFiltersLabels;
+  onClearTags: () => void;
+  onTagToggle: (tag: string) => void;
+  tags: string[];
+}): React.ReactNode {
+  if (tags.length === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-sm font-medium">{labels.tagsLabel}</span>
+        {currentTags.length > 0 ? (
+          <button
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            onClick={onClearTags}
+            type="button"
+          >
+            {labels.clear}
+          </button>
+        ) : null}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {tags.map((tag) => {
+          const isActive = currentTags.includes(tag);
+          return (
+            <Badge
+              className={`cursor-pointer transition-all ${
+                isActive
+                  ? "bg-primary text-primary-foreground border-transparent"
+                  : "hover:bg-muted"
+              }`}
+              key={tag}
+              onClick={() => {
+                onTagToggle(tag);
+              }}
+              variant={isActive ? "default" : "outline"}
+            >
+              {tag}
+            </Badge>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function ActiveFiltersSummary({
+  currentDifficulty,
+  currentTags,
+  labels,
+  onClearAll,
+  searchQuery,
+}: {
+  currentDifficulty: string;
+  currentTags: string[];
+  labels: TutorialFiltersLabels;
+  onClearAll: () => void;
+  searchQuery: string;
+}): React.ReactNode {
+  if (!currentDifficulty && currentTags.length === 0 && !searchQuery) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+      <span>{labels.activeFilters}</span>
+      {currentDifficulty ? (
+        <Badge className="capitalize" variant="secondary">
+          {labels.difficulty[currentDifficulty] || currentDifficulty}
+        </Badge>
+      ) : null}
+      {currentTags.map((tag) => (
+        <Badge key={tag} variant="secondary">
+          {tag}
+        </Badge>
+      ))}
+      {searchQuery ? (
+        <Badge variant="secondary">
+          {labels.searchFilter} &quot;{searchQuery}&quot;
+        </Badge>
+      ) : null}
+      <button
+        className="text-xs hover:underline"
+        onClick={onClearAll}
+        type="button"
+      >
+        {labels.clearAll}
+      </button>
+    </div>
+  );
+}
+
+const DEFAULT_DIFFICULTY_OPTIONS = [
+  "all",
+  "beginner",
+  "intermediate",
+  "advanced",
+];
+
+function TutorialFiltersImpl({
+  currentDifficulty,
+  currentTags,
+  difficultyOptions = DEFAULT_DIFFICULTY_OPTIONS,
+  isPending = false,
+  labels,
+  onFilterChange,
+  searchQuery,
+  tags,
+}: TutorialFiltersProps): React.ReactNode {
+  const activeDifficulty = currentDifficulty || "all";
+
+  const handleDifficultyChange = (difficulty: string): void => {
+    onFilterChange({ difficulty });
+  };
+
+  const handleSearchChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): void => {
+    onFilterChange({ search: event.target.value });
+  };
+
+  const handleTagToggle = (tag: string): void => {
+    const newTags = currentTags.includes(tag)
+      ? currentTags.filter((t) => t !== tag)
+      : [...currentTags, tag];
+    onFilterChange({ tags: newTags });
+  };
+
+  const handleClearAll = (): void => {
+    onFilterChange({ difficulty: "all", search: "", tags: [] });
+    const input = document.querySelector<HTMLInputElement>("#tutorial-search");
+    if (input) input.value = "";
+  };
+
+  return (
+    <div className="space-y-4 mb-8">
+      <SearchInput
+        isPending={isPending}
+        labels={labels}
+        onSearchChange={handleSearchChange}
+        searchQuery={searchQuery}
+      />
+      <DifficultyFilter
+        activeDifficulty={activeDifficulty}
+        difficultyOptions={difficultyOptions}
+        isPending={isPending}
+        labels={labels}
+        onDifficultyChange={handleDifficultyChange}
+      />
+      <TagFilter
+        currentTags={currentTags}
+        labels={labels}
+        onClearTags={() => {
+          onFilterChange({ tags: [] });
+        }}
+        onTagToggle={handleTagToggle}
+        tags={tags}
+      />
+      <ActiveFiltersSummary
+        currentDifficulty={currentDifficulty}
+        currentTags={currentTags}
+        labels={labels}
+        onClearAll={handleClearAll}
+        searchQuery={searchQuery}
+      />
+    </div>
+  );
+}
+
+export const TutorialFilters = memo(TutorialFiltersImpl);
+TutorialFilters.displayName = "TutorialFilters";

--- a/apps/registry/registry/default/tutorial-intro-content/tutorial-intro-content.tsx
+++ b/apps/registry/registry/default/tutorial-intro-content/tutorial-intro-content.tsx
@@ -1,2 +1,196 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+import ReactMarkdown from "react-markdown";
+
+import { cn } from "@vllnt/ui";
+
+export type TutorialIntroContentProps = {
+  className?: string;
+  content: string;
+  title: string;
+};
+
+// Server-side markdown components (no 'use client')
+const serverMarkdownComponents = {
+  a: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children?: React.ReactNode;
+  }) => (
+    <a
+      className="text-primary underline underline-offset-4 hover:text-primary/80 font-medium"
+      href={href}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+  blockquote: ({
+    children,
+    ...props
+  }: React.BlockquoteHTMLAttributes<HTMLQuoteElement> & {
+    children?: React.ReactNode;
+  }) => (
+    <blockquote
+      className="border-l-4 border-primary pl-4 italic text-muted-foreground my-6 py-2 text-sm"
+      {...props}
+    >
+      {children}
+    </blockquote>
+  ),
+  code: ({
+    children,
+    className: codeClassName,
+    ...props
+  }: React.HTMLAttributes<HTMLElement> & { children?: React.ReactNode }) => {
+    const isBlock = codeClassName?.includes("language-");
+    if (isBlock) {
+      return (
+        <code className={cn("font-mono text-sm", codeClassName)} {...props}>
+          {children}
+        </code>
+      );
+    }
+    return (
+      <code
+        className="bg-muted px-1.5 py-0.5 rounded text-sm font-mono"
+        {...props}
+      >
+        {children}
+      </code>
+    );
+  },
+  h1: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLHeadingElement> & {
+    children?: React.ReactNode;
+  }) => (
+    <h1 className="text-2xl font-bold mt-8 mb-4" {...props}>
+      {children}
+    </h1>
+  ),
+  h2: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLHeadingElement> & {
+    children?: React.ReactNode;
+  }) => (
+    <h2 className="text-xl font-bold mt-6 mb-3" {...props}>
+      {children}
+    </h2>
+  ),
+  h3: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLHeadingElement> & {
+    children?: React.ReactNode;
+  }) => (
+    <h3 className="text-lg font-bold mt-4 mb-2" {...props}>
+      {children}
+    </h3>
+  ),
+  hr: (props: React.HTMLAttributes<HTMLHRElement>) => (
+    <hr className="my-8 border-border" {...props} />
+  ),
+  li: ({
+    children,
+    ...props
+  }: React.LiHTMLAttributes<HTMLLIElement> & {
+    children?: React.ReactNode;
+  }) => (
+    <li
+      className="mb-2 leading-relaxed text-muted-foreground text-sm pl-2"
+      {...props}
+    >
+      {children}
+    </li>
+  ),
+  ol: ({
+    children,
+    ...props
+  }: React.OlHTMLAttributes<HTMLOListElement> & {
+    children?: React.ReactNode;
+  }) => (
+    <ol
+      className="list-decimal list-outside mb-6 space-y-2 ml-6 text-muted-foreground text-sm"
+      {...props}
+    >
+      {children}
+    </ol>
+  ),
+  p: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLParagraphElement> & {
+    children?: React.ReactNode;
+  }) => (
+    <p
+      className="mb-4 leading-relaxed text-muted-foreground text-sm"
+      {...props}
+    >
+      {children}
+    </p>
+  ),
+  pre: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLPreElement> & { children?: React.ReactNode }) => (
+    <pre
+      className="bg-zinc-950 dark:bg-zinc-900 text-zinc-100 p-4 rounded-lg overflow-x-auto my-6 border border-zinc-800 shadow-lg font-mono text-sm"
+      {...props}
+    >
+      {children}
+    </pre>
+  ),
+  strong: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLElement> & { children?: React.ReactNode }) => (
+    <strong className="font-semibold text-foreground" {...props}>
+      {children}
+    </strong>
+  ),
+  ul: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLUListElement> & {
+    children?: React.ReactNode;
+  }) => (
+    <ul
+      className="list-disc list-outside mb-6 space-y-2 ml-6 text-muted-foreground text-sm"
+      {...props}
+    >
+      {children}
+    </ul>
+  ),
+};
+
+// Strip MDX component tags for server rendering (they render on client)
+function stripMDXComponents(content: string): string {
+  let cleaned = content.replaceAll(/<[A-Z][A-Za-z]*[^>]*\/>/g, "");
+  cleaned = cleaned.replaceAll(
+    /<[A-Z][A-Za-z]*[^>]*>[\S\s]*?<\/[A-Z][A-Za-z]*>/g,
+    "",
+  );
+  return cleaned;
+}
+
+export function TutorialIntroContent({
+  className,
+  content,
+  title,
+}: TutorialIntroContentProps): React.ReactNode {
+  const markdownContent = stripMDXComponents(content);
+
+  return (
+    <section className={cn("py-6", className)}>
+      <h2 className="text-2xl md:text-3xl font-bold mb-6">{title}</h2>
+      <div className="max-w-none [&_h2:first-of-type]:hidden">
+        <ReactMarkdown components={serverMarkdownComponents}>
+          {markdownContent}
+        </ReactMarkdown>
+      </div>
+    </section>
+  );
+}

--- a/apps/registry/registry/default/tutorial-mdx/tutorial-mdx.tsx
+++ b/apps/registry/registry/default/tutorial-mdx/tutorial-mdx.tsx
@@ -1,2 +1,299 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { lazy, memo, Suspense, use, useMemo } from "react";
+
+import { evaluate } from "@mdx-js/mdx";
+import * as runtime from "react/jsx-runtime";
+import ReactMarkdown, { type Components } from "react-markdown";
+
+import { cn } from "@vllnt/ui";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@vllnt/ui";
+import { Callout } from "@vllnt/ui";
+import { Checklist } from "@vllnt/ui";
+import { CodePlayground, FileTree } from "@vllnt/ui";
+import { BeforeAfter, Comparison } from "@vllnt/ui";
+import { Exercise } from "@vllnt/ui";
+import { FAQ, FAQItem } from "@vllnt/ui";
+import { Glossary, KeyConcept } from "@vllnt/ui";
+import {
+  LearningObjectives,
+  Prerequisites,
+  Summary,
+} from "@vllnt/ui";
+import { CommonMistake, ProTip } from "@vllnt/ui";
+import { Quiz } from "@vllnt/ui";
+import { Step, StepByStep } from "@vllnt/ui";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@vllnt/ui";
+import { SimpleTerminal, Terminal } from "@vllnt/ui";
+import { VideoEmbed } from "@vllnt/ui";
+
+// Lazy load FlowDiagram to avoid loading @xyflow/react (~185KB) on every page
+const LazyFlowDiagram = lazy(() =>
+  import("../flow-diagram").then((module_) => ({
+    default: module_.FlowDiagram,
+  })),
+);
+
+// Wrapper component with Suspense fallback for FlowDiagram
+function FlowDiagramWithSuspense(
+  props: React.ComponentProps<typeof LazyFlowDiagram>,
+) {
+  return (
+    <Suspense
+      fallback={
+        <div
+          aria-label="Loading diagram..."
+          className="h-96 bg-muted animate-pulse rounded-lg"
+        />
+      }
+    >
+      <LazyFlowDiagram {...props} />
+    </Suspense>
+  );
+}
+
+// MDX component map - all available components for tutorials
+const mdxComponents = {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  BeforeAfter,
+  Callout,
+  Checklist,
+  CodePlayground,
+  CommonMistake,
+  Comparison,
+  Exercise,
+  FAQ,
+  FAQItem,
+  FileTree,
+  FlowDiagram: FlowDiagramWithSuspense,
+  Glossary,
+  KeyConcept,
+  LearningObjectives,
+  Prerequisites,
+  ProTip,
+  Quiz,
+  SimpleTerminal,
+  Step,
+  StepByStep,
+  Summary,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  Terminal,
+  VideoEmbed,
+};
+
+// Base markdown components for styling
+const markdownComponents: Components = {
+  a: ({ children, href, ...props }) => (
+    <a
+      className="text-primary underline underline-offset-4 hover:text-primary/80 font-medium"
+      href={href}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+  blockquote: ({ children, ...props }) => (
+    <blockquote
+      className="border-l-4 border-primary pl-4 italic text-muted-foreground my-6 py-2 text-sm"
+      {...props}
+    >
+      {children}
+    </blockquote>
+  ),
+  code: ({ children, className, ...props }) => {
+    const isBlock = className?.includes("language-");
+    if (isBlock) {
+      return (
+        <code className={cn("font-mono text-sm", className)} {...props}>
+          {children}
+        </code>
+      );
+    }
+    return (
+      <code
+        className="bg-muted px-1.5 py-0.5 rounded text-sm font-mono"
+        {...props}
+      >
+        {children}
+      </code>
+    );
+  },
+  h1: ({ children, ...props }) => (
+    <h1 className="text-2xl font-bold mt-8 mb-4" {...props}>
+      {children}
+    </h1>
+  ),
+  h2: ({ children, ...props }) => (
+    <h2 className="text-xl font-bold mt-6 mb-3" {...props}>
+      {children}
+    </h2>
+  ),
+  h3: ({ children, ...props }) => (
+    <h3 className="text-lg font-bold mt-4 mb-2" {...props}>
+      {children}
+    </h3>
+  ),
+  h4: ({ children, ...props }) => (
+    <h4 className="text-base font-bold mt-3 mb-2" {...props}>
+      {children}
+    </h4>
+  ),
+  hr: ({ ...props }) => <hr className="my-8 border-border" {...props} />,
+  li: ({ children, ...props }) => (
+    <li
+      className="mb-2 leading-relaxed text-muted-foreground text-sm pl-2"
+      {...props}
+    >
+      {children}
+    </li>
+  ),
+  ol: ({ children, ...props }) => (
+    <ol
+      className="list-decimal list-outside mb-6 space-y-2 ml-6 text-muted-foreground text-sm"
+      {...props}
+    >
+      {children}
+    </ol>
+  ),
+  p: ({ children, ...props }) => (
+    <p
+      className="mb-4 leading-relaxed text-muted-foreground text-sm"
+      {...props}
+    >
+      {children}
+    </p>
+  ),
+  pre: ({ children, ...props }) => (
+    <pre
+      className="bg-zinc-950 dark:bg-zinc-900 text-zinc-100 p-4 rounded-lg overflow-x-auto my-6 border border-zinc-800 shadow-lg font-mono text-sm"
+      {...props}
+    >
+      {children}
+    </pre>
+  ),
+  strong: ({ children, ...props }) => (
+    <strong className="font-semibold text-foreground" {...props}>
+      {children}
+    </strong>
+  ),
+  table: ({ children, ...props }) => (
+    <div className="my-6 overflow-x-auto">
+      <table className="w-full border-collapse border border-border" {...props}>
+        {children}
+      </table>
+    </div>
+  ),
+  td: ({ children, ...props }) => (
+    <td className="border border-border p-2 text-sm" {...props}>
+      {children}
+    </td>
+  ),
+  th: ({ children, ...props }) => (
+    <th
+      className="border border-border bg-muted p-2 text-left font-medium text-sm"
+      {...props}
+    >
+      {children}
+    </th>
+  ),
+  ul: ({ children, ...props }) => (
+    <ul
+      className="list-disc list-outside mb-6 space-y-2 ml-6 text-muted-foreground text-sm"
+      {...props}
+    >
+      {children}
+    </ul>
+  ),
+};
+
+// Combine all components
+const allComponents = {
+  ...markdownComponents,
+  ...mdxComponents,
+};
+
+export type TutorialMDXProps = {
+  className?: string;
+  content: string;
+};
+
+// Check if content contains JSX components (excluding code blocks)
+function hasJSXComponents(content: string): boolean {
+  const contentWithoutCodeBlocks = content.replaceAll(/```[\S\s]*?```/g, "");
+  return /<[A-Z][A-Za-z]*[\s/>]/.test(contentWithoutCodeBlocks);
+}
+
+// Component that renders MDX with Suspense
+function MDXWithSuspense({ className, content }: TutorialMDXProps) {
+  const mdxPromise = useMemo(
+    () =>
+      evaluate(content, {
+        ...runtime,
+        baseUrl: import.meta.url,
+      }),
+    [content],
+  );
+
+  return (
+    <div className={className}>
+      <Suspense fallback={<MDXLoadingFallback />}>
+        <MDXContent mdxPromise={mdxPromise} />
+      </Suspense>
+    </div>
+  );
+}
+
+// Component that renders plain markdown
+function MarkdownOnly({ className, content }: TutorialMDXProps) {
+  return (
+    <div className={className}>
+      <ReactMarkdown components={markdownComponents}>{content}</ReactMarkdown>
+    </div>
+  );
+}
+
+// Component that uses the promise
+function MDXContent({
+  mdxPromise,
+}: {
+  mdxPromise: Promise<{
+    default: React.ComponentType<{ components: typeof allComponents }>;
+  }>;
+}) {
+  const { default: Component } = use(mdxPromise);
+  return <Component components={allComponents} />;
+}
+
+function MDXLoadingFallback() {
+  return <div aria-hidden="true" className="min-h-[100px]" />;
+}
+
+// Main component that decides which renderer to use
+function TutorialMDXImpl({
+  className,
+  content,
+}: TutorialMDXProps): React.ReactNode {
+  const hasJSX = hasJSXComponents(content);
+
+  if (hasJSX) {
+    return <MDXWithSuspense className={className} content={content} />;
+  }
+
+  return <MarkdownOnly className={className} content={content} />;
+}
+
+export const TutorialMDX = memo(TutorialMDXImpl);
+TutorialMDX.displayName = "TutorialMDX";
+
+export { mdxComponents };

--- a/apps/registry/registry/default/usage-breakdown/usage-breakdown.tsx
+++ b/apps/registry/registry/default/usage-breakdown/usage-breakdown.tsx
@@ -1,6 +1,235 @@
-export {
-  UsageBreakdown,
-  type UsageBreakdownItem,
-  type UsageBreakdownProps,
-  type UsageBreakdownTone,
+"use client";
+
+import { forwardRef, type ReactNode, useMemo } from "react";
+
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
 } from "@vllnt/ui";
+
+export type UsageBreakdownTone = "danger" | "default" | "success" | "warning";
+
+export type UsageBreakdownItem = {
+  description?: string;
+  icon?: ReactNode;
+  id: string;
+  label: string;
+  meta?: string;
+  tone?: UsageBreakdownTone;
+  trend?: {
+    direction: "down" | "up";
+    label: string;
+  };
+  value: number;
+  valueLabel?: string;
+};
+
+export type UsageBreakdownProps = React.ComponentPropsWithoutRef<
+  typeof Card
+> & {
+  description?: string;
+  emptyMessage?: string;
+  items: UsageBreakdownItem[];
+  maxItems?: number;
+  title?: string;
+};
+
+type UsageBreakdownRowProps = {
+  item: UsageBreakdownItem;
+  maxValue: number;
+  rank: number;
+  totalValue: number;
+};
+
+const toneClasses: Record<UsageBreakdownTone, string> = {
+  danger:
+    "bg-destructive/10 text-destructive border-destructive/20 dark:text-destructive",
+  default: "bg-muted text-muted-foreground border-border",
+  success:
+    "bg-emerald-500/10 text-emerald-700 border-emerald-500/20 dark:text-emerald-300",
+  warning:
+    "bg-amber-500/10 text-amber-700 border-amber-500/20 dark:text-amber-300",
+};
+
+function formatPercent(value: number): string {
+  if (!Number.isFinite(value)) return "0%";
+  return `${Math.round(value)}%`;
+}
+
+function formatValue(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: value >= 100 ? 0 : 1,
+  }).format(value);
+}
+
+function getRelativeWidth(value: number, maxValue: number): number {
+  if (maxValue <= 0) return 0;
+  return Math.max((value / maxValue) * 100, 4);
+}
+
+function getShare(value: number, totalValue: number): number {
+  if (totalValue <= 0) return 0;
+  return (value / totalValue) * 100;
+}
+
+function UsageBreakdownTrend({ item }: { item: UsageBreakdownItem }) {
+  if (!item.trend) return null;
+
+  const trendTone = item.tone ?? "default";
+  const TrendIcon =
+    item.trend.direction === "down" ? ArrowDownRight : ArrowUpRight;
+
+  return (
+    <Badge className={cn("gap-1 border", toneClasses[trendTone])}>
+      <TrendIcon className="h-3.5 w-3.5" />
+      {item.trend.label}
+    </Badge>
+  );
+}
+
+function UsageBreakdownMeter({
+  maxValue,
+  value,
+}: {
+  maxValue: number;
+  value: number;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="h-2 overflow-hidden rounded-full bg-muted">
+        <div
+          aria-hidden="true"
+          className="h-full rounded-full bg-primary transition-[width]"
+          style={{ width: `${getRelativeWidth(value, maxValue)}%` }}
+        />
+      </div>
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>Relative usage</span>
+        <span>{formatPercent(getShare(value, maxValue))}</span>
+      </div>
+    </div>
+  );
+}
+
+function UsageBreakdownRow({
+  item,
+  maxValue,
+  rank,
+  totalValue,
+}: UsageBreakdownRowProps) {
+  return (
+    <li className="rounded-lg border bg-background/70 p-4">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border bg-muted text-sm font-semibold text-muted-foreground">
+          {item.icon ?? rank}
+        </div>
+        <div className="min-w-0 flex-1 space-y-3">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0 space-y-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="truncate font-medium text-foreground">
+                  {item.label}
+                </span>
+                {item.meta ? (
+                  <Badge className="border-border" variant="outline">
+                    {item.meta}
+                  </Badge>
+                ) : null}
+                <UsageBreakdownTrend item={item} />
+              </div>
+              {item.description ? (
+                <p className="text-sm text-muted-foreground">
+                  {item.description}
+                </p>
+              ) : null}
+            </div>
+            <div className="text-left sm:text-right">
+              <div className="font-semibold text-foreground">
+                {item.valueLabel ?? formatValue(item.value)}
+              </div>
+              <div className="text-sm text-muted-foreground">
+                {formatPercent(getShare(item.value, totalValue))} of total
+              </div>
+            </div>
+          </div>
+          <UsageBreakdownMeter maxValue={maxValue} value={item.value} />
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function getSortedItems(items: UsageBreakdownItem[], maxItems?: number) {
+  const rankedItems = [...items].sort(
+    (left, right) => right.value - left.value,
+  );
+  return typeof maxItems === "number"
+    ? rankedItems.slice(0, maxItems)
+    : rankedItems;
+}
+
+const UsageBreakdown = forwardRef<HTMLDivElement, UsageBreakdownProps>(
+  (
+    {
+      className,
+      description,
+      emptyMessage = "No usage data available.",
+      items,
+      maxItems,
+      title = "Usage breakdown",
+      ...props
+    },
+    ref,
+  ) => {
+    const sortedItems = useMemo(
+      () => getSortedItems(items, maxItems),
+      [items, maxItems],
+    );
+    const totalValue = useMemo(
+      () => sortedItems.reduce((sum, item) => sum + item.value, 0),
+      [sortedItems],
+    );
+    const maxValue = sortedItems[0]?.value ?? 0;
+
+    return (
+      <Card className={cn("w-full", className)} ref={ref} {...props}>
+        <CardHeader>
+          <CardTitle>{title}</CardTitle>
+          {description ? (
+            <CardDescription>{description}</CardDescription>
+          ) : null}
+        </CardHeader>
+        <CardContent>
+          {sortedItems.length === 0 ? (
+            <div className="rounded-lg border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
+              {emptyMessage}
+            </div>
+          ) : (
+            <ol className="space-y-3">
+              {sortedItems.map((item, index) => (
+                <UsageBreakdownRow
+                  item={item}
+                  key={item.id}
+                  maxValue={maxValue}
+                  rank={index + 1}
+                  totalValue={totalValue}
+                />
+              ))}
+            </ol>
+          )}
+        </CardContent>
+      </Card>
+    );
+  },
+);
+
+UsageBreakdown.displayName = "UsageBreakdown";
+
+export { UsageBreakdown };

--- a/apps/registry/registry/default/video-embed/video-embed.tsx
+++ b/apps/registry/registry/default/video-embed/video-embed.tsx
@@ -1,2 +1,94 @@
-// Re-export from @vllnt/ui package
-export * from '@vllnt/ui'
+"use client";
+
+import { useState } from "react";
+
+import { Play, Video } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+export type VideoEmbedProps = {
+  aspectRatio?: "1/1" | "4/3" | "16/9";
+  src: string;
+  thumbnail?: string;
+  title: string;
+  type?: "custom" | "vimeo" | "youtube";
+};
+
+function getEmbedUrl(source: string, type: string): string {
+  if (type === "youtube") {
+    const videoId =
+      /(?:youtube\.com\/(?:watch\?v=|embed\/)|youtu\.be\/)([^&?]+)/.exec(
+        source,
+      )?.[1];
+    return videoId ? `https://www.youtube.com/embed/${videoId}` : source;
+  }
+  if (type === "vimeo") {
+    const videoId = /vimeo\.com\/(\d+)/.exec(source)?.[1];
+    return videoId ? `https://player.vimeo.com/video/${videoId}` : source;
+  }
+  return source;
+}
+
+export function VideoEmbed({
+  aspectRatio = "16/9",
+  src,
+  thumbnail,
+  title,
+  type = "youtube",
+}: VideoEmbedProps) {
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const embedUrl = getEmbedUrl(src, type);
+  const aspectClass =
+    aspectRatio === "16/9"
+      ? "aspect-video"
+      : aspectRatio === "4/3"
+        ? "aspect-[4/3]"
+        : "aspect-square";
+
+  return (
+    <div className="my-6">
+      <div
+        className={cn(
+          "relative rounded-lg overflow-hidden bg-muted border",
+          aspectClass,
+        )}
+      >
+        {isPlaying ? (
+          <iframe
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            className="absolute inset-0 w-full h-full"
+            src={`${embedUrl}?autoplay=1`}
+            title={title}
+          />
+        ) : (
+          <button
+            className="absolute inset-0 w-full h-full flex items-center justify-center group"
+            onClick={() => {
+              setIsPlaying(true);
+            }}
+            type="button"
+          >
+            {thumbnail ? (
+              <img
+                alt={title}
+                className="absolute inset-0 w-full h-full object-cover"
+                src={thumbnail}
+              />
+            ) : (
+              <div className="absolute inset-0 bg-gradient-to-br from-muted to-muted-foreground/20" />
+            )}
+            <div className="relative z-10 flex h-16 w-16 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-transform group-hover:scale-110">
+              <Play className="h-6 w-6 ml-1" />
+            </div>
+          </button>
+        )}
+      </div>
+      <p className="mt-2 text-sm text-center text-muted-foreground flex items-center justify-center gap-1">
+        <Video className="h-4 w-4" />
+        {title}
+      </p>
+    </div>
+  );
+}

--- a/apps/registry/registry/default/view-switcher/view-switcher.tsx
+++ b/apps/registry/registry/default/view-switcher/view-switcher.tsx
@@ -1,1 +1,122 @@
-export * from '@vllnt/ui'
+"use client";
+
+import { memo, Suspense } from "react";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import { cn } from "@vllnt/ui";
+
+type ViewOption = {
+  key: string;
+  label: string;
+};
+
+type ViewSwitcherProps = {
+  className?: string;
+  defaultKey?: string;
+  options: ViewOption[];
+  paramName?: string;
+};
+
+function ViewSwitcherInner({
+  className,
+  defaultKey,
+  options,
+  paramName: parameterName = "view",
+}: ViewSwitcherProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParameters = useSearchParams();
+
+  const resolvedDefault = defaultKey ?? options[0]?.key ?? "";
+  const currentKey = searchParameters.get(parameterName) ?? resolvedDefault;
+
+  function handleSelect(key: string): void {
+    const parameters = new URLSearchParams(searchParameters.toString());
+    if (key === resolvedDefault) {
+      parameters.delete(parameterName);
+    } else {
+      parameters.set(parameterName, key);
+    }
+    const query = parameters.toString();
+    router.push(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center rounded-lg border bg-muted p-1",
+        className,
+      )}
+      role="tablist"
+    >
+      {options.map((option) => (
+        <button
+          aria-selected={currentKey === option.key}
+          className={cn(
+            "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+            currentKey === option.key
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+          key={option.key}
+          onClick={() => {
+            handleSelect(option.key);
+          }}
+          role="tab"
+          type="button"
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ViewSwitcherFallback({
+  className,
+  defaultKey,
+  options,
+}: ViewSwitcherProps) {
+  const resolvedDefault = defaultKey ?? options[0]?.key ?? "";
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center rounded-lg border bg-muted p-1",
+        className,
+      )}
+      role="tablist"
+    >
+      {options.map((option) => (
+        <button
+          aria-selected={resolvedDefault === option.key}
+          className={cn(
+            "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+            resolvedDefault === option.key
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+          key={option.key}
+          role="tab"
+          type="button"
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+const ViewSwitcher = memo(function ViewSwitcher(props: ViewSwitcherProps) {
+  return (
+    <Suspense fallback={<ViewSwitcherFallback {...props} />}>
+      <ViewSwitcherInner {...props} />
+    </Suspense>
+  );
+});
+
+ViewSwitcher.displayName = "ViewSwitcher";
+
+export { ViewSwitcher };
+export type { ViewOption, ViewSwitcherProps };

--- a/apps/registry/registry/default/viewport-bookmarks/viewport-bookmarks.tsx
+++ b/apps/registry/registry/default/viewport-bookmarks/viewport-bookmarks.tsx
@@ -1,6 +1,200 @@
-export {
-  type ViewportBookmark,
-  ViewportBookmarks,
-  type ViewportBookmarksLabels,
-  type ViewportBookmarksProps,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * One saved viewport.
+ *
+ * @public
+ */
+export type ViewportBookmark = {
+  /** Optional accent color for the row glyph. */
+  color?: string;
+  /** Optional secondary line (zoom level, last-visited, owner). */
+  detail?: ReactNode;
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Display name for the bookmark. */
+  label: ReactNode;
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type ViewportBookmarksLabels = {
+  /** Empty-state copy. Defaults to `"No saved views"`. */
+  empty?: string;
+  /** Aria-label override. Defaults to `"Viewport bookmarks"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No saved views",
+  region: "Viewport bookmarks",
+} as const satisfies Required<ViewportBookmarksLabels>;
+
+/**
+ * Props for {@link ViewportBookmarks}.
+ *
+ * @public
+ */
+export type ViewportBookmarksProps = {
+  /** Optional active bookmark id — renders the row in the selected state. */
+  activeId?: string;
+  /** Bookmark entries in render order. */
+  bookmarks: ViewportBookmark[];
+  /** Localizable strings. */
+  labels?: ViewportBookmarksLabels;
+  /** Click handler — receives the activated bookmark id. */
+  onSelect?: (id: string) => void;
+  /** Optional title rendered above the rows. Defaults to `"Saved views"`. */
+  title?: ReactNode;
+} & ComponentPropsWithoutRef<"section">;
+
+const Row = (props: {
+  active: boolean;
+  bookmark: ViewportBookmark;
+  onSelect?: (id: string) => void;
+}): React.ReactElement => {
+  const { active, bookmark, onSelect } = props;
+  const handleClick = (): void => {
+    onSelect?.(bookmark.id);
+  };
+  const rowClass =
+    "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors";
+  const activeClass = active
+    ? "bg-muted/60 text-foreground"
+    : "text-muted-foreground hover:bg-muted/30 hover:text-foreground";
+  if (onSelect) {
+    return (
+      <button
+        aria-pressed={active}
+        className={cn(
+          rowClass,
+          activeClass,
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        )}
+        data-viewport-bookmark={bookmark.id}
+        data-viewport-bookmark-active={active}
+        onClick={handleClick}
+        type="button"
+      >
+        <RowBody bookmark={bookmark} />
+      </button>
+    );
+  }
+  return (
+    <span
+      className={cn(rowClass, activeClass)}
+      data-viewport-bookmark={bookmark.id}
+      data-viewport-bookmark-active={active}
+    >
+      <RowBody bookmark={bookmark} />
+    </span>
+  );
+};
+
+const RowBody = (props: { bookmark: ViewportBookmark }): React.ReactElement => {
+  const { bookmark } = props;
+  return (
+    <>
+      <span
+        aria-hidden="true"
+        className="h-1.5 w-1.5 rounded-full"
+        style={{ backgroundColor: bookmark.color ?? "hsl(var(--foreground))" }}
+      />
+      <span className="flex flex-1 flex-col text-left">
+        <span className="truncate font-medium">{bookmark.label}</span>
+        {bookmark.detail ? (
+          <span
+            className="truncate text-[10px] text-muted-foreground"
+            data-viewport-bookmark-detail
+          >
+            {bookmark.detail}
+          </span>
+        ) : null}
+      </span>
+    </>
+  );
+};
+
+/**
+ * Saved-view list for the canvas — the spatial parallel of a tab
+ * bar's pinned tabs. Each bookmark stores a viewport target the host
+ * resolves to a pan / zoom transition. Pure presentation; the host
+ * owns the bookmark store and the camera animation.
+ *
+ * @example
+ * ```tsx
+ * <ViewportBookmarks
+ *   activeId={active}
+ *   bookmarks={[
+ *     { id: "home", label: "Home base", color: "#5b8def" },
+ *     { id: "incidents", label: "Incidents", detail: "5 open", color: "#ef4444" },
+ *   ]}
+ *   onSelect={jumpTo}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const ViewportBookmarks = forwardRef<
+  HTMLElement,
+  ViewportBookmarksProps
+>((props, ref) => {
+  const {
+    activeId,
+    bookmarks,
+    className,
+    labels,
+    onSelect,
+    title = "Saved views",
+    ...rest
+  } = props;
+  const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+  return (
+    <section
+      aria-label={resolvedLabels.region}
+      className={cn(
+        "flex w-full flex-col gap-1 rounded-lg border border-border bg-background p-2 text-foreground",
+        className,
+      )}
+      data-viewport-bookmarks
+      ref={ref}
+      {...rest}
+    >
+      <header className="px-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </header>
+      {bookmarks.length === 0 ? (
+        <p
+          className="px-2 py-3 text-center text-[11px] text-muted-foreground"
+          data-viewport-bookmarks-state="empty"
+        >
+          {resolvedLabels.empty}
+        </p>
+      ) : (
+        <ul className="space-y-0.5">
+          {bookmarks.map((bookmark) => (
+            <li key={bookmark.id}>
+              <Row
+                active={activeId === bookmark.id}
+                bookmark={bookmark}
+                onSelect={onSelect}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+});
+ViewportBookmarks.displayName = "ViewportBookmarks";

--- a/apps/registry/registry/default/wallet-card/wallet-card.tsx
+++ b/apps/registry/registry/default/wallet-card/wallet-card.tsx
@@ -1,2 +1,169 @@
-// Re-export from @vllnt/ui package
-export { WalletCard } from '@vllnt/ui'
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@vllnt/ui";
+import {
+  CreditBadge,
+  type CreditBadgeStatus,
+} from "@vllnt/ui";
+
+export type WalletCardProps = React.ComponentPropsWithoutRef<typeof Card> & {
+  availableLabel?: string;
+  balanceLabel: string;
+  note?: string;
+  pendingLabel?: string;
+  primaryActionLabel?: string;
+  renewsLabel?: string;
+  secondaryActionLabel?: string;
+  status: CreditBadgeStatus;
+};
+
+type WalletActionsProps = {
+  primaryActionLabel?: string;
+  secondaryActionLabel?: string;
+};
+
+type WalletDetailsProps = {
+  availableLabel?: string;
+  balanceLabel: string;
+  note?: string;
+  pendingLabel?: string;
+  renewsLabel?: string;
+};
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-4 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="text-right font-medium">{value}</span>
+    </div>
+  );
+}
+
+function WalletDetails({
+  availableLabel,
+  balanceLabel,
+  note,
+  pendingLabel,
+  renewsLabel,
+}: WalletDetailsProps) {
+  return (
+    <CardContent className="space-y-4">
+      <div className="rounded-lg border border-border/70 bg-background px-4 py-3">
+        <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+          Current balance
+        </p>
+        <p className="mt-2 text-3xl font-semibold tracking-tight">
+          {balanceLabel}
+        </p>
+      </div>
+      <div className="space-y-3 rounded-lg border border-border/70 bg-muted/20 px-4 py-4">
+        {availableLabel ? (
+          <DetailRow label="Available now" value={availableLabel} />
+        ) : null}
+        {pendingLabel ? (
+          <DetailRow label="Pending" value={pendingLabel} />
+        ) : null}
+        {renewsLabel ? <DetailRow label="Refresh" value={renewsLabel} /> : null}
+      </div>
+      {note ? (
+        <p className="rounded-lg bg-muted px-4 py-3 text-sm text-muted-foreground">
+          {note}
+        </p>
+      ) : null}
+    </CardContent>
+  );
+}
+
+function WalletActions({
+  primaryActionLabel,
+  secondaryActionLabel,
+}: WalletActionsProps) {
+  if (!primaryActionLabel && !secondaryActionLabel) {
+    return null;
+  }
+
+  return (
+    <CardFooter className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+      {secondaryActionLabel ? (
+        <Button className="w-full sm:w-auto" variant="outline">
+          {secondaryActionLabel}
+        </Button>
+      ) : null}
+      {primaryActionLabel ? (
+        <Button className="w-full sm:w-auto">{primaryActionLabel}</Button>
+      ) : null}
+    </CardFooter>
+  );
+}
+
+export const WalletCard = React.forwardRef<
+  React.ComponentRef<typeof Card>,
+  WalletCardProps
+>(
+  (
+    {
+      availableLabel,
+      balanceLabel,
+      className,
+      note,
+      pendingLabel,
+      primaryActionLabel,
+      renewsLabel,
+      secondaryActionLabel,
+      status,
+      ...props
+    },
+    reference,
+  ) => {
+    return (
+      <Card
+        className={cn(
+          "w-full max-w-md border-border/70 bg-card shadow-sm",
+          className,
+        )}
+        ref={reference}
+        {...props}
+      >
+        <CardHeader className="space-y-4 pb-4">
+          <div className="space-y-1">
+            <CardTitle className="text-lg">Wallet</CardTitle>
+            <CardDescription>
+              Track credits, pending top-ups, and replenishment timing.
+            </CardDescription>
+          </div>
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-border/70 bg-muted/30 px-4 py-3">
+            <div>
+              <p className="text-sm font-medium">Available balance</p>
+              <p className="text-xs text-muted-foreground">
+                {renewsLabel ?? "Credits refresh automatically when enabled."}
+              </p>
+            </div>
+            <CreditBadge amount={balanceLabel} status={status} />
+          </div>
+        </CardHeader>
+        <WalletDetails
+          availableLabel={availableLabel}
+          balanceLabel={balanceLabel}
+          note={note}
+          pendingLabel={pendingLabel}
+          renewsLabel={renewsLabel}
+        />
+        <WalletActions
+          primaryActionLabel={primaryActionLabel}
+          secondaryActionLabel={secondaryActionLabel}
+        />
+      </Card>
+    );
+  },
+);
+
+WalletCard.displayName = "WalletCard";

--- a/apps/registry/registry/default/watchlist/watchlist.tsx
+++ b/apps/registry/registry/default/watchlist/watchlist.tsx
@@ -1,1 +1,145 @@
-export { Watchlist } from "@vllnt/ui";
+import * as React from "react";
+
+import { ArrowDownRight, ArrowUpRight, Star } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+export type WatchlistItem = {
+  change: number;
+  name?: string;
+  price: number | string;
+  starred?: boolean;
+  symbol: string;
+  volume?: string;
+};
+
+export type WatchlistProps = {
+  eyebrow?: string;
+  items: WatchlistItem[];
+  title?: string;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+function formatPrice(price: number | string): string {
+  return typeof price === "number"
+    ? price.toLocaleString(undefined, {
+        maximumFractionDigits: 2,
+        minimumFractionDigits: 2,
+      })
+    : price;
+}
+
+function formatChange(change: number): string {
+  const sign = change > 0 ? "+" : "";
+  return `${sign}${change.toFixed(2)}%`;
+}
+
+function WatchlistRow({ item }: { item: WatchlistItem }): React.JSX.Element {
+  const isPositive = item.change >= 0;
+  const TrendIcon = isPositive ? ArrowUpRight : ArrowDownRight;
+
+  return (
+    <li className="grid grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-3 rounded-xl px-3 py-2.5 transition-colors hover:bg-muted/40">
+      <span
+        aria-hidden="true"
+        className={cn(
+          "flex h-7 w-7 items-center justify-center rounded-full border",
+          item.starred
+            ? "border-amber-400/40 bg-amber-400/10 text-amber-500"
+            : "border-border bg-background text-muted-foreground",
+        )}
+      >
+        <Star
+          className={cn("h-3.5 w-3.5", item.starred && "fill-current")}
+          strokeWidth={1.75}
+        />
+      </span>
+      <div className="min-w-0">
+        <p className="truncate text-sm font-semibold text-foreground">
+          {item.symbol}
+        </p>
+        {item.name ? (
+          <p className="truncate text-xs text-muted-foreground">{item.name}</p>
+        ) : null}
+      </div>
+      <div className="text-right">
+        <p className="text-sm font-semibold tabular-nums text-foreground">
+          {formatPrice(item.price)}
+        </p>
+        {item.volume ? (
+          <p className="text-[11px] text-muted-foreground tabular-nums">
+            {item.volume}
+          </p>
+        ) : null}
+      </div>
+      <span
+        className={cn(
+          "inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs font-medium tabular-nums",
+          isPositive
+            ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+            : "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400",
+        )}
+      >
+        <TrendIcon className="h-3 w-3" />
+        {formatChange(item.change)}
+      </span>
+    </li>
+  );
+}
+
+export const Watchlist = React.forwardRef<HTMLDivElement, WatchlistProps>(
+  (
+    {
+      className,
+      eyebrow = "Tracked symbols",
+      items,
+      title = "Watchlist",
+      ...props
+    },
+    reference,
+  ) => {
+    if (items.length === 0) {
+      return null;
+    }
+
+    const advancing = items.filter((item) => item.change >= 0).length;
+    const declining = items.length - advancing;
+
+    return (
+      <section
+        aria-label={title}
+        className={cn(
+          "rounded-2xl border border-border bg-card/80 p-4 shadow-sm",
+          className,
+        )}
+        ref={reference}
+        {...props}
+      >
+        <header className="mb-3 flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-[0.28em] text-muted-foreground">
+              {eyebrow}
+            </p>
+            <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+          </div>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-emerald-600 dark:text-emerald-400">
+              <ArrowUpRight className="h-3 w-3" />
+              {advancing} up
+            </span>
+            <span className="inline-flex items-center gap-1 rounded-full border border-rose-500/30 bg-rose-500/10 px-2 py-1 text-rose-600 dark:text-rose-400">
+              <ArrowDownRight className="h-3 w-3" />
+              {declining} down
+            </span>
+          </div>
+        </header>
+        <ul className="divide-y divide-border/60">
+          {items.map((item) => (
+            <WatchlistRow item={item} key={item.symbol} />
+          ))}
+        </ul>
+      </section>
+    );
+  },
+);
+
+Watchlist.displayName = "Watchlist";

--- a/apps/registry/registry/default/workspace-switcher/workspace-switcher.tsx
+++ b/apps/registry/registry/default/workspace-switcher/workspace-switcher.tsx
@@ -1,1 +1,89 @@
-export { WorkspaceSwitcher, type WorkspaceSwitcherProps } from '@vllnt/ui'
+"use client";
+
+import { forwardRef, useMemo, useState } from "react";
+
+import { cn } from "@vllnt/ui";
+
+export type WorkspaceOption = {
+  description?: string;
+  id: string;
+  label: string;
+};
+
+export type WorkspaceSwitcherProps = Omit<
+  React.ComponentPropsWithoutRef<"div">,
+  "defaultValue" | "onChange"
+> & {
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  value?: string;
+  workspaces: WorkspaceOption[];
+};
+
+const WorkspaceSwitcher = forwardRef<HTMLDivElement, WorkspaceSwitcherProps>(
+  (
+    { className, defaultValue, onValueChange, value, workspaces, ...props },
+    ref,
+  ) => {
+    const fallbackValue = defaultValue ?? workspaces[0]?.id ?? "";
+    const [internalValue, setInternalValue] = useState(fallbackValue);
+    const currentValue = value ?? internalValue;
+
+    const currentWorkspace = useMemo(
+      () => workspaces.find((workspace) => workspace.id === currentValue),
+      [currentValue, workspaces],
+    );
+
+    function handleSelect(nextValue: string) {
+      if (value === undefined) {
+        setInternalValue(nextValue);
+      }
+      onValueChange?.(nextValue);
+    }
+
+    return (
+      <div
+        className={cn(
+          "inline-flex min-w-0 items-center gap-1 rounded-full border border-border/70 bg-muted/50 p-1",
+          className,
+        )}
+        ref={ref}
+        role="radiogroup"
+        {...props}
+      >
+        {workspaces.map((workspace) => {
+          const isActive = workspace.id === currentValue;
+          return (
+            <button
+              aria-checked={isActive}
+              className={cn(
+                "rounded-full px-3 py-1.5 text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+              key={workspace.id}
+              onClick={() => {
+                handleSelect(workspace.id);
+              }}
+              role="radio"
+              title={workspace.description}
+              type="button"
+            >
+              {workspace.label}
+            </button>
+          );
+        })}
+        {currentWorkspace?.description ? (
+          <span className="hidden pl-2 pr-1 text-xs text-muted-foreground md:inline">
+            {currentWorkspace.description}
+          </span>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+WorkspaceSwitcher.displayName = "WorkspaceSwitcher";
+
+export { WorkspaceSwitcher };

--- a/apps/registry/registry/default/world-breadcrumbs/world-breadcrumbs.tsx
+++ b/apps/registry/registry/default/world-breadcrumbs/world-breadcrumbs.tsx
@@ -1,7 +1,204 @@
-export {
-  WorldBreadcrumbs,
-  type WorldBreadcrumbsLabels,
-  type WorldBreadcrumbsProps,
-  type WorldCrumb,
-  type WorldCrumbKind,
-} from '@vllnt/ui'
+"use client";
+
+import {
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@vllnt/ui";
+
+/**
+ * One spatial trail crumb.
+ *
+ * @public
+ */
+export type WorldCrumb = {
+  /** Stable identifier — used as the React key. */
+  id: string;
+  /** Optional kind (drives the leading glyph). */
+  kind?: WorldCrumbKind;
+  /** Display label. */
+  label: ReactNode;
+};
+
+/**
+ * Glyph hint for a crumb kind.
+ *
+ * @public
+ */
+export type WorldCrumbKind =
+  | "agent"
+  | "artifact"
+  | "group"
+  | "run"
+  | "task"
+  | "world";
+
+const KIND_GLYPH: Record<WorldCrumbKind, string> = {
+  agent: "◇",
+  artifact: "◌",
+  group: "▤",
+  run: "▶",
+  task: "▢",
+  world: "✦",
+};
+
+/**
+ * Localizable strings.
+ *
+ * @public
+ */
+export type WorldBreadcrumbsLabels = {
+  /** Empty-state copy. Defaults to `"No location"`. */
+  empty?: string;
+  /** Aria-label override. Defaults to `"World breadcrumbs"`. */
+  region?: string;
+};
+
+const DEFAULT_LABELS = {
+  empty: "No location",
+  region: "World breadcrumbs",
+} as const satisfies Required<WorldBreadcrumbsLabels>;
+
+/**
+ * Props for {@link WorldBreadcrumbs}.
+ *
+ * @public
+ */
+export type WorldBreadcrumbsProps = {
+  /** Trail in render order — the last crumb represents the active location. */
+  crumbs: WorldCrumb[];
+  /** Localizable strings. */
+  labels?: WorldBreadcrumbsLabels;
+  /** Click handler — receives the activated crumb id. */
+  onSelect?: (id: string) => void;
+} & ComponentPropsWithoutRef<"nav">;
+
+const Crumb = (props: {
+  crumb: WorldCrumb;
+  isLast: boolean;
+  onSelect?: (id: string) => void;
+}): React.ReactElement => {
+  const { crumb, isLast, onSelect } = props;
+  const glyph = crumb.kind ? KIND_GLYPH[crumb.kind] : null;
+  const handleClick = (): void => {
+    onSelect?.(crumb.id);
+  };
+  const text = (
+    <span className="inline-flex items-center gap-1">
+      {glyph ? (
+        <span aria-hidden="true" className="text-muted-foreground">
+          {glyph}
+        </span>
+      ) : null}
+      <span className="truncate">{crumb.label}</span>
+    </span>
+  );
+  if (isLast || !onSelect) {
+    return (
+      <span
+        aria-current={isLast ? "location" : undefined}
+        className={cn(
+          "inline-flex items-center text-xs",
+          isLast ? "font-semibold text-foreground" : "text-muted-foreground",
+        )}
+        data-world-breadcrumb={crumb.id}
+        data-world-breadcrumb-active={isLast}
+      >
+        {text}
+      </span>
+    );
+  }
+  return (
+    <button
+      className="inline-flex items-center rounded-sm text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      data-world-breadcrumb={crumb.id}
+      data-world-breadcrumb-active="false"
+      onClick={handleClick}
+      type="button"
+    >
+      {text}
+    </button>
+  );
+};
+
+/**
+ * Spatial trail showing where the viewport sits in a hierarchy of
+ * worlds / groups / runs / agents. Distinct from \`Breadcrumb\`
+ * (route-based, document-tree style) — this primitive describes the
+ * canvas's spatial location and supports per-kind glyphs.
+ *
+ * Pure presentation; the host computes the trail from the active
+ * viewport target and the world graph, and resolves \`onSelect\` to a
+ * camera transition.
+ *
+ * @example
+ * ```tsx
+ * <WorldBreadcrumbs
+ *   crumbs={[
+ *     { id: "world", kind: "world", label: "Production" },
+ *     { id: "group", kind: "group", label: "Ingest cluster" },
+ *     { id: "run",   kind: "run",   label: "research-2025" },
+ *   ]}
+ *   onSelect={jumpTo}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const WorldBreadcrumbs = forwardRef<HTMLElement, WorldBreadcrumbsProps>(
+  (props, ref) => {
+    const { className, crumbs, labels, onSelect, ...rest } = props;
+    const resolvedLabels = { ...DEFAULT_LABELS, ...labels };
+    if (crumbs.length === 0) {
+      return (
+        <nav
+          aria-label={resolvedLabels.region}
+          className={cn(
+            "inline-flex items-center text-xs text-muted-foreground",
+            className,
+          )}
+          data-world-breadcrumbs
+          data-world-breadcrumbs-state="empty"
+          ref={ref}
+          {...rest}
+        >
+          {resolvedLabels.empty}
+        </nav>
+      );
+    }
+    return (
+      <nav
+        aria-label={resolvedLabels.region}
+        className={cn(
+          "inline-flex items-center gap-1.5 text-xs text-muted-foreground",
+          className,
+        )}
+        data-world-breadcrumbs
+        ref={ref}
+        {...rest}
+      >
+        {crumbs.map((crumb, index) => (
+          <span className="inline-flex items-center gap-1.5" key={crumb.id}>
+            <Crumb
+              crumb={crumb}
+              isLast={index === crumbs.length - 1}
+              onSelect={onSelect}
+            />
+            {index < crumbs.length - 1 ? (
+              <span
+                aria-hidden="true"
+                className="text-muted-foreground/60"
+                data-world-breadcrumb-sep
+              >
+                ›
+              </span>
+            ) : null}
+          </span>
+        ))}
+      </nav>
+    );
+  },
+);
+WorldBreadcrumbs.displayName = "WorldBreadcrumbs";

--- a/apps/registry/registry/default/world-clock-bar/world-clock-bar.tsx
+++ b/apps/registry/registry/default/world-clock-bar/world-clock-bar.tsx
@@ -1,1 +1,154 @@
-export * from "@vllnt/ui";
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@vllnt/ui";
+import { Badge } from "@vllnt/ui";
+
+export type WorldClockBarZone = {
+  city: string;
+  locale?: string;
+  timeZone: string;
+};
+
+export type WorldClockBarProps = React.ComponentPropsWithoutRef<"div"> & {
+  now?: Date | number | string;
+  showDate?: boolean;
+  title?: string;
+  updateIntervalMs?: number;
+  zones: WorldClockBarZone[];
+};
+
+function normalizeDate(input: Date | number | string): Date {
+  if (input instanceof Date) {
+    return new Date(input.getTime());
+  }
+
+  return new Date(input);
+}
+
+function useLiveDate(now: WorldClockBarProps["now"], updateIntervalMs: number) {
+  const fixedNow = React.useMemo(
+    () => (now ? normalizeDate(now) : undefined),
+    [now],
+  );
+  const [liveNow, setLiveNow] = React.useState<Date>(fixedNow ?? new Date());
+
+  React.useEffect(() => {
+    if (fixedNow) {
+      setLiveNow(fixedNow);
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      setLiveNow(new Date());
+    }, updateIntervalMs);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [fixedNow, updateIntervalMs]);
+
+  return liveNow;
+}
+
+function formatZoneDateTime(
+  zone: WorldClockBarZone,
+  date: Date,
+  showDate: boolean,
+) {
+  const locale = zone.locale ?? "en-US";
+  const timeFormatter = new Intl.DateTimeFormat(locale, {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: zone.timeZone,
+    timeZoneName: "short",
+  });
+  const dateFormatter = new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "short",
+    timeZone: zone.timeZone,
+    weekday: "short",
+  });
+
+  return {
+    date: showDate ? dateFormatter.format(date) : "",
+    time: timeFormatter.format(date),
+  };
+}
+
+function WorldClockCard({
+  date,
+  showDate,
+  zone,
+}: {
+  date: Date;
+  showDate: boolean;
+  zone: WorldClockBarZone;
+}) {
+  const formatted = formatZoneDateTime(zone, date, showDate);
+
+  return (
+    <div className="min-w-[190px] rounded-lg border bg-card px-4 py-3 shadow-sm">
+      <div className="text-sm font-medium">{zone.city}</div>
+      <div className="mt-1 text-2xl font-semibold tracking-tight">
+        {formatted.time}
+      </div>
+      {showDate ? (
+        <div className="mt-1 text-xs text-muted-foreground">
+          {formatted.date}
+        </div>
+      ) : null}
+      <div className="mt-3 text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+        {zone.timeZone}
+      </div>
+    </div>
+  );
+}
+
+export const WorldClockBar = React.forwardRef<
+  HTMLDivElement,
+  WorldClockBarProps
+>(
+  (
+    {
+      className,
+      now,
+      showDate = true,
+      title = "World clock",
+      updateIntervalMs = 60_000,
+      zones,
+      ...props
+    },
+    ref,
+  ) => {
+    const liveNow = useLiveDate(now, updateIntervalMs);
+
+    return (
+      <div className={cn("space-y-3", className)} ref={ref} {...props}>
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
+            <p className="text-sm text-muted-foreground">
+              Synchronized time across distributed teams and regions.
+            </p>
+          </div>
+          <Badge variant="outline">{zones.length} zones</Badge>
+        </div>
+
+        <div className="flex gap-3 overflow-x-auto pb-1">
+          {zones.map((zone) => (
+            <WorldClockCard
+              date={liveNow}
+              key={`${zone.city}-${zone.timeZone}`}
+              showDate={showDate}
+              zone={zone}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  },
+);
+
+WorldClockBar.displayName = "WorldClockBar";

--- a/apps/registry/registry/default/zoom-hud/zoom-hud.tsx
+++ b/apps/registry/registry/default/zoom-hud/zoom-hud.tsx
@@ -1,1 +1,61 @@
-export { ZoomHUD, type ZoomHUDProps } from '@vllnt/ui'
+import { forwardRef } from "react";
+
+import { Minus, Plus, RotateCcw } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+import { Button } from "@vllnt/ui";
+
+export type ZoomHUDProps = React.ComponentPropsWithoutRef<"div"> & {
+  onReset?: () => void;
+  onZoomIn?: () => void;
+  onZoomOut?: () => void;
+  zoom: number;
+};
+
+const ZoomHUD = forwardRef<HTMLDivElement, ZoomHUDProps>(
+  ({ className, onReset, onZoomIn, onZoomOut, zoom, ...props }, ref) => (
+    <div
+      className={cn(
+        "inline-flex items-center gap-1 rounded-sm border border-border bg-background p-1 font-mono",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    >
+      <Button
+        aria-label="Zoom out"
+        onClick={onZoomOut}
+        size="icon"
+        type="button"
+        variant="ghost"
+      >
+        <Minus className="size-4" />
+      </Button>
+      <div className="min-w-16 px-2 text-center text-xs font-medium tabular-nums text-foreground">
+        {Math.round(zoom * 100)}%
+      </div>
+      <Button
+        aria-label="Zoom in"
+        onClick={onZoomIn}
+        size="icon"
+        type="button"
+        variant="ghost"
+      >
+        <Plus className="size-4" />
+      </Button>
+      <Button
+        aria-label="Reset zoom"
+        onClick={onReset}
+        size="icon"
+        type="button"
+        variant="ghost"
+      >
+        <RotateCcw className="size-4" />
+      </Button>
+    </div>
+  ),
+);
+
+ZoomHUD.displayName = "ZoomHUD";
+
+export { ZoomHUD };

--- a/apps/registry/scripts/inline-component-source.ts
+++ b/apps/registry/scripts/inline-component-source.ts
@@ -1,0 +1,169 @@
+/**
+ * Inline real component source from `@vllnt/ui` package into registry shim files.
+ *
+ * Why: shadcn-CLI installs (`pnpm dlx shadcn@latest add https://<host>/r/<x>.json`)
+ * must produce working standalone code in any React codebase. The previous shim
+ * pattern (`export * from "@vllnt/ui"`) re-exported everything but stripped the
+ * leaf component's source, so consumers couldn't customize. Pure copy-paste with
+ * sibling components inlined would bloat the consumer project across 200+ files.
+ *
+ * Hybrid approach:
+ *   - Leaf component source is inlined (consumers can customize the actual file)
+ *   - Sibling primitives, lib utilities, and hooks resolve through `@vllnt/ui`
+ *     as a single npm peer dep — `import { Dialog, cn } from "@vllnt/ui"` etc.
+ *
+ * Rewrites applied to each component source:
+ *   - `from "../../lib/utils"`           → `from "@vllnt/ui"`
+ *   - `from "../../lib/types"`           → `from "@vllnt/ui"`
+ *   - `from "../../lib/use-X"`           → `from "@vllnt/ui"`
+ *   - `from "../<sibling>/<sibling>"`    → `from "@vllnt/ui"`
+ *   - `from "../<sibling>"`              → `from "@vllnt/ui"`
+ *
+ * `registryDependencies` is set to `[]` for each component (no transitive registry
+ * pulls — `@vllnt/ui` covers all internals). The npm `dependencies` field gets
+ * `@vllnt/ui` so the shadcn CLI installs the package automatically.
+ *
+ * Wire into the build: `pnpm registry:build` runs this before `shadcn build`.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, "../../..");
+const registryJsonPath = join(repoRoot, "apps/registry/registry.json");
+const componentsRoot = join(repoRoot, "packages/ui/src/components");
+const shimsRoot = join(repoRoot, "apps/registry/registry/default");
+const packageJsonPath = join(repoRoot, "packages/ui/package.json");
+
+const PACKAGE_NAME = "@vllnt/ui";
+const RESERVED_REGISTRY_NAMES = new Set([
+  "utils",
+  "types",
+  "use-debounce",
+  "use-horizontal-scroll",
+  "use-mounted",
+]);
+
+type RegistryFile = {
+  path: string;
+  type: string;
+};
+
+type RegistryItem = {
+  category?: string;
+  dependencies?: string[];
+  description?: string;
+  files: RegistryFile[];
+  name: string;
+  registryDependencies?: string[];
+  title?: string;
+  type: string;
+};
+
+type Registry = {
+  items: RegistryItem[];
+};
+
+const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+  version: string;
+};
+const PACKAGE_VERSION_RANGE = `^${packageJson.version}`;
+const PACKAGE_DEP = `${PACKAGE_NAME}@${PACKAGE_VERSION_RANGE}`;
+
+const rewriteImports = (source: string): string => {
+  // Collect import lines that target lib utilities or sibling components
+  // and replace each with a single deduped `import ... from "@vllnt/ui"` block.
+  let code = source;
+
+  // `../../lib/(utils|types|use-X)` → `@vllnt/ui`
+  code = code.replace(
+    /from\s+["'](?:\.\.\/)+lib\/(?:utils|types|use-[a-z-]+)["']/g,
+    `from "${PACKAGE_NAME}"`,
+  );
+
+  // `../<sibling>/<file>` → `@vllnt/ui`
+  code = code.replace(
+    /from\s+["']\.\.\/[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*["']/g,
+    `from "${PACKAGE_NAME}"`,
+  );
+
+  // `../<sibling>` → `@vllnt/ui`
+  code = code.replace(
+    /from\s+["']\.\.\/[a-z][a-z0-9-]*["']/g,
+    `from "${PACKAGE_NAME}"`,
+  );
+
+  return code;
+};
+
+const registry = JSON.parse(readFileSync(registryJsonPath, "utf8")) as Registry;
+
+let processed = 0;
+let skipped = 0;
+
+for (const item of registry.items) {
+  if (RESERVED_REGISTRY_NAMES.has(item.name)) {
+    // Lib/hook entries from a previous run — drop them (now redundant with @vllnt/ui)
+    continue;
+  }
+
+  const sourcePath = join(componentsRoot, item.name, `${item.name}.tsx`);
+  if (!existsSync(sourcePath)) {
+    skipped += 1;
+    continue;
+  }
+
+  const sourceCode = readFileSync(sourcePath, "utf8");
+  const code = rewriteImports(sourceCode);
+
+  // Write rewritten source to shim path
+  const shimDir = join(shimsRoot, item.name);
+  if (!existsSync(shimDir)) {
+    mkdirSync(shimDir, { recursive: true });
+  }
+  writeFileSync(join(shimDir, `${item.name}.tsx`), code);
+
+  // No transitive registry pulls — @vllnt/ui covers all internals
+  item.registryDependencies = [];
+
+  // Ensure @vllnt/ui is in npm dependencies (preserve any other declared deps)
+  const otherDeps = (item.dependencies ?? []).filter(
+    (dep) => !dep.startsWith(`${PACKAGE_NAME}@`) && dep !== PACKAGE_NAME,
+  );
+  item.dependencies = [PACKAGE_DEP, ...otherDeps];
+
+  processed += 1;
+}
+
+// Drop reserved entries that any earlier sync run may have added
+registry.items = registry.items.filter(
+  (item) => !RESERVED_REGISTRY_NAMES.has(item.name),
+);
+
+// Clean up any lingering shim directories for the dropped names
+for (const name of RESERVED_REGISTRY_NAMES) {
+  const dir = join(shimsRoot, name);
+  if (existsSync(dir)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// Sort items alphabetically for deterministic output
+registry.items.sort((a, b) => a.name.localeCompare(b.name));
+
+writeFileSync(registryJsonPath, `${JSON.stringify(registry, null, 2)}\n`);
+
+console.log(
+  `Inlined ${processed} component source files (skipped ${skipped} with no matching source).`,
+);
+console.log(
+  `All siblings/utilities now resolve through ${PACKAGE_NAME}@${PACKAGE_VERSION_RANGE}.`,
+);

--- a/apps/registry/tsconfig.json
+++ b/apps/registry/tsconfig.json
@@ -8,5 +8,5 @@
     "baseUrl": "."
   },
   "include": ["**/*.ts", "**/*.tsx", "**/*.json", "next-env.d.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "registry/**"]
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -15,8 +15,10 @@ export type {
 export {
   getOtherLanguage,
   LANGUAGE_NAMES,
+  type SupportedLanguage,
   type SupportedLanguage as UISupportedLanguage,
 } from "./lib/types";
 export { useDebounce } from "./lib/use-debounce";
 export { useHorizontalScroll } from "./lib/use-horizontal-scroll";
+export { useMounted } from "./lib/use-mounted";
 export { cn } from "./lib/utils";


### PR DESCRIPTION
Closes #100

## Summary

- **Inline real component source** in registry shims (was: `export * from "@vllnt/ui"` shims producing 1-line installs)
- **Resolve siblings/utilities through `@vllnt/ui`** — single npm peer dep replaces 200+ transitive registry pulls
- **Auto-add `@vllnt/ui` to consumer's `package.json`** via the registry's `dependencies` field

Result: `pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/<name>.json` now produces working code in any React codebase.

## How it works

A sync script (`apps/registry/scripts/inline-component-source.ts`) runs before `shadcn build`:

1. Reads source from `packages/ui/src/components/<name>/<name>.tsx`
2. Rewrites:
   - `from "../../lib/utils"` → `from "@vllnt/ui"`
   - `from "../../lib/types"` → `from "@vllnt/ui"`
   - `from "../../lib/use-X"` → `from "@vllnt/ui"`
   - `from "../<sibling>/<sibling>"` → `from "@vllnt/ui"`
3. Writes to `apps/registry/registry/default/<name>/<name>.tsx`
4. Sets `dependencies: ["@vllnt/ui@^0.2.1"]` so shadcn CLI installs the npm package
5. Sets `registryDependencies: []` — no transitive registry pulls, `@vllnt/ui` covers all internals

`registryDependencies` is empty so no host URL is needed in any output — the registry stays portable to whatever Vercel project domain hosts it.

## Verified

End-to-end install tested against a fresh shadcn-compatible project:

```
pnpm dlx shadcn@latest add http://<registry>/r/command.json
→ creates components/command.tsx with `import { Dialog, cn } from "@vllnt/ui"`
→ adds @vllnt/ui@^0.2.1 to package.json
```

Programmatic scan of all 222 generated component JSONs: **0** leaked `../`, `@/components/<x>`, `@/lib/`, or `@/hooks/` imports.

## Test plan

- [ ] CI green
- [ ] Vercel preview deploys serve new shape
- [ ] Manual install of `command`, `playback-ghost`, `gantt-chart`, `accordion` against preview URL