### PR TITLE
feat(registry): add props field to /r/<name>.json (#242)

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -594,6 +594,49 @@
           "code": "import { Button, Spinner } from \"@vllnt/ui\";\n\nexport function Demo() {\n  return (\n    <Button disabled>\n      <Spinner className=\"h-4 w-4\" />\n      Saving…\n    </Button>\n  );\n}\n",
           "framework": "react"
         }
+      ],
+      "props": [
+        {
+          "name": "variant",
+          "type": "\"default\" | \"secondary\" | \"outline\" | \"ghost\" | \"destructive\" | \"link\"",
+          "required": false,
+          "defaultValue": "\"default\"",
+          "description": "Visual variant. Use \"destructive\" only for irreversible actions; \"link\" only inside text flow."
+        },
+        {
+          "name": "size",
+          "type": "\"default\" | \"sm\" | \"lg\" | \"icon\"",
+          "required": false,
+          "defaultValue": "\"default\"",
+          "description": "Size token. Use \"icon\" for icon-only buttons."
+        },
+        {
+          "name": "asChild",
+          "type": "boolean",
+          "required": false,
+          "defaultValue": "false",
+          "description": "If true, the underlying element is the first child (Radix Slot pattern). Use to render a Next.js Link or another routing element while keeping Button styles."
+        },
+        {
+          "name": "disabled",
+          "type": "boolean",
+          "required": false,
+          "defaultValue": "false",
+          "description": "Visually and functionally disabled. Pair with `aria-disabled` if you need event handlers to keep firing."
+        },
+        {
+          "name": "type",
+          "type": "\"button\" | \"submit\" | \"reset\"",
+          "required": false,
+          "defaultValue": "\"button\"",
+          "description": "HTML button type. Set explicitly to \"submit\" inside <form>, otherwise the implicit submit behaviour can surprise users."
+        },
+        {
+          "name": "...rest",
+          "type": "ButtonHTMLAttributes<HTMLButtonElement>",
+          "required": false,
+          "description": "All native <button> attributes are forwarded."
+        }
       ]
     },
     {
@@ -963,6 +1006,65 @@
           "description": "Pair Combobox with React.useState for full control over the selected value.",
           "code": "\"use client\";\nimport * as React from \"react\";\nimport { Combobox } from \"@vllnt/ui\";\n\nconst options = [\n  { label: \"Pending\", value: \"pending\" },\n  { label: \"Approved\", value: \"approved\" },\n  { label: \"Rejected\", value: \"rejected\" },\n];\n\nexport function Demo() {\n  const [value, setValue] = React.useState(\"pending\");\n  return (\n    <Combobox\n      options={options}\n      value={value}\n      onValueChange={setValue}\n      placeholder=\"Status\"\n    />\n  );\n}\n",
           "framework": "react"
+        }
+      ],
+      "props": [
+        {
+          "name": "options",
+          "type": "ComboboxOption[]",
+          "required": true,
+          "description": "List of options. Each option must have a unique `value`. Optional `keywords` are added to the searchable haystack."
+        },
+        {
+          "name": "value",
+          "type": "string",
+          "required": false,
+          "description": "Controlled selected value. Pair with `onValueChange`. Omit for uncontrolled."
+        },
+        {
+          "name": "onValueChange",
+          "type": "(value: string) => void",
+          "required": false,
+          "description": "Called when the user picks an option (or clears by re-selecting the active one)."
+        },
+        {
+          "name": "placeholder",
+          "type": "string",
+          "required": false,
+          "defaultValue": "\"Select an option\"",
+          "description": "Trigger label when no option is selected."
+        },
+        {
+          "name": "searchPlaceholder",
+          "type": "string",
+          "required": false,
+          "defaultValue": "\"Search options...\"",
+          "description": "Placeholder for the type-ahead search input inside the listbox."
+        },
+        {
+          "name": "emptyText",
+          "type": "string",
+          "required": false,
+          "defaultValue": "\"No option found.\"",
+          "description": "Shown when the search yields zero matches."
+        },
+        {
+          "name": "className",
+          "type": "string",
+          "required": false,
+          "description": "Class applied to the popover content (the listbox container)."
+        },
+        {
+          "name": "triggerClassName",
+          "type": "string",
+          "required": false,
+          "description": "Class applied to the trigger button."
+        },
+        {
+          "name": "commandClassName",
+          "type": "string",
+          "required": false,
+          "description": "Class applied to the inner Command element."
         }
       ]
     },
@@ -4390,5 +4492,5 @@
     }
   ],
   "version": "0.2.1",
-  "generatedAt": "2026-05-10T15:12:14.518Z"
+  "generatedAt": "2026-05-10T15:22:31.217Z"
 }

