### PR TITLE
feat(deploy): add ntk.yaml for ntk/deployer

### DIFF
--- a/ntk.yaml
+++ b/ntk.yaml
@@ -1,0 +1,57 @@
+# ntk.yaml — vllnt/ui deploy config (ntk CLI / vllnt platform deployer).
+#
+# Public repo: this file is declarative and PUBLIC-SAFE only.
+#   - No secrets, tokens, or credentials (the deploy token is passed via the
+#     NTK_TOKEN env at deploy time, never committed).
+#   - No internal infra identifiers (registry host, tailnet IDs, node names, IPs).
+#   - Secrets + per-env private vars are injected by the deployer from the
+#     platform vault at deploy time — they are never declared here.
+# Preview hostnames are tailnet-only and derived by the deployer per-PR; they
+# are intentionally not declared in this file. See docs/specs/ntk.md.
+
+project: ui                          # token-scope + allowlist key (granted server-side)
+
+apps:
+  # Component registry / docs site → ui.vllnt.ai
+  - name: ui-registry
+    path: apps/registry
+    port: 3000
+    healthcheck: /
+    domains:
+      production: ui.vllnt.ai
+    visibility:                      # previews are tailnet-only (hostname derived by deployer)
+      production: public
+      preview:    tailnet
+    replicas:
+      production: 1
+      preview:    1
+    resources:
+      requests: { cpu: 100m, memory: 256Mi }
+      limits:   { cpu: 1000m, memory: 1024Mi }
+    env:
+      production:
+        SITE_URL: https://ui.vllnt.ai
+        NEXT_PUBLIC_SITE_URL: https://ui.vllnt.ai
+    build:
+      dockerfile: Dockerfile         # repo-root Dockerfile builds @vllnt/ui-registry
+      context: .
+
+  # Component workshop → storybook.vllnt.ai
+  - name: storybook
+    path: apps/storybook
+    port: 8080
+    healthcheck: /healthz
+    domains:
+      production: storybook.vllnt.ai
+    visibility:
+      production: public
+      preview:    tailnet
+    replicas:
+      production: 1
+      preview:    1
+    resources:
+      requests: { cpu: 50m, memory: 64Mi }
+      limits:   { cpu: 500m, memory: 256Mi }
+    build:
+      dockerfile: apps/storybook/Dockerfile
+      context: .

--- a/ntk.yaml
+++ b/ntk.yaml
@@ -38,10 +38,13 @@ apps:
       args:
         # Registry inlines the storybook URL at build time (Next.js bakes
         # NEXT_PUBLIC_* during `next build`) so it can embed live component
-        # previews. Points at the public storybook. (Preview registry ->
-        # preview storybook cross-linking is a planned per-env enhancement —
-        # see docs/specs/ntk.md.)
-        NEXT_PUBLIC_STORYBOOK_URL: https://storybook.vllnt.ai
+        # previews. {url:storybook} is resolved per-env by the deployer:
+        #   production → https://storybook.vllnt.ai
+        #   preview    → the matching pr-<N> storybook (tailnet)
+        # so a preview registry links to its own preview storybook. The tailnet
+        # base stays in the deployer, never this public file. ntk.yaml token
+        # reference: vllnt/infra docs/specs/ntk.md.
+        NEXT_PUBLIC_STORYBOOK_URL: "{url:storybook}"
 
   # Component workshop → storybook.vllnt.ai
   - name: storybook

--- a/ntk.yaml
+++ b/ntk.yaml
@@ -35,6 +35,13 @@ apps:
     build:
       dockerfile: Dockerfile         # repo-root Dockerfile builds @vllnt/ui-registry
       context: .
+      args:
+        # Registry inlines the storybook URL at build time (Next.js bakes
+        # NEXT_PUBLIC_* during `next build`) so it can embed live component
+        # previews. Points at the public storybook. (Preview registry ->
+        # preview storybook cross-linking is a planned per-env enhancement —
+        # see docs/specs/ntk.md.)
+        NEXT_PUBLIC_STORYBOOK_URL: https://storybook.vllnt.ai
 
   # Component workshop → storybook.vllnt.ai
   - name: storybook


### PR DESCRIPTION
Adds a repo-root `ntk.yaml` so vllnt/ui is deployable via the ntk CLI / vllnt platform deployer (Vercel/Convex-style, one config per repo).

## What
Declarative config for both monorepo apps:

| app | path | domain | port |
|-----|------|--------|------|
| ui-registry | apps/registry | ui.vllnt.ai | 3000 |
| storybook | apps/storybook | storybook.vllnt.ai | 8080 |

Per app: `healthcheck`, production `domains`, `visibility` (prod=public, preview=tailnet), `replicas`, `resources`, `build` (Dockerfile + context), public `env`.

## Public-safe (this repo is public)
- No secrets, tokens, or credentials. The deploy token is passed via `NTK_TOKEN` at deploy time, never committed.
- No internal infra identifiers (registry host, tailnet IDs, node names, IPs).
- Secrets + private per-env vars are injected by the deployer from the platform vault at deploy time.
- Preview hostnames are tailnet-only, derived per-PR by the deployer — intentionally not declared here.

Schema reference: vllnt/infra `docs/specs/ntk.md`. Validated against the ntkconfig parser schema (strict unknown-field decode, visibility model private|tailnet|public|funnel).