### PR TITLE
feat(site): add /request-component page with prefilled GitHub issue (#245)

### DIFF
--- a/apps/registry/app/request-component/page.tsx
+++ b/apps/registry/app/request-component/page.tsx
@@ -1,0 +1,33 @@
+import { Sidebar } from "@vllnt/ui";
+import type { Metadata } from "next";
+
+import { canonical } from "@/lib/seo";
+import { getSidebarSections } from "@/lib/sidebar-sections";
+
+import { RequestComponentForm } from "./request-component-form";
+
+export const metadata: Metadata = {
+  alternates: { canonical: canonical("/request-component") },
+  description:
+    "Request a new VLLNT UI component. The form opens a prefilled GitHub issue — no backend.",
+  robots: { follow: true, index: false },
+  title: "Request a component · VLLNT UI",
+};
+
+export default function RequestComponentPage() {
+  return (
+    <>
+      <Sidebar sections={getSidebarSections()} />
+      <main className="flex-1 overflow-y-auto bg-background">
+        <div className="container mx-auto max-w-2xl px-4 py-16 lg:px-8">
+          <h1 className="text-4xl font-bold mb-3">Request a component</h1>
+          <p className="text-muted-foreground text-lg mb-8">
+            Don&rsquo;t see what you need? Fill out the fields and we&rsquo;ll
+            open a prefilled GitHub issue with the right labels and template.
+          </p>
+          <RequestComponentForm />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/apps/registry/app/request-component/request-component-form.tsx
+++ b/apps/registry/app/request-component/request-component-form.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import type * as React from "react";
+import { useState } from "react";
+
+const REPO = "vllnt/ui";
+
+function buildIssueUrl({
+  name,
+  problem,
+  reference,
+  similar,
+  useCase,
+}: {
+  name: string;
+  problem: string;
+  reference: string;
+  similar: string;
+  useCase: string;
+}): string {
+  const body = [
+    "## What problem are you trying to solve?",
+    "",
+    problem || "_describe the user-facing need_",
+    "",
+    "## Proposed solution",
+    "",
+    name ? `Component: **${name}**` : "_component name_",
+    "",
+    similar ? `Similar to: ${similar}` : "",
+    "",
+    "## Use case",
+    "",
+    useCase || "_describe the concrete scenario_",
+    "",
+    "## References / prior art",
+    "",
+    reference || "_links, screenshots, design references_",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const params = new URLSearchParams({
+    template: "feature_request.yml",
+    title: `[feat] ${name || "new component"}`,
+    body,
+    labels: "enhancement,component",
+  });
+
+  return `https://github.com/${REPO}/issues/new?${params.toString()}`;
+}
+
+function Field({
+  autoFocus,
+  label,
+  onChange,
+  placeholder,
+  required,
+  value,
+}: {
+  autoFocus?: boolean;
+  label: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  required?: boolean;
+  value: string;
+}) {
+  return (
+    <label className="block">
+      <span className="text-sm font-medium">
+        {label}
+        {required ? <span className="ml-1 text-destructive">*</span> : null}
+      </span>
+      <input
+        autoFocus={autoFocus}
+        className="mt-2 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        required={required}
+        type="text"
+        value={value}
+      />
+    </label>
+  );
+}
+
+function TextField({
+  label,
+  onChange,
+  placeholder,
+  required,
+  rows = 3,
+  value,
+}: {
+  label: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  required?: boolean;
+  rows?: number;
+  value: string;
+}) {
+  return (
+    <label className="block">
+      <span className="text-sm font-medium">
+        {label}
+        {required ? <span className="ml-1 text-destructive">*</span> : null}
+      </span>
+      <textarea
+        className="mt-2 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        required={required}
+        rows={rows}
+        value={value}
+      />
+    </label>
+  );
+}
+
+export function RequestComponentForm() {
+  const [name, setName] = useState("");
+  const [problem, setProblem] = useState("");
+  const [similar, setSimilar] = useState("");
+  const [useCase, setUseCase] = useState("");
+  const [reference, setReference] = useState("");
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const url = buildIssueUrl({ name, problem, reference, similar, useCase });
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+
+  return (
+    <form className="space-y-5" onSubmit={handleSubmit}>
+      <Field
+        autoFocus
+        label="Component name"
+        onChange={setName}
+        placeholder="e.g. ToastStack"
+        required
+        value={name}
+      />
+      <TextField
+        label="What problem does it solve?"
+        onChange={setProblem}
+        placeholder="The user-facing need, not the implementation."
+        required
+        rows={3}
+        value={problem}
+      />
+      <Field
+        label="Similar to (optional)"
+        onChange={setSimilar}
+        placeholder="shadcn Toast, Radix Toast, etc."
+        value={similar}
+      />
+      <TextField
+        label="Use case"
+        onChange={setUseCase}
+        placeholder="The concrete scenario where you'd reach for this."
+        rows={3}
+        value={useCase}
+      />
+      <TextField
+        label="References / prior art (optional)"
+        onChange={setReference}
+        placeholder="Links, screenshots, design references…"
+        rows={3}
+        value={reference}
+      />
+      <button
+        className="inline-flex h-10 items-center rounded-md bg-foreground px-5 text-sm font-medium text-background hover:opacity-90"
+        type="submit"
+      >
+        Open prefilled GitHub issue
+      </button>
+      <p className="text-xs text-muted-foreground">
+        Submitting opens a new GitHub issue tab — nothing is sent to a server.
+      </p>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
`apps/registry/app/request-component/` — page + client form. On submit, builds a GitHub new-issue URL with the `feature_request.yml` template, prefills the body, applies `enhancement,component` labels, opens in a new tab.

No backend, no email. Pure URL-builder pattern.

## Form fields
- Component name (required)
- What problem does it solve? (required, textarea)
- Similar to (optional)
- Use case (optional, textarea)
- References / prior art (optional, textarea)

## Metadata
- canonical: `/request-component`
- robots: index=false (utility page)
- title: "Request a component · VLLNT UI"

## Test plan
- [ ] After deploy: `/request-component` renders with all 5 fields.
- [ ] Submit opens GitHub with prefilled body + correct labels.
- [ ] Form is keyboard-navigable + screen-reader friendly.

## Pairs with
- #265 `/report` bug page — same pattern, different intent.

Closes #245