### PR TITLE
feat(registry): surface request-component entry points

### DIFF
--- a/apps/registry/app/[locale]/components/page.tsx
+++ b/apps/registry/app/[locale]/components/page.tsx
@@ -112,6 +112,22 @@ export default async function ComponentsPage({ params }: Props) {
               </div>
             </section>
           ))}
+
+          <section className="mt-4 flex flex-col items-center gap-3 rounded-lg border border-dashed bg-card px-6 py-12 text-center">
+            <h2 className="text-xl font-semibold">
+              Don&rsquo;t see what you need?
+            </h2>
+            <p className="text-muted-foreground max-w-md">
+              Request a new component and we&rsquo;ll open a prefilled GitHub
+              issue with the right labels and template.
+            </p>
+            <Link
+              className="mt-2 inline-flex h-10 items-center rounded-md bg-foreground px-5 text-sm font-medium text-background hover:opacity-90"
+              href={localizePathname("/request-component", locale)}
+            >
+              Request a component
+            </Link>
+          </section>
         </div>
       </main>
     </>

--- a/apps/registry/app/[locale]/request-component/request-component-form.tsx
+++ b/apps/registry/app/[locale]/request-component/request-component-form.tsx
@@ -18,34 +18,22 @@ function buildIssueUrl({
   similar: string;
   useCase: string;
 }): string {
-  const body = [
-    "## What problem are you trying to solve?",
-    "",
-    problem || "_describe the user-facing need_",
-    "",
-    "## Proposed solution",
-    "",
-    name ? `Component: **${name}**` : "_component name_",
-    "",
-    similar ? `Similar to: ${similar}` : "",
-    "",
-    "## Use case",
-    "",
-    useCase || "_describe the concrete scenario_",
-    "",
-    "## References / prior art",
-    "",
-    reference || "_links, screenshots, design references_",
+  const proposal = [
+    name ? `Component: **${name}**` : "",
+    useCase ? `Use case: ${useCase}` : "",
+    reference ? `References / prior art: ${reference}` : "",
   ]
     .filter(Boolean)
-    .join("\n");
+    .join("\n\n");
 
   const params = new URLSearchParams({
     template: "feature_request.yml",
     title: `[feat] ${name || "new component"}`,
-    body,
     labels: "enhancement,component",
   });
+  if (problem) params.set("problem", problem);
+  if (proposal) params.set("proposal", proposal);
+  if (similar) params.set("alternatives", similar);
 
   return `https://github.com/${REPO}/issues/new?${params.toString()}`;
 }

--- a/apps/registry/components/footer/footer.tsx
+++ b/apps/registry/components/footer/footer.tsx
@@ -3,8 +3,6 @@ import Link from "next/link";
 const GITHUB_URL = "https://github.com/vllnt/ui";
 const STORYBOOK_URL = "https://storybook.vllnt.ai";
 const SPONSOR_URL = "https://github.com/sponsors/bntvllnt";
-const REQUEST_URL =
-  "https://github.com/vllnt/ui/issues/new?template=feature_request.yml&labels=enhancement,component";
 const REPORT_URL =
   "https://github.com/vllnt/ui/issues/new?template=bug_report.yml&labels=bug";
 const DISCUSSIONS_URL = "https://github.com/vllnt/ui/discussions";
@@ -48,7 +46,7 @@ const COLUMNS: readonly FooterColumn[] = [
   },
   {
     links: [
-      { external: true, href: REQUEST_URL, label: "Request a component" },
+      { href: "/request-component", label: "Request a component" },
       { external: true, href: REPORT_URL, label: "Report a bug" },
       { external: true, href: DISCUSSIONS_URL, label: "Discussions" },
       { external: true, href: SPONSOR_URL, label: "Sponsor" },

--- a/apps/registry/components/header/header.tsx
+++ b/apps/registry/components/header/header.tsx
@@ -53,6 +53,10 @@ export function Header({ locale }: HeaderProps) {
       title: t("navComponents"),
     },
     { href: localizePathname("/templates", locale), title: "Templates" },
+    {
+      href: localizePathname("/request-component", locale),
+      title: "Request",
+    },
   ];
 
   const searchItems = registry.items.reduce<

--- a/apps/registry/lib/sidebar-sections.ts
+++ b/apps/registry/lib/sidebar-sections.ts
@@ -84,6 +84,10 @@ export function getSidebarSections(
           title: "Components",
         },
         { href: localizePathname("/templates", locale), title: "Templates" },
+        {
+          href: localizePathname("/request-component", locale),
+          title: "Request a component",
+        },
       ],
     },
     {

--- a/packages/ui/src/components/navbar-saas/navbar-saas.tsx
+++ b/packages/ui/src/components/navbar-saas/navbar-saas.tsx
@@ -64,7 +64,7 @@ export function NavbarSaas({
               )
             ) : null}
             {navItems.length > 0 ? (
-              <nav className="hidden md:flex gap-6">
+              <nav className="hidden lg:flex gap-6">
                 {navItems.map((item) => (
                   <Link
                     className={cn(


### PR DESCRIPTION
Closes #396

## What

The `/request-component` page (an on-site form that opens a prefilled GitHub feature-request issue, no backend) already existed but had **zero inbound links** — it was unreachable unless you guessed the URL. This wires it into three high-intent surfaces so users can easily request new components from the site.

## Changes

- **Header nav** (`header.tsx`) — add a `Request` item
- **`/components` page** (`page.tsx`) — add an end-of-list CTA card: "Don't see what you need? → Request a component"
- **Footer** (`footer.tsx`) — repoint the existing "Request a component" link from the raw GitHub issue URL to the on-site `/request-component` form (single canonical entry); drop the now-unused `REQUEST_URL` const

All three point to the same existing form. No new redirect logic — discoverability only.

## Flow

```
header nav "Request" ┐
/components CTA       ├─▶ /request-component (form) ─▶ prefilled GitHub issue
footer link          ┘
```

## Verification

- typecheck: clean (`tsc --noEmit`)
- CI: registry build + preview deploy passed → https://pr-392-ui-registry.preview.vllnt.ai
- Live browser (real Chromium): header click → navigates to form (h1 + 5 fields); CTA renders with correct href; footer link is internal (no `target=_blank`); mobile 375px responsive; no error overlay

## Notes

- Footer only renders on landing/preview pages; header + CTA cover the sidebar-layout pages.