### PR TITLE
feat(seo): add robots.ts allowing all crawlers + AI bots (#233)

### DIFF
--- a/apps/registry/app/robots.ts
+++ b/apps/registry/app/robots.ts
@@ -1,0 +1,36 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+
+const AI_CRAWLERS = [
+  "GPTBot",
+  "ClaudeBot",
+  "Claude-Web",
+  "anthropic-ai",
+  "PerplexityBot",
+  "Google-Extended",
+  "Applebot-Extended",
+  "CCBot",
+  "Bytespider",
+  "Amazonbot",
+  "cohere-ai",
+];
+
+export default function robots(): MetadataRoute.Robots {
+  const aiAllow = AI_CRAWLERS.map((userAgent) => ({
+    userAgent,
+    allow: "/",
+  }));
+
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+      ...aiAllow,
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}


### PR DESCRIPTION
## Summary
Adds `apps/registry/app/robots.ts` so crawlers get explicit directives instead of the empty default.

- `User-agent: *` → `allow: /`
- Explicit allow for **11 AI crawlers**: `GPTBot`, `ClaudeBot`, `Claude-Web`, `anthropic-ai`, `PerplexityBot`, `Google-Extended`, `Applebot-Extended`, `CCBot`, `Bytespider`, `Amazonbot`, `cohere-ai`.
- `sitemap` → `https://ui.vllnt.ai/sitemap.xml` (companion #234, in flight).
- `host` pinned to canonical URL.
- `NEXT_PUBLIC_SITE_URL` respected so preview deploys emit the right host.

## Why explicit AI allows?
Per locked decision in epic #252, AI crawlers are allowed. Naming them explicitly:
- Surfaces intent to anyone reading the file.
- Future-proofs against bots changing their compliance to the wildcard rule.
- Gives us a single audit point if we later want to disallow one.

## Validation
- TypeScript types come from `next` (`MetadataRoute.Robots`).
- File is a Next.js metadata route — built into the framework, no extra deps.

## Test plan
- [ ] After deploy: `curl -s https://ui.vllnt.ai/robots.txt` returns `User-agent: *` block + 11 AI crawlers + `Sitemap:` line + `Host:` line.
- [ ] Companion #234 (sitemap) deploys around the same time so the `Sitemap:` link resolves.

Closes #233