### PR TITLE
feat(site): add Footer + render in Landing (#243)

### DIFF
--- a/apps/registry/components/footer/footer.tsx
+++ b/apps/registry/components/footer/footer.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+
+const GITHUB_URL = "https://github.com/vllnt/ui";
+const STORYBOOK_URL = "https://storybook.vllnt.ai";
+const SPONSOR_URL = "https://github.com/sponsors/bntvllnt";
+const REQUEST_URL =
+  "https://github.com/vllnt/ui/issues/new?template=feature_request.yml&labels=enhancement,component";
+const REPORT_URL =
+  "https://github.com/vllnt/ui/issues/new?template=bug_report.yml&labels=bug";
+const DISCUSSIONS_URL = "https://github.com/vllnt/ui/discussions";
+const LICENSE_URL = "https://github.com/vllnt/ui/blob/main/LICENSE";
+const COC_URL = "https://github.com/vllnt/ui/blob/main/CODE_OF_CONDUCT.md";
+
+type FooterLink = {
+  readonly href: string;
+  readonly label: string;
+  readonly external?: boolean;
+};
+
+type FooterColumn = {
+  readonly title: string;
+  readonly links: readonly FooterLink[];
+};
+
+const COLUMNS: readonly FooterColumn[] = [
+  {
+    title: "Library",
+    links: [
+      { href: "/components", label: "Components" },
+      { href: "/docs", label: "Docs" },
+      { href: "/philosophy", label: "Philosophy" },
+    ],
+  },
+  {
+    title: "Resources",
+    links: [
+      { external: true, href: STORYBOOK_URL, label: "Storybook" },
+      { href: "/r/registry.json", label: "Registry JSON" },
+      { href: "/llms.txt", label: "llms.txt" },
+      { href: "/mcp", label: "MCP" },
+      { external: true, href: GITHUB_URL, label: "GitHub" },
+    ],
+  },
+  {
+    title: "Community",
+    links: [
+      { external: true, href: REQUEST_URL, label: "Request a component" },
+      { external: true, href: REPORT_URL, label: "Report a bug" },
+      { external: true, href: DISCUSSIONS_URL, label: "Discussions" },
+      { external: true, href: SPONSOR_URL, label: "Sponsor" },
+    ],
+  },
+  {
+    title: "Legal",
+    links: [
+      { external: true, href: LICENSE_URL, label: "License (MIT)" },
+      { external: true, href: COC_URL, label: "Code of Conduct" },
+    ],
+  },
+];
+
+export function Footer() {
+  return (
+    <footer className="border-t border-border bg-background">
+      <div className="mx-auto max-w-7xl px-4 py-12 lg:px-8">
+        <div className="grid grid-cols-2 gap-8 sm:grid-cols-4">
+          {COLUMNS.map((column) => (
+            <div key={column.title}>
+              <h3 className="text-sm font-semibold">{column.title}</h3>
+              <ul className="mt-4 space-y-2">
+                {column.links.map((link) =>
+                  link.external ? (
+                    <li key={link.href}>
+                      <a
+                        className="text-sm text-muted-foreground hover:text-foreground"
+                        href={link.href}
+                        rel="noreferrer"
+                        target="_blank"
+                      >
+                        {link.label}
+                      </a>
+                    </li>
+                  ) : (
+                    <li key={link.href}>
+                      <Link
+                        className="text-sm text-muted-foreground hover:text-foreground"
+                        href={link.href}
+                      >
+                        {link.label}
+                      </Link>
+                    </li>
+                  ),
+                )}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <div className="mt-12 flex flex-col gap-2 border-t border-border pt-6 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs text-muted-foreground">
+            VLLNT UI · MIT licensed · Built with Radix UI, Tailwind CSS, and CVA
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Maintained by{" "}
+            <a
+              className="hover:text-foreground"
+              href="https://github.com/vllnt"
+              rel="noreferrer"
+              target="_blank"
+            >
+              VLLNT
+            </a>
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/registry/components/landing/landing.tsx
+++ b/apps/registry/components/landing/landing.tsx
@@ -7,6 +7,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 
+import { Footer } from "@/components/footer/footer";
 import {
   getCategoryCount,
   getComponentCount,
@@ -298,6 +299,7 @@ export function Landing() {
       <AgentCallout />
       <FeaturedComponents />
       <CommunityCTA />
+      <Footer />
     </>
   );
 }


### PR DESCRIPTION
## Summary
\`apps/registry/components/footer/footer.tsx\` ships with 4 columns:

| Column | Links |
|---|---|
| Library | Components · Docs · Philosophy |
| Resources | Storybook · Registry JSON · llms.txt · MCP · GitHub |
| Community | Request a component · Report a bug · Discussions · Sponsor |
| Legal | License (MIT) · Code of Conduct |

Plus license tagline + maintainer credit.

## Integration
Rendered as the **last section of the Landing composition** (#264). This avoids the layout-shell overflow refactor that previously blocked Footer integration — the layout still uses \`h-full overflow-hidden\` with \`<main className=\"flex-1 overflow-y-auto\">\`, and the Footer scrolls with the home content cleanly.

## Per-page rollout (follow-up)
Other pages (\`/components\`, \`/docs\`, \`/philosophy\`, \`/components/[slug]\`, \`/design\` once it ships) get Footer in mechanical follow-up PRs — three-line integration each. Doing it page-by-page keeps the existing scroll model intact.

## Test plan
- [ ] After deploy: \`/\` shows Footer at bottom of scrollable content.
- [ ] All 4 columns present.
- [ ] External links open in new tab with rel=noreferrer.
- [ ] Internal links use Next.js Link (client-side nav).
- [ ] Mobile (375×667): columns collapse to 2-col.

## Pairs with
- #244 Header GitHub (already merged)
- #261 FUNDING.yml (already merged — Sponsor link routes here)

Closes #243 (home — per-page rollout in follow-up)