### PR TITLE
feat(registry): sharing + backlink system

### DIFF
--- a/apps/registry/app/[locale]/components/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/components/[slug]/page.tsx
@@ -1,16 +1,22 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
-import { Breadcrumb, CodeBlock, Sidebar, TableOfContents } from "@vllnt/ui";
+import {
+  Breadcrumb,
+  CodeBlock,
+  ShareSection,
+  Sidebar,
+  TableOfContents,
+} from "@vllnt/ui";
 import { ExternalLink } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-
 import { setRequestLocale } from "next-intl/server";
 
 import { PreviewPlaygroundTabs } from "@/components/playground";
 import { QuickAdd } from "@/components/quick-add";
+import { ShareEmbedBar } from "@/components/share-embed-bar";
 import { type Locale, routing } from "@/i18n/routing";
 import componentMetadata from "@/lib/component-metadata.json";
 import {
@@ -24,6 +30,7 @@ import {
   getRegistryPackageVersion,
 } from "@/lib/playground";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
+import { oembedUrl, withRef } from "@/lib/share";
 import {
   getCategoryForComponent,
   getSidebarSections,
@@ -96,6 +103,9 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     alternates: {
       canonical: canonical(pathname, locale),
       languages: languageAlternates(pathname),
+      types: {
+        "application/json+oembed": oembedUrl(canonical(pathname, locale)),
+      },
     },
     description,
     openGraph: generateOGMetadata(ogParameters, { locale, pathname }),
@@ -234,6 +244,11 @@ export default async function ComponentPage(props: Props) {
                 </p>
                 <div className="flex flex-wrap items-center gap-3">
                   <QuickAdd componentName={component.name} />
+                  <ShareEmbedBar
+                    pageUrl={canonical(`/components/${component.name}`, locale)}
+                    slug={component.name}
+                    title={displayTitle}
+                  />
                   <Link
                     className="inline-flex h-9 items-center rounded-md border border-border px-4 text-sm font-medium hover:bg-muted"
                     href={localizePathname(
@@ -342,6 +357,16 @@ export default async function ComponentPage(props: Props) {
                   </div>
                 </div>
               ) : null}
+
+              <ShareSection
+                shareOn="Share on"
+                shareTitle="Share this component"
+                title={`${displayTitle} — VLLNT UI`}
+                url={withRef(
+                  canonical(`/components/${component.name}`, locale),
+                  "share",
+                )}
+              />
             </div>
 
             {/* Table of Contents */}

--- a/apps/registry/app/[locale]/templates/page.tsx
+++ b/apps/registry/app/[locale]/templates/page.tsx
@@ -1,4 +1,4 @@
-import { Sidebar } from "@vllnt/ui";
+import { ShareSection, Sidebar } from "@vllnt/ui";
 import { ArrowRight } from "lucide-react";
 import type { Metadata } from "next";
 import Image from "next/image";
@@ -6,10 +6,12 @@ import Link from "next/link";
 import Script from "next/script";
 import { setRequestLocale } from "next-intl/server";
 
+import { BadgeSnippets } from "@/components/badge-snippets";
 import type { Locale } from "@/i18n/routing";
 import { jsonLdScriptAttributes, softwareApplicationLd } from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
+import { withRef } from "@/lib/share";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 import { getTemplatePath, TEMPLATES } from "@/lib/templates";
 
@@ -143,6 +145,15 @@ export default async function TemplatesPage({ params }: Props) {
               </li>
             ))}
           </ul>
+
+          <BadgeSnippets />
+
+          <ShareSection
+            shareOn="Share on"
+            shareTitle="Share these templates"
+            title="VLLNT UI Templates"
+            url={withRef(canonical("/templates", locale), "share")}
+          />
         </div>
       </main>
     </>

--- a/apps/registry/app/api/badge/route.ts
+++ b/apps/registry/app/api/badge/route.ts
@@ -1,0 +1,53 @@
+const LEFT_TEXT = "built with";
+const RIGHT_TEXT = "VLLNT UI";
+
+const LEFT_BG = "#1f2937";
+const RIGHT_BG = "#6d28d9";
+const TEXT_COLOR = "#ffffff";
+
+const HEIGHT = 28;
+const PADDING = 10;
+const CHAR_WIDTH = 6.4;
+const RADIUS = 4;
+
+const FONT_STACK =
+  "Verdana,DejaVu Sans,system-ui,-apple-system,Segoe UI,sans-serif";
+
+function segmentWidth(text: string): number {
+  return Math.round(text.length * CHAR_WIDTH + PADDING * 2);
+}
+
+/**
+ * Static "Built with VLLNT UI" badge served as SVG (same pattern as /api/og).
+ *
+ * The badge image carries no link equity on its own — consumers wrap it in an
+ * `<a href="https://ui.vllnt.ai?ref=badge">` (see buildBadgeSnippets), and
+ * that anchor in their page DOM is the backlink.
+ */
+export function GET(): Response {
+  const leftWidth = segmentWidth(LEFT_TEXT);
+  const rightWidth = segmentWidth(RIGHT_TEXT);
+  const totalWidth = leftWidth + rightWidth;
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="${HEIGHT}" role="img" aria-label="Built with VLLNT UI">
+  <title>Built with VLLNT UI</title>
+  <defs>
+    <clipPath id="r"><rect width="${totalWidth}" height="${HEIGHT}" rx="${RADIUS}" /></clipPath>
+  </defs>
+  <g clip-path="url(#r)">
+    <rect width="${leftWidth}" height="${HEIGHT}" fill="${LEFT_BG}" />
+    <rect x="${leftWidth}" width="${rightWidth}" height="${HEIGHT}" fill="${RIGHT_BG}" />
+  </g>
+  <g fill="${TEXT_COLOR}" font-family="${FONT_STACK}" font-size="12">
+    <text x="${leftWidth / 2}" y="18" text-anchor="middle">${LEFT_TEXT}</text>
+    <text x="${leftWidth + rightWidth / 2}" y="18" text-anchor="middle" font-weight="bold">${RIGHT_TEXT}</text>
+  </g>
+</svg>`;
+
+  return new Response(svg, {
+    headers: {
+      "cache-control": "public, max-age=86400, s-maxage=604800, immutable",
+      "content-type": "image/svg+xml; charset=utf-8",
+    },
+  });
+}

--- a/apps/registry/app/api/oembed/route.ts
+++ b/apps/registry/app/api/oembed/route.ts
@@ -1,0 +1,147 @@
+import type { NextRequest } from "next/server";
+import { z } from "zod";
+
+import componentMetadata from "@/lib/component-metadata.json";
+import {
+  buildEmbedSnippet,
+  EMBED_DEFAULT_HEIGHT,
+  EMBED_DEFAULT_WIDTH,
+  SITE_URL,
+} from "@/lib/share";
+import registryData from "@/registry.json";
+import type { Registry, RegistryComponent } from "@/types/registry";
+
+const registry = registryData as Registry;
+const metadataMap = componentMetadata as Record<
+  string,
+  { category?: string; description?: string; title?: string }
+>;
+
+const querySchema = z.object({
+  format: z.enum(["json", "xml"]).default("json"),
+  maxheight: z.coerce.number().int().positive().max(2000).optional(),
+  maxwidth: z.coerce.number().int().positive().max(2000).optional(),
+  url: z.url(),
+});
+
+const COMPONENT_PATH = /\/components\/([^#/?]+)/;
+
+const JSON_HEADERS = {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=3600, s-maxage=86400",
+  "content-type": "application/json; charset=utf-8",
+} as const;
+
+function slugFromUrl(pageUrl: string): string | undefined {
+  try {
+    const parsed = new URL(pageUrl);
+    if (parsed.origin !== new URL(SITE_URL).origin) {
+      return undefined;
+    }
+    return COMPONENT_PATH.exec(parsed.pathname)?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+function findComponent(slug: string): RegistryComponent | undefined {
+  return registry.items.find(
+    (item): item is RegistryComponent =>
+      item.name === slug && item.type === "registry:component",
+  );
+}
+
+function buildThumbnailUrl(input: {
+  category?: string;
+  description: string;
+  slug: string;
+  title: string;
+}): string {
+  const url = new URL("/api/og", SITE_URL);
+  url.searchParams.set("title", input.title);
+  url.searchParams.set("type", "component");
+  if (input.description) {
+    url.searchParams.set("description", input.description);
+  }
+  if (input.category) {
+    url.searchParams.set("category", input.category);
+  }
+  url.searchParams.set("url", `ui.vllnt.ai/components/${input.slug}`);
+  return url.toString();
+}
+
+function buildPayload(
+  slug: string,
+  component: RegistryComponent,
+  size: { height: number; width: number },
+): Record<string, unknown> {
+  const meta = metadataMap[slug];
+  const title = meta?.title ?? component.title ?? slug;
+  const description = meta?.description ?? component.description ?? "";
+  const { height, width } = size;
+
+  return {
+    author_name: "VLLNT UI",
+    author_url: SITE_URL,
+    height,
+    html: buildEmbedSnippet(slug, title, { height, ref: "oembed", width }),
+    provider_name: "VLLNT UI",
+    provider_url: SITE_URL,
+    thumbnail_height: 1260,
+    thumbnail_url: buildThumbnailUrl({
+      category: meta?.category,
+      description,
+      slug,
+      title,
+    }),
+    thumbnail_width: 2400,
+    title,
+    type: "rich",
+    version: "1.0",
+    width,
+  };
+}
+
+/**
+ * oEmbed provider endpoint (https://oembed.com). Lets WordPress, Ghost,
+ * Discourse, dev.to, and similar tools auto-unfurl any
+ * `ui.vllnt.ai/components/*` URL into a rich embed. The returned `html`
+ * carries the live-preview iframe and a caption anchor — that anchor lands in
+ * the host's DOM and becomes the backlink.
+ */
+export function GET(request: NextRequest): Response {
+  const parsed = querySchema.safeParse(
+    Object.fromEntries(request.nextUrl.searchParams),
+  );
+
+  if (!parsed.success) {
+    return Response.json(
+      { error: "Invalid oEmbed request" },
+      { headers: JSON_HEADERS, status: 400 },
+    );
+  }
+
+  if (parsed.data.format === "xml") {
+    return Response.json(
+      { error: "Only json format is supported" },
+      { headers: JSON_HEADERS, status: 501 },
+    );
+  }
+
+  const slug = slugFromUrl(parsed.data.url);
+  const component = slug ? findComponent(slug) : undefined;
+
+  if (!slug || !component) {
+    return Response.json(
+      { error: "No embeddable component for that URL" },
+      { headers: JSON_HEADERS, status: 404 },
+    );
+  }
+
+  const width = Math.min(parsed.data.maxwidth ?? EMBED_DEFAULT_WIDTH, 2000);
+  const height = Math.min(parsed.data.maxheight ?? EMBED_DEFAULT_HEIGHT, 2000);
+
+  return Response.json(buildPayload(slug, component, { height, width }), {
+    headers: JSON_HEADERS,
+  });
+}

--- a/apps/registry/app/embed/[slug]/page.tsx
+++ b/apps/registry/app/embed/[slug]/page.tsx
@@ -1,0 +1,81 @@
+import { ArrowUpRight } from "lucide-react";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { ComponentPreview } from "@/components/component-preview/component-preview";
+import componentMetadata from "@/lib/component-metadata.json";
+import { componentUrl, withRef } from "@/lib/share";
+import registryData from "@/registry.json";
+import type { Registry, RegistryComponent } from "@/types/registry";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ theme?: string }>;
+};
+
+const registry = registryData as Registry;
+const metadataMap = componentMetadata as Record<
+  string,
+  { description: string; title: string }
+>;
+
+function findComponent(slug: string): RegistryComponent | undefined {
+  return registry.items.find(
+    (item): item is RegistryComponent =>
+      item.name === slug && item.type === "registry:component",
+  );
+}
+
+export function generateStaticParams() {
+  return registry.items
+    .filter(
+      (item): item is RegistryComponent => item.type === "registry:component",
+    )
+    .map((item) => ({ slug: item.name }));
+}
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const { slug } = await props.params;
+  const component = findComponent(slug);
+  const title = metadataMap[slug]?.title ?? component?.title ?? slug;
+
+  return {
+    robots: { follow: false, index: false },
+    title: `${title} — VLLNT UI embed`,
+  };
+}
+
+export default async function EmbedPage(props: Props) {
+  const { slug } = await props.params;
+  const { theme } = await props.searchParams;
+  const component = findComponent(slug);
+
+  if (!component) {
+    notFound();
+  }
+
+  const title = metadataMap[slug]?.title ?? component.title ?? slug;
+  const isDark = theme === "dark";
+  const link = withRef(componentUrl(slug), "embed");
+
+  return (
+    <div className={isDark ? "dark" : undefined}>
+      <div className="flex min-h-dvh flex-col bg-background text-foreground">
+        <div className="flex flex-1 items-center justify-center p-6">
+          <ComponentPreview componentName={slug} />
+        </div>
+        <a
+          className="flex items-center justify-between gap-2 border-t border-border px-4 py-2 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          href={link}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <span>
+            {title} — <strong className="font-semibold">VLLNT UI</strong>
+          </span>
+          <ArrowUpRight className="size-3.5" />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/registry/app/embed/layout.tsx
+++ b/apps/registry/app/embed/layout.tsx
@@ -1,0 +1,28 @@
+import "@vllnt/ui/styles.css";
+import "@vllnt/ui/themes/default.css";
+import "../globals.css";
+
+import type { Metadata } from "next";
+import type React from "react";
+
+/**
+ * Standalone shell for chromeless `/embed/*` previews. Lives outside the
+ * `[locale]` segment so embeds are locale-neutral (one canonical embed per
+ * component, no i18n duplicate content) and free of the site header/footer.
+ */
+
+export const metadata: Metadata = {
+  robots: { follow: false, index: false },
+};
+
+export default function EmbedLayout({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className="bg-transparent">{children}</body>
+    </html>
+  );
+}

--- a/apps/registry/components/badge-snippets/badge-snippets.tsx
+++ b/apps/registry/components/badge-snippets/badge-snippets.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import * as React from "react";
+
+import { track } from "@vercel/analytics";
+import { Button } from "@vllnt/ui";
+import { Check, Copy } from "lucide-react";
+
+import { BADGE_SVG_PATH, buildBadgeSnippets } from "@/lib/share";
+
+type SnippetFormat = "html" | "jsx" | "markdown";
+
+const FORMATS: readonly { label: string; value: SnippetFormat }[] = [
+  { label: "HTML", value: "html" },
+  { label: "Markdown", value: "markdown" },
+  { label: "JSX", value: "jsx" },
+];
+
+export function BadgeSnippets(): React.ReactElement {
+  const snippets = React.useMemo(() => buildBadgeSnippets(), []);
+  const [format, setFormat] = React.useState<SnippetFormat>("html");
+  const [copied, setCopied] = React.useState(false);
+
+  const handleCopy = React.useCallback(async () => {
+    await navigator.clipboard.writeText(snippets[format]);
+    setCopied(true);
+    track("badge_copy", { format });
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  }, [format, snippets]);
+
+  return (
+    <section className="mt-16 rounded-md border border-border bg-card p-6">
+      <h2 className="text-xl font-semibold">Built something? Add the badge</h2>
+      <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+        Drop this into your README or site footer. The link points back to VLLNT
+        UI, so every project that ships it helps others discover the library.
+      </p>
+
+      <div className="mt-5 flex items-center gap-3">
+        {/* eslint-disable-next-line @next/next/no-img-element -- external badge endpoint, intentionally unoptimized */}
+        <img alt="Built with VLLNT UI" height={28} src={BADGE_SVG_PATH} />
+      </div>
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        {FORMATS.map((option) => (
+          <Button
+            key={option.value}
+            onClick={() => {
+              setFormat(option.value);
+            }}
+            size="sm"
+            variant={option.value === format ? "default" : "outline"}
+          >
+            {option.label}
+          </Button>
+        ))}
+      </div>
+
+      <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-stretch">
+        <code className="flex-1 overflow-x-auto rounded-md border border-border bg-muted/30 p-3 font-mono text-xs text-foreground">
+          {snippets[format]}
+        </code>
+        <Button
+          className="gap-2 sm:self-start"
+          onClick={handleCopy}
+          variant="outline"
+        >
+          {copied ? (
+            <>
+              <Check className="size-3" />
+              Copied!
+            </>
+          ) : (
+            <>
+              <Copy className="size-3" />
+              Copy
+            </>
+          )}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/apps/registry/components/badge-snippets/index.ts
+++ b/apps/registry/components/badge-snippets/index.ts
@@ -1,0 +1,1 @@
+export { BadgeSnippets } from "./badge-snippets";

--- a/apps/registry/components/playground/component-playground-shell.tsx
+++ b/apps/registry/components/playground/component-playground-shell.tsx
@@ -32,10 +32,27 @@ export function ComponentPlaygroundShell({
   packageVersion,
   surface,
 }: ComponentPlaygroundShellProps): React.ReactElement {
+  const [sharedCode, setSharedCode] = React.useState<string | undefined>();
+
+  React.useEffect(() => {
+    if (surface !== "route" || typeof window === "undefined") {
+      return;
+    }
+    const shared = new URLSearchParams(window.location.search).get("code");
+    if (shared) {
+      setSharedCode(shared);
+    }
+  }, [surface]);
+
+  const effectiveExample = sharedCode
+    ? { ...example, code: sharedCode }
+    : example;
+
   return (
     <SandpackPlayground
       componentName={componentName}
-      example={example}
+      example={effectiveExample}
+      key={sharedCode ? "shared" : "default"}
       packageVersion={packageVersion}
       surface={surface}
     />

--- a/apps/registry/components/playground/sandpack-playground.tsx
+++ b/apps/registry/components/playground/sandpack-playground.tsx
@@ -7,10 +7,13 @@ import {
   SandpackLayout,
   SandpackPreview,
   SandpackProvider,
+  useActiveCode,
 } from "@codesandbox/sandpack-react";
 import { track } from "@vercel/analytics";
+import { Check, Share2 } from "lucide-react";
 
 import type { PlaygroundExample } from "@/lib/playground";
+import { withRef } from "@/lib/share";
 
 type SandpackPlaygroundProps = {
   componentName: string;
@@ -106,6 +109,45 @@ export default {
   };
 }
 
+/**
+ * Encodes the current editor code into a shareable `?code=` URL on the
+ * dedicated playground route. Lives inside SandpackProvider so it can read
+ * live edits via {@link useActiveCode}.
+ */
+function PlaygroundShareButton({
+  componentName,
+}: {
+  componentName: string;
+}): React.ReactElement {
+  const { code } = useActiveCode();
+  const [copied, setCopied] = React.useState(false);
+
+  const handleShare = React.useCallback(async () => {
+    const url = new URL(
+      `/components/${componentName}/playground`,
+      window.location.origin,
+    );
+    url.searchParams.set("code", code);
+    await navigator.clipboard.writeText(withRef(url.toString(), "share"));
+    setCopied(true);
+    track("playground_share", { component: componentName });
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  }, [code, componentName]);
+
+  return (
+    <button
+      className="inline-flex items-center gap-2 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+      onClick={handleShare}
+      type="button"
+    >
+      {copied ? <Check className="size-3" /> : <Share2 className="size-3" />}
+      {copied ? "Link copied!" : "Share playground"}
+    </button>
+  );
+}
+
 export function SandpackPlayground({
   componentName,
   example,
@@ -150,6 +192,11 @@ export function SandpackPlayground({
         template="react-ts"
         theme="auto"
       >
+        {surface === "route" ? (
+          <div className="flex justify-end border-b bg-muted/30 px-4 py-2">
+            <PlaygroundShareButton componentName={componentName} />
+          </div>
+        ) : null}
         <SandpackLayout className="!m-0 !rounded-none !border-0">
           <SandpackCodeEditor
             className="min-h-[460px] flex-1"

--- a/apps/registry/components/share-embed-bar/index.ts
+++ b/apps/registry/components/share-embed-bar/index.ts
@@ -1,0 +1,1 @@
+export { ShareEmbedBar } from "./share-embed-bar";

--- a/apps/registry/components/share-embed-bar/share-embed-bar.tsx
+++ b/apps/registry/components/share-embed-bar/share-embed-bar.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import * as React from "react";
+
+import { track } from "@vercel/analytics";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  ShareDialog,
+  type ShareDialogPlatform,
+} from "@vllnt/ui";
+import { Check, Code2, Copy, Link2, Share2 } from "lucide-react";
+
+import { buildEmbedSnippet, withRef } from "@/lib/share";
+
+type ShareEmbedBarProps = {
+  pageUrl: string;
+  slug: string;
+  title: string;
+};
+
+const SHARE_PLATFORMS: ShareDialogPlatform[] = [
+  {
+    buildUrl: (url, title) =>
+      `https://twitter.com/intent/tweet?url=${encodeURIComponent(withRef(url, "share"))}&text=${encodeURIComponent(title)}`,
+    key: "x",
+    label: "X",
+  },
+  {
+    buildUrl: (url) =>
+      `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(withRef(url, "share"))}`,
+    key: "linkedin",
+    label: "LinkedIn",
+  },
+  {
+    buildUrl: (url, title) =>
+      `https://www.reddit.com/submit?url=${encodeURIComponent(withRef(url, "share"))}&title=${encodeURIComponent(title)}`,
+    key: "reddit",
+    label: "Reddit",
+  },
+  {
+    buildUrl: (url, title) =>
+      `https://news.ycombinator.com/submitlink?u=${encodeURIComponent(withRef(url, "share"))}&t=${encodeURIComponent(title)}`,
+    key: "hackernews",
+    label: "Hacker News",
+  },
+  {
+    buildUrl: (url, title) =>
+      `https://bsky.app/intent/compose?text=${encodeURIComponent(`${title} ${withRef(url, "share")}`)}`,
+    key: "bluesky",
+    label: "Bluesky",
+  },
+];
+
+function CopyLinkButton({
+  pageUrl,
+  slug,
+}: {
+  pageUrl: string;
+  slug: string;
+}): React.ReactElement {
+  const [copied, setCopied] = React.useState(false);
+
+  const handleCopy = React.useCallback(async () => {
+    await navigator.clipboard.writeText(withRef(pageUrl, "permalink"));
+    setCopied(true);
+    track("permalink_copy", { component: slug });
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  }, [pageUrl, slug]);
+
+  return (
+    <Button className="gap-2" onClick={handleCopy} size="sm" variant="outline">
+      {copied ? (
+        <>
+          <Check className="size-3" />
+          Link copied!
+        </>
+      ) : (
+        <>
+          <Link2 className="size-3" />
+          Copy link
+        </>
+      )}
+    </Button>
+  );
+}
+
+function EmbedDialog({
+  onOpenChange,
+  open,
+  slug,
+  title,
+}: {
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  slug: string;
+  title: string;
+}): React.ReactElement {
+  const [copied, setCopied] = React.useState(false);
+  const snippet = React.useMemo(
+    () => buildEmbedSnippet(slug, title),
+    [slug, title],
+  );
+
+  const handleCopy = React.useCallback(async () => {
+    await navigator.clipboard.writeText(snippet);
+    setCopied(true);
+    track("embed_copy", { component: slug });
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  }, [slug, snippet]);
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Embed {title}</DialogTitle>
+          <DialogDescription>
+            Paste this into any blog or docs page to embed a live preview with a
+            link back to VLLNT UI.
+          </DialogDescription>
+        </DialogHeader>
+        <textarea
+          className="h-32 w-full resize-none rounded-md border border-border bg-muted/30 p-3 font-mono text-xs text-foreground"
+          readOnly
+          spellCheck={false}
+          value={snippet}
+        />
+        <Button className="gap-2" onClick={handleCopy} variant="outline">
+          {copied ? (
+            <>
+              <Check className="size-3" />
+              Copied!
+            </>
+          ) : (
+            <>
+              <Copy className="size-3" />
+              Copy embed code
+            </>
+          )}
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function ShareEmbedBar({
+  pageUrl,
+  slug,
+  title,
+}: ShareEmbedBarProps): React.ReactElement {
+  const [shareOpen, setShareOpen] = React.useState(false);
+  const [embedOpen, setEmbedOpen] = React.useState(false);
+
+  return (
+    <>
+      <Button
+        className="gap-2"
+        onClick={() => {
+          setShareOpen(true);
+          track("share_open", { component: slug });
+        }}
+        size="sm"
+        variant="outline"
+      >
+        <Share2 className="size-3" />
+        Share
+      </Button>
+      <Button
+        className="gap-2"
+        onClick={() => {
+          setEmbedOpen(true);
+        }}
+        size="sm"
+        variant="outline"
+      >
+        <Code2 className="size-3" />
+        Embed
+      </Button>
+      <CopyLinkButton pageUrl={pageUrl} slug={slug} />
+
+      <ShareDialog
+        buildCopyUrl={(url) => withRef(url, "share")}
+        description={`Share the ${title} component`}
+        onOpenChange={setShareOpen}
+        onShare={(platform) => {
+          track("share_click", { component: slug, platform });
+        }}
+        open={shareOpen}
+        platforms={SHARE_PLATFORMS}
+        title={`Share ${title}`}
+      />
+
+      <EmbedDialog
+        onOpenChange={setEmbedOpen}
+        open={embedOpen}
+        slug={slug}
+        title={title}
+      />
+    </>
+  );
+}

--- a/apps/registry/lib/share.ts
+++ b/apps/registry/lib/share.ts
@@ -1,0 +1,86 @@
+import type { Locale } from "@/i18n/routing";
+import { canonical } from "@/lib/seo";
+
+/**
+ * Centralized builders for the sharing and backlink system.
+ *
+ * Backlink rule: a link that should pass SEO equity must live in the HOST
+ * page's DOM (the embed snippet caption, the badge anchor), not inside an
+ * `<iframe>` — a search engine credits an iframe's links to the iframe origin.
+ */
+
+export const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+
+/** Attribution source tags appended as `?ref=` so referrals stay measurable. */
+export type ShareRef = "badge" | "embed" | "oembed" | "permalink" | "share";
+
+/** Append a `ref` query param to an absolute URL, preserving existing params. */
+export function withRef(absoluteUrl: string, ref: ShareRef): string {
+  const url = new URL(absoluteUrl);
+  url.searchParams.set("ref", ref);
+  return url.toString();
+}
+
+/** Absolute, canonical URL of a component detail page. */
+export function componentUrl(slug: string, locale: Locale = "en"): string {
+  return canonical(`/components/${slug}`, locale);
+}
+
+/** Absolute URL of the chromeless, locale-neutral embed preview for a component. */
+export function embedUrl(slug: string, theme?: "dark" | "light"): string {
+  const url = new URL(`/embed/${slug}`, SITE_URL);
+  if (theme) {
+    url.searchParams.set("theme", theme);
+  }
+  return url.toString();
+}
+
+/** Absolute URL of the oEmbed JSON endpoint for a given component page URL. */
+export function oembedUrl(pageUrl: string): string {
+  const url = new URL("/api/oembed", SITE_URL);
+  url.searchParams.set("url", pageUrl);
+  url.searchParams.set("format", "json");
+  return url.toString();
+}
+
+export const EMBED_DEFAULT_WIDTH = 600;
+export const EMBED_DEFAULT_HEIGHT = 420;
+
+/**
+ * Embed snippet: a sized `<iframe>` for the live preview plus a visible
+ * caption anchor. The caption anchor is the backlink — it lands in the host
+ * page's DOM, so a search engine credits VLLNT UI for the link.
+ */
+export function buildEmbedSnippet(
+  slug: string,
+  title: string,
+  options: { height?: number; ref?: ShareRef; width?: number } = {},
+): string {
+  const width = options.width ?? EMBED_DEFAULT_WIDTH;
+  const height = options.height ?? EMBED_DEFAULT_HEIGHT;
+  const iframeSource = embedUrl(slug);
+  const link = withRef(componentUrl(slug), options.ref ?? "embed");
+  return [
+    `<iframe src="${iframeSource}" width="${width}" height="${height}" style="border:1px solid #e5e7eb;border-radius:12px;max-width:100%;" loading="lazy" title="${title} — VLLNT UI"></iframe>`,
+    `<p><a href="${link}">${title} — VLLNT UI</a></p>`,
+  ].join("\n");
+}
+
+export const BADGE_SVG_PATH = "/api/badge";
+
+/** Copyable "Built with VLLNT UI" badge snippets. The anchor is the backlink. */
+export function buildBadgeSnippets(): {
+  html: string;
+  jsx: string;
+  markdown: string;
+} {
+  const href = withRef(SITE_URL, "badge");
+  const img = new URL(BADGE_SVG_PATH, SITE_URL).toString();
+  const alt = "Built with VLLNT UI";
+  return {
+    html: `<a href="${href}" target="_blank" rel="noopener"><img src="${img}" alt="${alt}" height="28" /></a>`,
+    jsx: `<a href="${href}" target="_blank" rel="noopener">\n  <img src="${img}" alt="${alt}" height={28} />\n</a>`,
+    markdown: `[![${alt}](${img})](${href})`,
+  };
+}

--- a/apps/registry/middleware.ts
+++ b/apps/registry/middleware.ts
@@ -6,6 +6,6 @@ export default createMiddleware(routing);
 
 export const config = {
   matcher: [
-    "/((?!api|_next|_vercel|mcp|r/|atom\\.xml|rss\\.xml|design\\.txt|llms\\.txt|llms-full\\.txt|sitemap\\.xml|robots\\.txt|manifest\\.webmanifest|.*\\.[^/]+$).*)",
+    "/((?!api|_next|_vercel|mcp|embed|r/|atom\\.xml|rss\\.xml|design\\.txt|llms\\.txt|llms-full\\.txt|sitemap\\.xml|robots\\.txt|manifest\\.webmanifest|.*\\.[^/]+$).*)",
   ],
 };


### PR DESCRIPTION
Closes #391

## Sharing + backlink system

Adds a sharing system to `ui.vllnt.ai` aimed at growing **backlinks** and social reach. The SEO foundation (per-component metadata, OG images, JSON-LD, feeds, sitemap) already existed — what was missing was an *active* engine that makes other sites link back. This PR adds it.

### Backlink rule (why the design looks like this)
A link only passes SEO equity when it lives in the **host page's DOM** — not inside an `<iframe>` (a search engine credits iframe links to the iframe's origin). So every mechanism here ships a real `<a>` anchor that lands on the embedding site, `?ref`-tagged for attribution.

### What's included

**A1 — Embed + oEmbed engine**
- `GET /embed/[slug]` — chromeless, locale-neutral, `noindex` live preview (renders `ComponentPreview`), `?theme=dark|light`, with a caption link back to the component page. Frameable; excluded from the i18n middleware.
- `GET /api/oembed?url=…` — oEmbed provider so WordPress / Ghost / Discourse / dev.to auto-unfurl any `…/components/*` URL. Returned `html` = iframe **+ caption anchor** (the backlink); `thumbnail_url` reuses the OG image. 404s non-component URLs.
- Component pages expose an `application/json+oembed` auto-discovery `<link>`.

**A2 — Attribution badge**
- `GET /api/badge` — "Built with VLLNT UI" SVG (same pattern as `/api/og`).
- Copy-able **HTML / Markdown / JSX** snippets on the templates page; the wrapping `<a href="…?ref=badge">` is the backlink. Every site shipped from a template becomes a persistent link.

**A3 — Share / Embed toolbar** (component pages)
- `Share` (dogfoods `ShareDialog` → X, LinkedIn, Reddit, Hacker News, Bluesky + copy link), `Embed` (copy iframe+caption snippet), `Copy link` (permalink). All `?ref`-tagged.

**B1 — Share bars** — `ShareSection` (dogfooded from `@vllnt/ui`) on component + templates pages.

**B2 — Playground share URLs** — encodes edited Sandpack code into a `?code=` link, restored on load.

All outbound links carry `?ref` / UTM and emit `@vercel/analytics` events (`embed_copy`, `badge_copy`, `permalink_copy`, `share_click`, `playground_share`) so referral growth is measurable (cross-check with GSC backlinks).

### New files
- `lib/share.ts` — centralized URL/snippet builders (`withRef`, `embedUrl`, `oembedUrl`, `buildEmbedSnippet`, `buildBadgeSnippets`).
- `app/embed/{layout,[slug]/page}.tsx`, `app/api/oembed/route.ts`, `app/api/badge/route.ts`
- `components/share-embed-bar/*`, `components/badge-snippets/*`

### Validation
- `tsc --noEmit` — clean.
- ESLint (changed files) — clean.
- `next build` — 0 errors; `/embed`, `/api/oembed`, `/api/badge` all build.
- Live smoke test (prod build): badge SVG 200, oEmbed 200 (+404 on non-component), embed page renders light/dark with caption, detail toolbar + ShareSection render, Embed dialog emits the correct iframe+caption snippet.

### Honest scope notes
- Social share links are `rel=nofollow` (reach/traffic, not direct backlinks) — the backlink value comes from A1 (embed caption) and A2 (badge).
- Embed pages read `?theme`, so they render on-demand (dynamic) rather than fully prerendered — fine for iframes, CDN-cacheable.
- B1 share bar on `/changelog` was **deferred**: that file carries pre-existing lint debt (`LocaleParams`, import order) unrelated to this change, and the surgical-scope rule says don't refactor it here.

### Follow-ups
- Add the badge to the templates themselves (not just the snippet UI) so deployed template sites link back by default.
- Optional: short-id playground share links (current `?code=` URLs can get long).
