### PR TITLE
fix: clear all 7 react-doctor BLOCKING errors (#266)

### DIFF
--- a/apps/registry/registry/default/combobox/combobox.tsx
+++ b/apps/registry/registry/default/combobox/combobox.tsx
@@ -106,6 +106,7 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
     reference,
   ) => {
     const [open, setOpen] = React.useState(false);
+    const listboxId = React.useId();
     const { resolvedValue, setResolvedValue } = useComboboxValue(
       value,
       onValueChange,
@@ -123,7 +124,9 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
       <Popover onOpenChange={setOpen} open={open}>
         <PopoverTrigger asChild>
           <Button
+            aria-controls={listboxId}
             aria-expanded={open}
+            aria-haspopup="listbox"
             className={cn("w-full justify-between", triggerClassName)}
             ref={reference}
             role="combobox"
@@ -143,7 +146,7 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
         >
           <Command className={commandClassName}>
             <CommandInput placeholder={searchPlaceholder} />
-            <CommandList>
+            <CommandList id={listboxId}>
               <CommandEmpty>{emptyText}</CommandEmpty>
               <CommandGroup>
                 {options.map((option) => (

--- a/packages/ui/src/components/ai-chat-input/ai-chat-input.stories.tsx
+++ b/packages/ui/src/components/ai-chat-input/ai-chat-input.stories.tsx
@@ -14,27 +14,29 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  render: () => {
-    const [value, setValue] = React.useState(
-      "Draft a release note for the latest accessibility fixes.",
-    );
+function DefaultChatInputDemo() {
+  const [value, setValue] = React.useState(
+    "Draft a release note for the latest accessibility fixes.",
+  );
 
-    return (
-      <div className="max-w-2xl">
-        <AIChatInput
-          helperText="Shift + Enter adds a new line"
-          onSubmit={(event) => {
-            event.preventDefault();
-          }}
-          onValueChange={setValue}
-          status="2 files attached"
-          toolbar={<Badge variant="secondary">Repo context</Badge>}
-          value={value}
-        />
-      </div>
-    );
-  },
+  return (
+    <div className="max-w-2xl">
+      <AIChatInput
+        helperText="Shift + Enter adds a new line"
+        onSubmit={(event) => {
+          event.preventDefault();
+        }}
+        onValueChange={setValue}
+        status="2 files attached"
+        toolbar={<Badge variant="secondary">Repo context</Badge>}
+        value={value}
+      />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <DefaultChatInputDemo />,
 };
 
 export const Submitting: Story = {

--- a/packages/ui/src/components/combobox/combobox.tsx
+++ b/packages/ui/src/components/combobox/combobox.tsx
@@ -106,6 +106,7 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
     reference,
   ) => {
     const [open, setOpen] = React.useState(false);
+    const listboxId = React.useId();
     const { resolvedValue, setResolvedValue } = useComboboxValue(
       value,
       onValueChange,
@@ -123,7 +124,9 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
       <Popover onOpenChange={setOpen} open={open}>
         <PopoverTrigger asChild>
           <Button
+            aria-controls={listboxId}
             aria-expanded={open}
+            aria-haspopup="listbox"
             className={cn("w-full justify-between", triggerClassName)}
             ref={reference}
             role="combobox"
@@ -143,7 +146,7 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
         >
           <Command className={commandClassName}>
             <CommandInput placeholder={searchPlaceholder} />
-            <CommandList>
+            <CommandList id={listboxId}>
               <CommandEmpty>{emptyText}</CommandEmpty>
               <CommandGroup>
                 {options.map((option) => (

--- a/packages/ui/src/components/conversation-thread/conversation-thread.stories.tsx
+++ b/packages/ui/src/components/conversation-thread/conversation-thread.stories.tsx
@@ -89,33 +89,35 @@ export const EmptyState: Story = {
   ),
 };
 
-export const Streaming: Story = {
-  render: () => {
-    const [messages] = React.useState<ConversationMessage[]>([
-      {
-        id: "user-1",
-        role: "user",
-        content: "Draft the announcement post.",
-      },
-      {
-        id: "assistant-1",
-        role: "assistant",
-        content: "I’m drafting a concise launch announcement",
-        isStreaming: true,
-      },
-    ]);
+function StreamingThreadDemo() {
+  const [messages] = React.useState<ConversationMessage[]>([
+    {
+      id: "user-1",
+      role: "user",
+      content: "Draft the announcement post.",
+    },
+    {
+      id: "assistant-1",
+      role: "assistant",
+      content: "I’m drafting a concise launch announcement",
+      isStreaming: true,
+    },
+  ]);
 
-    return (
-      <ConversationThread isStreaming={true} messages={messages}>
-        <ConversationHeader>
-          <ConversationTitle>Workspace assistant</ConversationTitle>
-        </ConversationHeader>
-        <ConversationMessages>
-          <ConversationEmpty />
-          <ConversationScrollButton />
-          <ConversationLoading />
-        </ConversationMessages>
-      </ConversationThread>
-    );
-  },
+  return (
+    <ConversationThread isStreaming={true} messages={messages}>
+      <ConversationHeader>
+        <ConversationTitle>Workspace assistant</ConversationTitle>
+      </ConversationHeader>
+      <ConversationMessages>
+        <ConversationEmpty />
+        <ConversationScrollButton />
+        <ConversationLoading />
+      </ConversationMessages>
+    </ConversationThread>
+  );
+}
+
+export const Streaming: Story = {
+  render: () => <StreamingThreadDemo />,
 };

--- a/packages/ui/src/components/multi-select/multi-select.stories.tsx
+++ b/packages/ui/src/components/multi-select/multi-select.stories.tsx
@@ -31,17 +31,19 @@ export const Searchable: Story = {
   },
 };
 
+function ControlledMultiSelectDemo(props: React.ComponentProps<typeof MultiSelect>) {
+  const [value, setValue] = React.useState(["react", "vue"]);
+
+  return (
+    <div className="w-full max-w-sm">
+      <MultiSelect {...props} onValueChange={setValue} value={value} />
+    </div>
+  );
+}
+
 export const Controlled: Story = {
   args: {
     searchable: true,
   },
-  render: (args) => {
-    const [value, setValue] = React.useState(["react", "vue"]);
-
-    return (
-      <div className="w-full max-w-sm">
-        <MultiSelect {...args} onValueChange={setValue} value={value} />
-      </div>
-    );
-  },
+  render: (args) => <ControlledMultiSelectDemo {...args} />,
 };

--- a/packages/ui/src/components/segmented-control/segmented-control.stories.tsx
+++ b/packages/ui/src/components/segmented-control/segmented-control.stories.tsx
@@ -35,19 +35,21 @@ export const Disabled: Story = {
   ),
 };
 
-export const Controlled: Story = {
-  render: () => {
-    const [value, setValue] = React.useState("activity");
+function ControlledSegmentedControlDemo() {
+  const [value, setValue] = React.useState("activity");
 
-    return (
-      <div className="w-full max-w-sm space-y-3">
-        <SegmentedControl aria-label="Dashboard section" onValueChange={setValue} value={value}>
-          <SegmentedControlItem value="activity">Activity</SegmentedControlItem>
-          <SegmentedControlItem value="usage">Usage</SegmentedControlItem>
-          <SegmentedControlItem value="members">Members</SegmentedControlItem>
-        </SegmentedControl>
-        <p className="text-sm text-muted-foreground">Selected: {value}</p>
-      </div>
-    );
-  },
+  return (
+    <div className="w-full max-w-sm space-y-3">
+      <SegmentedControl aria-label="Dashboard section" onValueChange={setValue} value={value}>
+        <SegmentedControlItem value="activity">Activity</SegmentedControlItem>
+        <SegmentedControlItem value="usage">Usage</SegmentedControlItem>
+        <SegmentedControlItem value="members">Members</SegmentedControlItem>
+      </SegmentedControl>
+      <p className="text-sm text-muted-foreground">Selected: {value}</p>
+    </div>
+  );
+}
+
+export const Controlled: Story = {
+  render: () => <ControlledSegmentedControlDemo />,
 };

--- a/packages/ui/src/components/tags-input/tags-input.stories.tsx
+++ b/packages/ui/src/components/tags-input/tags-input.stories.tsx
@@ -27,19 +27,21 @@ export const Empty: Story = {
   },
 };
 
-export const Controlled: Story = {
-  render: () => {
-    const [value, setValue] = React.useState(["Design", "Docs"]);
+function ControlledTagsInputDemo() {
+  const [value, setValue] = React.useState(["Design", "Docs"]);
 
-    return (
-      <div className="w-full max-w-sm">
-        <TagsInput
-          aria-label="Controlled tags"
-          onValueChange={setValue}
-          placeholder="Add a workflow tag"
-          value={value}
-        />
-      </div>
-    );
-  },
+  return (
+    <div className="w-full max-w-sm">
+      <TagsInput
+        aria-label="Controlled tags"
+        onValueChange={setValue}
+        placeholder="Add a workflow tag"
+        value={value}
+      />
+    </div>
+  );
+}
+
+export const Controlled: Story = {
+  render: () => <ControlledTagsInputDemo />,
 };


### PR DESCRIPTION
## Summary
react-doctor reported **7 errors** on `main` before this PR. After: **0 errors**, score **62 → 67**.

| Rule | Before | After |
|---|---|---|
| `role-has-required-aria-props` | 2 (combobox) | 0 |
| `rules-of-hooks` | 5 (story files) | 0 |

## Two root causes

### 1. Combobox a11y — missing `aria-controls`
The Button trigger had `role="combobox"` + `aria-expanded` but no `aria-controls`. Per [WAI-ARIA Combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/), `aria-controls` must point at the listbox id.

- Added `const listboxId = React.useId()` for a stable, SSR-safe id.
- Set `id={listboxId}` on `CommandList`.
- Added `aria-controls={listboxId}` and `aria-haspopup="listbox"` to the trigger.
- **Mirrored** to `registry/default/combobox/combobox.tsx` so both consumers stay aligned (drift is tracked separately in #269).

### 2. Story files — `useState` from anonymous render arrows
Five `Controlled` / `Default` / `Streaming` stories invoked hooks from `render: () => { ... }` arrows. React's `rules-of-hooks` requires hooks be called from a React function component (capitalised) or custom hook.

Each render body was extracted into a named React component (e.g. `ControlledTagsInputDemo`, `StreamingThreadDemo`) which the story now renders. **Pure refactor — runtime behaviour identical.**

## Files changed
- `packages/ui/src/components/combobox/combobox.tsx`
- `apps/registry/registry/default/combobox/combobox.tsx`
- `packages/ui/src/components/conversation-thread/conversation-thread.stories.tsx`
- `packages/ui/src/components/tags-input/tags-input.stories.tsx`
- `packages/ui/src/components/segmented-control/segmented-control.stories.tsx`
- `packages/ui/src/components/multi-select/multi-select.stories.tsx`
- `packages/ui/src/components/ai-chat-input/ai-chat-input.stories.tsx`

## Validation
- `npx react-doctor . --offline --json` → `errorCount: 0`, `score: 67` (was 62).
- Stories: refactor-only — Storybook visual snapshots unchanged.
- Combobox: ARIA addition only — no layout / behavioural change.

## Test plan
- [ ] CI `react-doctor` (#280) passes with 0 new errors.
- [ ] Storybook builds; the 5 refactored stories render and respond to interaction as before.
- [ ] Combobox stories pass axe-core checks.
- [ ] Visual regression suite green for combobox + 5 stories.

## Unblocks
- #279 (react-doctor sweep epic) — Phase 0 complete after this lands; Phase 1 warning sweep can begin.
- CI gate from #280 can tighten from `--fail-on error` (current) to `--fail-on warning` for changed files.

Closes #266