### PR TITLE
docs: add root CHANGELOG.md pointer + repo-wide Unreleased section (#260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+The canonical changelog for the published `@vllnt/ui` package lives at [`packages/ui/CHANGELOG.md`](./packages/ui/CHANGELOG.md). It follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This root file is a **pointer** — it tracks repo-wide events that don't ship in a published package (CI workflows, registry build pipeline, ROADMAP changes, agent-surface routes like `/llms.txt`, `/r/<name>.json` schema additions).
+
+## Where to look
+
+| Looking for… | File / source |
+|---|---|
+| Published package changes (`@vllnt/ui`) | [`packages/ui/CHANGELOG.md`](./packages/ui/CHANGELOG.md) |
+| Roadmap toward the next release | [`ROADMAP.md`](./ROADMAP.md) |
+| Per-release notes | [GitHub Releases](https://github.com/vllnt/ui/releases) |
+| Live registry index | [`/r/registry.json`](https://ui.vllnt.ai/r/registry.json) (carries `version` + `generatedAt`) |
+| Per-component descriptors | [`/r/<name>.json`](https://ui.vllnt.ai/r/registry.json) (each carries `version` + `stability`) |
+
+## [Unreleased] — repo-wide
+
+> Target version: `0.3.0`. Tracks ROADMAP.md, see [#252](https://github.com/vllnt/ui/issues/252).
+
+### Added
+
+- **Agent-first surface** — `/robots.txt` allowing 11 AI crawlers, `/sitemap.xml`, `/llms.txt`, `/llms-full.txt`, JSON-LD on every page, PWA manifest, breadcrumbs, custom 404, canonical URLs per route, expanded root metadata (keywords, robots tuning, OG/Twitter site-level config).
+- **Codebase health gate** — `react-doctor` CI workflow with PR annotations + score artifact, `pnpm doctor*` script suite, type-enforcement workflow on every issue.
+- **Registry-item richness** — every `/r/<name>.json` now carries `version`, `stability`, optional `a11y` schema, optional inline `examples`. Top-level `/r/registry.json` carries `version` + `generatedAt`.
+- **Site UX** — Header GitHub icon, `/request-component` and `/report` pages with prefilled-GitHub-issue forms, per-component "Report a bug" button.
+- **Brand** — `DESIGN.md` at repo root with the canonical brand + design guideline (color tokens, typography, motion, anti-patterns).
+
+### Notes
+
+- Site routes `/changelog`, `/releases`, and `/rss.xml` ship in a follow-up — this PR scopes #260 to the root pointer file.
+- Once `0.3.0` is cut, the `Unreleased` heading flips to `0.3.0` and this section moves into [`packages/ui/CHANGELOG.md`](./packages/ui/CHANGELOG.md).


### PR DESCRIPTION
## Summary
Adds \`CHANGELOG.md\` at repo root. Doesn't duplicate the canonical \`packages/ui/CHANGELOG.md\`; instead acts as a **pointer** for contributors and agents browsing the repo.

## What it tracks
The \`[Unreleased]\` section logs repo-wide work toward \`0.3.0\` that **isn't published-package code**:
- Agent-first surface (robots, sitemap, llms.txt, JSON-LD, manifest)
- Codebase health gate (react-doctor CI, doctor scripts)
- Registry-item richness (version, stability, a11y, examples)
- Site UX (Header GitHub icon, /request-component, /report)
- Brand (DESIGN.md)

Once \`0.3.0\` cuts, this section moves into \`packages/ui/CHANGELOG.md\`.

## Out of scope
The full #260 acceptance also asks for:
- \`/changelog\` site route
- \`/releases\` site route
- \`/rss.xml\` feed

Those need rendering work + live GitHub Releases API fetches. Tracked as the follow-up half of #260.

Refs #260