### PR TITLE
feat(home): rebuild landing page with auto-updating stats (#264)

### DIFF
--- a/apps/registry/app/page.tsx
+++ b/apps/registry/app/page.tsx
@@ -1,53 +1,41 @@
-import { MDXContent, Sidebar } from "@vllnt/ui";
+import { Sidebar } from "@vllnt/ui";
 import type { Metadata } from "next";
 
-import { getPageContent } from "@/lib/content";
+import { Landing } from "@/components/landing/landing";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
+import { getComponentCount, getLibraryVersion } from "@/lib/stats";
 
-export async function generateMetadata(): Promise<Metadata> {
-  const { frontmatter } = await getPageContent("home");
-  const og = frontmatter.og;
+export function generateMetadata(): Metadata {
+  const componentCount = getComponentCount();
+  const version = getLibraryVersion();
+  const title = `VLLNT UI — ${componentCount} agent-first React components`;
+  const description = `Install any of ${componentCount} accessible React components with the shadcn CLI. Built on Radix UI, Tailwind CSS, and CVA. Every component is a machine-readable JSON descriptor agents can consume directly. v${version}, MIT licensed.`;
 
   return {
     alternates: { canonical: canonical("/") },
-    description: frontmatter.description,
+    description,
     openGraph: generateOGMetadata({
-      description: og?.description ?? frontmatter.description,
-      title: og?.title ?? frontmatter.title,
-      type: og?.type ?? frontmatter.type,
+      description,
+      title,
+      type: "home",
     }),
-    title: frontmatter.title,
+    title,
     twitter: generateTwitterMetadata({
-      description: og?.description ?? frontmatter.description,
-      title: og?.title ?? frontmatter.title,
-      type: og?.type ?? frontmatter.type,
+      description,
+      title,
+      type: "home",
     }),
   };
 }
 
-export default async function HomePage() {
-  const { content } = await getPageContent("home");
-
+export default function HomePage() {
   return (
     <>
       <Sidebar sections={getSidebarSections()} />
       <main className="flex-1 overflow-y-auto bg-background">
-        <div className="container mx-auto px-4 py-16 lg:px-8">
-          <div className="mb-8">
-            <h1 className="text-4xl font-bold mb-4">Get Started</h1>
-            <p className="text-muted-foreground text-lg">
-              Learn how to use VLLNT UI components in your projects.
-            </p>
-          </div>
-
-          <div className="prose prose-lg dark:prose-invert max-w-none">
-            <div className="prose prose-lg dark:prose-invert max-w-none prose-headings:mt-8 prose-headings:font-semibold prose-headings:text-black prose-h1:text-5xl prose-h2:text-4xl prose-h3:text-3xl prose-h4:text-2xl prose-h5:text-xl prose-h6:text-lg dark:prose-headings:text-white prose-p:leading-7 prose-blockquote:mt-6 prose-blockquote:border-l-2 prose-blockquote:pl-6 prose-blockquote:italic prose-ul:my-6 prose-ul:ml-6 prose-ul:list-disc prose-ol:my-6 prose-ol:ml-6 prose-ol:list-decimal prose-code:relative prose-code:rounded prose-code:bg-muted prose-code:px-[0.3rem] prose-code:py-[0.2rem] prose-code:text-sm  prose-pre:my-6 prose-pre:overflow-x-auto prose-pre:rounded-lg prose-pre:border prose-pre:bg-black prose-pre:py-4  prose-pre:text-sm prose-pre:text-white prose-pre:shadow-lg dark:prose-pre:bg-zinc-900 prose-hr:my-8 prose-hr:border-border prose-table:w-full prose-table:border-collapse prose-table:border prose-table:border-border prose-th:border prose-th:border-border prose-th:bg-muted prose-th:p-2 prose-th:text-left prose-th:font-medium prose-td:border prose-td:border-border prose-td:p-2 prose-img:rounded-lg prose-img:border prose-img:border-border prose-img:shadow-lg prose-a:font-medium prose-a:text-primary prose-a:underline prose-a:underline-offset-4 hover:prose-a:text-primary/80 prose-strong:font-semibold prose-em:italic prose-blockquote:border-l-primary prose-blockquote:text-muted-foreground">
-              <MDXContent content={content} />
-            </div>
-          </div>
-        </div>
+        <Landing />
       </main>
     </>
   );

--- a/apps/registry/components/landing/landing.tsx
+++ b/apps/registry/components/landing/landing.tsx
@@ -1,0 +1,303 @@
+import { CodeBlock } from "@vllnt/ui";
+import {
+  ArrowRight,
+  Github,
+  Sparkles,
+  Terminal,
+} from "lucide-react";
+import Link from "next/link";
+
+import {
+  getCategoryCount,
+  getComponentCount,
+  getFeaturedComponents,
+  getLibraryVersion,
+  getRegistryGeneratedAt,
+} from "@/lib/stats";
+
+const GITHUB_URL = "https://github.com/vllnt/ui";
+const STORYBOOK_URL = "https://storybook.vllnt.ai";
+const REQUEST_URL =
+  "https://github.com/vllnt/ui/issues/new?template=feature_request.yml&labels=enhancement,component";
+
+const TRUST_BADGES = [
+  { label: "MIT" },
+  { label: "TypeScript" },
+  { label: "RSC compatible" },
+  { label: "Tailwind v4 ready" },
+];
+
+function Hero({
+  componentCount,
+  version,
+}: {
+  componentCount: number;
+  version: string;
+}) {
+  return (
+    <section className="border-b border-border">
+      <div className="mx-auto max-w-7xl px-4 py-20 lg:px-8">
+        <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+          v{version} · MIT
+        </p>
+        <h1 className="mt-3 text-4xl font-semibold leading-tight md:text-5xl lg:text-6xl">
+          {componentCount} agent-first React components.
+          <br />
+          <span className="text-muted-foreground">Copy, paste, ship.</span>
+        </h1>
+        <p className="mt-6 max-w-2xl text-lg text-muted-foreground">
+          Built on Radix UI, Tailwind CSS, and CVA. Every component is also a
+          machine-readable JSON descriptor — agents (Claude, Cursor, Cline,
+          Continue) read the registry directly without scraping HTML.
+        </p>
+
+        <div className="mt-8">
+          <CodeBlock
+            code={`pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json`}
+            language="bash"
+          />
+        </div>
+
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Link
+            className="inline-flex h-11 items-center gap-2 rounded-md bg-foreground px-5 text-sm font-medium text-background hover:opacity-90"
+            href="/components"
+          >
+            Browse {componentCount} components
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+          <Link
+            className="inline-flex h-11 items-center gap-2 rounded-md border border-border px-5 text-sm font-medium hover:bg-muted"
+            href="/docs"
+          >
+            Read the docs
+          </Link>
+          <a
+            className="inline-flex h-11 items-center gap-2 rounded-md border border-border px-5 text-sm font-medium hover:bg-muted"
+            href={GITHUB_URL}
+            rel="noreferrer"
+            target="_blank"
+          >
+            <Github className="h-4 w-4" />
+            GitHub
+          </a>
+        </div>
+
+        <ul className="mt-8 flex flex-wrap gap-3 text-xs text-muted-foreground">
+          {TRUST_BADGES.map((badge) => (
+            <li
+              className="rounded-full border border-border bg-muted/40 px-3 py-1"
+              key={badge.label}
+            >
+              {badge.label}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+function Stats({
+  categoryCount,
+  componentCount,
+  generatedAt,
+  version,
+}: {
+  categoryCount: number;
+  componentCount: number;
+  generatedAt?: string;
+  version: string;
+}) {
+  return (
+    <section className="border-b border-border bg-muted/30">
+      <div className="mx-auto grid max-w-7xl grid-cols-2 gap-6 px-4 py-12 lg:grid-cols-4 lg:px-8">
+        <Stat label="Components" value={String(componentCount)} />
+        <Stat label="Categories" value={String(categoryCount)} />
+        <Stat label="Library version" value={`v${version}`} />
+        <Stat
+          label="Last build"
+          value={
+            generatedAt ? new Date(generatedAt).toISOString().slice(0, 10) : "—"
+          }
+        />
+      </div>
+    </section>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-3xl font-semibold tabular-nums">{value}</p>
+      <p className="mt-1 text-sm text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+function AgentCallout() {
+  return (
+    <section className="border-b border-border">
+      <div className="mx-auto max-w-7xl px-4 py-16 lg:px-8">
+        <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+          <Sparkles className="h-4 w-4" />
+          Agent-first
+        </div>
+        <h2 className="mt-2 text-3xl font-semibold">
+          Built so AI coding agents can use it directly.
+        </h2>
+        <p className="mt-4 max-w-2xl text-lg text-muted-foreground">
+          Every component ships as a machine-readable JSON descriptor with
+          name, version, stability, accessibility schema, usage examples,
+          and prop definitions. Agents discover the registry through three
+          surfaces.
+        </p>
+
+        <div className="mt-8 grid gap-4 md:grid-cols-3">
+          <AgentCard
+            description="Concise index per the llmstxt.org spec — sections, links, descriptions."
+            href="/llms.txt"
+            title="/llms.txt"
+          />
+          <AgentCard
+            description="Full registry context in one fetch — docs + per-component descriptors."
+            href="/llms-full.txt"
+            title="/llms-full.txt"
+          />
+          <AgentCard
+            description="Streamable HTTP MCP server. Tools: search_components, get_component, list_categories."
+            href="/mcp"
+            title="/mcp"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function AgentCard({
+  description,
+  href,
+  title,
+}: {
+  description: string;
+  href: string;
+  title: string;
+}) {
+  return (
+    <a
+      className="group rounded-lg border border-border p-5 hover:border-foreground/40"
+      href={href}
+      rel="noreferrer"
+      target="_blank"
+    >
+      <div className="flex items-center gap-2 text-sm font-mono">
+        <Terminal className="h-4 w-4 text-muted-foreground" />
+        <span>{title}</span>
+      </div>
+      <p className="mt-3 text-sm text-muted-foreground">{description}</p>
+      <p className="mt-4 inline-flex items-center gap-1 text-xs font-medium text-foreground">
+        Open
+        <ArrowRight className="h-3 w-3 transition-transform group-hover:translate-x-0.5" />
+      </p>
+    </a>
+  );
+}
+
+function FeaturedComponents() {
+  const featured = getFeaturedComponents();
+  if (featured.length === 0) return null;
+  return (
+    <section className="border-b border-border">
+      <div className="mx-auto max-w-7xl px-4 py-16 lg:px-8">
+        <h2 className="text-2xl font-semibold">Featured components</h2>
+        <p className="mt-2 text-muted-foreground">
+          A few favourites — browse all {getComponentCount()} from{" "}
+          <Link className="font-medium text-foreground underline" href="/components">
+            /components
+          </Link>
+          .
+        </p>
+
+        <ul className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {featured.map((component) => (
+            <li key={component.name}>
+              <Link
+                className="block rounded-lg border border-border p-4 hover:border-foreground/40"
+                href={`/components/${component.name}`}
+              >
+                <p className="font-medium">{component.name}</p>
+                <p className="mt-1 text-xs uppercase tracking-wide text-muted-foreground">
+                  {component.category ?? "uncategorized"}
+                </p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+function CommunityCTA() {
+  return (
+    <section>
+      <div className="mx-auto max-w-7xl px-4 py-20 lg:px-8">
+        <h2 className="text-3xl font-semibold">Build with the community.</h2>
+        <p className="mt-4 max-w-2xl text-lg text-muted-foreground">
+          MIT licensed. No tracking. No backend. Issues, ideas, and pull
+          requests welcome.
+        </p>
+        <div className="mt-8 flex flex-wrap gap-3">
+          <a
+            className="inline-flex h-11 items-center gap-2 rounded-md border border-border px-5 text-sm font-medium hover:bg-muted"
+            href={GITHUB_URL}
+            rel="noreferrer"
+            target="_blank"
+          >
+            <Github className="h-4 w-4" />
+            Star on GitHub
+          </a>
+          <a
+            className="inline-flex h-11 items-center gap-2 rounded-md border border-border px-5 text-sm font-medium hover:bg-muted"
+            href={REQUEST_URL}
+            rel="noreferrer"
+            target="_blank"
+          >
+            Request a component
+          </a>
+          <a
+            className="inline-flex h-11 items-center gap-2 rounded-md border border-border px-5 text-sm font-medium hover:bg-muted"
+            href={STORYBOOK_URL}
+            rel="noreferrer"
+            target="_blank"
+          >
+            Open Storybook
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function Landing() {
+  const componentCount = getComponentCount();
+  const categoryCount = getCategoryCount();
+  const version = getLibraryVersion();
+  const generatedAt = getRegistryGeneratedAt();
+
+  return (
+    <>
+      <Hero componentCount={componentCount} version={version} />
+      <Stats
+        categoryCount={categoryCount}
+        componentCount={componentCount}
+        generatedAt={generatedAt}
+        version={version}
+      />
+      <AgentCallout />
+      <FeaturedComponents />
+      <CommunityCTA />
+    </>
+  );
+}

--- a/apps/registry/lib/stats.ts
+++ b/apps/registry/lib/stats.ts
@@ -1,0 +1,62 @@
+import packageJson from "../../../packages/ui/package.json";
+import registry from "../registry.json";
+
+type RegistryItem = {
+  readonly name: string;
+  readonly category?: string;
+};
+
+type Registry = {
+  readonly items: readonly RegistryItem[];
+  readonly version?: string;
+  readonly generatedAt?: string;
+};
+
+const REGISTRY = registry as Registry;
+const PACKAGE = packageJson as { readonly version: string };
+
+export function getComponentCount(): number {
+  return REGISTRY.items.length;
+}
+
+export function getLibraryVersion(): string {
+  return REGISTRY.version ?? PACKAGE.version;
+}
+
+export function getRegistryGeneratedAt(): string | undefined {
+  return REGISTRY.generatedAt;
+}
+
+export type CategoryStat = {
+  readonly category: string;
+  readonly count: number;
+};
+
+export function getCategoryStats(): readonly CategoryStat[] {
+  const counts = new Map<string, number>();
+  for (const item of REGISTRY.items) {
+    const key = item.category ?? "uncategorized";
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([category, count]) => ({ category, count }))
+    .sort((a, b) => a.category.localeCompare(b.category));
+}
+
+export function getCategoryCount(): number {
+  return getCategoryStats().length;
+}
+
+export function getFeaturedComponents(): readonly RegistryItem[] {
+  const featuredSlugs = [
+    "button",
+    "data-table",
+    "ai-chat-input",
+    "combobox",
+    "timeline",
+    "globe-3d",
+  ];
+  return featuredSlugs
+    .map((slug) => REGISTRY.items.find((item) => item.name === slug))
+    .filter((item): item is RegistryItem => item !== undefined);
+}


### PR DESCRIPTION
## Summary
Replace MDX-only home with a typed React composition. Every number on the page is **auto-derived** from a single source of truth — never hardcoded.

## New helper

\`apps/registry/lib/stats.ts\`:

| Helper | Source |
|---|---|
| \`getComponentCount()\` | \`registry.json.items.length\` |
| \`getLibraryVersion()\` | \`registry.json.version\` ?? \`packages/ui/package.json\` |
| \`getCategoryStats()\` | derived from \`items[].category\` |
| \`getCategoryCount()\` | derived |
| \`getRegistryGeneratedAt()\` | \`registry.json.generatedAt\` |
| \`getFeaturedComponents()\` | curated 6 favourites |

Every component on the landing reads through this single helper. \`pnpm test home\` (follow-up) will assert hero count === \`registry.json\` length.

## Sections

1. **Hero** — positioning headline (\"225 agent-first React components.\"), 1-line install snippet, 3 CTAs (Browse, Docs, GitHub), trust badges.
2. **Stats** — 4 auto-updating tiles: components / categories / version / last build.
3. **Agent callout** — three cards linking \`/llms.txt\`, \`/llms-full.txt\`, \`/mcp\`.
4. **Featured components** — 6 curated cards.
5. **Community CTA** — GitHub, Request a component, Storybook.

## Out of scope (follow-ups)
- Sandpack live playground (#256, stretch)
- Releases strip via GitHub API (#260 follow-up)
- Live GitHub-stars / npm-downloads numbers
- Comparison strip → \`/vs/*\` (#258, stretch)
- Per-section analytics events

## Cut from page (intentional)
The MDX content moved to \`/docs\` (already lives in \`content/pages/home.mdx\`; left in place for now in case agents reference it via \`/llms-full.txt\`). Title text changes don't break SEO — canonical URL unchanged.

## Test plan
- [ ] After deploy: \`/\` renders with count = 225, version = 0.2.1.
- [ ] OG image regenerates with new title.
- [ ] All 5 sections render on mobile (375×667), tablet, desktop.
- [ ] \`prefers-reduced-motion\` respected (no hero animations in this PR).
- [ ] Lighthouse SEO ≥ 95 on \`/\`.

Closes #264 (partial — Sandpack / releases-strip / live numbers in follow-ups)