### PR TITLE
feat(seo): serve /llms-full.txt with full docs + component descriptors (#236)

### DIFF
--- a/apps/registry/app/llms-full.txt/route.ts
+++ b/apps/registry/app/llms-full.txt/route.ts
@@ -1,0 +1,120 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import registry from "../../registry.json";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+
+type RegistryItem = {
+  readonly name: string;
+  readonly title: string;
+  readonly description: string;
+  readonly category: string;
+  readonly dependencies?: readonly string[];
+  readonly registryDependencies?: readonly string[];
+};
+
+const DOC_PAGES: ReadonlyArray<{ slug: string; title: string }> = [
+  { slug: "home", title: "Get Started" },
+  { slug: "docs", title: "Documentation" },
+  { slug: "philosophy", title: "Philosophy" },
+  { slug: "components", title: "Components Overview" },
+];
+
+function stripFrontmatter(source: string): string {
+  if (!source.startsWith("---")) return source;
+  const end = source.indexOf("\n---", 3);
+  if (end === -1) return source;
+  return source.slice(end + 4).replace(/^\n+/, "");
+}
+
+async function readDocPage(slug: string): Promise<string> {
+  const file = path.join(
+    process.cwd(),
+    "content",
+    "pages",
+    `${slug}.mdx`,
+  );
+  try {
+    const raw = await readFile(file, "utf8");
+    return stripFrontmatter(raw).trim();
+  } catch {
+    return "";
+  }
+}
+
+async function buildLlmsFullTxt(): Promise<string> {
+  const items = (registry as { readonly items: readonly RegistryItem[] }).items;
+
+  const lines: string[] = [];
+
+  lines.push("# VLLNT UI — Full Reference");
+  lines.push("");
+  lines.push(
+    "> One-fetch, complete agent context for the VLLNT UI registry. " +
+      `${items.length} components, install via shadcn CLI against /r/<name>.json. ` +
+      `Site: ${SITE_URL}`,
+  );
+  lines.push("");
+
+  lines.push("## Install");
+  lines.push("");
+  lines.push("```bash");
+  lines.push(`pnpm dlx shadcn@latest add ${SITE_URL}/r/<name>.json`);
+  lines.push(`# Or with npm: npx shadcn@latest add ${SITE_URL}/r/<name>.json`);
+  lines.push("```");
+  lines.push("");
+
+  for (const page of DOC_PAGES) {
+    const body = await readDocPage(page.slug);
+    if (!body) continue;
+    lines.push(`## ${page.title}`);
+    lines.push("");
+    lines.push(`Source: ${SITE_URL}/${page.slug === "home" ? "" : page.slug}`);
+    lines.push("");
+    lines.push(body);
+    lines.push("");
+  }
+
+  lines.push("## Components");
+  lines.push("");
+  lines.push(
+    `${items.length} components total. Each entry links to a machine-readable JSON descriptor at /r/<name>.json.`,
+  );
+  lines.push("");
+
+  for (const item of [...items].sort((a, b) => a.name.localeCompare(b.name))) {
+    lines.push(`### ${item.title}`);
+    lines.push("");
+    lines.push(`- Slug: \`${item.name}\``);
+    lines.push(`- Category: \`${item.category}\``);
+    lines.push(`- Description: ${item.description}`);
+    lines.push(`- Page: ${SITE_URL}/components/${item.name}`);
+    lines.push(`- Schema: ${SITE_URL}/r/${item.name}.json`);
+    if (item.dependencies && item.dependencies.length > 0) {
+      lines.push(`- npm deps: ${item.dependencies.join(", ")}`);
+    }
+    if (item.registryDependencies && item.registryDependencies.length > 0) {
+      lines.push(`- registry deps: ${item.registryDependencies.join(", ")}`);
+    }
+    lines.push(
+      `- Install: \`pnpm dlx shadcn@latest add ${SITE_URL}/r/${item.name}.json\``,
+    );
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+export const dynamic = "force-static";
+export const revalidate = 86400;
+
+export async function GET(): Promise<Response> {
+  const body = await buildLlmsFullTxt();
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=0, s-maxage=86400, stale-while-revalidate=604800",
+    },
+  });
+}


### PR DESCRIPTION
## Summary
Next.js Route Handler at \`apps/registry/app/llms-full.txt/route.ts\` emits \`text/plain\`. One fetch returns:

- Install snippets (\`pnpm dlx shadcn@latest add\`)
- Full MDX bodies of \`home\`, \`docs\`, \`philosophy\`, \`components\` pages (frontmatter stripped)
- Per-component block: title, slug, category, description, page URL, \`/r/<name>.json\` link, npm deps, registry deps, install command

## Implementation notes
- MDX read via \`node:fs/promises\` at build time (\`force-static\` + \`revalidate=86400\`).
- Each missing MDX falls through to empty string — the route never crashes if content is reorganized.
- Sorted alphabetically across all 225 components for stable diffs.

## Test plan
- [ ] After deploy: \`curl -s https://ui.vllnt.ai/llms-full.txt | wc -c\` returns < 1MB.
- [ ] Sample component (\`button\`) section shows install command + page link + JSON link.
- [ ] All 4 doc-page sections present.

## Depends on
- #235 (llms.txt — companion, lighter index)
- #234 (sitemap — site is crawlable independently)

Closes #236