### PR TITLE
ci(react-doctor): scoping config + pre-commit hook + barrel-import fixes

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+# react-doctor pre-commit gate.
+#
+# Blocks commits that introduce React *errors* on staged files.
+# Warnings are advisory and never block a commit (gate is --fail-on error,
+# matching .github/workflows/react-doctor.yml and doctor.config.json).
+#
+# Enabled via `git config core.hooksPath .githooks`, which the root
+# package.json "prepare" script runs automatically on `pnpm install`.
+#
+# Skip once with:  git commit --no-verify
+#
+# Implementation note: we feed the staged file list to `--changed-files-from`
+# rather than using `--staged`. In this pnpm monorepo React is a peerDependency,
+# and `--staged` copies files into a temp sandbox whose generated package.json
+# has no React dep ("No React dependency found"), which would block every commit.
+# `--changed-files-from` scans the listed files in place, with real resolution.
+
+# Only run when React/TS source is staged — keep doc/config-only commits fast.
+files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(tsx|jsx|ts)$')
+if [ -z "$files" ]; then
+  exit 0
+fi
+
+echo "react-doctor: scanning staged files…"
+printf '%s\n' "$files" | npx --yes react-doctor . --offline --changed-files-from /dev/stdin --fail-on error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,40 @@ External shared configs (separate npm packages): `@vllnt/eslint-config`, `@vllnt
 | `pnpm -F @vllnt/ui test:visual` | Playwright CT visual snapshots |
 | `pnpm -F @vllnt/ui test:coverage` | Vitest with coverage |
 | `pnpm check:circular` | Fail on circular imports |
+| `pnpm doctor` | react-doctor health scan (top rules) |
+| `pnpm doctor:full` | Verbose full scan with per-file detail |
+| `pnpm doctor:errors` | Scan, exit non-zero on any **error** (CI/pre-commit gate) |
+| `pnpm doctor:staged` | Scan only staged files (what the pre-commit hook runs) |
+
+---
+
+## React health (react-doctor)
+
+[react-doctor](https://github.com/millionco/react-doctor) scans React-specific
+correctness, a11y, and dead-code health. Three surfaces, one shared gate
+(**errors block, warnings are advisory**):
+
+| Surface | Trigger | Gate |
+|---------|---------|------|
+| CI ([`.github/workflows/react-doctor.yml`](./.github/workflows/react-doctor.yml)) | PR (diff) + push to main (full report) | `--fail-on error` |
+| Pre-commit ([`.githooks/pre-commit`](./.githooks/pre-commit)) | `git commit` with staged `.ts/.tsx` | `--fail-on error` on staged files |
+| Local | `pnpm doctor*` scripts | per script |
+
+The pre-commit hook is enabled automatically: the root `package.json` `prepare`
+script points `core.hooksPath` at `.githooks/` on `pnpm install`. Bypass once
+with `git commit --no-verify`.
+
+### Config — [`doctor.config.json`](./doctor.config.json)
+
+- `ignore.files` skips generated/build output so the score reflects hand-written
+  source: `registry/default/**` (generated from `packages/ui/src` by
+  `inline-component-source.ts`), `storybook-static`, `dist`, `.next`, Pagefind
+  and shadcn registry output, and `*.visual.tsx` Playwright CT fixtures (test
+  entry files the import graph can't see).
+- Two rules are `off` because they conflict with deliberate library patterns:
+  `no-multi-comp` (compound components such as `Alert`/`AlertTitle` co-located
+  by design) and `only-export-components` (shadcn `cva` variants/types
+  co-exported with the component).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,12 @@ Key scripts (from repo root):
 | `pnpm test:once` | Vitest single-run across the workspace |
 | `pnpm -F @vllnt/ui test:visual` | Playwright CT visual snapshots |
 | `pnpm check:circular` | Fail on circular imports |
+| `pnpm doctor` | react-doctor React-health scan |
+
+A [react-doctor](https://github.com/millionco/react-doctor) **pre-commit hook**
+(in `.githooks/`, enabled automatically on `pnpm install`) blocks commits that
+introduce React *errors* on staged files; warnings are advisory. Bypass once
+with `git commit --no-verify`. See AGENTS.md → *React health* for details.
 
 ## Branching & PRs
 

--- a/doctor.config.json
+++ b/doctor.config.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://react.doctor/schema/config.json",
+  "failOn": "error",
+  "rules": {
+    "react-doctor/no-multi-comp": "off",
+    "react-doctor/only-export-components": "off"
+  },
+  "ignore": {
+    "files": [
+      "**/registry/default/**",
+      "**/storybook-static/**",
+      "**/dist/**",
+      "**/.next/**",
+      "**/public/r/**",
+      "**/public/_pagefind/**",
+      "**/*.visual.tsx",
+      "**/*.visual.fixture.tsx"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "packageManager": "pnpm@9.15.4",
   "scripts": {
+    "prepare": "git config core.hooksPath .githooks || true",
     "dev": "turbo dev",
     "build": "turbo build",
     "lint": "turbo lint",
@@ -26,7 +27,7 @@
     "doctor:json": "npx --yes react-doctor . --offline --json > .react-doctor.json",
     "doctor:errors": "npx --yes react-doctor . --offline --fail-on error",
     "doctor:diff": "npx --yes react-doctor . --offline --diff origin/main",
-    "doctor:staged": "npx --yes react-doctor . --offline --staged --fail-on error",
+    "doctor:staged": "git diff --cached --name-only --diff-filter=ACM | grep -E '\\.(tsx|jsx|ts)$' | npx --yes react-doctor . --offline --changed-files-from /dev/stdin --fail-on error",
     "doctor:score": "npx --yes react-doctor . --offline --score"
   },
   "devDependencies": {

--- a/packages/ui/src/components/activity-log/activity-log.tsx
+++ b/packages/ui/src/components/activity-log/activity-log.tsx
@@ -5,7 +5,7 @@ import { forwardRef, useMemo, useState } from "react";
 import { ArrowRight, ChevronLeft, ChevronRight } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Avatar, AvatarFallback } from "../avatar";
