### PR TITLE
feat(seo): add canonical URLs to every page (#237)

### DIFF
--- a/apps/registry/app/components/[slug]/page.tsx
+++ b/apps/registry/app/components/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { QuickAdd } from "@/components/quick-add";
 import { StorybookEmbed } from "@/components/storybook-embed";
 import componentMetadata from "@/lib/component-metadata.json";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
+import { canonical } from "@/lib/seo";
 import {
   getCategoryForComponent,
   getSidebarSections,
@@ -76,6 +77,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   };
 
   return {
+    alternates: { canonical: canonical(`/components/${slug}`) },
     description,
     openGraph: generateOGMetadata(ogParameters),
     title: `${title} - VLLNT UI`,

--- a/apps/registry/app/components/page.tsx
+++ b/apps/registry/app/components/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import componentMetadata from "@/lib/component-metadata.json";
 import { getPageContent } from "@/lib/content";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
+import { canonical } from "@/lib/seo";
 import {
   components,
   getSidebarSections,
@@ -25,6 +26,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const og = frontmatter.og;
 
   return {
+    alternates: { canonical: canonical("/components") },
     description: frontmatter.description,
     openGraph: generateOGMetadata({
       description: og?.description ?? frontmatter.description,

--- a/apps/registry/app/docs/page.tsx
+++ b/apps/registry/app/docs/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 
 import { getPageContent } from "@/lib/content";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
+import { canonical } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -10,6 +11,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const og = frontmatter.og;
 
   return {
+    alternates: { canonical: canonical("/docs") },
     description: frontmatter.description,
     openGraph: generateOGMetadata({
       description: og?.description ?? frontmatter.description,

--- a/apps/registry/app/page.tsx
+++ b/apps/registry/app/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 
 import { getPageContent } from "@/lib/content";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
+import { canonical } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -10,6 +11,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const og = frontmatter.og;
 
   return {
+    alternates: { canonical: canonical("/") },
     description: frontmatter.description,
     openGraph: generateOGMetadata({
       description: og?.description ?? frontmatter.description,

--- a/apps/registry/app/philosophy/page.tsx
+++ b/apps/registry/app/philosophy/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 
 import { getPageContent } from "@/lib/content";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
+import { canonical } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -10,6 +11,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const og = frontmatter.og;
 
   return {
+    alternates: { canonical: canonical("/philosophy") },
     description: frontmatter.description,
     openGraph: generateOGMetadata({
       description: og?.description ?? frontmatter.description,

--- a/apps/registry/lib/seo.ts
+++ b/apps/registry/lib/seo.ts
@@ -1,0 +1,9 @@
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+
+export function canonical(pathname: string): string {
+  const trimmed = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  if (trimmed === "/") {
+    return SITE_URL;
+  }
+  return `${SITE_URL}${trimmed.replace(/\/$/, "")}`;
+}


### PR DESCRIPTION
## Summary
New \`lib/seo.ts\` exports a tiny \`canonical(path)\` helper that resolves a relative pathname against \`NEXT_PUBLIC_SITE_URL\` (default \`https://ui.vllnt.ai\`).

Every page's \`generateMetadata\` now sets \`alternates.canonical\`:

| Page | Canonical |
|---|---|
| \`app/page.tsx\` | \`/\` |
| \`app/components/page.tsx\` | \`/components\` |
| \`app/components/[slug]/page.tsx\` | \`/components/{slug}\` |
| \`app/docs/page.tsx\` | \`/docs\` |
| \`app/philosophy/page.tsx\` | \`/philosophy\` |

## Why
Eliminates duplicate-content risk for trailing-slash variants, search-param noise, and future i18n routes (#281). Google merges link/quality signals on the canonical URL.

## Test plan
- [ ] After deploy: \`curl -s https://ui.vllnt.ai/components/button | grep canonical\` returns \`<link rel="canonical" href="https://ui.vllnt.ai/components/button" />\`.
- [ ] Same for /, /components, /docs, /philosophy.

Closes #237