### PR TITLE
feat(dx): add pnpm doctor* scripts (#278)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,14 @@
     "test:once": "turbo test:once",
     "clean": "turbo clean",
     "check:circular": "turbo check:circular",
-    "registry:build": "turbo registry:build"
+    "registry:build": "turbo registry:build",
+    "doctor": "npx --yes react-doctor . --offline",
+    "doctor:full": "npx --yes react-doctor . --offline --full --verbose",
+    "doctor:json": "npx --yes react-doctor . --offline --json > .react-doctor.json",
+    "doctor:errors": "npx --yes react-doctor . --offline --fail-on error",
+    "doctor:diff": "npx --yes react-doctor . --offline --diff origin/main",
+    "doctor:staged": "npx --yes react-doctor . --offline --staged --fail-on error",
+    "doctor:score": "npx --yes react-doctor . --offline --score"
   },
   "devDependencies": {
     "turbo": "^2.4.4"


### PR DESCRIPTION
## Summary
Adds 7 root scripts as muscle-memory entry points to `react-doctor`:

| Script | What |
|---|---|
| `pnpm doctor` | quick offline scan |
| `pnpm doctor:full` | verbose, full pass |
| `pnpm doctor:json` | JSON report at `.react-doctor.json` |
| `pnpm doctor:errors` | fail-on-error gate |
| `pnpm doctor:diff` | scan against `origin/main` |
| `pnpm doctor:staged` | scan staged files only (pre-commit ready) |
| `pnpm doctor:score` | numeric score only |

## Decisions
- Uses `npx --yes react-doctor` — matches the CI workflow (#280) pattern. **No devDependency added**, no lockfile churn.
- **Husky + lint-staged deferred** — repo has no `.husky/` today. Adding that is a separate infrastructure decision, not bundled here. The `doctor:staged` script is ready when Husky lands.

## Validation
- JSON parses (`jq empty package.json`).
- Script names follow the existing `doctor:` namespace convention.
- No new deps means no security review needed for this PR.

## Test plan
- [ ] `pnpm doctor` runs from repo root.
- [ ] `pnpm doctor:errors` exits 0 on `main` (Phase 0 #266 cleared all errors).
- [ ] `pnpm doctor:score` prints numeric score.
- [ ] Post-merge: AGENTS.md / CONTRIBUTING.md to gain a "before pushing: pnpm doctor" pointer (separate small follow-up).

## Depends on
- #280 (CI react-doctor workflow — already merged) for cadence consistency.

Closes #278