### PR TITLE
feat(registry): inline usage examples in /r/<name>.json (#254)

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -574,7 +574,27 @@
       ],
       "category": "core",
       "version": "0.2.1",
-      "stability": "stable"
+      "stability": "stable",
+      "examples": [
+        {
+          "title": "Default",
+          "description": "Default button with primary variant.",
+          "code": "import { Button } from \"@vllnt/ui\";\n\nexport function Demo() {\n  return <Button>Click me</Button>;\n}\n",
+          "framework": "react"
+        },
+        {
+          "title": "Variants",
+          "description": "All variant styles in one row.",
+          "code": "import { Button } from \"@vllnt/ui\";\n\nexport function Demo() {\n  return (\n    <div className=\"flex gap-2\">\n      <Button variant=\"default\">Default</Button>\n      <Button variant=\"secondary\">Secondary</Button>\n      <Button variant=\"outline\">Outline</Button>\n      <Button variant=\"ghost\">Ghost</Button>\n      <Button variant=\"destructive\">Delete</Button>\n    </div>\n  );\n}\n",
+          "framework": "react"
+        },
+        {
+          "title": "Loading state",
+          "description": "Disabled button with a spinner — keeps width stable so layouts don't jump.",
+          "code": "import { Button, Spinner } from \"@vllnt/ui\";\n\nexport function Demo() {\n  return (\n    <Button disabled>\n      <Spinner className=\"h-4 w-4\" />\n      Saving…\n    </Button>\n  );\n}\n",
+          "framework": "react"
+        }
+      ]
     },
     {
       "name": "calendar",
@@ -930,7 +950,21 @@
         ],
         "focusManagement": "auto",
         "notes": "Trigger button has role='combobox'. Listbox id is wired via React.useId() so consumers don't need to manage it."
-      }
+      },
+      "examples": [
+        {
+          "title": "Default",
+          "description": "Single-select combobox with type-ahead.",
+          "code": "import { Combobox } from \"@vllnt/ui\";\n\nconst options = [\n  { label: \"React\", value: \"react\" },\n  { label: \"Vue\", value: \"vue\" },\n  { label: \"Svelte\", value: \"svelte\" },\n  { label: \"Solid\", value: \"solid\" },\n];\n\nexport function Demo() {\n  return <Combobox options={options} placeholder=\"Pick a framework\" />;\n}\n",
+          "framework": "react"
+        },
+        {
+          "title": "Controlled",
+          "description": "Pair Combobox with React.useState for full control over the selected value.",
+          "code": "\"use client\";\nimport * as React from \"react\";\nimport { Combobox } from \"@vllnt/ui\";\n\nconst options = [\n  { label: \"Pending\", value: \"pending\" },\n  { label: \"Approved\", value: \"approved\" },\n  { label: \"Rejected\", value: \"rejected\" },\n];\n\nexport function Demo() {\n  const [value, setValue] = React.useState(\"pending\");\n  return (\n    <Combobox\n      options={options}\n      value={value}\n      onValueChange={setValue}\n      placeholder=\"Status\"\n    />\n  );\n}\n",
+          "framework": "react"
+        }
+      ]
     },
     {
       "name": "command",
@@ -1334,7 +1368,15 @@
       ],
       "category": "core",
       "version": "0.2.1",
-      "stability": "stable"
+      "stability": "stable",
+      "examples": [
+        {
+          "title": "Default",
+          "description": "Empty state for an empty list — explain what's empty + offer a single primary action.",
+          "code": "import { Button, EmptyState } from \"@vllnt/ui\";\nimport { Inbox } from \"lucide-react\";\n\nexport function Demo() {\n  return (\n    <EmptyState\n      icon={<Inbox className=\"h-8 w-8\" />}\n      title=\"No tickets yet\"\n      description=\"Create your first support ticket to start tracking conversations.\"\n      action={<Button>Create ticket</Button>}\n    />\n  );\n}\n",
+          "framework": "react"
+        }
+      ]
     },
     {
       "name": "era-comparison",
@@ -4348,5 +4390,5 @@
     }
   ],
   "version": "0.2.1",
-  "generatedAt": "2026-05-10T15:02:17.375Z"
+  "generatedAt": "2026-05-10T15:12:14.518Z"
 }

