### PR TITLE
feat(seo): add sitemap.ts enumerating routes + 225 components (#234)

### DIFF
--- a/apps/registry/app/sitemap.ts
+++ b/apps/registry/app/sitemap.ts
@@ -1,0 +1,66 @@
+import type { MetadataRoute } from "next";
+
+import registry from "../registry.json";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+
+type RegistryItem = {
+  readonly name: string;
+};
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: SITE_URL,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 1.0,
+    },
+    {
+      url: `${SITE_URL}/components`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 1.0,
+    },
+    {
+      url: `${SITE_URL}/docs`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/philosophy`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+  ];
+
+  const items = (registry as { readonly items: readonly RegistryItem[] }).items;
+
+  const componentRoutes: MetadataRoute.Sitemap = items.map((item) => ({
+    url: `${SITE_URL}/components/${item.name}`,
+    lastModified,
+    changeFrequency: "weekly",
+    priority: 0.7,
+  }));
+
+  const registryEndpoints: MetadataRoute.Sitemap = [
+    {
+      url: `${SITE_URL}/r/registry.json`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.3,
+    },
+    ...items.map((item) => ({
+      url: `${SITE_URL}/r/${item.name}.json`,
+      lastModified,
+      changeFrequency: "weekly" as const,
+      priority: 0.3,
+    })),
+  ];
+
+  return [...staticRoutes, ...componentRoutes, ...registryEndpoints];
+}


### PR DESCRIPTION
## Summary
Adds `apps/registry/app/sitemap.ts` emitting a programmatic sitemap from `registry.json`.

| Section | URLs | Priority |
|---|---|---|
| Static (`/`, `/components`, `/docs`, `/philosophy`) | 4 | 1.0 / 1.0 / 0.8 / 0.6 |
| Component pages (`/components/<name>`) | 225 | 0.7 |
| Raw registry JSON (`/r/registry.json` + per-item `/r/<name>.json`) | 226 | 0.3 |
| **Total** | **~455** | |

## Why include /r/*.json?
Agents (Cursor, Claude, Continue) discover the library via these endpoints. Listing them in the sitemap (low priority) makes them crawlable without polluting search-engine ranking signal.

## Validation
- Imports `registry.json` via Next.js JSON module support.
- TypeScript types via `next/MetadataRoute.Sitemap`.
- All `lastModified` set at request time so re-deploys refresh dates.

## Test plan
- [ ] After deploy: `curl -s https://ui.vllnt.ai/sitemap.xml | xmllint --noout -` passes (valid XML).
- [ ] URL count ≈ 455.
- [ ] Sample component URL (e.g. `/components/button`) appears with `priority=0.7`.

## Depends on
- #233 (robots.ts links to this URL — both ship same window).

Closes #234