### PR TITLE
chore: add .github/FUNDING.yml for GitHub Sponsors button (#261)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [bntvllnt]
+custom: ["https://bntvllnt.com"]


### PR DESCRIPTION
## Summary
Adds `.github/FUNDING.yml` so GitHub renders a Sponsor button on the repo header. Routes to `bntvllnt` GitHub Sponsors with custom URL fallback to bntvllnt.com.

Closes #261