+import { Avatar, AvatarFallback } from "../avatar/avatar";
 import { Badge } from "../badge";
 import { Button } from "../button";
 import {

--- a/packages/ui/src/components/ai-chat-input/ai-chat-input.tsx
+++ b/packages/ui/src/components/ai-chat-input/ai-chat-input.tsx
@@ -4,7 +4,7 @@ import { cva } from "class-variance-authority";
 import { LoaderCircle, SendHorizontal } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 import { Textarea } from "../textarea";
 
 const formShellVariants = cva(

--- a/packages/ui/src/components/ai-message-bubble/ai-message-bubble.tsx
+++ b/packages/ui/src/components/ai-message-bubble/ai-message-bubble.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "../../lib/utils";
-import { Avatar, AvatarFallback } from "../avatar";
+import { Avatar, AvatarFallback } from "../avatar/avatar";
 import { Badge } from "../badge";
 
 const bubbleVariants = cva(

--- a/packages/ui/src/components/ai-tool-call-display/ai-tool-call-display.tsx
+++ b/packages/ui/src/components/ai-tool-call-display/ai-tool-call-display.tsx
@@ -4,7 +4,7 @@ import { cva } from "class-variance-authority";
 import { AlertCircle, CheckCircle2, Clock3, Wrench } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 
 const statusVariants = cva(
   "rounded-full px-2 py-0 text-[10px] uppercase tracking-wide",

--- a/packages/ui/src/components/annotation/annotation.tsx
+++ b/packages/ui/src/components/annotation/annotation.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode } from "react";
 
 import { cn } from "../../lib/utils";
-import { Popover, PopoverContent, PopoverTrigger } from "../popover";
+import { Popover, PopoverContent, PopoverTrigger } from "../popover/popover";
 
 const toneClasses = {
   amber: "bg-amber-500/20 text-amber-950 dark:text-amber-100",

--- a/packages/ui/src/components/avatar-group/avatar-group.tsx
+++ b/packages/ui/src/components/avatar-group/avatar-group.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "../../lib/utils";
-import { Avatar, AvatarFallback, AvatarImage } from "../avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "../avatar/avatar";
 
 const avatarGroupVariants = cva("flex items-center", {
   defaultVariants: {

--- a/packages/ui/src/components/blog-card/blog-card.tsx
+++ b/packages/ui/src/components/blog-card/blog-card.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 import {
   Card,
   CardContent,

--- a/packages/ui/src/components/canvas-shell/canvas-foundation-demo.tsx
+++ b/packages/ui/src/components/canvas-shell/canvas-foundation-demo.tsx
@@ -1,6 +1,6 @@
 import { Activity, Bot, Compass, Layers3, Sparkles } from "lucide-react";
 
-import { BottomBar } from "../bottom-bar";
+import { BottomBar } from "../bottom-bar/bottom-bar";
 import { Button } from "../button";
 import { CanvasView } from "../canvas-view";
 import { ChatDockSection } from "../chat-dock-section";

--- a/packages/ui/src/components/category-filter/category-filter.tsx
+++ b/packages/ui/src/components/category-filter/category-filter.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 
 type CategoryFilterProps = {
   categories: string[];

--- a/packages/ui/src/components/chat-dock-section/chat-dock-section.tsx
+++ b/packages/ui/src/components/chat-dock-section/chat-dock-section.tsx
@@ -4,7 +4,7 @@ import { ArrowUpRight, MessageSquareText } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 
 export type ChatDockMessage = {
   body: ReactNode;

--- a/packages/ui/src/components/code-playground/code-playground.tsx
+++ b/packages/ui/src/components/code-playground/code-playground.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from "react";
 
 import type { HeadingTag } from "../../lib/types";
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 
 type CodeLineProps = {
   highlightLines: number[];

--- a/packages/ui/src/components/combobox/combobox.tsx
+++ b/packages/ui/src/components/combobox/combobox.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { Check, ChevronsUpDown } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 import {
   Command,
   CommandEmpty,

--- a/packages/ui/src/components/completion-dialog/completion-dialog.tsx
+++ b/packages/ui/src/components/completion-dialog/completion-dialog.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from "react";
 
 import type { HeadingTag } from "../../lib/types";
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 
 export type CompletionDialogProps = {
   /** Heading tag for the dialog title. Defaults to `h2`. */

--- a/packages/ui/src/components/connector-edge/connector-edge.tsx
+++ b/packages/ui/src/components/connector-edge/connector-edge.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import type { CSSProperties } from "react";
 
 import { cn } from "../../lib/utils";
-import { EdgeLabel } from "../edge-label";
+import { EdgeLabel } from "../edge-label/edge-label";
 
 export type ConnectorEdgePoint = {
   x: number;

--- a/packages/ui/src/components/content-intro/content-intro.tsx
+++ b/packages/ui/src/components/content-intro/content-intro.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from "react";
 
 import type { HeadingTag } from "../../lib/types";
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 
 export type ContentIntroSection = {
   id: string;

--- a/packages/ui/src/components/conversation-thread/conversation-thread.tsx
+++ b/packages/ui/src/components/conversation-thread/conversation-thread.tsx
@@ -16,7 +16,7 @@ import {
 import { ArrowDown, RefreshCw, ThumbsDown, ThumbsUp } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { ThinkingBlock } from "../thinking-block";
+import { ThinkingBlock } from "../thinking-block/thinking-block";
 
 /** A single tool call made by the assistant. */
 export type ToolCall = {

--- a/packages/ui/src/components/countdown-timer/countdown-timer.tsx
+++ b/packages/ui/src/components/countdown-timer/countdown-timer.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 import {
   Card,
   CardContent,

--- a/packages/ui/src/components/data-table/data-table.tsx
+++ b/packages/ui/src/components/data-table/data-table.tsx
@@ -19,7 +19,7 @@ import {
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 import { Checkbox } from "../checkbox";
 import { Input } from "../input";
 import {

--- a/packages/ui/src/components/date-picker/date-picker.tsx
+++ b/packages/ui/src/components/date-picker/date-picker.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { CalendarIcon } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 import { Calendar, type CalendarProps } from "../calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "../popover";
 

--- a/packages/ui/src/components/exercise/exercise.tsx
+++ b/packages/ui/src/components/exercise/exercise.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from "react";
 
 import type { HeadingTag } from "../../lib/types";
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 
 const difficultyConfig = {
   easy: { className: "text-green-600 dark:text-green-400", label: "Easy" },

--- a/packages/ui/src/components/file-upload/file-upload.tsx
+++ b/packages/ui/src/components/file-upload/file-upload.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { FileUp, UploadCloud, X } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 
 export type FileUploadProps = Omit<
   React.ComponentPropsWithoutRef<"input">,

--- a/packages/ui/src/components/filter-bar/filter-bar.tsx
+++ b/packages/ui/src/components/filter-bar/filter-bar.tsx
@@ -3,7 +3,7 @@
 import { memo, useCallback, useTransition } from "react";
 
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 
 export type FilterOption = {
   label: string;

--- a/packages/ui/src/components/flashcard/flashcard.tsx
+++ b/packages/ui/src/components/flashcard/flashcard.tsx
@@ -6,7 +6,7 @@ import { RefreshCcw } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 import { Button } from "../button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "../card";
 

--- a/packages/ui/src/components/form/form.tsx
+++ b/packages/ui/src/components/form/form.tsx
@@ -19,7 +19,7 @@ import {
 } from "react-hook-form";
 
 import { cn } from "../../lib/utils";
-import { Label } from "../label";
+import { Label } from "../label/label";
 
 type FormInstance<TFieldValues extends FieldValues> = UseFormReturn<
   TFieldValues,

--- a/packages/ui/src/components/inline-input/inline-input.tsx
+++ b/packages/ui/src/components/inline-input/inline-input.tsx
@@ -3,7 +3,7 @@
 import type { KeyboardEvent } from "react";
 
 import { cn } from "../../lib/utils";
-import { Input } from "../input";
+import { Input } from "../input/input";
 
 export type InlineInputProps = {
   className?: string;

--- a/packages/ui/src/components/live-feed/live-feed.tsx
+++ b/packages/ui/src/components/live-feed/live-feed.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 import {
   Card,
   CardContent,

--- a/packages/ui/src/components/metric-gauge/metric-gauge.tsx
+++ b/packages/ui/src/components/metric-gauge/metric-gauge.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 import {
   Card,
   CardContent,

--- a/packages/ui/src/components/model-selector/model-selector.tsx
+++ b/packages/ui/src/components/model-selector/model-selector.tsx
@@ -5,7 +5,7 @@ import { useMemo, useRef, useState } from "react";
 import { ArrowUpDown, Filter } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 import { Button } from "../button";
 import {
   Command,

--- a/packages/ui/src/components/multi-select/multi-select.tsx
+++ b/packages/ui/src/components/multi-select/multi-select.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { Check, ChevronDown } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 import { Button } from "../button";
 import {
   Command,

--- a/packages/ui/src/components/navbar-saas/navbar-saas.tsx
+++ b/packages/ui/src/components/navbar-saas/navbar-saas.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 import { useSidebar } from "../sidebar-provider";
 import { ThemeToggle } from "../theme-toggle";
 

--- a/packages/ui/src/components/number-input/number-input.tsx
+++ b/packages/ui/src/components/number-input/number-input.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { Minus, Plus } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 
 export type NumberInputProps = Omit<
   React.ComponentPropsWithoutRef<"input">,

--- a/packages/ui/src/components/object-card/object-card.tsx
+++ b/packages/ui/src/components/object-card/object-card.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import type { ReactNode } from "react";
 
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 import { Button } from "../button";
 
 export type ObjectCardMetric = {

--- a/packages/ui/src/components/overview-board/overview-board.tsx
+++ b/packages/ui/src/components/overview-board/overview-board.tsx
@@ -4,7 +4,7 @@ import { AlertCircle, ArrowRight, Inbox, ListTodo, Siren } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 
 export type OverviewCardTone = "danger" | "default" | "warning";
 

--- a/packages/ui/src/components/progress-card/progress-card.tsx
+++ b/packages/ui/src/components/progress-card/progress-card.tsx
@@ -5,7 +5,7 @@ import { memo, useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
 import { useMounted } from "../../lib/use-mounted";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 import {
   Card,
   CardContent,

--- a/packages/ui/src/components/progress-tracker/progress-tracker.tsx
+++ b/packages/ui/src/components/progress-tracker/progress-tracker.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import type { ReactNode } from "react";
 
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 import {
   Card,
   CardContent,

--- a/packages/ui/src/components/scope-selector/scope-selector.tsx
+++ b/packages/ui/src/components/scope-selector/scope-selector.tsx
@@ -5,7 +5,7 @@ import { forwardRef, useMemo, useState } from "react";
 import { Check, ChevronRight, Search } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 import { Button } from "../button";
 import { Input } from "../input";
 import { Popover, PopoverContent, PopoverTrigger } from "../popover";

--- a/packages/ui/src/components/search-dialog/search-dialog.tsx
+++ b/packages/ui/src/components/search-dialog/search-dialog.tsx
@@ -12,7 +12,7 @@ import {
 import { Search } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 import {
   CommandDialog,
   CommandEmpty,

--- a/packages/ui/src/components/sidebar-toggle/sidebar-toggle.tsx
+++ b/packages/ui/src/components/sidebar-toggle/sidebar-toggle.tsx
@@ -3,7 +3,7 @@
 import { Menu, X } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 
 export type SidebarToggleProps = {
   className?: string;

--- a/packages/ui/src/components/sidebar/sidebar.tsx
+++ b/packages/ui/src/components/sidebar/sidebar.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import { cn } from "../../lib/utils";
-import { useSidebar } from "../sidebar-provider";
+import { useSidebar } from "../sidebar-provider/sidebar-provider";
 
 export type SidebarItem = {
   href: string;

--- a/packages/ui/src/components/slideshow/slideshow.tsx
+++ b/packages/ui/src/components/slideshow/slideshow.tsx
@@ -8,7 +8,7 @@ import { createPortal } from "react-dom";
 import type { HeadingTag } from "../../lib/types";
 import { useMounted } from "../../lib/use-mounted";
 import { cn } from "../../lib/utils";
-import { CompletionDialog } from "../completion-dialog";
+import { CompletionDialog } from "../completion-dialog/completion-dialog";
 
 export type SlideshowSection = {
   id: string;

--- a/packages/ui/src/components/stat-card/stat-card.tsx
+++ b/packages/ui/src/components/stat-card/stat-card.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { ArrowDownRight, ArrowRight, ArrowUpRight } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Card, CardContent, CardDescription, CardHeader } from "../card";
+import { Card, CardContent, CardDescription, CardHeader } from "../card/card";
 
 const statCardVariants = cva("overflow-hidden border shadow-sm", {
   defaultVariants: {

--- a/packages/ui/src/components/status-board/status-board.tsx
+++ b/packages/ui/src/components/status-board/status-board.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import type { HeadingTag } from "../../lib/types";
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 import {
   Card,
   CardContent,

--- a/packages/ui/src/components/terminal/terminal.tsx
+++ b/packages/ui/src/components/terminal/terminal.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 
 import { Check, Copy, Terminal as TerminalIcon } from "lucide-react";
 
-import { Button } from "../button";
+import { Button } from "../button/button";
 
 export type TerminalLine = {
   content: string;

--- a/packages/ui/src/components/ticker-tape/ticker-tape.tsx
+++ b/packages/ui/src/components/ticker-tape/ticker-tape.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { ArrowDownRight, ArrowUpRight, Dot } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 
 export type TickerTapeItem = {
   change: number;

--- a/packages/ui/src/components/tour/tour.tsx
+++ b/packages/ui/src/components/tour/tour.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import type { ReactNode } from "react";
 
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 import { Button } from "../button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "../card";
 

--- a/packages/ui/src/components/tutorial-card/tutorial-card.tsx
+++ b/packages/ui/src/components/tutorial-card/tutorial-card.tsx
@@ -5,7 +5,7 @@ import { memo, useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
 import { useMounted } from "../../lib/use-mounted";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 import {
   Card,
   CardContent,

--- a/packages/ui/src/components/tutorial-complete/tutorial-complete.tsx
+++ b/packages/ui/src/components/tutorial-complete/tutorial-complete.tsx
@@ -6,7 +6,7 @@ import { Check, ChevronRight, RotateCcw } from "lucide-react";
 import type { ReactNode } from "react";
 
 import type { HeadingTag } from "../../lib/types";
-import { Button } from "../button";
+import { Button } from "../button/button";
 import { ProfileSection } from "../profile-section";
 import { ShareSection } from "../share-section";
 

--- a/packages/ui/src/components/tutorial-filters/tutorial-filters.tsx
+++ b/packages/ui/src/components/tutorial-filters/tutorial-filters.tsx
@@ -2,7 +2,7 @@
 
 import { memo } from "react";
 
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 
 export type TutorialFiltersLabels = {
   activeFilters: string;

--- a/packages/ui/src/components/tutorial-mdx/tutorial-mdx.tsx
+++ b/packages/ui/src/components/tutorial-mdx/tutorial-mdx.tsx
@@ -12,7 +12,7 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
-} from "../accordion";
+} from "../accordion/accordion";
 import { Callout } from "../callout";
 import { Checklist } from "../checklist";
 import { CodePlayground, FileTree } from "../code-playground";

--- a/packages/ui/src/components/usage-breakdown/usage-breakdown.tsx
+++ b/packages/ui/src/components/usage-breakdown/usage-breakdown.tsx
@@ -5,7 +5,7 @@ import { forwardRef, type ReactNode, useMemo } from "react";
 import { ArrowDownRight, ArrowUpRight } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 import {
   Card,
   CardContent,

--- a/packages/ui/src/components/world-clock-bar/world-clock-bar.tsx
+++ b/packages/ui/src/components/world-clock-bar/world-clock-bar.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 
 import type { HeadingTag } from "../../lib/types";
 import { cn } from "../../lib/utils";
-import { Badge } from "../badge";
+import { Badge } from "../badge/badge";
 
 export type WorldClockBarZone = {
   city: string;

--- a/packages/ui/src/components/zoom-hud/zoom-hud.tsx
+++ b/packages/ui/src/components/zoom-hud/zoom-hud.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import { Minus, Plus, RotateCcw } from "lucide-react";
 
 import { cn } from "../../lib/utils";
-import { Button } from "../button";
+import { Button } from "../button/button";
 
 export type ZoomHUDProps = React.ComponentPropsWithoutRef<"div"> & {
   onReset?: () => void;


### PR DESCRIPTION
## What

react-doctor enforcement infrastructure for the sweep, plus a batch of `no-barrel-import` fixes.

- **`doctor.config.json`** — scopes the scan to hand-written source: excludes generated/build output (`registry/default`, `storybook-static`, `dist`, `.next`, `public/r`, `public/_pagefind`, `*.visual.tsx` CT fixtures); disables two rules that fight deliberate library patterns (`no-multi-comp`, `only-export-components`); `failOn: error`.
- **`.githooks/pre-commit`** — blocks commits that introduce React **errors** on staged files (warnings advisory). Auto-enabled by a root `prepare` script that sets `core.hooksPath`. Bypass with `git commit --no-verify`.
- **52 barrel-import fixes** — sibling `../badge` → `../badge/badge` across components (better tree-shaking; matches the repo's "direct imports internal" rule).
- **Docs** — `AGENTS.md` + `CONTRIBUTING.md`.

## Why these numbers

`npx react-doctor .` on this branch: **0 errors, 161 warnings, score 80 "Great"** (config baseline was 1103 warnings / score 71 in a clean checkout).

The bulk of the reduction is **config exclusion of noise**, not silencing real issues:
- ~546 warnings were in `storybook-static/` — a gitignored build artifact (absent in CI anyway).
- ~600 were in `registry/default/**` — generated from `packages/ui/src` by `inline-component-source.ts` (and only flagged there because that app is on React 19; the library peers `react >=18`).
- ~225 were `unused-file` on `*.visual.tsx` Playwright CT fixtures (test entry files invisible to the import graph).

Errors were already **0** on `main` (fixed by #387). The CI workflow (#280) already exists and passes; this PR makes its scan accurate and adds the pre-commit hook portion of #278 (the committed git hook wasn't actually present).

## Two judgment calls

1. **`--staged` is broken in this monorepo.** Its temp sandbox can't resolve React (declared as a `peerDependency`), so it errors with "No React dependency found" for any staged TS file — it would block *every* commit. The hook and `doctor:staged` use `--changed-files-from /dev/stdin` instead.
2. **Did not force `no-barrel-import` to zero.** A comprehensive barrel→direct conversion re-introduced a circular-import cycle the barrel indirection guards, breaking a `tutorial-complete` render test. Scoped to the imports react-doctor flagged; **26 advisory `no-barrel-import` warnings remain by design**.

The remaining 161 warnings are deliberate patterns, false positives (e.g. `aria-multiselectable` on `role="tree"` is valid), or risky refactors of working code (`prefer-tag-over-role` semantic swaps, author-suppressed `exhaustive-deps`) — left as advisory signal, not silently disabled. A dedicated a11y pass on `prefer-tag-over-role` (49) is worth a follow-up issue.

## Validation

- `tsc --project tsconfig.build.json` — clean
- `eslint .` (full) — clean
- `tsup` build — ESM + DTS pass
- `vitest run` — **237 files / 1313 tests pass**
- Pre-commit hook tested: skips non-React commits, passes clean code, blocks an error (exit 1) — and dogfooded on the 52-file commit here.
- No registry drift.

Part of #279
