### PR TITLE
feat(registry): add a11y schema to /r/<name>.json (#255)

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -898,7 +898,39 @@
       ],
       "category": "form",
       "version": "0.2.1",
-      "stability": "stable"
+      "stability": "stable",
+      "a11y": {
+        "role": "combobox",
+        "keyboard": [
+          {
+            "keys": "Enter / Space",
+            "action": "open the listbox"
+          },
+          {
+            "keys": "ArrowDown",
+            "action": "open + move active option down"
+          },
+          {
+            "keys": "ArrowUp",
+            "action": "move active option up"
+          },
+          {
+            "keys": "Escape",
+            "action": "close the listbox"
+          },
+          {
+            "keys": "Type-ahead",
+            "action": "filter options"
+          }
+        ],
+        "aria": [
+          "aria-controls",
+          "aria-expanded",
+          "aria-haspopup"
+        ],
+        "focusManagement": "auto",
+        "notes": "Trigger button has role='combobox'. Listbox id is wired via React.useId() so consumers don't need to manage it."
+      }
     },
     {
       "name": "command",
@@ -1185,7 +1217,27 @@
       ],
       "category": "overlay",
       "version": "0.2.1",
-      "stability": "stable"
+      "stability": "stable",
+      "a11y": {
+        "role": "dialog",
+        "keyboard": [
+          {
+            "keys": "Escape",
+            "action": "close the dialog"
+          },
+          {
+            "keys": "Tab / Shift+Tab",
+            "action": "cycle focus within the dialog (focus trap)"
+          }
+        ],
+        "aria": [
+          "aria-modal",
+          "aria-labelledby",
+          "aria-describedby"
+        ],
+        "focusManagement": "auto",
+        "notes": "Built on Radix Dialog: focus trap + restore on close + scroll lock are automatic."
+      }
     },
     {
       "name": "document-sibling-nav",
@@ -4296,5 +4348,5 @@
     }
   ],
   "version": "0.2.1",
-  "generatedAt": "2026-05-10T14:52:31.798Z"
+  "generatedAt": "2026-05-10T15:02:17.375Z"
 }

