### PR TITLE
ci: add storybook build job (matrix) + relocate Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,7 @@
-# ui — vllnt-cluster build pipeline (ui-registry app from monorepo).
+# ui — vllnt-cluster build pipeline.
+# Matrix builds both ui-registry (root Dockerfile) and storybook
+# (apps/storybook/Dockerfile) in parallel, each pushed to its own
+# OVH registry repo + deployed via the cluster deployer API.
 
 name: build
 
@@ -9,17 +12,13 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch: {}
 
-env:
-  SERVICE_NAME: ui-registry
-  IMAGE_BASE: "${{ vars.REGISTRY_HOST }}/vllnt/ui-registry"
-
 concurrency:
   group: build-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build-sign-scan-deploy:
-    name: build · sign · scan · deploy
+    name: build · sign · scan · deploy (${{ matrix.service }})
     runs-on: vllnt-cluster
     timeout-minutes: 25
     permissions:
@@ -27,6 +26,16 @@ jobs:
       checks: write
       deployments: write
       pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: ui-registry
+            dockerfile: Dockerfile
+          - service: storybook
+            dockerfile: apps/storybook/Dockerfile
+    env:
+      IMAGE_BASE: "${{ vars.REGISTRY_HOST }}/vllnt/${{ matrix.service }}"
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 1 }
@@ -58,6 +67,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: ${{ matrix.dockerfile }}
           push: true
           tags: "${{ env.IMAGE_BASE }}:${{ steps.tag.outputs.tag }}"
           provenance: false
@@ -89,7 +99,7 @@ jobs:
         env:
           DEPLOYER_API_BEARER: ${{ secrets.DEPLOYER_API_BEARER }}
         with:
-          service:   ui-registry
+          service:   ${{ matrix.service }}
           env:       ${{ steps.tag.outputs.env }}
           sha:       ${{ steps.tag.outputs.sha }}
           digest:    ${{ steps.build.outputs.digest }}

--- a/apps/storybook/Dockerfile
+++ b/apps/storybook/Dockerfile
@@ -1,0 +1,33 @@
+# Storybook static build for ui.vllnt.ai monorepo.
+# Build from repo root so pnpm workspace links resolve.
+# Final image: nginx-unprivileged serving the static export.
+
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS build
+WORKDIR /src
+
+# Install pnpm matching the project version
+RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
+
+# Copy lockfile + manifest first for layer caching
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json ./
+
+# Copy all packages so workspace resolution works
+COPY packages ./packages
+COPY apps ./apps
+
+# Install only what's needed for storybook build (workspace-aware)
+RUN pnpm install --frozen-lockfile --filter @vllnt/ui --filter @vllnt/ui... --include-workspace-root
+
+# Build storybook → packages/ui/storybook-static
+RUN pnpm --filter @vllnt/ui build-storybook
+
+# ---
+
+FROM nginxinc/nginx-unprivileged:alpine@sha256:4c18337659c90a01627f2e152b7c89524521c82dcedb255dc83d3689642b0803 AS runtime
+
+# nginx-unprivileged image ships with uid 101 + nginx group; configured to
+# listen on 8080 by default and write to /tmp. K8s spec uses runAsUser 101.
+COPY --chown=101:101 apps/storybook/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build --chown=101:101 /src/packages/ui/storybook-static /usr/share/nginx/html
+
+EXPOSE 8080

--- a/apps/storybook/nginx.conf
+++ b/apps/storybook/nginx.conf
@@ -1,0 +1,35 @@
+server {
+    listen       8080 default_server;
+    server_name  _;
+    root         /usr/share/nginx/html;
+    index        index.html;
+
+    # Healthcheck endpoint for K8s probes
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok\n";
+    }
+
+    # Static asset caching — long TTL on hashed files, none on HTML
+    location ~* \.(js|css|woff2?|svg|png|jpg|jpeg|gif|webp|ico)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    location / {
+        # Storybook generates fully-static HTML; no fallback needed
+        try_files $uri $uri/index.html =404;
+
+        # Security headers (defense in depth — Traefik middleware also adds these)
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    }
+
+    # Compression
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 256;
+}


### PR DESCRIPTION
## Summary

- Move `apps/storybook/Dockerfile` + `nginx.conf` from `infra` repo into this one (lives next to `packages/ui` workspace it builds from).
- Expand `build.yml` from single-job to matrix:
  - `ui-registry` — root `Dockerfile` (unchanged)
  - `storybook` — `apps/storybook/Dockerfile` (new)
- Both push to OVH registry under `vllnt/<service>` so the cluster deployer can resolve them.

## Why

Storybook was hand-built once + pushed to `ghcr.io/vllnt/storybook`; no pipeline rebuilt it on main commits. After the infra repo's deployer renderer switched to expecting `:main-<sha>` from OVH registry, every reconcile of storybook → `ImagePullBackOff`. Current pod survives only because the existing ReplicaSet hasn't been touched; any node reboot = `storybook.vllnt.ai` outage. Surfaced by `scripts/verify-prod-deploys.py` (drift=failing).

## Paired change

`infra` repo PR will follow with:
- Delete `apps/storybook/Dockerfile` + `nginx.conf` (now owned here)
- Update `apps/storybook/app.yaml` `image:` field → `dnpz4use.c1.gra9.container-registry.ovh.net/vllnt/storybook`

## Test plan

- [ ] After merge, both matrix jobs green on main push (vllnt-cluster runner)
- [ ] OVH registry has `vllnt/storybook:main-<sha>` tag
- [ ] Cluster deployer reconciles storybook to new image; pod 1/1 Ready
- [ ] `https://storybook.vllnt.ai/` returns 200
- [ ] `scripts/verify-prod-deploys.py --filter storybook` → drift=ok