### PR TITLE
feat(seo): add custom 404 page with popular components + request CTA (#240)

### DIFF
--- a/apps/registry/app/not-found.tsx
+++ b/apps/registry/app/not-found.tsx
@@ -1,0 +1,84 @@
+import { Sidebar } from "@vllnt/ui";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { getSidebarSections } from "@/lib/sidebar-sections";
+
+export const metadata: Metadata = {
+  description: "We couldn't find the page you were looking for.",
+  robots: { follow: true, index: false },
+  title: "Page not found · VLLNT UI",
+};
+
+const POPULAR_COMPONENTS: ReadonlyArray<{ name: string; slug: string }> = [
+  { name: "Button", slug: "button" },
+  { name: "DataTable", slug: "data-table" },
+  { name: "AI Chat Input", slug: "ai-chat-input" },
+  { name: "Combobox", slug: "combobox" },
+  { name: "Timeline", slug: "timeline" },
+  { name: "Globe 3D", slug: "globe-3d" },
+];
+
+const REQUEST_URL =
+  "https://github.com/vllnt/ui/issues/new?template=feature_request.yml&labels=enhancement,component";
+
+export default function NotFound() {
+  return (
+    <>
+      <Sidebar sections={getSidebarSections()} />
+      <main className="flex-1 overflow-y-auto bg-background">
+        <div className="container mx-auto px-4 py-24 lg:px-8 max-w-3xl">
+          <p className="text-sm font-medium text-muted-foreground tracking-wide uppercase">
+            404
+          </p>
+          <h1 className="mt-3 text-4xl font-semibold">Page not found</h1>
+          <p className="mt-4 text-lg text-muted-foreground">
+            That route does not exist. Try one of the popular components below,
+            or jump back to the index.
+          </p>
+
+          <div className="mt-8 flex flex-wrap gap-3">
+            <Link
+              className="inline-flex h-10 items-center rounded-md bg-foreground px-5 text-sm font-medium text-background hover:opacity-90"
+              href="/components"
+            >
+              Browse all components
+            </Link>
+            <Link
+              className="inline-flex h-10 items-center rounded-md border border-border px-5 text-sm font-medium hover:bg-muted"
+              href="/docs"
+            >
+              Read the docs
+            </Link>
+            <a
+              className="inline-flex h-10 items-center rounded-md border border-border px-5 text-sm font-medium hover:bg-muted"
+              href={REQUEST_URL}
+              rel="noreferrer"
+              target="_blank"
+            >
+              Request a component
+            </a>
+          </div>
+
+          <section className="mt-16">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              Popular components
+            </h2>
+            <ul className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3">
+              {POPULAR_COMPONENTS.map((component) => (
+                <li key={component.slug}>
+                  <Link
+                    className="block rounded-md border border-border px-4 py-3 text-sm font-medium hover:bg-muted"
+                    href={`/components/${component.slug}`}
+                  >
+                    {component.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
`apps/registry/app/not-found.tsx` renders inside the existing site chrome.

- 404 + 'Page not found' headline
- 3 CTAs: Browse all components, Read the docs, Request a component
- 6 popular components grid (Button, DataTable, AI Chat Input, Combobox, Timeline, Globe 3D)
- `metadata.robots = { index: false, follow: true }` (don't index 404 pages themselves)

Request CTA links to GitHub new-issue with `feature_request` template prefilled. When #245 (`/request-component`) lands, swap the link.

Closes #240