--- a/apps/registry/scripts/inline-component-source.ts
+++ b/apps/registry/scripts/inline-component-source.ts
@@ -72,6 +72,14 @@ type A11ySchema = {
   notes?: string;
 };
 
+type UsageExample = {
+  title: string;
+  description?: string;
+  code: string;
+  framework?: "react" | "next";
+  storyId?: string;
+};
+
 type ComponentMeta = {
   stability?: Stability;
   replacedBy?: string;
@@ -83,6 +91,7 @@ type RegistryItem = {
   category?: string;
   dependencies?: string[];
   description?: string;
+  examples?: UsageExample[];
   files: RegistryFile[];
   name: string;
   registryDependencies?: string[];
@@ -116,6 +125,24 @@ const readComponentMeta = (name: string): ComponentMeta => {
     return JSON.parse(readFileSync(metaPath, "utf8")) as ComponentMeta;
   } catch {
     return {};
+  }
+};
+
+const readComponentExamples = (name: string): UsageExample[] => {
+  const examplesPath = join(componentsRoot, name, "examples.json");
+  if (!existsSync(examplesPath)) return [];
+  try {
+    const raw = JSON.parse(readFileSync(examplesPath, "utf8")) as unknown;
+    if (!Array.isArray(raw)) return [];
+    return raw.filter(
+      (entry): entry is UsageExample =>
+        typeof entry === "object" &&
+        entry !== null &&
+        typeof (entry as UsageExample).title === "string" &&
+        typeof (entry as UsageExample).code === "string",
+    );
+  } catch {
+    return [];
   }
 };
 
@@ -201,6 +228,17 @@ for (const item of registry.items) {
     item.a11y = meta.a11y;
   } else {
     delete item.a11y;
+  }
+
+  // Stamp inline usage examples (see #254) — agents see how to use the
+  // component without scraping Storybook iframes. Source: optional
+  // packages/ui/src/components/<name>/examples.json. Schema:
+  // [{ title, description?, code, framework?, storyId? }].
+  const examples = readComponentExamples(item.name);
+  if (examples.length > 0) {
+    item.examples = examples;
+  } else {
+    delete item.examples;
   }
 
   processed += 1;

--- a/apps/registry/scripts/stamp-registry-metadata.ts
+++ b/apps/registry/scripts/stamp-registry-metadata.ts
@@ -35,8 +35,17 @@ type A11ySchema = {
   notes?: string;
 };
 
+type UsageExample = {
+  title: string;
+  description?: string;
+  code: string;
+  framework?: "react" | "next";
+  storyId?: string;
+};
+
 type RegistryItem = {
   a11y?: A11ySchema;
+  examples?: UsageExample[];
   name: string;
   version?: string;
   stability?: Stability;
@@ -72,6 +81,11 @@ for (const item of registry.items) {
     data.a11y = item.a11y;
   } else {
     delete data.a11y;
+  }
+  if (item.examples && item.examples.length > 0) {
+    data.examples = item.examples;
+  } else {
+    delete data.examples;
   }
 
   writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);

--- a/apps/registry/types/registry.ts
+++ b/apps/registry/types/registry.ts
@@ -28,11 +28,20 @@ export type A11ySchema = {
   notes?: string;
 };
 
+export type UsageExample = {
+  title: string;
+  description?: string;
+  code: string;
+  framework?: "react" | "next";
+  storyId?: string;
+};
+
 export type RegistryComponent = {
   a11y?: A11ySchema;
   category?: ComponentCategory;
   dependencies?: string[];
   description?: string;
+  examples?: UsageExample[];
   files: RegistryFile[];
   name: string;
   registryDependencies?: string[];

--- a/packages/ui/src/components/button/examples.json
+++ b/packages/ui/src/components/button/examples.json
@@ -1,0 +1,20 @@
+[
+  {
+    "title": "Default",
+    "description": "Default button with primary variant.",
+    "code": "import { Button } from \"@vllnt/ui\";\n\nexport function Demo() {\n  return <Button>Click me</Button>;\n}\n",
+    "framework": "react"
+  },
+  {
+    "title": "Variants",
+    "description": "All variant styles in one row.",
+    "code": "import { Button } from \"@vllnt/ui\";\n\nexport function Demo() {\n  return (\n    <div className=\"flex gap-2\">\n      <Button variant=\"default\">Default</Button>\n      <Button variant=\"secondary\">Secondary</Button>\n      <Button variant=\"outline\">Outline</Button>\n      <Button variant=\"ghost\">Ghost</Button>\n      <Button variant=\"destructive\">Delete</Button>\n    </div>\n  );\n}\n",
+    "framework": "react"
+  },
+  {
+    "title": "Loading state",
+    "description": "Disabled button with a spinner — keeps width stable so layouts don't jump.",
+    "code": "import { Button, Spinner } from \"@vllnt/ui\";\n\nexport function Demo() {\n  return (\n    <Button disabled>\n      <Spinner className=\"h-4 w-4\" />\n      Saving…\n    </Button>\n  );\n}\n",
+    "framework": "react"
+  }
+]

--- a/packages/ui/src/components/combobox/examples.json
+++ b/packages/ui/src/components/combobox/examples.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "Default",
+    "description": "Single-select combobox with type-ahead.",
+    "code": "import { Combobox } from \"@vllnt/ui\";\n\nconst options = [\n  { label: \"React\", value: \"react\" },\n  { label: \"Vue\", value: \"vue\" },\n  { label: \"Svelte\", value: \"svelte\" },\n  { label: \"Solid\", value: \"solid\" },\n];\n\nexport function Demo() {\n  return <Combobox options={options} placeholder=\"Pick a framework\" />;\n}\n",
+    "framework": "react"
+  },
+  {
+    "title": "Controlled",
+    "description": "Pair Combobox with React.useState for full control over the selected value.",
+    "code": "\"use client\";\nimport * as React from \"react\";\nimport { Combobox } from \"@vllnt/ui\";\n\nconst options = [\n  { label: \"Pending\", value: \"pending\" },\n  { label: \"Approved\", value: \"approved\" },\n  { label: \"Rejected\", value: \"rejected\" },\n];\n\nexport function Demo() {\n  const [value, setValue] = React.useState(\"pending\");\n  return (\n    <Combobox\n      options={options}\n      value={value}\n      onValueChange={setValue}\n      placeholder=\"Status\"\n    />\n  );\n}\n",
+    "framework": "react"
+  }
+]