--- a/apps/registry/scripts/inline-component-source.ts
+++ b/apps/registry/scripts/inline-component-source.ts
@@ -80,6 +80,15 @@ type UsageExample = {
   storyId?: string;
 };
 
+type PropDefinition = {
+  name: string;
+  type: string;
+  required?: boolean;
+  defaultValue?: string;
+  description?: string;
+  deprecated?: boolean;
+};
+
 type ComponentMeta = {
   stability?: Stability;
   replacedBy?: string;
@@ -94,6 +103,7 @@ type RegistryItem = {
   examples?: UsageExample[];
   files: RegistryFile[];
   name: string;
+  props?: PropDefinition[];
   registryDependencies?: string[];
   replacedBy?: string;
   stability?: Stability;
@@ -140,6 +150,24 @@ const readComponentExamples = (name: string): UsageExample[] => {
         entry !== null &&
         typeof (entry as UsageExample).title === "string" &&
         typeof (entry as UsageExample).code === "string",
+    );
+  } catch {
+    return [];
+  }
+};
+
+const readComponentProps = (name: string): PropDefinition[] => {
+  const propsPath = join(componentsRoot, name, "props.json");
+  if (!existsSync(propsPath)) return [];
+  try {
+    const raw = JSON.parse(readFileSync(propsPath, "utf8")) as unknown;
+    if (!Array.isArray(raw)) return [];
+    return raw.filter(
+      (entry): entry is PropDefinition =>
+        typeof entry === "object" &&
+        entry !== null &&
+        typeof (entry as PropDefinition).name === "string" &&
+        typeof (entry as PropDefinition).type === "string",
     );
   } catch {
     return [];
@@ -239,6 +267,19 @@ for (const item of registry.items) {
     item.examples = examples;
   } else {
     delete item.examples;
+  }
+
+  // Stamp prop definitions (see #242) — agents reading /r/<name>.json
+  // see the public API surface in TSDoc-shaped JSON. Source: optional
+  // packages/ui/src/components/<name>/props.json. Schema:
+  // [{ name, type, required?, defaultValue?, description?, deprecated? }].
+  // Auto-extraction from TS source is a future follow-up; props.json is
+  // the contract for now.
+  const props = readComponentProps(item.name);
+  if (props.length > 0) {
+    item.props = props;
+  } else {
+    delete item.props;
   }
 
   processed += 1;

--- a/apps/registry/scripts/stamp-registry-metadata.ts
+++ b/apps/registry/scripts/stamp-registry-metadata.ts
@@ -43,10 +43,20 @@ type UsageExample = {
   storyId?: string;
 };
 
+type PropDefinition = {
+  name: string;
+  type: string;
+  required?: boolean;
+  defaultValue?: string;
+  description?: string;
+  deprecated?: boolean;
+};
+
 type RegistryItem = {
   a11y?: A11ySchema;
   examples?: UsageExample[];
   name: string;
+  props?: PropDefinition[];
   version?: string;
   stability?: Stability;
   replacedBy?: string;
@@ -86,6 +96,11 @@ for (const item of registry.items) {
     data.examples = item.examples;
   } else {
     delete data.examples;
+  }
+  if (item.props && item.props.length > 0) {
+    data.props = item.props;
+  } else {
+    delete data.props;
   }
 
   writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);

--- a/apps/registry/types/registry.ts
+++ b/apps/registry/types/registry.ts
@@ -36,6 +36,15 @@ export type UsageExample = {
   storyId?: string;
 };
 
+export type PropDefinition = {
+  name: string;
+  type: string;
+  required?: boolean;
+  defaultValue?: string;
+  description?: string;
+  deprecated?: boolean;
+};
+
 export type RegistryComponent = {
   a11y?: A11ySchema;
   category?: ComponentCategory;
@@ -44,6 +53,7 @@ export type RegistryComponent = {
   examples?: UsageExample[];
   files: RegistryFile[];
   name: string;
+  props?: PropDefinition[];
   registryDependencies?: string[];
   replacedBy?: string;
   stability?: Stability;

--- a/packages/ui/src/components/button/props.json
+++ b/packages/ui/src/components/button/props.json
@@ -1,0 +1,43 @@
+[
+  {
+    "name": "variant",
+    "type": "\"default\" | \"secondary\" | \"outline\" | \"ghost\" | \"destructive\" | \"link\"",
+    "required": false,
+    "defaultValue": "\"default\"",
+    "description": "Visual variant. Use \"destructive\" only for irreversible actions; \"link\" only inside text flow."
+  },
+  {
+    "name": "size",
+    "type": "\"default\" | \"sm\" | \"lg\" | \"icon\"",
+    "required": false,
+    "defaultValue": "\"default\"",
+    "description": "Size token. Use \"icon\" for icon-only buttons."
+  },
+  {
+    "name": "asChild",
+    "type": "boolean",
+    "required": false,
+    "defaultValue": "false",
+    "description": "If true, the underlying element is the first child (Radix Slot pattern). Use to render a Next.js Link or another routing element while keeping Button styles."
+  },
+  {
+    "name": "disabled",
+    "type": "boolean",
+    "required": false,
+    "defaultValue": "false",
+    "description": "Visually and functionally disabled. Pair with `aria-disabled` if you need event handlers to keep firing."
+  },
+  {
+    "name": "type",
+    "type": "\"button\" | \"submit\" | \"reset\"",
+    "required": false,
+    "defaultValue": "\"button\"",
+    "description": "HTML button type. Set explicitly to \"submit\" inside <form>, otherwise the implicit submit behaviour can surprise users."
+  },
+  {
+    "name": "...rest",
+    "type": "ButtonHTMLAttributes<HTMLButtonElement>",
+    "required": false,
+    "description": "All native <button> attributes are forwarded."
+  }
+]

--- a/packages/ui/src/components/combobox/props.json
+++ b/packages/ui/src/components/combobox/props.json
@@ -1,0 +1,59 @@
+[
+  {
+    "name": "options",
+    "type": "ComboboxOption[]",
+    "required": true,
+    "description": "List of options. Each option must have a unique `value`. Optional `keywords` are added to the searchable haystack."
+  },
+  {
+    "name": "value",
+    "type": "string",
+    "required": false,
+    "description": "Controlled selected value. Pair with `onValueChange`. Omit for uncontrolled."
+  },
+  {
+    "name": "onValueChange",
+    "type": "(value: string) => void",
+    "required": false,
+    "description": "Called when the user picks an option (or clears by re-selecting the active one)."
+  },
+  {
+    "name": "placeholder",
+    "type": "string",
+    "required": false,
+    "defaultValue": "\"Select an option\"",
+    "description": "Trigger label when no option is selected."
+  },
+  {
+    "name": "searchPlaceholder",
+    "type": "string",
+    "required": false,
+    "defaultValue": "\"Search options...\"",
+    "description": "Placeholder for the type-ahead search input inside the listbox."
+  },
+  {
+    "name": "emptyText",
+    "type": "string",
+    "required": false,
+    "defaultValue": "\"No option found.\"",
+    "description": "Shown when the search yields zero matches."
+  },
+  {
+    "name": "className",
+    "type": "string",
+    "required": false,
+    "description": "Class applied to the popover content (the listbox container)."
+  },
+  {
+    "name": "triggerClassName",
+    "type": "string",
+    "required": false,
+    "description": "Class applied to the trigger button."
+  },
+  {
+    "name": "commandClassName",
+    "type": "string",
+    "required": false,
+    "description": "Class applied to the inner Command element."
+  }
+]


### PR DESCRIPTION
## Summary
Build pipeline reads optional \`packages/ui/src/components/<name>/props.json\` and stamps the array onto registry items + per-component JSON. Same pattern as #253 / #255 / #254.

## Schema

\`\`\`ts
type PropDefinition = {
  name: string;
  type: string;
  required?: boolean;
  defaultValue?: string;
  description?: string;
  deprecated?: boolean;
};
\`\`\`

## Seeds
Two \`props.json\` ship to validate the wiring:
- \`button/props.json\` — 6 props (variant, size, asChild, disabled, type, ...rest)
- \`combobox/props.json\` — 9 props (options, value, onValueChange, placeholder, search/empty texts, classNames)

Both are hand-authored TSDoc-shaped JSON. Other 220 components have no \`props\` field yet (additive, non-breaking) — filling them out is the ongoing follow-up.

## Future
- Auto-extract from TS source via \`react-docgen-typescript\` or the TS compiler API. Adding a docgen library now would invalidate the pnpm-lock and slow CI; deferred to a dedicated PR.
- Render a \`<PropsTable>\` on \`/components/[slug]\` consuming \`item.props\`. Separate UI PR.
- \`/llms-full.txt\` (#236) inlines props summaries — already gracefully degrades when absent.

## Test plan
- [ ] After deploy: \`curl https://ui.vllnt.ai/r/button.json | jq '.props | length'\` returns 6.
- [ ] \`curl https://ui.vllnt.ai/r/combobox.json | jq '.props | length'\` returns 9.
- [ ] Components without \`props.json\` have no \`props\` key — confirmed.

Closes #242 (auto-extraction tracked as follow-up)