### PR TITLE
fix(landing): CodeBlock takes children, not 'code' prop (#264 fallout)

### DIFF
--- a/apps/registry/components/landing/landing.tsx
+++ b/apps/registry/components/landing/landing.tsx
@@ -53,10 +53,9 @@ function Hero({
         </p>
 
         <div className="mt-8">
-          <CodeBlock
-            code={`pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json`}
-            language="bash"
-          />
+          <CodeBlock language="bash">
+            {`pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json`}
+          </CodeBlock>
         </div>
 
         <div className="mt-6 flex flex-wrap gap-3">


### PR DESCRIPTION
## Problem
Next.js build has been failing on every commit since #264 (landing rebuild) with:

\`\`\`
Type error: Property 'code' does not exist on type 'IntrinsicAttributes & CodeBlockProps'.
  ./components/landing/landing.tsx:57:13
\`\`\`

\`CodeBlock\` from \`@vllnt/ui\` accepts \`{ children: ReactNode; language?: string }\` — not a \`code\` prop.

## Fix
Pass the snippet as a child. Visual output identical.

\`\`\`tsx
<CodeBlock language=\"bash\">
  {\`pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json\`}
</CodeBlock>
\`\`\`

## Test plan
- [ ] Publish workflow recovers on main.
- [ ] Landing renders the install snippet correctly.

Refs #264