### PR TITLE
feat(seo): add JSON-LD structured data (Organization, WebSite, SoftwareSourceCode, BreadcrumbList) (#238)

### DIFF
--- a/apps/registry/app/components/[slug]/page.tsx
+++ b/apps/registry/app/components/[slug]/page.tsx
@@ -10,6 +10,11 @@ import { notFound } from "next/navigation";
 import { QuickAdd } from "@/components/quick-add";
 import { StorybookEmbed } from "@/components/storybook-embed";
 import componentMetadata from "@/lib/component-metadata.json";
+import {
+  breadcrumbLd,
+  jsonLdScript,
+  softwareSourceCodeLd,
+} from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical } from "@/lib/seo";
 import {
@@ -161,8 +166,31 @@ export default async function ComponentPage(props: Props) {
       : []),
   ] as { id: string; title: string }[];
 
+  const SITE_URL =
+    process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+
   return (
     <>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: jsonLdScript([
+            softwareSourceCodeLd({
+              description: displayDescription,
+              name: component.name,
+              title: displayTitle,
+            }),
+            breadcrumbLd([
+              { name: "Home", url: SITE_URL },
+              { name: "Components", url: `${SITE_URL}/components` },
+              {
+                name: displayTitle,
+                url: `${SITE_URL}/components/${component.name}`,
+              },
+            ]),
+          ]),
+        }}
+        type="application/ld+json"
+      />
       <Sidebar sections={getSidebarSections(getCategoryForComponent(slug))} />
       <main className="flex-1 overflow-y-auto bg-background overflow-x-hidden">
         <div className="mx-auto max-w-7xl px-4 py-8 lg:px-8">

--- a/apps/registry/app/layout.tsx
+++ b/apps/registry/app/layout.tsx
@@ -8,6 +8,7 @@ import type { Metadata } from "next";
 import type React from "react";
 
 import { Header } from "@/components/header";
+import { jsonLdScript, organizationLd, websiteLd } from "@/lib/jsonld";
 
 import "./globals.css";
 
@@ -80,6 +81,16 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{ __html: jsonLdScript(organizationLd()) }}
+          type="application/ld+json"
+        />
+        <script
+          dangerouslySetInnerHTML={{ __html: jsonLdScript(websiteLd()) }}
+          type="application/ld+json"
+        />
+      </head>
       <body className="h-full overflow-hidden">
         <ThemeProvider
           attribute="class"

--- a/apps/registry/lib/jsonld.ts
+++ b/apps/registry/lib/jsonld.ts
@@ -1,0 +1,90 @@
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+
+type JsonLdValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly JsonLdValue[]
+  | { readonly [key: string]: JsonLdValue };
+
+type JsonLdNode = { readonly [key: string]: JsonLdValue };
+
+export function organizationLd(): JsonLdNode {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "VLLNT",
+    url: SITE_URL,
+    sameAs: ["https://github.com/vllnt", "https://github.com/vllnt/ui"],
+  };
+}
+
+export function websiteLd(): JsonLdNode {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "VLLNT UI",
+    url: SITE_URL,
+    publisher: {
+      "@type": "Organization",
+      name: "VLLNT",
+    },
+  };
+}
+
+export function softwareSourceCodeLd(component: {
+  readonly name: string;
+  readonly title: string;
+  readonly description: string;
+}): JsonLdNode {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    name: component.title,
+    description: component.description,
+    codeRepository: "https://github.com/vllnt/ui",
+    programmingLanguage: "TypeScript",
+    runtimePlatform: "React",
+    license: "https://opensource.org/license/mit",
+    url: `${SITE_URL}/components/${component.name}`,
+  };
+}
+
+export function itemListLd(items: ReadonlyArray<{
+  readonly name: string;
+  readonly title: string;
+}>): JsonLdNode {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "VLLNT UI Components",
+    numberOfItems: items.length,
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.title,
+      url: `${SITE_URL}/components/${item.name}`,
+    })),
+  };
+}
+
+export function breadcrumbLd(trail: ReadonlyArray<{
+  readonly name: string;
+  readonly url: string;
+}>): JsonLdNode {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: trail.map((step, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: step.name,
+      item: step.url,
+    })),
+  };
+}
+
+export function jsonLdScript(node: JsonLdNode | readonly JsonLdNode[]): string {
+  return JSON.stringify(node);
+}


### PR DESCRIPTION
## Summary
New `lib/jsonld.ts` with typed builders for Schema.org JSON-LD nodes. Injected via `<script type="application/ld+json">` on:

- Root `layout.tsx` → `Organization` + `WebSite` (every page).
- `app/components/[slug]/page.tsx` → `SoftwareSourceCode` + `BreadcrumbList` per component.

`itemListLd` is exported for future use on `/components` index and `/templates` (#259).

## Validation
- `SoftwareSourceCode` includes `codeRepository`, `programmingLanguage: TypeScript`, `runtimePlatform: React`, `license: MIT`.
- `BreadcrumbList` follows the standard Schema.org pattern.

## Test plan
- [ ] After deploy: `curl -s https://ui.vllnt.ai/components/button | grep -A 2 'application/ld+json' | head -10` returns valid JSON-LD.
- [ ] Google [Rich Results Test](https://search.google.com/test/rich-results): zero errors on home + sample component.
- [ ] [validator.schema.org](https://validator.schema.org): zero errors.

## Pairs with
- #251 Breadcrumbs UI — visual breadcrumbs match the JSON-LD trail.

Closes #238