### PR TITLE
feat(seo): add app/manifest.ts (PWA manifest) (#239)

### DIFF
--- a/apps/registry/app/manifest.ts
+++ b/apps/registry/app/manifest.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    background_color: "#0a0a0a",
+    categories: ["developer", "productivity", "design"],
+    description:
+      "Agent-first React component registry. 225 accessible components built on Radix UI, Tailwind CSS, and CVA.",
+    display: "standalone",
+    name: "VLLNT UI",
+    orientation: "any",
+    scope: "/",
+    short_name: "VLLNT UI",
+    start_url: "/",
+    theme_color: "#0a0a0a",
+  };
+}


### PR DESCRIPTION
## Summary
Next.js `MetadataRoute.Manifest` emitted at `/manifest.webmanifest`:

- `name` + `short_name` ("VLLNT UI")
- `description` (positioning)
- `start_url: /` + `scope: /` + `display: standalone` + `orientation: any`
- `background_color` + `theme_color` = `#0a0a0a` (matches dark default)
- `categories: [developer, productivity, design]`

## Test plan
- [ ] After deploy: `curl https://ui.vllnt.ai/manifest.webmanifest` returns valid JSON.
- [ ] Lighthouse PWA category recognises the manifest.

## Out of scope
Icons. Will land in a separate PR once `app/icon.png` and `app/apple-icon.png` assets are produced.

Closes #239