### PR TITLE
ci: enforce type field on every issue (#282)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,7 @@ name: Bug report
 description: Report a broken behavior in @vllnt/ui
 title: "[bug] "
 labels: ["bug"]
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,7 @@ name: Feature request
 description: Propose a new component, variant, or API addition
 title: "[feat] "
 labels: ["enhancement"]
+type: Feature
 body:
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,38 @@
+name: Task
+description: A specific piece of work — chore, refactor, infra, docs, sweep
+title: "[task] "
+labels: ["enhancement"]
+type: Task
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What this task accomplishes and why.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Checklist of what "done" looks like.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, prior art, related issues.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I searched existing issues to avoid duplicates.
+          required: true

--- a/.github/workflows/issue-type-enforcer.yml
+++ b/.github/workflows/issue-type-enforcer.yml
@@ -1,0 +1,49 @@
+name: Issue Type Enforcer
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  issues: write
+
+concurrency:
+  group: issue-type-enforcer-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Require type on issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify issue type is set
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          OWNER="${REPO%/*}"
+          NAME="${REPO#*/}"
+
+          TYPE=$(gh api graphql \
+            -f query="query{repository(owner:\"$OWNER\",name:\"$NAME\"){issue(number:$ISSUE_NUMBER){issueType{name}}}}" \
+            --jq '.data.repository.issue.issueType.name // "NONE"')
+
+          echo "issue=#$ISSUE_NUMBER type=$TYPE"
+
+          if [ "$TYPE" = "NONE" ]; then
+            gh issue edit "$ISSUE_NUMBER" --add-label "needs-triage" -R "$REPO" >/dev/null
+            EXISTING=$(gh issue view "$ISSUE_NUMBER" -R "$REPO" --json comments --jq '[.comments[] | select(.body | contains("issue is missing a **type**"))] | length')
+            if [ "$EXISTING" = "0" ]; then
+              gh issue comment "$ISSUE_NUMBER" -R "$REPO" --body "This issue is missing a **type** (Task / Bug / Feature). A maintainer will set one shortly. See [CONTRIBUTING.md → Issue types](https://github.com/${REPO}/blob/main/CONTRIBUTING.md#issue-types)."
+            fi
+            exit 1
+          fi
+
+          gh issue edit "$ISSUE_NUMBER" --remove-label "needs-triage" -R "$REPO" >/dev/null 2>&1 || true
+          echo "Type set ($TYPE) — passing."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,3 +93,15 @@ Canary builds ship automatically on every push to `main`.
 ## Reporting bugs / requesting features
 
 Use the GitHub issue templates under [Issues](https://github.com/vllnt/ui/issues/new/choose). Include repro steps, expected vs. actual, and environment details.
+
+## Issue types
+
+Every issue carries a **type**: `Bug`, `Feature`, or `Task`. The repo's issue templates (`bug_report.yml`, `feature_request.yml`, `task.yml`) set this automatically — please use them.
+
+| Type | When |
+|------|------|
+| `Bug` | Something is broken — wrong output, crash, regression, accessibility violation, security issue. |
+| `Feature` | New user-visible capability — new component, new public API, new site surface. |
+| `Task` | Internal work — refactor, infra, docs, CI, sweeps, dependency bumps, version bumps. |
+
+A CI check (`.github/workflows/issue-type-enforcer.yml`) labels typeless issues `needs-triage` and posts a reminder. Maintainers triage these manually.


### PR DESCRIPTION
## Summary
- Add `type:` to all issue form templates so GitHub auto-sets it at creation:
  - `bug_report.yml` → `Bug`
  - `feature_request.yml` → `Feature`
  - **new** `task.yml` → `Task` (catch-all for chores / infra / docs / sweeps)
- Add `.github/workflows/issue-type-enforcer.yml` that runs on `issues.opened/edited/reopened`. If `issueType == null`, it adds `needs-triage` and posts a one-time comment pointing at `CONTRIBUTING.md`. When type is set, it removes `needs-triage` and passes.
- Document the policy in `CONTRIBUTING.md` (new "Issue types" section).

## Why
GitHub repo-level issue types were configured but not enforced. Typeless issues broke Insights / project board grouping and skipped any automation that depends on type. The 3-layer approach (template default + CI gate + docs) catches it at every entry point.

## Validation
- Each template is valid YAML (`yaml.safe_load`).
- Workflow uses the same `gh api graphql` query already used in this repo's manual sweep — proven to read `issueType` correctly.
- Comment is de-duplicated by string match so re-edits don't spam.

## Test plan
- [ ] Open a test issue without a template → workflow adds `needs-triage` and comments.
- [ ] Set the type via the GitHub UI → workflow re-runs (issues.edited), removes `needs-triage`, passes.
- [ ] Open via the new `task.yml` template → opens with type=Task, workflow passes silently.
- [ ] Verify all 50 currently-open issues remain in their pre-set types (this PR doesn't touch them).

Closes #282