### PR TITLE
feat(registry): serve DESIGN.md at /DESIGN.md and cross-link it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Repository-wide docs (audience = contributors, not just agents):
 
 The most-violated rules in PR review history:
 
-0. **Design rules are mandatory for UI work.** Any UI suggestion or component/site change must follow [`DESIGN.md`](./DESIGN.md) and the machine-readable tokens in [`packages/design/tokens.json`](./packages/design/tokens.json). List any intentional deviation in the PR body.
+0. **Design rules are mandatory for UI work.** Any UI suggestion or component/site change must follow [`DESIGN.md`](./DESIGN.md) (live at `https://ui.vllnt.ai/DESIGN.md`) and the machine-readable tokens in [`packages/design/tokens.json`](./packages/design/tokens.json). List any intentional deviation in the PR body.
 1. **Workspace gates green at HEAD** ([R6](./docs/agents/RULES.md#r6--workspace-gates-green-at-head)). Touched-file passes alone are not ship-OK. Run `pnpm -F @vllnt/ui lint && pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json && pnpm build && pnpm test:once` — all must be green.
 2. **PR body matches HEAD** ([R3](./docs/agents/RULES.md#r3--pr-body-matches-head)). After every push, rewrite the body to match the current head. Stale claims block ship.
 3. **Linked issue required** ([R5](./docs/agents/RULES.md#r5--linked-issue-required)). Every PR must reference a GitHub issue. Accepted keywords: `close` / `closes` / `closed`, `fix` / `fixes` / `fixed`, `resolve` / `resolves` / `resolved`, or repo phrases `Part of` / `Related to` — all case-insensitive, optional colon — followed by `#123` or `owner/repo#123`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for wanting to contribute. This repo welcomes issues, bug reports, and PR
 - Be respectful. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 - Security-sensitive reports go through [SECURITY.md](SECURITY.md), **not** public issues.
 - Every change keeps the repo shippable: lint, typecheck, tests, and build pass on `main`.
-- UI changes must follow [DESIGN.md](DESIGN.md) and the token contract in [packages/design/tokens.json](packages/design/tokens.json). Document intentional deviations in the PR body.
+- UI changes must follow [DESIGN.md](DESIGN.md) (live at <https://ui.vllnt.ai/DESIGN.md>) and the token contract in [packages/design/tokens.json](packages/design/tokens.json). Document intentional deviations in the PR body.
 
 ## Development setup
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,10 +3,15 @@
 > Single source of truth for VLLNT UI's brand and design conventions.
 > Humans read this file. Agents read it too — every UI suggestion must follow it.
 
-This is the **canonical** brand & design guideline for the library. The full
-machine-readable token set lives in `packages/design/tokens.json`, is documented
-in `packages/design/README.md`, and is mirrored publicly at `/r/design.json`.
-The site rendering at `/design` reads this file directly.
+This is the **canonical** brand & design guideline for the library. Read it on
+the web at three public surfaces, all generated from this one file:
+
+- [`/DESIGN.md`](https://ui.vllnt.ai/DESIGN.md) — this file as raw markdown (canonical for agents).
+- [`/design`](https://ui.vllnt.ai/design) — human-browsable rendering with a contents nav.
+- [`/r/design.json`](https://ui.vllnt.ai/r/design.json) — machine-readable token set.
+
+The full token set lives in `packages/design/tokens.json` and is documented in
+`packages/design/README.md`.
 
 ---
 
@@ -249,14 +254,18 @@ No coloured shadows. No multi-layered glow effects.
 
 ---
 
-## 14. Roadmap (this file)
+## 14. Surfaces and roadmap
 
-This document is the **v1 brand baseline** for VLLNT UI. Expansions tracked
-separately:
+This document is the **v1 brand baseline** for VLLNT UI. It ships on these
+surfaces today:
 
-- `packages/design/tokens.json` — machine-readable tokens (same source of truth, JSON form). Follow-up.
-- `/design` site route — human-browsable rendering of this file with live token previews. Follow-up.
-- `/r/design.json` — JSON endpoint mirroring tokens for agent consumption. Follow-up.
+- [`/DESIGN.md`](https://ui.vllnt.ai/DESIGN.md) — this file as raw markdown.
+- [`/design`](https://ui.vllnt.ai/design) — human-browsable rendering with a contents nav.
+- [`/r/design.json`](https://ui.vllnt.ai/r/design.json) — JSON token set, mirroring `packages/design/tokens.json`.
+
+Still planned:
+
+- Live token previews inline on the `/design` page.
 - `meta.json` a11y schemas per component (#255) — keyboard / ARIA / focus rules surfaced via the registry.
 
 ---

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Override CSS variables after importing styles:
 
 ## AI agents
 
-Building with an AI coding agent? Install the [`vllnt-ui` skill](skills/vllnt-ui/SKILL.md) — it gives agents the component set, design tokens, and usage patterns, pointing to the live registry and [`DESIGN.md`](DESIGN.md) for current detail. Agents working *in this repo* should read [AGENTS.md](AGENTS.md).
+Building with an AI coding agent? Install the [`vllnt-ui` skill](skills/vllnt-ui/SKILL.md) — it gives agents the component set, design tokens, and usage patterns, pointing to the live registry and [`DESIGN.md`](https://ui.vllnt.ai/DESIGN.md) for current detail. Agents working *in this repo* should read [AGENTS.md](AGENTS.md).
 
 ## Contributing
 

--- a/apps/registry/app/DESIGN.md/route.ts
+++ b/apps/registry/app/DESIGN.md/route.ts
@@ -1,0 +1,20 @@
+import { getDesignGuideMarkdown } from "@/lib/design-guide";
+
+const MARKDOWN_HEADERS = new Headers([
+  [
+    "Cache-Control",
+    "public, max-age=0, s-maxage=86400, stale-while-revalidate=604800",
+  ],
+  ["Content-Type", "text/markdown; charset=utf-8"],
+]);
+
+export const dynamic = "force-static";
+export const revalidate = 86_400;
+
+async function getDesignMarkdown(): Promise<Response> {
+  const body = await getDesignGuideMarkdown();
+
+  return new Response(body, { headers: MARKDOWN_HEADERS });
+}
+
+export { getDesignMarkdown as GET };

--- a/apps/registry/app/llms-full.txt/route.ts
+++ b/apps/registry/app/llms-full.txt/route.ts
@@ -105,6 +105,7 @@ async function buildDesignLines(): Promise<readonly string[]> {
     "## Design Guide",
     "",
     `Source: ${SITE_URL}/design`,
+    `Raw: ${SITE_URL}/DESIGN.md`,
     `Tokens: ${SITE_URL}/r/design.json`,
     "",
     designGuide,

--- a/apps/registry/app/llms.txt/route.ts
+++ b/apps/registry/app/llms.txt/route.ts
@@ -110,6 +110,7 @@ function buildRegistryLines(): readonly string[] {
     "",
     `- [Registry index](${SITE_URL}/r/registry.json): full machine-readable list of all components`,
     `- [Design tokens](${SITE_URL}/r/design.json): machine-readable VLLNT UI token contract`,
+    `- [Design guide (raw)](${SITE_URL}/DESIGN.md): canonical brand and design rules as raw markdown`,
     `- [Sitemap](${SITE_URL}/sitemap.xml): every public route, refreshed per deploy`,
     "- Install command: `pnpm dlx shadcn@latest add " +
       `${SITE_URL}/r/<name>.json` +

--- a/apps/registry/app/sitemap.ts
+++ b/apps/registry/app/sitemap.ts
@@ -91,19 +91,22 @@ function registryRoutes(
   items: readonly RegistryItem[],
   lastModified: Date,
 ): MetadataRoute.Sitemap {
-  return [
-    entry({
+  const rawRoutes = [
+    {
       changeFrequency: "weekly",
-      lastModified,
       priority: 0.3,
       url: `${SITE_URL}/r/registry.json`,
-    }),
-    entry({
+    },
+    {
       changeFrequency: "monthly",
-      lastModified,
       priority: 0.3,
       url: `${SITE_URL}/r/design.json`,
-    }),
+    },
+    { changeFrequency: "monthly", priority: 0.3, url: `${SITE_URL}/DESIGN.md` },
+  ] satisfies readonly Omit<SitemapEntryInput, "lastModified">[];
+
+  return [
+    ...rawRoutes.map((route) => entry({ ...route, lastModified })),
     ...items.map((item) =>
       entry({
         changeFrequency: "weekly",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16,6 +16,7 @@
   - Public npm: https://www.npmjs.com/package/@vllnt/ui
   - shadcn registry: https://ui.vllnt.ai/r
   - Docs: https://ui.vllnt.ai
+  - Design system: https://ui.vllnt.ai/DESIGN.md
   - Storybook: https://storybook.vllnt.ai
 
 ## Install

--- a/llms.txt
+++ b/llms.txt
@@ -33,6 +33,7 @@ import { Button } from "@vllnt/ui";
 ## Key docs
 
 - [Root README](https://github.com/vllnt/ui/blob/main/README.md) — overview + component index
+- [DESIGN](https://ui.vllnt.ai/DESIGN.md) — canonical brand, tokens, and design system rules
 - [Package README](https://github.com/vllnt/ui/blob/main/packages/ui/README.md) — setup, theming, full component tables
 - [CHANGELOG](https://github.com/vllnt/ui/blob/main/packages/ui/CHANGELOG.md) — version history
 - [CONTRIBUTING](https://github.com/vllnt/ui/blob/main/CONTRIBUTING.md) — dev + PR workflow

--- a/skills/vllnt-ui/SKILL.md
+++ b/skills/vllnt-ui/SKILL.md
@@ -45,7 +45,7 @@ The component set changes; the design rules don't. Hardcoded lists go stale —
 | Full component list / TOC | `https://ui.vllnt.ai/r/registry.json` | JSON — `items[]` with `name`, `title`, `description` |
 | Browse a component (props, demos) | `https://ui.vllnt.ai/components` · `…/components/{slug}` | HTML |
 | Install one component | `https://ui.vllnt.ai/r/{name}.json` | JSON (shadcn) |
-| Design system (canonical) | `https://raw.githubusercontent.com/vllnt/ui/main/DESIGN.md` | Markdown |
+| Design system (canonical) | `https://ui.vllnt.ai/DESIGN.md` | Markdown (raw) |
 | AI orientation (short) | `https://ui.vllnt.ai/llms.txt` | text |
 | AI deep reference (full) | `https://ui.vllnt.ai/llms-full.txt` | text |
 
@@ -53,8 +53,9 @@ Rules:
 - "What components exist?" / "is there an X component?" → fetch `/r/registry.json`
   and read `items[].name`. **Do not answer the component list from memory.**
 - Need exact props / a11y map / examples → fetch the component page or its `.tsx`.
-- Need a design decision not covered below → fetch `DESIGN.md`.
-- When `ui.vllnt.ai/design` ships (DESIGN.md §14 roadmap), prefer it over the raw link.
+- Need a design decision not covered below → fetch `https://ui.vllnt.ai/DESIGN.md`.
+- For human-readable browsing use `https://ui.vllnt.ai/design`. If `/DESIGN.md` is
+  unreachable, fall back to `https://raw.githubusercontent.com/vllnt/ui/main/DESIGN.md`.
 
 ---
 


### PR DESCRIPTION
## What

`https://ui.vllnt.ai/DESIGN.md` previously 404'd — the design guide was only reachable at `/design` (HTML), `/design.txt` (raw), and `/r/design.json` (tokens). This adds the missing raw-markdown surface at the literal `/DESIGN.md` URL and cross-links the design guide everywhere.

## Changes

- **New route** `apps/registry/app/DESIGN.md/route.ts` — serves the canonical guide as `text/markdown; charset=utf-8`, reusing `getDesignGuideMarkdown()` (same single source as `/design` and `/design.txt`; force-static, 24h revalidate). No branch skew: it reads the committed file like its siblings.
- **Cross-links** the guide from the generated `/llms.txt` (`Design guide (raw)`) and `/llms-full.txt` (`Raw:` line) routes, `sitemap.xml`, the root `llms.txt`/`llms-full.txt`, `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, and the `vllnt-ui` skill (canonical `ui.vllnt.ai/DESIGN.md`, GitHub raw kept as fallback).
- **Un-stale `DESIGN.md` §14** — the `/design` route and `/r/design.json` already shipped, so it now lists the public surfaces (incl. `/DESIGN.md`) and keeps only genuine follow-ups. Header updated to point at the three public surfaces.

## Verification

- `tsc --noEmit`: clean. ESLint on changed files: clean (the 2 remaining `prevent-abbreviations` are pre-existing on `getDocsPath`/`docsRoutes`; the `max-lines-per-function` my sitemap edit triggered is fixed via a data-driven refactor matching the sibling `staticRoutes`).
- Dev server, via `agent-browser`: `GET /DESIGN.md` → 200, `Content-Type: text/markdown; charset=utf-8`, exact path (no redirect); `/llms.txt`, `/llms-full.txt`, `/sitemap.xml` all contain the `/DESIGN.md` URL.
- `/design` re-rendered clean at desktop/tablet/mobile, §14 now "Surfaces and roadmap", no console error overlay.

## Notes

- Per the design decision, `/DESIGN.md` is added **alongside** `/design.txt` (both raw surfaces kept; no redirect).
- **Follow-up (not in this PR):** the root static `llms.txt`/`llms-full.txt` have drifted from the generated route output and have no generator — worth an issue to reconcile or generate them.

Part of #252