### PR TITLE
ci: run issue-link gate on pull requests

### DIFF
--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -1,7 +1,7 @@
 name: PR Issue Link
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited


### PR DESCRIPTION
## Summary
- Switch the issue-link workflow trigger from `pull_request_target` to `pull_request` so the eventual required check is produced on the PR head SHA.
- Preserve the existing activity types, read-only permissions, and `Enforce issue-linked PRs` job/check name.
- Keep the workflow dependency-free: no checkout, install, or execution of PR code.

## Validation
- `git diff --check` — passed on `d9f21b1494c4440d146a70f0297c13c9718730ad`.
- `python3` invariant check — passed: no `pull_request_target`, `pull_request` present, read-only permissions preserved, check name preserved, no `actions/checkout`.
- `python3` + PyYAML parse — passed.
- Broad package gates intentionally not run locally: workflow-only one-line trigger change, per task scope.

## Risk notes
- This PR does not mutate branch protection, rulesets, repository settings, releases, deployments, or production.
- Follow-up settings mutation remains unsafe until explicitly approved after this check runs successfully on recent PR heads.

Related to #152

## Branch freshness
<!-- pr-freshness:start -->
- Refreshed against `main` on 2026-05-31T15:06:18Z.
- Current head: `c0ea39015f77bd75f96b6ae830977818bc057187`.
- Current base: `7d14e563f349259d071634e02a8f489fedb6b0bd`.
- Merge state at refresh: `UNSTABLE`.
- Checks at refresh: RERUNNING (2 active/non-terminal check(s); 0 completed non-green check(s) currently visible).
- This section supersedes older current-head or CI-status notes above.
<!-- pr-freshness:end -->
