### PR TITLE
feat(site): add /report bug page + per-component Report a bug button (#265)

### DIFF
--- a/apps/registry/app/components/[slug]/page.tsx
+++ b/apps/registry/app/components/[slug]/page.tsx
@@ -210,7 +210,15 @@ export default async function ComponentPage(props: Props) {
                 <p className="text-muted-foreground text-lg mb-6">
                   {displayDescription}
                 </p>
-                <QuickAdd componentName={component.name} />
+                <div className="flex flex-wrap items-center gap-3">
+                  <QuickAdd componentName={component.name} />
+                  <Link
+                    className="inline-flex h-9 items-center rounded-md border border-border px-4 text-sm font-medium hover:bg-muted"
+                    href={`/report?component=${component.name}`}
+                  >
+                    Report a bug
+                  </Link>
+                </div>
               </div>
 
               {/* Preview — Storybook Embed */}

--- a/apps/registry/app/report/page.tsx
+++ b/apps/registry/app/report/page.tsx
@@ -1,0 +1,43 @@
+import { Sidebar } from "@vllnt/ui";
+import type { Metadata } from "next";
+
+import { canonical } from "@/lib/seo";
+import { getSidebarSections } from "@/lib/sidebar-sections";
+
+import { ReportBugForm } from "./report-bug-form";
+
+export const metadata: Metadata = {
+  alternates: { canonical: canonical("/report") },
+  description:
+    "Report a bug in VLLNT UI. The form opens a prefilled GitHub issue — no backend.",
+  robots: { follow: true, index: false },
+  title: "Report a bug · VLLNT UI",
+};
+
+type SearchParameters = {
+  readonly component?: string;
+};
+
+export default async function ReportBugPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParameters>;
+}) {
+  const { component } = await searchParams;
+
+  return (
+    <>
+      <Sidebar sections={getSidebarSections()} />
+      <main className="flex-1 overflow-y-auto bg-background">
+        <div className="container mx-auto max-w-2xl px-4 py-16 lg:px-8">
+          <h1 className="text-4xl font-bold mb-3">Report a bug</h1>
+          <p className="text-muted-foreground text-lg mb-8">
+            Found something broken? Fill out the fields and we&rsquo;ll open a
+            prefilled GitHub issue with the right labels and template.
+          </p>
+          <ReportBugForm initialComponent={component ?? ""} />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/apps/registry/app/report/report-bug-form.tsx
+++ b/apps/registry/app/report/report-bug-form.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import type * as React from "react";
+import { useState } from "react";
+
+const REPO = "vllnt/ui";
+
+function buildIssueUrl({
+  actual,
+  component,
+  expected,
+  repro,
+  summary,
+}: {
+  actual: string;
+  component: string;
+  expected: string;
+  repro: string;
+  summary: string;
+}): string {
+  const titleSlug = component ? `bug(${component}): ` : "[bug] ";
+  const body = [
+    component ? `Component: **${component}**` : "",
+    "",
+    "## Reproduction",
+    "",
+    repro || "_minimal repro / link / snippet_",
+    "",
+    "## Expected",
+    "",
+    expected || "_what you expected to happen_",
+    "",
+    "## Actual",
+    "",
+    actual || "_what actually happened — include console / screenshot_",
+    "",
+    "## Environment",
+    "",
+    "- VLLNT UI version: _e.g. 0.2.1_",
+    "- Browser:",
+    "- OS:",
+    "- Node / pnpm:",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const params = new URLSearchParams({
+    template: "bug_report.yml",
+    title: `${titleSlug}${summary || "bug summary"}`,
+    body,
+    labels: component ? `bug,component:${component}` : "bug",
+  });
+
+  return `https://github.com/${REPO}/issues/new?${params.toString()}`;
+}
+
+function Field({
+  autoFocus,
+  label,
+  onChange,
+  placeholder,
+  required,
+  value,
+}: {
+  autoFocus?: boolean;
+  label: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  required?: boolean;
+  value: string;
+}) {
+  return (
+    <label className="block">
+      <span className="text-sm font-medium">
+        {label}
+        {required ? <span className="ml-1 text-destructive">*</span> : null}
+      </span>
+      <input
+        autoFocus={autoFocus}
+        className="mt-2 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        required={required}
+        type="text"
+        value={value}
+      />
+    </label>
+  );
+}
+
+function TextField({
+  label,
+  onChange,
+  placeholder,
+  required,
+  rows = 3,
+  value,
+}: {
+  label: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  required?: boolean;
+  rows?: number;
+  value: string;
+}) {
+  return (
+    <label className="block">
+      <span className="text-sm font-medium">
+        {label}
+        {required ? <span className="ml-1 text-destructive">*</span> : null}
+      </span>
+      <textarea
+        className="mt-2 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        required={required}
+        rows={rows}
+        value={value}
+      />
+    </label>
+  );
+}
+
+export function ReportBugForm({
+  initialComponent = "",
+}: {
+  initialComponent?: string;
+}) {
+  const [component, setComponent] = useState(initialComponent);
+  const [summary, setSummary] = useState("");
+  const [repro, setRepro] = useState("");
+  const [expected, setExpected] = useState("");
+  const [actual, setActual] = useState("");
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const url = buildIssueUrl({ actual, component, expected, repro, summary });
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+
+  return (
+    <form className="space-y-5" onSubmit={handleSubmit}>
+      <Field
+        label="Component (optional)"
+        onChange={setComponent}
+        placeholder="e.g. button, combobox, ai-chat-input"
+        value={component}
+      />
+      <Field
+        autoFocus
+        label="One-line summary"
+        onChange={setSummary}
+        placeholder="Concise headline for the issue title."
+        required
+        value={summary}
+      />
+      <TextField
+        label="Reproduction"
+        onChange={setRepro}
+        placeholder="Minimal repo / sandbox link / runnable snippet."
+        required
+        rows={4}
+        value={repro}
+      />
+      <TextField
+        label="Expected behavior"
+        onChange={setExpected}
+        placeholder="What you expected to happen."
+        required
+        value={expected}
+      />
+      <TextField
+        label="Actual behavior"
+        onChange={setActual}
+        placeholder="What actually happened. Include console output or screenshots if useful."
+        required
+        rows={4}
+        value={actual}
+      />
+      <button
+        className="inline-flex h-10 items-center rounded-md bg-foreground px-5 text-sm font-medium text-background hover:opacity-90"
+        type="submit"
+      >
+        Open prefilled GitHub issue
+      </button>
+      <p className="text-xs text-muted-foreground">
+        Submitting opens a new GitHub issue tab — nothing is sent to a server.
+      </p>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
`apps/registry/app/report/{page.tsx,report-bug-form.tsx}`. Same URL-builder pattern as #245 — form opens a prefilled GitHub issue using `bug_report.yml`.

## Per-component button
Every `/components/[slug]` page now has a **Report a bug** link next to QuickAdd that pre-fills `/report?component=<slug>` so triagers see the component name immediately.

## Form fields
- Component (auto-prefilled from query param)
- One-line summary (becomes issue title)
- Reproduction (required, textarea)
- Expected behavior (required)
- Actual behavior (required, textarea)

## Labels applied
- Default: `bug`
- With component: `bug,component:<slug>`

## Metadata
- canonical: `/report`
- robots: index=false (utility page)

## Test plan
- [ ] After deploy: `/report` renders.
- [ ] `/components/button` shows 'Report a bug' button → `/report?component=button` with field pre-filled.
- [ ] Submit opens GitHub with prefilled body + `component:button` label.

Closes #265