### PR TITLE
fix(registry): render live component previews on /components listing

### DIFF
--- a/apps/registry/app/components/page.tsx
+++ b/apps/registry/app/components/page.tsx
@@ -2,6 +2,7 @@ import { Sidebar } from "@vllnt/ui";
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { ComponentThumbnail } from "@/components/component-thumbnail";
 import componentMetadata from "@/lib/component-metadata.json";
 import { getPageContent } from "@/lib/content";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
@@ -70,7 +71,8 @@ export default function ComponentsPage() {
                       href={`/components/${component.name}`}
                       key={component.name}
                     >
-                      <div className="flex-1 p-4 bg-muted/30 border-b min-h-[100px] flex flex-col justify-center">
+                      <ComponentThumbnail componentName={component.name} />
+                      <div className="flex flex-1 flex-col p-4">
                         <h3 className="text-sm font-medium group-hover:text-foreground transition-colors">
                           {component.title}
                         </h3>
@@ -79,13 +81,11 @@ export default function ComponentsPage() {
                             {meta.description}
                           </p>
                         ) : null}
-                      </div>
-                      <div className="px-3 py-2 shrink-0 flex items-center justify-between">
-                        <span className="text-xs text-muted-foreground">
-                          {storyCount > 0
-                            ? `${storyCount} ${storyCount === 1 ? "story" : "stories"}`
-                            : "No preview"}
-                        </span>
+                        {storyCount > 0 ? (
+                          <span className="mt-3 text-xs text-muted-foreground">
+                            {`${storyCount} ${storyCount === 1 ? "story" : "stories"}`}
+                          </span>
+                        ) : null}
                       </div>
                     </Link>
                   );

--- a/apps/registry/components/component-preview/component-preview.tsx
+++ b/apps/registry/components/component-preview/component-preview.tsx
@@ -246,6 +246,21 @@ function SimplePreview({ description }: { description: string }) {
   );
 }
 
+// Graceful fallback for components without a dedicated preview: a muted wordmark
+// tile derived from the component slug, so gallery cards still look intentional.
+function PlaceholderPreview({ componentName }: { componentName: string }) {
+  const label = componentName
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <span className="text-sm font-medium text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
 function ButtonPreview() {
   return (
     <div className="flex flex-wrap gap-2">
@@ -2480,6 +2495,6 @@ export function ComponentPreview({ componentName }: ComponentPreviewProps) {
     case "world-clock-bar":
       return <WorldClockBarPreview />;
     default:
-      return <div className="text-muted-foreground">Preview not available</div>;
+      return <PlaceholderPreview componentName={componentName} />;
   }
 }

--- a/apps/registry/components/component-thumbnail/component-thumbnail.tsx
+++ b/apps/registry/components/component-thumbnail/component-thumbnail.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import * as React from "react";
+
+import { ComponentPreview } from "@/components/component-preview/component-preview";
+
+type ComponentThumbnailProps = {
+  componentName: string;
+};
+
+/**
+ * Renders a live, non-interactive preview of a component for gallery cards.
+ *
+ * Defers mounting the heavy, client-side {@link ComponentPreview} until the card
+ * scrolls into view, so the 200+ component grid does not render and animate every
+ * preview up front. Mounting in the browser also keeps previews that depend on
+ * browser APIs (e.g. `useSearchParams`, `window`) out of the static build.
+ *
+ * @param componentName - Registry slug used to resolve the matching preview.
+ */
+export function ComponentThumbnail({
+  componentName,
+}: ComponentThumbnailProps): React.ReactElement {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    const element = containerRef.current;
+    if (!element || isVisible) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [isVisible]);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none flex h-44 items-center justify-center overflow-hidden border-b bg-muted/30 p-4"
+      ref={containerRef}
+    >
+      {isVisible ? <ComponentPreview componentName={componentName} /> : null}
+    </div>
+  );
+}

--- a/apps/registry/components/component-thumbnail/index.ts
+++ b/apps/registry/components/component-thumbnail/index.ts
@@ -1,0 +1,1 @@
+export { ComponentThumbnail } from "./component-thumbnail";


### PR DESCRIPTION
## What

`/components` rendered text-only cards — no visual of any component. This wires the existing (but orphaned) `ComponentPreview` into the listing cards so each card shows a live preview.

Fixes #379

## Why it was broken

`app/components/page.tsx` never rendered a preview. `components/component-preview/component-preview.tsx` (a live preview for 142 components) was **imported nowhere** — dead code. The 3 chart components also showed "No preview" despite having real previews in that switch.

## Change

- **New** `components/component-thumbnail/` — a lazy, `IntersectionObserver`-backed wrapper that mounts the heavy, client-only `ComponentPreview` once a card scrolls into view (so 225 previews don't all render/animate at once, and previews using browser-only hooks can't break the static build).
- `app/components/page.tsx` — render `<ComponentThumbnail>` on top of each card; drop the now-wrong "No preview" label.
- `component-preview.tsx` — replace the blunt `"Preview not available"` default with a graceful name-based placeholder tile (83 components have no dedicated preview).

Durable rationale: reuses complete existing infra, **zero external deps** (no Storybook/iframe/env), client-only render.

## Verification

- `pnpm build` PASS — `2 successful`, 243/243 pages, `/components` prerendered static, no SSR errors.
- Lint PASS on changed files.
- Live (agent-browser, prod render) at **desktop / tablet / mobile**: previews render, lazy-mount-on-scroll confirmed, Area/Bar charts now show real SVGs, **0 page errors, 0 console errors**.
- 142 live previews + 83 graceful placeholders.

## Follow-ups (out of scope, tracked in #379)

1. Detail page `/components/[slug]` Storybook iframe falls back to `http://localhost:6006` in prod (`NEXT_PUBLIC_STORYBOOK_URL` unset at build).
2. Dev-only React `value`/`onChange` warnings in a few demo previews (`PasswordInput`, etc.) — `value` → `defaultValue`.
