### PR TITLE
feat(registry): position ui.vllnt.ai as the UI design system for AI agents

### DIFF
--- a/apps/registry/SEO-AI-POSITIONING.md
+++ b/apps/registry/SEO-AI-POSITIONING.md
@@ -1,0 +1,42 @@
+# SEO: repositioning ui.vllnt.ai as the UI design system for AI agents
+
+GSC-grounded change set that shifts the site from "agent-readable shadcn clone"
+(unwinnable on generic component terms) to category owner of **UI for AI agents
+/ AI-first apps** — capturing the AI-component long-tail and creating the
+category before its search volume arrives.
+
+## What changed (code)
+
+| Area | Change | Files |
+|---|---|---|
+| Positioning | Homepage/root `<title>`, meta description, keywords lead with "UI design system for AI agents" | `app/[locale]/layout.tsx`, `app/[locale]/page.tsx` |
+| Hero | New H1 + subhead + primary CTA to `/ai` (extracted `HeroActions`) | `components/landing/landing.tsx` |
+| AI SEO source of truth | Per-component SEO title/description + "when to use" copy, and the AI component family grouped by job-to-be-done | `lib/ai-seo.ts` (new) |
+| Component pages | AI components get an SEO `<title>` override, richer meta description, and a "When to use this in an AI app" block linking the hub | `app/[locale]/components/[slug]/page.tsx` |
+| Category hub | `/ai` — manifesto, AI component family, agent-surface, FAQ (+`FAQPage` JSON-LD) | `app/[locale]/ai/page.tsx` (new) |
+| Use-case pages | `/build/{ai-chat-ui,tool-calls-agent-steps,rag-citations,ai-artifacts,model-comparison}` (+`FAQPage` JSON-LD) | `app/[locale]/build/[slug]/page.tsx`, `lib/use-cases.ts` (new) |
+| Comparisons | `/vs/vercel-ai-sdk`, `/vs/assistant-ui` | `app/[locale]/vs/*` (new) |
+| AEO | `faqPageLd()` helper | `lib/jsonld.ts` |
+| Crawl shaping | sitemap adds `/ai` (0.9), `/build/*` (0.8), `/vs/*`; AI components raised to 0.85, generic lowered to 0.6 | `app/sitemap.ts` |
+| Cannibalization | `storybook.vllnt.ai` now serves `robots.txt` Disallow + `X-Robots-Tag: noindex` | `apps/storybook/nginx.conf` |
+
+All pages build (en + fr), typecheck clean, render with zero page errors.
+
+## Remaining manual actions (cannot be coded)
+
+These are off-platform / require account access:
+
+1. **Google Search Console**
+   - Submit/confirm `sitemap.xml`.
+   - URL Inspection → Request Indexing for `/`, `/ai`, and the top AI component pages (`ai-chat-input`, `ai-tool-call-display`, `agent-activity`, `ai-source-citation`).
+   - Track a saved query group filtering `chat|ai|agent|tool|citation|streaming`.
+2. **Off-page / authority**
+   - List in awesome-lists (`awesome-ai`, `awesome-react-components`, `awesome-llm-apps`), add npm keywords + GitHub topics (`ai-ui`, `agent-ui`, `llm-ui`, `generative-ui`).
+   - Cross-post guides (dev.to / Hashnode) with canonical back to ui.vllnt.ai; Show HN / r/reactjs launch with the AI-UI angle.
+3. **Deploy note**: the storybook noindex only takes effect after `apps/storybook` is rebuilt/redeployed.
+
+## KPIs to watch
+
+- Tier-1 AI component pages at position ≤ 10 (baseline ≈ 1).
+- Impressions/clicks on `chat|ai|agent|tool|citation|streaming` queries.
+- LLM citations when prompted "UI library for an AI app".