--- a/packages/ui/src/components/empty-state/examples.json
+++ b/packages/ui/src/components/empty-state/examples.json
@@ -1,0 +1,8 @@
+[
+  {
+    "title": "Default",
+    "description": "Empty state for an empty list — explain what's empty + offer a single primary action.",
+    "code": "import { Button, EmptyState } from \"@vllnt/ui\";\nimport { Inbox } from \"lucide-react\";\n\nexport function Demo() {\n  return (\n    <EmptyState\n      icon={<Inbox className=\"h-8 w-8\" />}\n      title=\"No tickets yet\"\n      description=\"Create your first support ticket to start tracking conversations.\"\n      action={<Button>Create ticket</Button>}\n    />\n  );\n}\n",
+    "framework": "react"
+  }
+]


### PR DESCRIPTION
## Summary
Build pipeline reads optional \`packages/ui/src/components/<name>/examples.json\` and stamps the array onto registry items + per-component JSON. Pattern matches #253 (version) and #255 (a11y).

## Schema

\`\`\`ts
type UsageExample = {
  title: string;
  description?: string;
  code: string;
  framework?: "react" | "next";
  storyId?: string;
};
\`\`\`

## Seeds
Three components ship with examples to validate the pipeline:
- \`button/examples.json\` — Default, Variants, Loading state
- \`combobox/examples.json\` — Default, Controlled (\"use client\")
- \`empty-state/examples.json\` — Default

## Validation
- Local build: 222 items processed, 3 components have \`examples\`.
- \`jq '.items[] | select(.name == \"button\") | .examples | length'\` → 3.
- Components without \`examples.json\` get no \`examples\` key (additive).

## Future
- Auto-extract from Storybook \`*.stories.tsx\` (separate PR — non-trivial AST work).
- Component pages render examples as collapsible code blocks (separate PR — UI work).
- \`/llms-full.txt\` (#236) will inline example titles + code (already supports the field, gracefully degrades when absent).

Closes #254