### PR TITLE
feat(site): add Breadcrumbs UI on component + docs pages (#251)

### DIFF
--- a/apps/registry/app/components/[slug]/page.tsx
+++ b/apps/registry/app/components/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
-import { CodeBlock, Sidebar, TableOfContents } from "@vllnt/ui";
+import { Breadcrumb, CodeBlock, Sidebar, TableOfContents } from "@vllnt/ui";
 import { ExternalLink } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -198,6 +198,14 @@ export default async function ComponentPage(props: Props) {
             <div className="min-w-0">
               {/* Header */}
               <div className="mb-8">
+                <Breadcrumb
+                  className="mb-4 text-muted-foreground"
+                  items={[
+                    { href: "/", label: "Home" },
+                    { href: "/components", label: "Components" },
+                    { label: displayTitle },
+                  ]}
+                />
                 <h1 className="text-4xl font-bold mb-2">{displayTitle}</h1>
                 <p className="text-muted-foreground text-lg mb-6">
                   {displayDescription}

--- a/apps/registry/app/docs/page.tsx
+++ b/apps/registry/app/docs/page.tsx
@@ -1,10 +1,13 @@
-import { MDXContent, Sidebar } from "@vllnt/ui";
+import { Breadcrumb, MDXContent, Sidebar } from "@vllnt/ui";
 import type { Metadata } from "next";
 
 import { getPageContent } from "@/lib/content";
+import { breadcrumbLd, jsonLdScript } from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
 
 export async function generateMetadata(): Promise<Metadata> {
   const { frontmatter } = await getPageContent("docs");
@@ -32,10 +35,28 @@ export default async function DocumentationPage() {
 
   return (
     <>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: jsonLdScript(
+            breadcrumbLd([
+              { name: "Home", url: SITE_URL },
+              { name: "Docs", url: `${SITE_URL}/docs` },
+            ]),
+          ),
+        }}
+        type="application/ld+json"
+      />
       <Sidebar sections={getSidebarSections()} />
       <main className="flex-1 overflow-y-auto bg-background">
         <div className="container mx-auto px-4 py-16 lg:px-8">
           <div className="mb-8">
+            <Breadcrumb
+              className="mb-4 text-muted-foreground"
+              items={[
+                { href: "/", label: "Home" },
+                { label: "Docs" },
+              ]}
+            />
             <h1 className="text-4xl font-bold mb-4">Documentation</h1>
             <p className="text-muted-foreground text-lg">
               Learn how to use VLLNT UI components in your projects.


### PR DESCRIPTION
## Summary
Adds visual breadcrumbs to component and docs pages, matching the `BreadcrumbList` JSON-LD shipped in #238.

| Page | Trail |
|---|---|
| `/components/[slug]` | Home › Components › {Name} |
| `/docs` | Home › Docs |

Uses the existing `Breadcrumb` component from `@vllnt/ui` (already exported from the package barrel).

## Test plan
- [ ] After deploy: `/components/button` shows "Home › Components › Button" above the H1.
- [ ] `/docs` shows "Home › Docs".
- [ ] `view-source:` of both pages includes `<script type="application/ld+json">` with `BreadcrumbList`.
- [ ] Google [Rich Results Test](https://search.google.com/test/rich-results): zero errors on both routes.

## Depends on
- #238 JSON-LD library — already merged.

Closes #251