### PR TITLE
feat(site): add GitHub icon link in Header rightSlot (#244)

### DIFF
--- a/apps/registry/components/header/header.tsx
+++ b/apps/registry/components/header/header.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { NavbarSaas, SearchDialog } from "@vllnt/ui";
+import { Github } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 import registryData from "@/registry.json";
+
+const GITHUB_URL = "https://github.com/vllnt/ui";
 
 type Registry = {
   items: { description?: string; name: string; title: string; type: string }[];
@@ -32,16 +35,27 @@ export function Header() {
       brand="VLLNT UI"
       navItems={navItems}
       rightSlot={
-        <SearchDialog
-          buttonText="Search components..."
-          emptyText="No components found."
-          groupHeading="Components"
-          items={searchItems}
-          onSelect={(item) => {
-            router.push(`/components/${item.id}`);
-          }}
-          searchPlaceholder="Search components..."
-        />
+        <div className="flex items-center gap-2">
+          <SearchDialog
+            buttonText="Search components..."
+            emptyText="No components found."
+            groupHeading="Components"
+            items={searchItems}
+            onSelect={(item) => {
+              router.push(`/components/${item.id}`);
+            }}
+            searchPlaceholder="Search components..."
+          />
+          <a
+            aria-label="VLLNT UI on GitHub"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+            href={GITHUB_URL}
+            rel="noreferrer"
+            target="_blank"
+          >
+            <Github className="h-4 w-4" />
+          </a>
+        </div>
       }
     />
   );


### PR DESCRIPTION
## Summary
GitHub icon (lucide `Github`) appears next to the SearchDialog in the `NavbarSaas` rightSlot. Links to `https://github.com/vllnt/ui` in a new tab.

## Test plan
- [ ] After deploy: GitHub icon visible at top-right of every page.
- [ ] Click opens `https://github.com/vllnt/ui` in a new tab.
- [ ] Keyboard tab order: nav items → search trigger → GitHub icon.
- [ ] Screen reader announces "VLLNT UI on GitHub" via aria-label.

Closes #244