### PR TITLE
feat(seo): serve /llms.txt per llmstxt.org spec (#235)

### DIFF
--- a/apps/registry/app/llms.txt/route.ts
+++ b/apps/registry/app/llms.txt/route.ts
@@ -1,0 +1,126 @@
+import registry from "../../registry.json";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+
+type RegistryItem = {
+  readonly name: string;
+  readonly title: string;
+  readonly description: string;
+  readonly category: string;
+};
+
+const CATEGORY_ORDER: readonly string[] = [
+  "core",
+  "form",
+  "navigation",
+  "overlay",
+  "data",
+  "data-display",
+  "content",
+  "ai",
+  "educational",
+  "learning",
+  "billing",
+  "utility",
+];
+
+const CATEGORY_LABEL: Record<string, string> = {
+  ai: "AI",
+  billing: "Billing & Plans",
+  content: "Content",
+  core: "Core primitives",
+  data: "Data",
+  "data-display": "Data display",
+  educational: "Educational",
+  form: "Form",
+  learning: "Learning",
+  navigation: "Navigation",
+  overlay: "Overlay",
+  utility: "Utility",
+};
+
+function buildLlmsTxt(): string {
+  const items = (registry as { readonly items: readonly RegistryItem[] }).items;
+
+  const grouped = new Map<string, RegistryItem[]>();
+  for (const item of items) {
+    const bucket = grouped.get(item.category) ?? [];
+    bucket.push(item);
+    grouped.set(item.category, bucket);
+  }
+
+  const sortedCategories = [
+    ...CATEGORY_ORDER.filter((c) => grouped.has(c)),
+    ...[...grouped.keys()]
+      .filter((c) => !CATEGORY_ORDER.includes(c))
+      .sort(),
+  ];
+
+  const lines: string[] = [];
+
+  lines.push("# VLLNT UI");
+  lines.push("");
+  lines.push(
+    "> Agent-first React component registry. " +
+      `${items.length} accessible components built on Radix UI, Tailwind CSS, and CVA. ` +
+      "Install via the shadcn CLI against any /r/<name>.json endpoint.",
+  );
+  lines.push("");
+
+  lines.push("## Docs");
+  lines.push("");
+  lines.push(`- [Get Started](${SITE_URL}/): install and use any component`);
+  lines.push(
+    `- [Documentation](${SITE_URL}/docs): theming, registry usage, conventions`,
+  );
+  lines.push(
+    `- [Philosophy](${SITE_URL}/philosophy): design principles and component patterns`,
+  );
+  lines.push(
+    `- [Components index](${SITE_URL}/components): browse all components by category`,
+  );
+  lines.push("");
+
+  lines.push("## Registry API");
+  lines.push("");
+  lines.push(
+    `- [Registry index](${SITE_URL}/r/registry.json): full machine-readable list of all components`,
+  );
+  lines.push(
+    `- [Sitemap](${SITE_URL}/sitemap.xml): every public route, refreshed per deploy`,
+  );
+  lines.push(
+    "- Install command: `pnpm dlx shadcn@latest add " +
+      `${SITE_URL}/r/<name>.json` +
+      "`",
+  );
+  lines.push("");
+
+  for (const category of sortedCategories) {
+    const bucket = grouped.get(category);
+    if (!bucket || bucket.length === 0) continue;
+    const label = CATEGORY_LABEL[category] ?? category;
+    lines.push(`## Components — ${label}`);
+    lines.push("");
+    for (const item of [...bucket].sort((a, b) => a.name.localeCompare(b.name))) {
+      lines.push(
+        `- [${item.title}](${SITE_URL}/components/${item.name}): ${item.description}`,
+      );
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+export const dynamic = "force-static";
+export const revalidate = 86400;
+
+export function GET(): Response {
+  return new Response(buildLlmsTxt(), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=0, s-maxage=86400, stale-while-revalidate=604800",
+    },
+  });
+}


### PR DESCRIPTION
## Summary
Next.js Route Handler at \`apps/registry/app/llms.txt/route.ts\` emits \`text/plain\` following the [llmstxt.org](https://llmstxt.org) spec.

Format:
- \`# VLLNT UI\` H1
- \`> ...\` blockquote summary (auto-counts components)
- \`## Docs\` — Get Started, Documentation, Philosophy, Components index
- \`## Registry API\` — registry.json, sitemap, install command
- \`## Components — <Category>\` sections grouped by registry \`category\` (12 categories)

Generated from \`registry.json\` so the file stays in sync with all 225 components without manual edits.

## Validation
- \`force-static\` + \`revalidate=86400\` so the file is served from edge cache, regenerated daily.
- \`Cache-Control\` header tuned: \`s-maxage=86400, stale-while-revalidate=604800\`.
- Categories sorted by a curated order then alphabetical fallback.
- Component lists sorted alphabetically within each category.

## Test plan
- [ ] After deploy: \`curl -s https://ui.vllnt.ai/llms.txt | head -30\` shows H1 + blockquote + Docs + Registry API.
- [ ] Component count line matches \`registry.json.items.length\` (225).
- [ ] Validates against [llmstxt.org spec](https://llmstxt.org).

## Depends on
- #233 (robots.ts — already merged) — robots links the sitemap, llms.txt is independent.
- #234 (sitemap — already merged) — referenced from llms.txt.

Closes #235