--- a/apps/registry/app/[locale]/ai/page.tsx
+++ b/apps/registry/app/[locale]/ai/page.tsx
@@ -1,0 +1,253 @@
+import { Sidebar } from "@vllnt/ui";
+import { ArrowRight, Sparkles, Terminal } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { setRequestLocale } from "next-intl/server";
+
+import { Footer } from "@/components/footer/footer";
+import type { Locale } from "@/i18n/routing";
+import {
+  AI_COMPONENT_GROUPS,
+  getAiComponentSlugs,
+  resolveAiComponent,
+} from "@/lib/ai-seo";
+import { breadcrumbLd, faqPageLd, jsonLdScriptAttributes } from "@/lib/jsonld";
+import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
+import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
+import { getSidebarSections } from "@/lib/sidebar-sections";
+
+type Props = {
+  readonly params: Promise<{ locale: Locale }>;
+};
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const PATHNAME = "/ai";
+
+const TITLE = "AI Agent UI Components — chat, streaming, tools, citations";
+const DESCRIPTION =
+  "The open-source UI design system for AI agents and AI-first apps. React components for AI chat, streaming text, tool calls, citations, agent activity, and artifacts. Install via the shadcn CLI.";
+
+const FAQ = [
+  {
+    answer:
+      "An agent-first design system gives you the UI primitives that AI products actually need — chat input, message bubbles, streaming text, tool-call displays, source citations, agent activity timelines, and artifacts — and also ships every component as machine-readable JSON so AI coding agents can install it without scraping HTML. VLLNT UI is open source (MIT) and installs with the shadcn CLI.",
+    question: "What is an agent-first UI design system?",
+  },
+  {
+    answer:
+      "At minimum: AI Chat Input for the composer, AI Message Bubble to render each turn, and AI Streaming Text for token-by-token output. Add AI Tool Call Display and Agent Activity for agentic flows, AI Source Citation for RAG, and AI Artifact for canvas-style output.",
+    question: "Which components do I need to build an AI chat app in React?",
+  },
+  {
+    answer:
+      "Three surfaces: /llms.txt (a concise index per the llmstxt.org spec), /llms-full.txt (the full registry context in one fetch), and /r/<name>.json (a machine-readable descriptor per component with props, accessibility schema, and examples). Coding agents like Claude, Cursor, Cline, and Continue read these directly.",
+    question: "How do AI agents consume VLLNT UI?",
+  },
+  {
+    answer:
+      "Yes. VLLNT UI is open source under the MIT license. You own the source after install, with no backend and no tracking.",
+    question: "Is VLLNT UI free to use?",
+  },
+];
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const ogParameters = {
+    description: DESCRIPTION,
+    title: TITLE,
+    type: "page" as const,
+  };
+
+  return {
+    alternates: {
+      canonical: canonical(PATHNAME, locale),
+      languages: languageAlternates(PATHNAME),
+    },
+    description: DESCRIPTION,
+    openGraph: generateOGMetadata(ogParameters, {
+      locale,
+      pathname: PATHNAME,
+    }),
+    title: `${TITLE} | VLLNT UI`,
+    twitter: generateTwitterMetadata(ogParameters),
+  };
+}
+
+function ComponentCard({ locale, slug }: { locale: Locale; slug: string }) {
+  const resolved = resolveAiComponent(slug);
+  if (!resolved) {
+    return null;
+  }
+  return (
+    <li>
+      <Link
+        className="group flex h-full flex-col rounded-lg border border-border p-5 hover:border-foreground/40"
+        href={localizePathname(`/components/${resolved.name}`, locale)}
+      >
+        <p className="font-medium">{resolved.title}</p>
+        <p className="mt-2 flex-1 text-sm text-muted-foreground">
+          {resolved.description}
+        </p>
+        <span className="mt-4 inline-flex items-center gap-1 text-xs font-medium text-foreground">
+          View component
+          <ArrowRight className="size-3 transition-transform group-hover:translate-x-0.5" />
+        </span>
+      </Link>
+    </li>
+  );
+}
+
+export default async function AiHubPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const componentCount = getAiComponentSlugs().length;
+
+  return (
+    <>
+      <script
+        {...jsonLdScriptAttributes([
+          breadcrumbLd([
+            { name: "Home", url: SITE_URL },
+            { name: "AI components", url: `${SITE_URL}${PATHNAME}` },
+          ]),
+          faqPageLd(FAQ),
+        ])}
+      />
+      <Sidebar sections={getSidebarSections(undefined, locale)} />
+      <main className="flex-1 overflow-y-auto bg-background">
+        {/* Hero / manifesto */}
+        <section className="border-b border-border">
+          <div className="mx-auto max-w-7xl px-4 py-20 lg:px-8">
+            <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <Sparkles className="size-4" />
+              UI for AI agents
+            </div>
+            <h1 className="mt-3 text-4xl font-semibold leading-tight md:text-5xl">
+              The UI design system for AI agents and AI-first apps.
+            </h1>
+            <p className="mt-6 max-w-2xl text-lg text-muted-foreground">
+              Every AI product needs the same surfaces — a chat composer,
+              message bubbles, streaming output, tool calls, citations, agent
+              activity, and artifacts. VLLNT UI ships {componentCount} of them
+              as accessible React components you own after install, each also
+              readable by AI coding agents as JSON.
+            </p>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link
+                className="inline-flex h-11 items-center gap-2 rounded-md bg-foreground px-5 text-sm font-medium text-background hover:opacity-90"
+                href={localizePathname("/build/ai-chat-ui", locale)}
+              >
+                Build an AI chat UI
+                <ArrowRight className="size-4" />
+              </Link>
+              <Link
+                className="inline-flex h-11 items-center gap-2 rounded-md border border-border px-5 text-sm font-medium hover:bg-muted"
+                href={localizePathname("/docs/agents", locale)}
+              >
+                How agents consume the registry
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* Component family grouped by job-to-be-done */}
+        <section className="border-b border-border">
+          <div className="mx-auto max-w-7xl px-4 py-16 lg:px-8">
+            <h2 className="text-2xl font-semibold">The AI component family</h2>
+            <p className="mt-2 max-w-2xl text-muted-foreground">
+              Grouped by the job they do in an AI product. Mix and match — every
+              component installs independently with the shadcn CLI.
+            </p>
+
+            <div className="mt-10 space-y-12">
+              {AI_COMPONENT_GROUPS.map((group) => (
+                <div key={group.heading}>
+                  <h3 className="text-lg font-semibold">{group.heading}</h3>
+                  <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+                    {group.blurb}
+                  </p>
+                  <ul className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    {group.slugs.map((slug) => (
+                      <ComponentCard key={slug} locale={locale} slug={slug} />
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Agent surface */}
+        <section className="border-b border-border bg-muted/30">
+          <div className="mx-auto max-w-7xl px-4 py-16 lg:px-8">
+            <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <Terminal className="size-4" />
+              Readable by agents
+            </div>
+            <h2 className="mt-2 text-2xl font-semibold">
+              Your AI agent can install these too.
+            </h2>
+            <p className="mt-4 max-w-2xl text-lg text-muted-foreground">
+              The registry is exposed as structured data, so coding agents pick
+              the right component without scraping HTML.
+            </p>
+            <div className="mt-8 grid gap-4 md:grid-cols-3">
+              <a
+                className="group rounded-lg border border-border p-5 hover:border-foreground/40"
+                href="/llms.txt"
+                rel="noreferrer"
+                target="_blank"
+              >
+                <p className="font-mono text-sm">/llms.txt</p>
+                <p className="mt-3 text-sm text-muted-foreground">
+                  Concise index per the llmstxt.org spec — sections, links,
+                  descriptions.
+                </p>
+              </a>
+              <a
+                className="group rounded-lg border border-border p-5 hover:border-foreground/40"
+                href="/llms-full.txt"
+                rel="noreferrer"
+                target="_blank"
+              >
+                <p className="font-mono text-sm">/llms-full.txt</p>
+                <p className="mt-3 text-sm text-muted-foreground">
+                  Full registry context in one fetch — docs plus every component
+                  descriptor.
+                </p>
+              </a>
+              <Link
+                className="group rounded-lg border border-border p-5 hover:border-foreground/40"
+                href={localizePathname("/docs/agents", locale)}
+              >
+                <p className="font-mono text-sm">/r/&lt;name&gt;.json</p>
+                <p className="mt-3 text-sm text-muted-foreground">
+                  Per-component descriptor: props, accessibility schema, and
+                  usage examples.
+                </p>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section>
+          <div className="mx-auto max-w-7xl px-4 py-16 lg:px-8">
+            <h2 className="text-2xl font-semibold">Frequently asked</h2>
+            <dl className="mt-8 space-y-8">
+              {FAQ.map((item) => (
+                <div className="max-w-3xl" key={item.question}>
+                  <dt className="font-medium">{item.question}</dt>
+                  <dd className="mt-2 text-muted-foreground">{item.answer}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </section>
+
+        <Footer />
+      </main>
+    </>
+  );
+}

--- a/apps/registry/app/[locale]/build/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/build/[slug]/page.tsx
@@ -1,0 +1,168 @@
+import { CodeBlock, Sidebar } from "@vllnt/ui";
+import { ArrowRight } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+
+import { Footer } from "@/components/footer/footer";
+import { type Locale, routing } from "@/i18n/routing";
+import { resolveAiComponent } from "@/lib/ai-seo";
+import { breadcrumbLd, faqPageLd, jsonLdScriptAttributes } from "@/lib/jsonld";
+import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
+import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
+import { getSidebarSections } from "@/lib/sidebar-sections";
+import { getUseCase, USE_CASES } from "@/lib/use-cases";
+
+type Props = {
+  readonly params: Promise<{ locale: Locale; slug: string }>;
+};
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+
+export function generateStaticParams() {
+  return routing.locales.flatMap((locale) =>
+    USE_CASES.map((useCase) => ({ locale, slug: useCase.slug })),
+  );
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale, slug } = await params;
+  const useCase = getUseCase(slug);
+  if (!useCase) {
+    return {};
+  }
+
+  const pathname = `/build/${slug}`;
+  const ogParameters = {
+    description: useCase.description,
+    title: useCase.title,
+    type: "page" as const,
+  };
+
+  return {
+    alternates: {
+      canonical: canonical(pathname, locale),
+      languages: languageAlternates(pathname),
+    },
+    description: useCase.description,
+    openGraph: generateOGMetadata(ogParameters, { locale, pathname }),
+    title: `${useCase.title} | VLLNT UI`,
+    twitter: generateTwitterMetadata(ogParameters),
+  };
+}
+
+export default async function UseCasePage({ params }: Props) {
+  const { locale, slug } = await params;
+  setRequestLocale(locale);
+
+  const useCase = getUseCase(slug);
+  if (!useCase) {
+    notFound();
+  }
+
+  const components = useCase.componentSlugs.flatMap((componentSlug) => {
+    const resolved = resolveAiComponent(componentSlug);
+    return resolved ? [resolved] : [];
+  });
+
+  const installCommand = components
+    .map(
+      (component) =>
+        `pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/${component.name}.json`,
+    )
+    .join("\n");
+
+  return (
+    <>
+      <script
+        {...jsonLdScriptAttributes([
+          breadcrumbLd([
+            { name: "Home", url: SITE_URL },
+            { name: "AI components", url: `${SITE_URL}/ai` },
+            {
+              name: useCase.title,
+              url: `${SITE_URL}/build/${useCase.slug}`,
+            },
+          ]),
+          faqPageLd(useCase.faq),
+        ])}
+      />
+      <Sidebar sections={getSidebarSections(undefined, locale)} />
+      <main className="flex-1 overflow-y-auto bg-background">
+        <div className="mx-auto max-w-4xl px-4 py-16 lg:px-8">
+          <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+            <Link
+              className="hover:text-foreground"
+              href={localizePathname("/ai", locale)}
+            >
+              UI for AI agents
+            </Link>
+          </p>
+          <h1 className="mt-3 text-4xl font-semibold leading-tight md:text-5xl">
+            {useCase.title}
+          </h1>
+          <p className="mt-6 text-lg text-muted-foreground">{useCase.intro}</p>
+
+          {/* Components used */}
+          <h2 className="mt-14 text-2xl font-semibold">
+            Components you&apos;ll use
+          </h2>
+          <ul className="mt-6 space-y-3">
+            {components.map((component) => (
+              <li key={component.name}>
+                <Link
+                  className="group flex flex-col rounded-lg border border-border p-5 hover:border-foreground/40"
+                  href={localizePathname(
+                    `/components/${component.name}`,
+                    locale,
+                  )}
+                >
+                  <span className="flex items-center justify-between gap-2">
+                    <span className="font-medium">{component.title}</span>
+                    <ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                  </span>
+                  <span className="mt-2 text-sm text-muted-foreground">
+                    {component.description}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+
+          {/* Install */}
+          <h2 className="mt-14 text-2xl font-semibold">Install</h2>
+          <p className="mt-2 text-muted-foreground">
+            Add every component above with the shadcn CLI. You own the source
+            after install.
+          </p>
+          <div className="mt-4">
+            <CodeBlock language="bash">{installCommand}</CodeBlock>
+          </div>
+
+          {/* FAQ */}
+          <h2 className="mt-14 text-2xl font-semibold">Frequently asked</h2>
+          <dl className="mt-6 space-y-6">
+            {useCase.faq.map((item) => (
+              <div key={item.question}>
+                <dt className="font-medium">{item.question}</dt>
+                <dd className="mt-2 text-muted-foreground">{item.answer}</dd>
+              </div>
+            ))}
+          </dl>
+
+          <div className="mt-14 border-t border-border pt-8">
+            <Link
+              className="inline-flex items-center gap-1 font-medium text-foreground underline"
+              href={localizePathname("/ai", locale)}
+            >
+              Browse all AI agent components
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </div>
+        <Footer />
+      </main>
+    </>
+  );
+}

--- a/apps/registry/app/[locale]/components/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/components/[slug]/page.tsx
@@ -6,12 +6,12 @@ import { ExternalLink } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-
 import { setRequestLocale } from "next-intl/server";
 
 import { PreviewPlaygroundTabs } from "@/components/playground";
 import { QuickAdd } from "@/components/quick-add";
 import { type Locale, routing } from "@/i18n/routing";
+import { getAiSeo } from "@/lib/ai-seo";
 import componentMetadata from "@/lib/component-metadata.json";
 import {
   breadcrumbLd,
@@ -81,8 +81,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   const meta = metadata_map[slug];
   const category = getCategoryForComponent(slug);
+  const aiSeo = getAiSeo(slug);
   const title = meta?.title ?? component.title;
-  const description = meta?.description ?? component.description;
+  const description =
+    aiSeo?.description ?? meta?.description ?? component.description;
   const pathname = `/components/${slug}`;
 
   const ogParameters = {
@@ -99,7 +101,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     },
     description,
     openGraph: generateOGMetadata(ogParameters, { locale, pathname }),
-    title: `${title} - VLLNT UI`,
+    title: aiSeo?.title ?? `${title} - VLLNT UI`,
     twitter: generateTwitterMetadata(ogParameters),
   };
 }
@@ -117,8 +119,10 @@ export default async function ComponentPage(props: Props) {
   }
 
   const meta = metadata_map[slug];
+  const aiSeo = getAiSeo(slug);
   const displayTitle = meta?.title ?? component.title ?? component.name;
-  const displayDescription = meta?.description ?? component.description ?? "";
+  const displayDescription =
+    aiSeo?.description ?? meta?.description ?? component.description ?? "";
   const playgroundExample = getPlaygroundExample(component);
   const registryPackageVersion = getRegistryPackageVersion(registry.version);
 
@@ -245,6 +249,25 @@ export default async function ComponentPage(props: Props) {
                   </Link>
                 </div>
               </div>
+
+              {/* When to use in an AI app */}
+              {aiSeo?.whenToUse ? (
+                <div className="mb-8 rounded-lg border border-border bg-muted/30 p-6">
+                  <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+                    When to use this in an AI app
+                  </h2>
+                  <p className="mt-3 text-base leading-relaxed">
+                    {aiSeo.whenToUse}
+                  </p>
+                  <Link
+                    className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-foreground underline"
+                    href={localizePathname("/ai", locale)}
+                  >
+                    Browse all AI agent components
+                    <ExternalLink className="size-3" />
+                  </Link>
+                </div>
+              ) : null}
 
               {/* Preview + Playground */}
               {meta?.defaultStoryId ? (

--- a/apps/registry/app/[locale]/layout.tsx
+++ b/apps/registry/app/[locale]/layout.tsx
@@ -1,5 +1,6 @@
 import "@vllnt/ui/styles.css";
 import "@vllnt/ui/themes/default.css";
+import "../globals.css";
 
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -18,8 +19,6 @@ import {
   websiteLd,
 } from "@/lib/jsonld";
 import { alternateOgLocales, languageAlternates, ogLocale } from "@/lib/seo";
-
-import "../globals.css";
 
 type Props = {
   readonly children: React.ReactNode;
@@ -43,7 +42,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     category: "Developer Tools",
     creator: "VLLNT",
     description:
-      "Agent-first React component registry. 225 accessible components built on Radix UI, Tailwind CSS, and CVA. Install via the shadcn CLI.",
+      "The UI design system for AI agents and AI-first apps. Open-source React components for AI chat, streaming, tool calls, citations, agents, and artifacts — readable by AI agents via llms.txt. Install with the shadcn CLI.",
     formatDetection: {
       address: false,
       email: false,
@@ -51,22 +50,26 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     generator: "Next.js",
     keywords: [
-      "react",
-      "components",
+      "ui for ai agents",
+      "ai agent ui",
+      "ai ui components",
+      "ai chat ui",
+      "ai chat ui react",
+      "generative ui",
+      "llm ui components",
+      "agent-first ui",
+      "design system for ai",
+      "ai-first design system",
       "react components",
       "ui library",
       "component library",
       "tailwind",
-      "tailwindcss",
-      "radix",
       "radix-ui",
       "shadcn",
-      "shadcn-ui",
       "registry",
       "design system",
       "accessible",
       "typescript",
-      "ai",
       "llms.txt",
       "open source",
     ],
@@ -92,7 +95,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       },
       index: true,
     },
-    title: "VLLNT UI — 225 agent-first React components",
+    title: "VLLNT UI — UI components & design system for AI agents",
     twitter: {
       card: "summary_large_image",
       creator: "@vllnt",

--- a/apps/registry/app/[locale]/page.tsx
+++ b/apps/registry/app/[locale]/page.tsx
@@ -17,8 +17,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
   const componentCount = getComponentCount();
   const version = getLibraryVersion();
-  const title = `VLLNT UI — ${componentCount} agent-first React components`;
-  const description = `Install any of ${componentCount} accessible React components with the shadcn CLI. Built on Radix UI, Tailwind CSS, and CVA. Every component is a machine-readable JSON descriptor agents can consume directly. v${version}, MIT licensed.`;
+  const title = "VLLNT UI — UI components & design system for AI agents";
+  const description = `Open-source React components for building AI apps: chat, streaming text, tool calls, citations, agent activity, and artifacts. ${componentCount} accessible components, readable by AI agents via llms.txt + JSON. Install with the shadcn CLI. v${version}, MIT.`;
 
   return {
     alternates: {

--- a/apps/registry/app/[locale]/vs/assistant-ui/page.tsx
+++ b/apps/registry/app/[locale]/vs/assistant-ui/page.tsx
@@ -1,0 +1,141 @@
+import { Sidebar } from "@vllnt/ui";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { setRequestLocale } from "next-intl/server";
+
+import { Footer } from "@/components/footer/footer";
+import type { Locale } from "@/i18n/routing";
+import { breadcrumbLd, jsonLdScriptAttributes } from "@/lib/jsonld";
+import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
+import { getSidebarSections } from "@/lib/sidebar-sections";
+
+type Props = {
+  readonly params: Promise<{ locale: Locale }>;
+};
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const PATHNAME = "/vs/assistant-ui";
+
+type Row = {
+  readonly attribute: string;
+  readonly other: string;
+  readonly vllnt: string;
+};
+
+const ROWS: readonly Row[] = [
+  {
+    attribute: "Scope",
+    other: "Focused on the chat/assistant thread experience",
+    vllnt:
+      "Full design system — chat plus agents, artifacts, and 200+ UI components",
+  },
+  {
+    attribute: "Install model",
+    other: "npm dependency with a runtime",
+    vllnt: "shadcn CLI — source copied into your repo, yours to edit",
+  },
+  {
+    attribute: "Beyond chat",
+    other: "Primarily conversation-centric",
+    vllnt:
+      "Tool calls, agent activity, citations, model comparison, artifacts, dashboards",
+  },
+  {
+    attribute: "Agent-readable registry",
+    other: "No",
+    vllnt: "Yes — llms.txt, llms-full.txt, per-component JSON, MCP",
+  },
+  {
+    attribute: "Theming",
+    other: "Themeable chat primitives",
+    vllnt: "CSS variables + design tokens shared across the whole product",
+  },
+  {
+    attribute: "When to pick it",
+    other: "You want an opinionated chat thread fast",
+    vllnt: "You're building a whole AI-first product, not just a chat box",
+  },
+];
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+
+  return {
+    alternates: {
+      canonical: canonical(PATHNAME, locale),
+      languages: languageAlternates(PATHNAME),
+    },
+    description:
+      "VLLNT UI vs assistant-ui: a full AI-first design system you own via the shadcn CLI vs a focused chat-thread library. Honest comparison of scope, install, and theming.",
+    title: "VLLNT UI vs assistant-ui | VLLNT UI",
+  };
+}
+
+export default async function VsAssistantUiPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return (
+    <>
+      <script
+        {...jsonLdScriptAttributes(
+          breadcrumbLd([
+            { name: "Home", url: SITE_URL },
+            { name: "VLLNT UI vs assistant-ui", url: `${SITE_URL}${PATHNAME}` },
+          ]),
+        )}
+      />
+      <Sidebar sections={getSidebarSections(undefined, locale)} />
+      <main className="flex-1 overflow-y-auto bg-background">
+        <div className="mx-auto max-w-4xl px-4 py-16 lg:px-8">
+          <h1 className="text-4xl font-semibold leading-tight md:text-5xl">
+            VLLNT UI vs assistant-ui
+          </h1>
+          <p className="mt-6 text-lg text-muted-foreground">
+            assistant-ui gives you an opinionated chat thread fast. VLLNT UI is
+            a broader, agent-first design system: the same chat surfaces, plus
+            the tool calls, agent activity, citations, artifacts, and product UI
+            an AI-first app needs — all installed via the shadcn CLI so you own
+            the source.
+          </p>
+
+          <div className="mt-12 overflow-x-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="border-b border-border text-left">
+                  <th className="py-3 pr-4 font-medium">Attribute</th>
+                  <th className="py-3 pr-4 font-medium">VLLNT UI</th>
+                  <th className="py-3 font-medium">assistant-ui</th>
+                </tr>
+              </thead>
+              <tbody>
+                {ROWS.map((row) => (
+                  <tr
+                    className="border-b border-border align-top"
+                    key={row.attribute}
+                  >
+                    <td className="py-3 pr-4 font-medium">{row.attribute}</td>
+                    <td className="py-3 pr-4 text-muted-foreground">
+                      {row.vllnt}
+                    </td>
+                    <td className="py-3 text-muted-foreground">{row.other}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="mt-12 border-t border-border pt-8">
+            <Link
+              className="inline-flex items-center gap-1 font-medium text-foreground underline"
+              href={localizePathname("/ai", locale)}
+            >
+              Explore all AI agent components
+            </Link>
+          </div>
+        </div>
+        <Footer />
+      </main>
+    </>
+  );
+}

--- a/apps/registry/app/[locale]/vs/vercel-ai-sdk/page.tsx
+++ b/apps/registry/app/[locale]/vs/vercel-ai-sdk/page.tsx
@@ -1,0 +1,143 @@
+import { Sidebar } from "@vllnt/ui";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { setRequestLocale } from "next-intl/server";
+
+import { Footer } from "@/components/footer/footer";
+import type { Locale } from "@/i18n/routing";
+import { breadcrumbLd, jsonLdScriptAttributes } from "@/lib/jsonld";
+import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
+import { getSidebarSections } from "@/lib/sidebar-sections";
+
+type Props = {
+  readonly params: Promise<{ locale: Locale }>;
+};
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const PATHNAME = "/vs/vercel-ai-sdk";
+
+type Row = {
+  readonly attribute: string;
+  readonly other: string;
+  readonly vllnt: string;
+};
+
+const ROWS: readonly Row[] = [
+  {
+    attribute: "What it is",
+    other: "A runtime/data layer — streaming, useChat, model providers",
+    vllnt: "A UI design system — presentational React components you own",
+  },
+  {
+    attribute: "Primary job",
+    other: "How the AI app talks to models and streams responses",
+    vllnt:
+      "How the AI app looks and behaves (chat, tools, citations, artifacts)",
+  },
+  {
+    attribute: "Component breadth",
+    other: "Focused on chat/conversation primitives",
+    vllnt: "Full design system — chat plus the rest of the product UI",
+  },
+  {
+    attribute: "You own the source",
+    other: "Consumed as an npm dependency",
+    vllnt: "Yes — installed via shadcn CLI into your repo",
+  },
+  {
+    attribute: "Agent-readable registry",
+    other: "No",
+    vllnt: "Yes — llms.txt, llms-full.txt, per-component JSON",
+  },
+  {
+    attribute: "Best together?",
+    other: "Use the AI SDK for the data layer — they compose cleanly",
+    vllnt: "Use VLLNT UI for the interface",
+  },
+];
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+
+  return {
+    alternates: {
+      canonical: canonical(PATHNAME, locale),
+      languages: languageAlternates(PATHNAME),
+    },
+    description:
+      "VLLNT UI vs the Vercel AI SDK: a UI design system you own vs a model/streaming runtime. They solve different problems and compose together. Honest comparison.",
+    title: "VLLNT UI vs Vercel AI SDK | VLLNT UI",
+  };
+}
+
+export default async function VsVercelAiSdkPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return (
+    <>
+      <script
+        {...jsonLdScriptAttributes(
+          breadcrumbLd([
+            { name: "Home", url: SITE_URL },
+            {
+              name: "VLLNT UI vs Vercel AI SDK",
+              url: `${SITE_URL}${PATHNAME}`,
+            },
+          ]),
+        )}
+      />
+      <Sidebar sections={getSidebarSections(undefined, locale)} />
+      <main className="flex-1 overflow-y-auto bg-background">
+        <div className="mx-auto max-w-4xl px-4 py-16 lg:px-8">
+          <h1 className="text-4xl font-semibold leading-tight md:text-5xl">
+            VLLNT UI vs Vercel AI SDK
+          </h1>
+          <p className="mt-6 text-lg text-muted-foreground">
+            These aren&apos;t competitors — they&apos;re layers. The Vercel AI
+            SDK is the data layer that streams tokens and talks to model
+            providers. VLLNT UI is the design system that renders the result:
+            chat input, message bubbles, streaming text, tool calls, citations,
+            and artifacts. Most AI apps want both.
+          </p>
+
+          <div className="mt-12 overflow-x-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="border-b border-border text-left">
+                  <th className="py-3 pr-4 font-medium">Attribute</th>
+                  <th className="py-3 pr-4 font-medium">VLLNT UI</th>
+                  <th className="py-3 font-medium">Vercel AI SDK</th>
+                </tr>
+              </thead>
+              <tbody>
+                {ROWS.map((row) => (
+                  <tr
+                    className="border-b border-border align-top"
+                    key={row.attribute}
+                  >
+                    <td className="py-3 pr-4 font-medium">{row.attribute}</td>
+                    <td className="py-3 pr-4 text-muted-foreground">
+                      {row.vllnt}
+                    </td>
+                    <td className="py-3 text-muted-foreground">{row.other}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="mt-12 border-t border-border pt-8">
+            <Link
+              className="inline-flex items-center gap-1 font-medium text-foreground underline"
+              href={localizePathname("/build/ai-chat-ui", locale)}
+            >
+              Build an AI chat UI with VLLNT UI
+            </Link>
+          </div>
+        </div>
+        <Footer />
+      </main>
+    </>
+  );
+}

--- a/apps/registry/app/sitemap.ts
+++ b/apps/registry/app/sitemap.ts
@@ -1,10 +1,14 @@
 import type { MetadataRoute } from "next";
 
+import { getAiComponentSlugs } from "../lib/ai-seo";
 import { DOCS_PAGES, getDocsPath } from "../lib/docs-pages";
 import { getTemplatePath, TEMPLATES } from "../lib/templates";
+import { getUseCasePath, USE_CASES } from "../lib/use-cases";
 import registry from "../registry.json";
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+
+const AI_COMPONENT_SLUGS = new Set(getAiComponentSlugs());
 
 type RegistryItem = {
   readonly name: string;
@@ -35,6 +39,7 @@ function entry({
 function staticRoutes(lastModified: Date): MetadataRoute.Sitemap {
   const routes = [
     { changeFrequency: "weekly", priority: 1, url: SITE_URL },
+    { changeFrequency: "weekly", priority: 0.9, url: `${SITE_URL}/ai` },
     { changeFrequency: "weekly", priority: 1, url: `${SITE_URL}/components` },
     { changeFrequency: "weekly", priority: 0.8, url: `${SITE_URL}/templates` },
     { changeFrequency: "weekly", priority: 0.8, url: `${SITE_URL}/changelog` },
@@ -46,6 +51,17 @@ function staticRoutes(lastModified: Date): MetadataRoute.Sitemap {
     },
     { changeFrequency: "monthly", priority: 0.8, url: `${SITE_URL}/design` },
     { changeFrequency: "weekly", priority: 0.8, url: `${SITE_URL}/releases` },
+    { changeFrequency: "monthly", priority: 0.7, url: `${SITE_URL}/vs/shadcn` },
+    {
+      changeFrequency: "monthly",
+      priority: 0.7,
+      url: `${SITE_URL}/vs/vercel-ai-sdk`,
+    },
+    {
+      changeFrequency: "monthly",
+      priority: 0.7,
+      url: `${SITE_URL}/vs/assistant-ui`,
+    },
   ] satisfies readonly Omit<SitemapEntryInput, "lastModified">[];
 
   return routes.map((route) => entry({ ...route, lastModified }));
@@ -73,15 +89,28 @@ function templateRoutes(lastModified: Date): MetadataRoute.Sitemap {
   );
 }
 
+function buildGuideRoutes(lastModified: Date): MetadataRoute.Sitemap {
+  return USE_CASES.map((useCase) =>
+    entry({
+      changeFrequency: "monthly",
+      lastModified,
+      priority: 0.8,
+      url: `${SITE_URL}${getUseCasePath(useCase)}`,
+    }),
+  );
+}
+
 function componentRoutes(
   items: readonly RegistryItem[],
   lastModified: Date,
 ): MetadataRoute.Sitemap {
+  // Concentrate crawl budget on the AI wedge: AI components rank higher than
+  // generic clones, which sit below the default.
   return items.map((item) =>
     entry({
       changeFrequency: "weekly",
       lastModified,
-      priority: 0.7,
+      priority: AI_COMPONENT_SLUGS.has(item.name) ? 0.85 : 0.6,
       url: `${SITE_URL}/components/${item.name}`,
     }),
   );
@@ -123,6 +152,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     ...staticRoutes(lastModified),
     ...docsRoutes(lastModified),
     ...templateRoutes(lastModified),
+    ...buildGuideRoutes(lastModified),
     ...componentRoutes(items, lastModified),
     ...registryRoutes(items, lastModified),
   ];

--- a/apps/registry/components/landing/landing.tsx
+++ b/apps/registry/components/landing/landing.tsx
@@ -27,6 +27,47 @@ const TRUST_BADGES = [
   { label: "Tailwind v4 ready" },
 ];
 
+function HeroActions({ componentCount }: { componentCount: number }) {
+  return (
+    <div className="mt-6 flex flex-wrap gap-3">
+      <Link
+        className="inline-flex h-11 items-center gap-2 rounded-md bg-foreground px-5 text-sm font-medium text-background hover:opacity-90"
+        href="/ai"
+      >
+        Explore AI components
+        <ArrowRight className="size-4" />
+      </Link>
+      <Link
+        className="inline-flex h-11 items-center gap-2 rounded-md border border-border px-5 text-sm font-medium hover:bg-muted"
+        href="/components"
+      >
+        Browse all {componentCount}
+      </Link>
+      <Link
+        className="inline-flex h-11 items-center gap-2 rounded-md border border-border px-5 text-sm font-medium hover:bg-muted"
+        href="/templates"
+      >
+        Browse templates
+      </Link>
+      <Link
+        className="inline-flex h-11 items-center gap-2 rounded-md border border-border px-5 text-sm font-medium hover:bg-muted"
+        href="/docs"
+      >
+        Read the docs
+      </Link>
+      <a
+        className="inline-flex h-11 items-center gap-2 rounded-md border border-border px-5 text-sm font-medium hover:bg-muted"
+        href={GITHUB_URL}
+        rel="noreferrer"
+        target="_blank"
+      >
+        <GitHubMark className="size-4" />
+        GitHub
+      </a>
+    </div>
+  );
+}
+
 function Hero({
   componentCount,
   version,
@@ -41,50 +82,23 @@ function Hero({
           v{version} / MIT
         </p>
         <h1 className="mt-3 text-4xl font-semibold leading-tight md:text-5xl lg:text-6xl">
-          {componentCount} agent-first React components.
+          The UI design system for AI agents.
           <br />
           <span className="text-muted-foreground">Copy, paste, ship.</span>
         </h1>
         <p className="mt-6 max-w-2xl text-lg text-muted-foreground">
-          Built on Radix UI, Tailwind CSS, and CVA. Every component is also a
-          machine-readable JSON descriptor: agents (Claude, Cursor, Cline,
-          Continue) read the registry directly without scraping HTML.
+          {componentCount} open-source React components for building AI apps —
+          chat, streaming, tool calls, citations, agents, and artifacts. Every
+          component is also a machine-readable JSON descriptor: agents (Claude,
+          Cursor, Cline, Continue) read the registry directly without scraping
+          HTML.
         </p>
 
         <div className="mt-8">
           <CodeBlock language="bash">{INSTALL_COMMAND}</CodeBlock>
         </div>
 
-        <div className="mt-6 flex flex-wrap gap-3">
-          <Link
-            className="inline-flex h-11 items-center gap-2 rounded-md bg-foreground px-5 text-sm font-medium text-background hover:opacity-90"
-            href="/components"
-          >
-            Browse {componentCount} components
-            <ArrowRight className="size-4" />
-          </Link>
-          <Link
-            className="inline-flex h-11 items-center gap-2 rounded-md border border-border px-5 text-sm font-medium hover:bg-muted"
-            href="/templates"
-          >
-            Browse templates
-          </Link>
-          <Link
-            className="inline-flex h-11 items-center gap-2 rounded-md border border-border px-5 text-sm font-medium hover:bg-muted"
-            href="/docs"
-          >
-            Read the docs
-          </Link>
-          <a
-            className="inline-flex h-11 items-center gap-2 rounded-md border border-border px-5 text-sm font-medium hover:bg-muted"
-            href={GITHUB_URL}
-            rel="noreferrer"
-            target="_blank"
-          >
-            <GitHubMark className="size-4" />
-            GitHub
-          </a>
-        </div>
+        <HeroActions componentCount={componentCount} />
 
         <ul className="mt-8 flex flex-wrap gap-3 text-xs text-muted-foreground">
           {TRUST_BADGES.map((badge) => (

--- a/apps/registry/lib/ai-seo.ts
+++ b/apps/registry/lib/ai-seo.ts
@@ -1,0 +1,229 @@
+import registry from "../registry.json";
+
+/**
+ * Single source of truth for the "UI for AI agents" SEO positioning.
+ *
+ * Two surfaces consume this:
+ * 1. The component page (`/components/[slug]`) — overrides the document title +
+ *    meta description for AI components and renders a "When to use in an AI app"
+ *    block, so both Google and answer engines understand the use-case.
+ * 2. The AI category hub (`/ai`) — groups the AI component family by
+ *    job-to-be-done and links to every member, concentrating internal-link
+ *    equity on the wedge.
+ *
+ * Keep SEO copy here, not in the generated `component-metadata.json` (that file
+ * is rebuilt by `registry:build` and would overwrite hand-written copy).
+ */
+
+export type AiComponentSeo = {
+  /** Meta description (~150–160 chars), use-case first. */
+  readonly description: string;
+  /** Registry slug this copy belongs to. */
+  readonly slug: string;
+  /** Full <title> including the brand suffix — used verbatim. */
+  readonly title: string;
+  /** Prose rendered as "When to use this in an AI app" on the component page. */
+  readonly whenToUse: string;
+};
+
+/**
+ * Per-component SEO copy for the core AI-agent components. Slugs not present here
+ * fall back to the registry title/description and render no use-case block.
+ */
+export const AI_SEO: readonly AiComponentSeo[] = [
+  {
+    description:
+      "Visualize an AI agent's execution chain in React — steps, tools, decisions, and progress. The activity timeline for agentic apps. Install via the shadcn CLI.",
+    slug: "agent-activity",
+    title: "Agent Activity — visualize an AI agent's steps in React | VLLNT UI",
+    whenToUse:
+      "Reach for Agent Activity to show a multi-step agent run as it happens — each step, tool, and decision in sequence. It fits autonomous or long-running agent workflows where users need to follow progress in real time.",
+  },
+  {
+    description:
+      "Rendered output panel for AI-generated content in React: toolbar with copy, edit, download, fullscreen, and version chips. The artifacts/canvas UI. Install via the shadcn CLI.",
+    slug: "ai-artifact",
+    title:
+      "AI Artifact — render AI-generated output (canvas) in React | VLLNT UI",
+    whenToUse:
+      "Use AI Artifact for substantial generated output — code, documents, designs — that deserves its own panel beside the chat. The built-in toolbar and version chips mirror the artifacts / canvas pattern users now expect from AI products.",
+  },
+  {
+    description:
+      "React prompt composer for AI chat and agents: attachments, auto-expand, toolbar actions, and submit/streaming states. Accessible, install via the shadcn CLI.",
+    slug: "ai-chat-input",
+    title: "AI Chat Input — React prompt composer for AI chat apps | VLLNT UI",
+    whenToUse:
+      "AI Chat Input is the message composer at the bottom of any chat or agent surface. It handles multi-line growth, attachments, and submit/streaming states, so you can wire it straight to your model or agent runtime.",
+  },
+  {
+    description:
+      "Render assistant, user, tool, and system messages in React. Markdown-ready chat bubbles for LLM and agent apps. Accessible, install via the shadcn CLI.",
+    slug: "ai-message-bubble",
+    title:
+      "AI Message Bubble — chat message UI for LLM apps in React | VLLNT UI",
+    whenToUse:
+      "Use AI Message Bubble to render each turn in a conversation. Role variants (user, assistant, tool, system) keep an LLM transcript readable and consistent with the rest of your design system.",
+  },
+  {
+    description:
+      "Drop an AI assistant into any app: a slide-out React panel with header, content, and footer slots plus a standalone trigger. Install via the shadcn CLI.",
+    slug: "ai-sidebar",
+    title: "AI Sidebar — slide-out AI assistant panel for React | VLLNT UI",
+    whenToUse:
+      "Add AI Sidebar when you want a co-pilot alongside an existing product UI rather than a full-page chat. The provider + trigger pattern lets any screen open the assistant in context.",
+  },
+  {
+    description:
+      "Display sources and citations for RAG answers in React: title, origin label, and excerpt. Make AI answers verifiable. Accessible, install via the shadcn CLI.",
+    slug: "ai-source-citation",
+    title:
+      "AI Source Citation — RAG sources & citations UI for React | VLLNT UI",
+    whenToUse:
+      "Use AI Source Citation to attribute RAG or grounded answers to their sources. Compact reference cards let users verify where an AI response came from — essential for trustworthy retrieval-augmented apps.",
+  },
+  {
+    description:
+      "Render streaming LLM output in React with a live cursor as tokens arrive. The generative-UI text primitive for AI apps. Install via the shadcn CLI.",
+    slug: "ai-streaming-text",
+    title:
+      "AI Streaming Text — token streaming UI for LLM output in React | VLLNT UI",
+    whenToUse:
+      "Use AI Streaming Text for any partial assistant output that arrives token-by-token. The live cursor signals 'still generating' and keeps long responses readable as they stream in.",
+  },
+  {
+    description:
+      "Render an AI agent's tool/function calls in React: name, serialized input, status, and returned output. Built for agentic apps. Install via the shadcn CLI.",
+    slug: "ai-tool-call-display",
+    title: "AI Tool Call Display — render agent tool calls in React | VLLNT UI",
+    whenToUse:
+      "Use AI Tool Call Display whenever an agent invokes tools or functions. It surfaces the call name, arguments, status, and result so users can follow exactly what the agent did.",
+  },
+  {
+    description:
+      "Signal the end of an AI task or workflow in React with a completion dialog covering loading, error, and success states. Install via the shadcn CLI.",
+    slug: "completion-dialog",
+    title: "Completion Dialog — AI task completion UI for React | VLLNT UI",
+    whenToUse:
+      "Use Completion Dialog to close out an agent task or multi-step workflow with a clear success or error summary, so users know the run finished and what happened.",
+  },
+  {
+    description:
+      "Compare AI model responses side by side in React: optional blind mode, metadata stats, and a vote bar. Evaluate LLMs in your UI. Install via the shadcn CLI.",
+    slug: "model-comparison",
+    title:
+      "Model Comparison — compare LLM responses side by side in React | VLLNT UI",
+    whenToUse:
+      "Use Model Comparison to evaluate two model responses head-to-head. Blind mode and a vote bar make it suitable for human-preference and eval workflows.",
+  },
+  {
+    description:
+      "Searchable prompt template gallery in React: category filter, variable fill-in form, and onSelect. Ship a reusable prompt library. Install via the shadcn CLI.",
+    slug: "prompt-templates",
+    title:
+      "Prompt Templates — prompt library UI for AI apps in React | VLLNT UI",
+    whenToUse:
+      "Use Prompt Templates to give users a curated, fillable prompt library instead of a blank box. Variable fields turn a saved prompt into a quick form.",
+  },
+  {
+    description:
+      "Collapsible React block that streams an AI's thinking/reasoning steps. Surface chain-of-thought without cluttering the final answer. Install via the shadcn CLI.",
+    slug: "thinking-block",
+    title:
+      "Thinking Block — show AI reasoning / chain-of-thought in React | VLLNT UI",
+    whenToUse:
+      "Use Thinking Block to reveal an agent's reasoning or scratchpad separately from its final answer. Collapsible plus streaming support keeps the transcript clean while staying transparent.",
+  },
+];
+
+export type AiComponentGroup = {
+  readonly blurb: string;
+  readonly heading: string;
+  readonly slugs: readonly string[];
+};
+
+/**
+ * The AI component family grouped by job-to-be-done. Drives the `/ai` hub and
+ * the internal-linking structure that concentrates equity on AI components.
+ */
+export const AI_COMPONENT_GROUPS: readonly AiComponentGroup[] = [
+  {
+    blurb:
+      "The conversation surface — compose prompts, render turns, and embed an assistant anywhere.",
+    heading: "Chat & assistant",
+    slugs: ["ai-chat-input", "ai-message-bubble", "ai-sidebar"],
+  },
+  {
+    blurb:
+      "Show output as it generates and make an agent's thinking transparent.",
+    heading: "Streaming & reasoning",
+    slugs: ["ai-streaming-text", "thinking-block"],
+  },
+  {
+    blurb:
+      "Render what an agent is doing — tool calls, function results, and multi-step runs.",
+    heading: "Tools & agent actions",
+    slugs: ["ai-tool-call-display", "agent-activity"],
+  },
+  {
+    blurb: "Attribute RAG answers so users can verify where they came from.",
+    heading: "Sources & grounding",
+    slugs: ["ai-source-citation"],
+  },
+  {
+    blurb:
+      "Give substantial generated content its own panel, and close out completed tasks.",
+    heading: "Artifacts & output",
+    slugs: ["ai-artifact", "completion-dialog"],
+  },
+  {
+    blurb: "Ship a reusable prompt library and compare models head-to-head.",
+    heading: "Prompts & evaluation",
+    slugs: ["prompt-templates", "model-comparison"],
+  },
+  {
+    blurb:
+      "Shared, multiplayer surfaces for products where humans and agents work side by side.",
+    heading: "Collaboration for AI-first teams",
+    slugs: ["workspace-switcher", "live-cursor", "canvas-shell"],
+  },
+];
+
+type RegistryItem = {
+  readonly description?: string;
+  readonly name: string;
+  readonly title?: string;
+  readonly type?: string;
+};
+
+const ITEMS = (registry as { readonly items: readonly RegistryItem[] }).items;
+
+export type ResolvedAiComponent = {
+  readonly description: string;
+  readonly name: string;
+  readonly title: string;
+};
+
+export function getAiSeo(slug: string): AiComponentSeo | undefined {
+  return AI_SEO.find((entry) => entry.slug === slug);
+}
+
+/** Resolve a slug to display title + description (override description wins). */
+export function resolveAiComponent(
+  slug: string,
+): ResolvedAiComponent | undefined {
+  const item = ITEMS.find((entry) => entry.name === slug);
+  if (!item) {
+    return undefined;
+  }
+  return {
+    description: getAiSeo(slug)?.description ?? item.description ?? "",
+    name: item.name,
+    title: item.title ?? item.name,
+  };
+}
+
+/** Every AI-component slug referenced by the groups, de-duplicated. */
+export function getAiComponentSlugs(): readonly string[] {
+  return [...new Set(AI_COMPONENT_GROUPS.flatMap((group) => group.slugs))];
+}

--- a/apps/registry/lib/jsonld.ts
+++ b/apps/registry/lib/jsonld.ts
@@ -131,6 +131,26 @@ export function techArticleLd(article: {
   };
 }
 
+export function faqPageLd(
+  entries: ReadonlyArray<{
+    readonly question: string;
+    readonly answer: string;
+  }>,
+): JsonLdNode {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: entries.map((entry) => ({
+      "@type": "Question",
+      name: entry.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: entry.answer,
+      },
+    })),
+  };
+}
+
 export function jsonLdScript(node: JsonLdNode | readonly JsonLdNode[]): string {
   return JSON.stringify(node).replaceAll("<", "\\u003c");
 }

--- a/apps/registry/lib/use-cases.ts
+++ b/apps/registry/lib/use-cases.ts
@@ -1,0 +1,134 @@
+/**
+ * Use-case landing pages (`/build/[slug]`). Each targets a high-intent "how do I
+ * build X" query and routes the visitor to the AI components that solve it —
+ * capturing Funnel-A demand and feeding answer engines a copy-paste answer.
+ */
+
+export type UseCaseFaq = {
+  readonly answer: string;
+  readonly question: string;
+};
+
+export type UseCase = {
+  /** Component slugs that solve this use-case, in build order. */
+  readonly componentSlugs: readonly string[];
+  /** Meta description (~150–160 chars). */
+  readonly description: string;
+  readonly faq: readonly UseCaseFaq[];
+  /** Problem framing rendered under the H1. */
+  readonly intro: string;
+  /** URL slug under /build/. */
+  readonly slug: string;
+  /** H1 + OG title (no brand suffix). */
+  readonly title: string;
+};
+
+export const USE_CASES: readonly UseCase[] = [
+  {
+    componentSlugs: [
+      "ai-chat-input",
+      "ai-message-bubble",
+      "ai-streaming-text",
+      "ai-sidebar",
+    ],
+    description:
+      "Build an AI chat interface in React with open-source components: prompt input, message bubbles, and streaming output. Install via the shadcn CLI.",
+    faq: [
+      {
+        answer:
+          "A composer (AI Chat Input), a way to render turns (AI Message Bubble), and streaming output (AI Streaming Text). AI Sidebar lets you embed the chat as a co-pilot beside an existing app.",
+        question: "What components do I need for an AI chat UI?",
+      },
+      {
+        answer:
+          "Yes. The components are presentational — wire their callbacks and state to the Vercel AI SDK, LangChain, or any custom streaming endpoint.",
+        question: "Does this work with the Vercel AI SDK or my own backend?",
+      },
+    ],
+    intro:
+      "Every AI chat app needs the same three surfaces: a composer to send prompts, bubbles to render the conversation, and streaming output as the model responds. These components give you all three — accessible, themeable, and ready to wire to any model or agent runtime.",
+    slug: "ai-chat-ui",
+    title: "Build an AI chat UI in React",
+  },
+  {
+    componentSlugs: [
+      "ai-tool-call-display",
+      "agent-activity",
+      "thinking-block",
+    ],
+    description:
+      "Show an AI agent's tool calls and multi-step execution in React: arguments, status, results, and a live activity timeline. Install via the shadcn CLI.",
+    faq: [
+      {
+        answer:
+          "Use AI Tool Call Display for each invocation — it renders the tool name, serialized arguments, status, and returned output. Pair it with Agent Activity to show the full multi-step run.",
+        question: "How do I display an agent's function/tool calls?",
+      },
+      {
+        answer:
+          "Yes — Thinking Block renders streaming chain-of-thought in a collapsible panel, separate from the final answer.",
+        question: "Can I show the agent's reasoning?",
+      },
+    ],
+    intro:
+      "Agentic apps are only trustworthy when users can see what the agent is doing. Render each tool invocation with its arguments and result, surface the agent's reasoning, and show the whole run as a live timeline.",
+    slug: "tool-calls-agent-steps",
+    title: "Render tool calls & agent steps in React",
+  },
+  {
+    componentSlugs: ["ai-source-citation", "ai-message-bubble"],
+    description:
+      "Make AI answers verifiable in React with source citation components for RAG: title, origin, and excerpt next to each grounded response. Install via the shadcn CLI.",
+    faq: [
+      {
+        answer:
+          "Render an AI Source Citation card per retrieved source — each shows a title, origin label, and optional excerpt — beneath the AI Message Bubble that contains the answer.",
+        question: "How do I show sources for a RAG answer?",
+      },
+    ],
+    intro:
+      "Retrieval-augmented answers need attribution to be trusted. Render the sources behind each response as compact citation cards so users can verify where the AI got its information.",
+    slug: "rag-citations",
+    title: "Show RAG sources & citations in React",
+  },
+  {
+    componentSlugs: ["ai-artifact", "canvas-shell", "completion-dialog"],
+    description:
+      "Give AI-generated content its own panel in React: an artifacts/canvas surface with toolbar, versions, and a task-completion dialog. Install via the shadcn CLI.",
+    faq: [
+      {
+        answer:
+          "It's the side panel that holds substantial AI output (popularized by Claude Artifacts and ChatGPT Canvas). AI Artifact gives you the rendered output area with a toolbar and version chips; Canvas Shell provides the surrounding workspace.",
+        question: "What is the artifacts / canvas pattern?",
+      },
+    ],
+    intro:
+      "When an AI generates something substantial — code, a document, a design — it deserves its own space beside the chat. Render it as an artifact with copy, edit, download, and version controls, then close out the run with a completion dialog.",
+    slug: "ai-artifacts",
+    title: "Add AI artifacts & canvas to your app",
+  },
+  {
+    componentSlugs: ["model-comparison", "prompt-templates"],
+    description:
+      "Compare AI model responses side by side in React with blind mode, vote bars, and a reusable prompt library. Build LLM evals into your product. Install via shadcn CLI.",
+    faq: [
+      {
+        answer:
+          "Use Model Comparison to render two responses side by side with blind mode and a vote bar — suitable for human-preference evals. Pair it with Prompt Templates so testers can reuse curated prompts.",
+        question: "How do I build an LLM comparison or eval UI?",
+      },
+    ],
+    intro:
+      "Evaluating models — or letting users pick a winner — needs a side-by-side surface. Compare two responses with optional blind mode and a vote bar, and give users a reusable, fillable prompt library to test with.",
+    slug: "model-comparison",
+    title: "Compare LLM responses in your UI",
+  },
+];
+
+export function getUseCase(slug: string): undefined | UseCase {
+  return USE_CASES.find((useCase) => useCase.slug === slug);
+}
+
+export function getUseCasePath(useCase: UseCase): string {
+  return `/build/${useCase.slug}`;
+}

--- a/apps/storybook/nginx.conf
+++ b/apps/storybook/nginx.conf
@@ -11,6 +11,14 @@ server {
         return 200 "ok\n";
     }
 
+    # Keep Storybook out of search indexes — the canonical component docs live
+    # at ui.vllnt.ai/components/*. Indexing storybook.vllnt.ai cannibalizes them.
+    location = /robots.txt {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "User-agent: *\nDisallow: /\n";
+    }
+
     # Static asset caching — long TTL on hashed files, none on HTML
     location ~* \.(js|css|woff2?|svg|png|jpg|jpeg|gif|webp|ico)$ {
         expires 1y;
@@ -26,6 +34,9 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+        # Do not index Storybook — canonical docs are on ui.vllnt.ai/components/*
+        add_header X-Robots-Tag "noindex, nofollow" always;
     }
 
     # Compression


### PR DESCRIPTION
Part of #252

## Why

Google Search Console for `ui.vllnt.ai` shows the site is brand-new and mid-indexing, with one telling signal: the only ranking win is a **novel** term ("workspace switcher ui", position 3) while ~15 generic "react floating action button" variants sit at position 58–95. Competition — not quality — is the ceiling on generic component terms.

This PR stops competing as "shadcn, but agent-readable" and repositions the site as the category owner: **the UI design system for AI agents and AI-first apps.** It captures the winnable AI-component long-tail and creates the category before its search volume arrives.

## What

- **Positioning** — homepage/root `<title>`, meta description, and keywords lead with "UI design system for AI agents"; new hero H1 + primary CTA to `/ai`.
- **`lib/ai-seo.ts`** (new, single source of truth) — per-component SEO titles/descriptions + "when to use in an AI app" copy for 12 AI components, plus the AI component family grouped by job-to-be-done.
- **Component pages** — AI components get an SEO `<title>` override, richer meta description, and a "When to use this in an AI app" block linking the hub. Generic components are unchanged.
- **`/ai` hub** (new) — manifesto, the AI component family, agent-surface (llms.txt/JSON), FAQ.
- **`/build/*` use-case pages** (new, 5) — ai-chat-ui, tool-calls-agent-steps, rag-citations, ai-artifacts, model-comparison.
- **`/vs/*` comparisons** (new) — vercel-ai-sdk, assistant-ui.
- **AEO** — `faqPageLd()` helper; `FAQPage` JSON-LD on the hub + use-case pages for AI Overviews / answer-engine eligibility.
- **Crawl shaping** — sitemap raises AI components (0.85) + hub (0.9), lowers generic (0.6), adds the new routes.
- **Cannibalization fix** — `apps/storybook/nginx.conf` now serves `robots.txt` Disallow + `X-Robots-Tag: noindex`, so `storybook.vllnt.ai` stops competing with `ui.vllnt.ai/components/*`.

See `apps/registry/SEO-AI-POSITIONING.md` for the full rationale + remaining manual (off-platform) actions.

## Validation

- `tsc --noEmit` — 0 errors.
- `next build` — success; `/ai`, `/build/{5}`, `/vs/vercel-ai-sdk`, `/vs/assistant-ui` prerender for **en + fr**.
- Real-browser (desktop + mobile): hub, AI component page (title override + when-to-use block), generic component (correctly no block), homepage, use-case, and vs pages all render with **zero page errors**.

## Follow-up (manual, can't be coded)

- GSC: submit sitemap + Request Indexing for `/`, `/ai`, top AI components.
- Off-page: awesome-lists, npm keywords, GitHub topics, guide cross-posts.
- The storybook noindex only takes effect after `apps/storybook` is redeployed.
