### PR TITLE
fix(react-doctor): clear render-phase setState + derived-state warnings

### DIFF
--- a/apps/registry/registry/default/animated-text/animated-text.tsx
+++ b/apps/registry/registry/default/animated-text/animated-text.tsx
@@ -162,15 +162,22 @@ function buildRevealPlan(
 }
 
 function useRevealProgress(active: boolean, length: number, stagger: number) {
-  const [progress, setProgress] = React.useState(0);
+  const [progress, setProgress] = React.useState(() => (active ? 0 : length));
+  const [revealKey, setRevealKey] = React.useState({ active, length, stagger });
+
+  if (
+    revealKey.active !== active ||
+    revealKey.length !== length ||
+    revealKey.stagger !== stagger
+  ) {
+    setRevealKey({ active, length, stagger });
+    setProgress(active ? 0 : length);
+  }
 
   React.useEffect(() => {
     if (!active) {
-      setProgress(length);
       return;
     }
-
-    setProgress(0);
 
     const revealInterval = window.setInterval(
       () => {

--- a/apps/registry/registry/default/combobox/combobox.tsx
+++ b/apps/registry/registry/default/combobox/combobox.tsx
@@ -41,12 +41,6 @@ function useComboboxValue(
 ) {
   const [internalValue, setInternalValue] = React.useState(value ?? "");
 
-  React.useEffect(() => {
-    if (value !== undefined) {
-      setInternalValue(value);
-    }
-  }, [value]);
-
   const resolvedValue = value ?? internalValue;
 
   const setResolvedValue = (nextValue: string) => {

--- a/apps/registry/registry/default/date-picker/date-picker.tsx
+++ b/apps/registry/registry/default/date-picker/date-picker.tsx
@@ -42,12 +42,6 @@ const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
     );
     const selectedDate = value ?? internalValue;
 
-    React.useEffect(() => {
-      if (value !== undefined) {
-        setInternalValue(value);
-      }
-    }, [value]);
-
     const handleSelect = (nextDate: Date | undefined) => {
       if (value === undefined) {
         setInternalValue(nextDate);

--- a/apps/registry/registry/default/file-upload/file-upload.tsx
+++ b/apps/registry/registry/default/file-upload/file-upload.tsx
@@ -27,12 +27,6 @@ function useFileUploadState(
     controlledFiles ?? [],
   );
 
-  React.useEffect(() => {
-    if (controlledFiles !== undefined) {
-      setInternalFiles(controlledFiles);
-    }
-  }, [controlledFiles]);
-
   const resolvedFiles = controlledFiles ?? internalFiles;
 
   const updateFiles = React.useCallback(

--- a/apps/registry/registry/default/lang-provider/lang-provider.tsx
+++ b/apps/registry/registry/default/lang-provider/lang-provider.tsx
@@ -17,18 +17,18 @@ export function LangProvider({
 }: LangProviderProps) {
   const pathname = usePathname();
 
-  useEffect(() => {
-    // Extract language from pathname - matches /en, /fr, /en/, /fr/, etc.
-    const langMatch = /^\/([a-z]{2})(?:\/|$)/.exec(pathname);
-    const lang =
-      langMatch &&
-      supportedLanguages.includes(langMatch[1] as SupportedLanguage)
-        ? (langMatch[1] as SupportedLanguage)
-        : defaultLanguage;
+  // Derive the language during render from the pathname.
+  // Matches /en, /fr, /en/, /fr/, etc.
+  const langMatch = /^\/([a-z]{2})(?:\/|$)/.exec(pathname);
+  const lang =
+    langMatch && supportedLanguages.includes(langMatch[1] as SupportedLanguage)
+      ? (langMatch[1] as SupportedLanguage)
+      : defaultLanguage;
 
-    // Update the HTML lang attribute
+  useEffect(() => {
+    // Sync the derived language to the document's lang attribute.
     document.documentElement.setAttribute("lang", lang);
-  }, [pathname, defaultLanguage, supportedLanguages]);
+  }, [lang]);
 
   return null;
 }

--- a/packages/ui/src/components/animated-text/animated-text.tsx
+++ b/packages/ui/src/components/animated-text/animated-text.tsx
@@ -162,15 +162,22 @@ function buildRevealPlan(
 }
 
 function useRevealProgress(active: boolean, length: number, stagger: number) {
-  const [progress, setProgress] = React.useState(0);
+  const [progress, setProgress] = React.useState(() => (active ? 0 : length));
+  const [revealKey, setRevealKey] = React.useState({ active, length, stagger });
+
+  if (
+    revealKey.active !== active ||
+    revealKey.length !== length ||
+    revealKey.stagger !== stagger
+  ) {
+    setRevealKey({ active, length, stagger });
+    setProgress(active ? 0 : length);
+  }
 
   React.useEffect(() => {
     if (!active) {
-      setProgress(length);
       return;
     }
-
-    setProgress(0);
 
     const revealInterval = window.setInterval(
       () => {

--- a/packages/ui/src/components/combobox/combobox.tsx
+++ b/packages/ui/src/components/combobox/combobox.tsx
@@ -41,12 +41,6 @@ function useComboboxValue(
 ) {
   const [internalValue, setInternalValue] = React.useState(value ?? "");
 
-  React.useEffect(() => {
-    if (value !== undefined) {
-      setInternalValue(value);
-    }
-  }, [value]);
-
   const resolvedValue = value ?? internalValue;
 
   const setResolvedValue = (nextValue: string) => {

--- a/packages/ui/src/components/date-picker/date-picker.tsx
+++ b/packages/ui/src/components/date-picker/date-picker.tsx
@@ -42,12 +42,6 @@ const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
     );
     const selectedDate = value ?? internalValue;
 
-    React.useEffect(() => {
-      if (value !== undefined) {
-        setInternalValue(value);
-      }
-    }, [value]);
-
     const handleSelect = (nextDate: Date | undefined) => {
       if (value === undefined) {
         setInternalValue(nextDate);

--- a/packages/ui/src/components/file-upload/file-upload.tsx
+++ b/packages/ui/src/components/file-upload/file-upload.tsx
@@ -27,12 +27,6 @@ function useFileUploadState(
     controlledFiles ?? [],
   );
 
-  React.useEffect(() => {
-    if (controlledFiles !== undefined) {
-      setInternalFiles(controlledFiles);
-    }
-  }, [controlledFiles]);
-
   const resolvedFiles = controlledFiles ?? internalFiles;
 
   const updateFiles = React.useCallback(

--- a/packages/ui/src/components/lang-provider/lang-provider.tsx
+++ b/packages/ui/src/components/lang-provider/lang-provider.tsx
@@ -17,18 +17,18 @@ export function LangProvider({
 }: LangProviderProps) {
   const pathname = usePathname();
 
-  useEffect(() => {
-    // Extract language from pathname - matches /en, /fr, /en/, /fr/, etc.
-    const langMatch = /^\/([a-z]{2})(?:\/|$)/.exec(pathname);
-    const lang =
-      langMatch &&
-      supportedLanguages.includes(langMatch[1] as SupportedLanguage)
-        ? (langMatch[1] as SupportedLanguage)
-        : defaultLanguage;
+  // Derive the language during render from the pathname.
+  // Matches /en, /fr, /en/, /fr/, etc.
+  const langMatch = /^\/([a-z]{2})(?:\/|$)/.exec(pathname);
+  const lang =
+    langMatch && supportedLanguages.includes(langMatch[1] as SupportedLanguage)
+      ? (langMatch[1] as SupportedLanguage)
+      : defaultLanguage;
 
-    // Update the HTML lang attribute
+  useEffect(() => {
+    // Sync the derived language to the document's lang attribute.
     document.documentElement.setAttribute("lang", lang);
-  }, [pathname, defaultLanguage, supportedLanguages]);
+  }, [lang]);
 
   return null;
 }

--- a/packages/ui/src/components/progress-tracker/progress-tracker.tsx
+++ b/packages/ui/src/components/progress-tracker/progress-tracker.tsx
@@ -150,15 +150,17 @@ function useChecklistProgress(
   const [persistedIds, setPersistedIds] = React.useState<string[]>(() =>
     readPersistedChecklistItems(persistKey),
   );
+  const [trackedPersistKey, setTrackedPersistKey] = React.useState(persistKey);
   const setPersistedIdsIfChanged = React.useCallback((nextIds: string[]) => {
     setPersistedIds((currentIds) =>
       areStringArraysEqual(currentIds, nextIds) ? currentIds : nextIds,
     );
   }, []);
 
-  React.useEffect(() => {
+  if (trackedPersistKey !== persistKey) {
+    setTrackedPersistKey(persistKey);
     setPersistedIdsIfChanged(readPersistedChecklistItems(persistKey));
-  }, [persistKey, setPersistedIdsIfChanged]);
+  }
 
   React.useEffect(() => {
     if (!persistKey || typeof window === "undefined") return;

--- a/packages/ui/src/components/spinner/unicode-spinner.tsx
+++ b/packages/ui/src/components/spinner/unicode-spinner.tsx
@@ -682,10 +682,12 @@ export const UnicodeSpinner = React.forwardRef<
     const preset = UNICODE_SPINNER_PRESETS[animation];
     const resolvedInterval = interval ?? preset.interval;
     const [frameIndex, setFrameIndex] = React.useState(0);
+    const [previousAnimation, setPreviousAnimation] = React.useState(animation);
 
-    React.useEffect(() => {
+    if (previousAnimation !== animation) {
+      setPreviousAnimation(animation);
       setFrameIndex(0);
-    }, [animation]);
+    }
 
     React.useEffect(() => {
       if (paused) {


### PR DESCRIPTION
Focused react-doctor correctness pass on current main — replaces the closed batch PRs #345/#346/#347 with the high-value subset.

## Fixes
- **2 errors** `no-adjust-state-on-prop-change` → animated-text + unicode-spinner: replaced effect-driven resets with React's documented adjust-state-during-render pattern (track previous prop in state, compare on render). No more transient wrong value.
- derived-state / exhaustive-deps warnings in combobox, date-picker, file-upload, lang-provider, progress-tracker.
- registry mirror copies kept in sync.

Scope is deliberately the correctness diagnostics only (not the 772 `unused-file` noise or stylistic rules). Behavior-preserving; no eslint-disable. Lockfile untouched.

Related to #271