### PR TITLE
ci: add react-doctor workflow with PR annotations + main artifact (#280)

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,0 +1,61 @@
+name: react-doctor
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+concurrency:
+  group: react-doctor-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Scan codebase health
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: react-doctor (PR diff)
+        if: github.event_name == 'pull_request'
+        run: |
+          npx --yes react-doctor . \
+            --diff origin/${{ github.base_ref }} \
+            --annotations \
+            --fail-on error \
+            --offline
+
+      - name: react-doctor (full scan on main)
+        if: github.event_name == 'push'
+        run: |
+          npx --yes react-doctor . \
+            --json \
+            --offline > rd-report.json
+          jq '.summary' rd-report.json
+
+      - name: Upload report
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: react-doctor-report
+          path: rd-report.json
+          retention-days: 30


### PR DESCRIPTION
## Summary
Adds `.github/workflows/react-doctor.yml` so codebase health (score 62 baseline) is enforced and tracked.

## Behavior
- **Pull requests**: scans the diff against the base branch with `--annotations` so diagnostics surface inline on changed hunks. `--fail-on error` blocks merges that introduce **new** errors. Existing 7 errors are tracked separately in #266.
- **Push to main**: full scan, JSON report uploaded as a 30-day artifact for the score badge / regression tracking.
- Concurrency group cancels superseded runs.

## Validation
- YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Uses the same `pnpm/action-setup@v4` + `setup-node@v4` pattern as `ci.yml`.
- `--offline` flag is set so the runner doesn't make telemetry calls.

## Test plan
- [ ] First PR after merge triggers the workflow on the diff.
- [ ] Push to main triggers full scan and uploads artifact.
- [ ] Annotations appear on the PR diff for any new violation.
- [ ] Existing 7 baseline errors do not block this PR (it's diff-mode against base).

## Score gate strategy (per #279 epic)
- Phase 1 (now): `--fail-on error` only.
- Phase 2 (after #266 lands): tighten to `--fail-on warning` for changed files.
- Phase 3 (after sweep): repo-wide; gate score ≥ 80.

Closes #280