### PR TITLE
docs: fix stale component count + add repo metadata (#249)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Features
 
-- **144 components** — primitives (Button, Input), composites (Command, DataTable, Carousel), and domain families (AI, Financial, Ops, Educational, Billing, Animation)
+- **225 components** — primitives (Button, Input), composites (Command, DataTable, Carousel), and domain families (AI, Financial, Ops, Educational, Billing, Animation, Maps, Canvas, Timelines)
 - **Accessible by default** — Radix UI handles focus, keyboard nav, and ARIA
 - **Tailwind CSS + CVA** — variant-driven styling with full theme override via CSS variables
 - **shadcn-compatible registry** — install individual components with `shadcn add`
@@ -98,7 +98,7 @@ Override CSS variables after importing styles:
 ## Components
 
 <details>
-<summary>All 144 components</summary>
+<summary>All 225 components</summary>
 
 | Category | Components |
 |----------|------------|

--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "@vllnt/ui-monorepo",
   "private": true,
   "version": "0.1.0",
+  "homepage": "https://ui.vllnt.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vllnt/ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/vllnt/ui/issues"
+  },
   "packageManager": "pnpm@9.15.4",
   "scripts": {
     "dev": "turbo dev",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@vllnt/ui",
   "version": "0.2.1",
-  "description": "React component library — 93 components built on Radix UI, Tailwind CSS, and CVA",
+  "description": "React component library — 225 components built on Radix UI, Tailwind CSS, and CVA",
   "license": "MIT",
   "author": "vllnt",
-  "homepage": "https://github.com/vllnt/ui#readme",
+  "homepage": "https://ui.vllnt.ai",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/vllnt/ui.git",


### PR DESCRIPTION
## Summary
- `README.md` opening feature line said **144 components**; actual count from `apps/registry/registry.json` is **225**. Fixed (2 occurrences).
- `packages/ui/package.json` description claimed **93 components**. Fixed.
- Root `package.json` had no `homepage`, `repository`, or `bugs` fields — added so npm and discovery tools link back to `ui.vllnt.ai` / GitHub.
- `packages/ui/package.json` `homepage` repointed from GitHub anchor to canonical site `https://ui.vllnt.ai`.

## Validation
- `jq empty` passes on both JSON files.
- Component count cross-checked: `jq '.items | length' apps/registry/registry.json` → 225.
- No source code changes; lint / typecheck / build / test gates unaffected.

## Test plan
- [ ] README renders correctly on GitHub with new count + categories.
- [ ] `pnpm install` still resolves at the root.
- [ ] `npm view @vllnt/ui-monorepo` (when published) would show new repo metadata (private package, so this is for npm-style introspection only).

Closes #249