### PR TITLE
feat(sidebar): add navbar toggle to collapse sidebar on desktop

### DIFF
--- a/packages/ui/src/components/navbar-saas/navbar-saas.test.tsx
+++ b/packages/ui/src/components/navbar-saas/navbar-saas.test.tsx
@@ -134,4 +134,17 @@ describe("NavbarSaas", () => {
       expect(container.querySelector(".lucide-menu")).not.toBeInTheDocument();
     });
   });
+
+  it("renders the sidebar toggle on desktop and toggles its icon", () => {
+    setViewportWidth(1280);
+    const { container } = renderNavbar();
+
+    const trigger = screen.getByTestId("navbar-saas-mobile-trigger");
+    expect(trigger).toHaveAttribute("aria-label", "Toggle sidebar");
+    expect(container.querySelector(".lucide-menu")).toBeInTheDocument();
+
+    fireEvent.click(trigger);
+
+    expect(container.querySelector(".lucide-x")).toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/components/navbar-saas/navbar-saas.tsx
+++ b/packages/ui/src/components/navbar-saas/navbar-saas.tsx
@@ -10,8 +10,6 @@ import { Button } from "../button";
 import { useSidebar } from "../sidebar-provider";
 import { ThemeToggle } from "../theme-toggle";
 
-import { useMobile } from "./use-mobile";
-
 export type NavItem = {
   href: string;
   title: string;
@@ -34,16 +32,16 @@ export function NavbarSaas({
 }: NavbarSaasProps) {
   const pathname = usePathname();
   const { open, setOpen } = useSidebar();
-  const isMobile = useMobile();
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 shrink-0">
       <div className="w-full">
         <div className="mx-auto flex h-16 items-center justify-between px-4">
           <div className="flex items-center gap-4">
-            {showMobileMenu && isMobile ? (
+            {showMobileMenu ? (
               <Button
-                className="lg:hidden"
+                aria-expanded={open}
+                aria-label="Toggle sidebar"
                 data-testid="navbar-saas-mobile-trigger"
                 onClick={() => {
                   setOpen(!open);

--- a/packages/ui/src/components/sidebar/sidebar.test.tsx
+++ b/packages/ui/src/components/sidebar/sidebar.test.tsx
@@ -78,6 +78,14 @@ function SidebarStateProbe() {
       >
         Open sidebar
       </button>
+      <button
+        onClick={() => {
+          setOpen(false);
+        }}
+        type="button"
+      >
+        Close sidebar
+      </button>
     </>
   );
 }
@@ -198,6 +206,21 @@ describe("Sidebar", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("sidebar-state")).toHaveTextContent("closed");
+    });
+  });
+
+  it("collapses to zero width on desktop when closed", async () => {
+    const { container } = renderSidebar();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sidebar-state")).toHaveTextContent("open");
+    });
+    expect(container.querySelector("aside")).toHaveClass("w-64");
+
+    fireEvent.click(screen.getByRole("button", { name: "Close sidebar" }));
+
+    await waitFor(() => {
+      expect(container.querySelector("aside")).toHaveClass("w-0", "border-r-0");
     });
   });
 });

--- a/packages/ui/src/components/sidebar/sidebar.tsx
+++ b/packages/ui/src/components/sidebar/sidebar.tsx
@@ -6,6 +6,7 @@ import { ChevronDown } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+import { useMounted } from "../../lib/use-mounted";
 import { cn } from "../../lib/utils";
 import { useSidebar } from "../sidebar-provider";
 
@@ -139,10 +140,13 @@ export function Sidebar({ sections }: SidebarProps) {
   const pathname = usePathname();
   const { open, setOpen } = useSidebar();
   const isMobile = useMobile(setOpen);
+  const mounted = useMounted();
   const scrollContainerReference = useRef<HTMLDivElement>(null);
   const { showBottomFade, showTopFade } = useScrollFade(
     scrollContainerReference,
   );
+
+  const collapsed = mounted && !isMobile && !open;
 
   return (
     <>
@@ -167,15 +171,16 @@ export function Sidebar({ sections }: SidebarProps) {
       {/* Sidebar */}
       <aside
         className={cn(
-          "fixed lg:relative top-16 lg:top-0 bottom-0 lg:bottom-auto left-0 z-40 lg:h-full border-r bg-background transition-transform duration-300 ease-in-out",
+          "fixed lg:relative top-16 lg:top-0 bottom-0 lg:bottom-auto left-0 z-40 lg:h-full bg-background transition-[transform,width] duration-300 ease-in-out",
           "flex flex-col",
           "overflow-hidden",
           "shrink-0",
-          isMobile ? "w-full" : "w-64",
-          isMobile && !open && "-translate-x-full",
+          collapsed ? "border-r-0" : "border-r",
+          collapsed ? "w-0" : isMobile ? "w-full" : "w-64",
           isMobile && open && "translate-x-0",
-          !isMobile && !open && "-translate-x-full lg:translate-x-0",
-          !isMobile && "lg:translate-x-0",
+          isMobile && !open && "-translate-x-full",
+          !isMobile && !collapsed && "-translate-x-full lg:translate-x-0",
+          !isMobile && collapsed && "-translate-x-full",
         )}
       >
         <div className="relative flex-1 overflow-hidden">


### PR DESCRIPTION
Closes #389

## What

Adds a sidebar toggle in the navbar that works on **desktop**, not just mobile. Previously the navbar hamburger only rendered on mobile and the desktop sidebar was permanently pinned open. Now the toggle collapses the sidebar to zero width on desktop, reflowing content to full width. Mobile drawer behavior is unchanged.

## Why

There was no way to hide the docs sidebar on desktop to get more reading width. A "toggle" only adds value where one didn't exist — desktop.

## Changes

- **`navbar-saas.tsx`** — render the toggle at all breakpoints (still gated by `showMobileMenu`); drop the `isMobile`/`lg:hidden` gate; add `aria-label="Toggle sidebar"` + `aria-expanded`. Removed the now-unused `useMobile()` call (the hook stays a public export).
- **`sidebar.tsx`** — on desktop, collapse to `w-0` with no border when `open` is false; animate via `transition-[transform,width]`. Guarded by the existing `useMounted()` hook so SSR / first paint stays **flash-free** (sidebar visible until the user explicitly collapses — matches prior no-FOUC behavior). Mobile drawer untouched.
- Tests for both: desktop-collapse (`aside` → `w-0`) and desktop-toggle render/click.

## Testing

- `@vllnt/ui` full lint: pass · typecheck: clean (changed files) · vitest: 12/12 pass · `check:use-client`: pass
- Live verify in real Chromium (registry app):
  - Desktop: `aside` 256px ↔ 0, `main` 1024px ↔ 1280px on toggle; icon X ↔ ☰; content reflows full-width; **zero console errors**
  - Mobile: drawer closed by default, opens via toggle, closes via navbar X; zero console errors
- Rebased onto latest `main` (coexists cleanly with #384 scrollbar fix).

## Notes

- `registry/default/*` shims are generated by `inline-component-source.ts` — no manual edits needed; they regenerate from package source on `registry:build`.
- The pre-existing mobile overlay-click-to-close is inert (the drawer is full-width, so the overlay sits behind it); the navbar X is the working close path. Left as-is — out of scope.