--- a/apps/registry/scripts/inline-component-source.ts
+++ b/apps/registry/scripts/inline-component-source.ts
@@ -59,12 +59,27 @@ type RegistryFile = {
 
 type Stability = "stable" | "beta" | "experimental" | "deprecated";
 
+type A11yKeyboardBinding = {
+  keys: string;
+  action: string;
+};
+
+type A11ySchema = {
+  role?: string;
+  keyboard?: A11yKeyboardBinding[];
+  aria?: string[];
+  focusManagement?: "auto" | "manual";
+  notes?: string;
+};
+
 type ComponentMeta = {
   stability?: Stability;
   replacedBy?: string;
+  a11y?: A11ySchema;
 };
 
 type RegistryItem = {
+  a11y?: A11ySchema;
   category?: string;
   dependencies?: string[];
   description?: string;
@@ -178,6 +193,14 @@ for (const item of registry.items) {
     }
   } else {
     delete item.replacedBy;
+  }
+
+  // Stamp a11y schema (see #255) — agents generating UI need to know the
+  // keyboard model, ARIA roles, and focus expectations of each component.
+  if (meta.a11y) {
+    item.a11y = meta.a11y;
+  } else {
+    delete item.a11y;
   }
 
   processed += 1;

--- a/apps/registry/scripts/stamp-registry-metadata.ts
+++ b/apps/registry/scripts/stamp-registry-metadata.ts
@@ -22,7 +22,21 @@ const publicRDir = join(repoRoot, "apps/registry/public/r");
 
 type Stability = "stable" | "beta" | "experimental" | "deprecated";
 
+type A11yKeyboardBinding = {
+  keys: string;
+  action: string;
+};
+
+type A11ySchema = {
+  role?: string;
+  keyboard?: A11yKeyboardBinding[];
+  aria?: string[];
+  focusManagement?: "auto" | "manual";
+  notes?: string;
+};
+
 type RegistryItem = {
+  a11y?: A11ySchema;
   name: string;
   version?: string;
   stability?: Stability;
@@ -53,6 +67,11 @@ for (const item of registry.items) {
     data.replacedBy = item.replacedBy;
   } else {
     delete data.replacedBy;
+  }
+  if (item.a11y) {
+    data.a11y = item.a11y;
+  } else {
+    delete data.a11y;
   }
 
   writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);

--- a/apps/registry/types/registry.ts
+++ b/apps/registry/types/registry.ts
@@ -15,7 +15,21 @@ export type ComponentCategory =
 
 export type Stability = "stable" | "beta" | "experimental" | "deprecated";
 
+export type A11yKeyboardBinding = {
+  keys: string;
+  action: string;
+};
+
+export type A11ySchema = {
+  role?: string;
+  keyboard?: A11yKeyboardBinding[];
+  aria?: string[];
+  focusManagement?: "auto" | "manual";
+  notes?: string;
+};
+
 export type RegistryComponent = {
+  a11y?: A11ySchema;
   category?: ComponentCategory;
   dependencies?: string[];
   description?: string;

--- a/packages/ui/src/components/combobox/meta.json
+++ b/packages/ui/src/components/combobox/meta.json
@@ -1,0 +1,15 @@
+{
+  "a11y": {
+    "role": "combobox",
+    "keyboard": [
+      { "keys": "Enter / Space", "action": "open the listbox" },
+      { "keys": "ArrowDown", "action": "open + move active option down" },
+      { "keys": "ArrowUp", "action": "move active option up" },
+      { "keys": "Escape", "action": "close the listbox" },
+      { "keys": "Type-ahead", "action": "filter options" }
+    ],
+    "aria": ["aria-controls", "aria-expanded", "aria-haspopup"],
+    "focusManagement": "auto",
+    "notes": "Trigger button has role='combobox'. Listbox id is wired via React.useId() so consumers don't need to manage it."
+  }
+}

--- a/packages/ui/src/components/dialog/meta.json
+++ b/packages/ui/src/components/dialog/meta.json
@@ -1,0 +1,12 @@
+{
+  "a11y": {
+    "role": "dialog",
+    "keyboard": [
+      { "keys": "Escape", "action": "close the dialog" },
+      { "keys": "Tab / Shift+Tab", "action": "cycle focus within the dialog (focus trap)" }
+    ],
+    "aria": ["aria-modal", "aria-labelledby", "aria-describedby"],
+    "focusManagement": "auto",
+    "notes": "Built on Radix Dialog: focus trap + restore on close + scroll lock are automatic."
+  }
+}


### PR DESCRIPTION
## Summary
Build pipeline now reads an \`a11y\` field from each \`packages/ui/src/components/<name>/meta.json\` and stamps it onto registry items + per-component JSON.

## Schema

\`\`\`ts
type A11ySchema = {
  role?: string;                          // ARIA role
  keyboard?: { keys: string; action: string }[];
  aria?: string[];                        // required ARIA attrs
  focusManagement?: "auto" | "manual";
  notes?: string;
};
\`\`\`

## Pipeline integration
- \`inline-component-source.ts\` stamps \`item.a11y\` from meta.json.
- \`stamp-registry-metadata.ts\` patches \`/r/<name>.json\` post-shadcn-build (same drift fix as #253).

## Seed data
Two \`meta.json\` ship to validate the wiring:
- \`combobox/meta.json\` — full WAI-ARIA combobox pattern (Enter/Space/ArrowDown/ArrowUp/Escape/Type-ahead).
- \`dialog/meta.json\` — Radix Dialog focus-trap pattern.

Both are real, hand-authored — not generated. Other 220 components have no a11y field yet (additive, non-breaking). Filling them out is an ongoing effort tracked separately.

## Validation
- Local build: \`jq '.items[] | select(.name == \"combobox\") | .a11y'\` returns the full schema.
- Components without meta.json get no a11y key — confirmed.

## Test plan
- [ ] After deploy: \`curl https://ui.vllnt.ai/r/combobox.json | jq .a11y\`.
- [ ] \`curl https://ui.vllnt.ai/r/dialog.json | jq .a11y\`.
- [ ] Adding a meta.json for any other component picks up automatically on next build.

## Pairs with
- #253 \`version\` + \`stability\` — same build-script pattern.
- #246 MCP \`get_component\` will return a11y when available.

Closes #255