### PR TITLE
feat(registry): namespace registry as @vllnt for shadcn registry index

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ pnpm add @vllnt/ui
 
 > Published on the public [npm registry](https://www.npmjs.com/package/@vllnt/ui) with signed provenance. See [`packages/ui/README.md`](packages/ui/README.md) for full setup.
 
+### shadcn registry
+
+Install individual components with the [shadcn](https://ui.shadcn.com) CLI — no package dependency, you own the code:
+
+```bash
+pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json
+```
+
+Or by `@vllnt` namespace once it's in the [shadcn registry index](https://ui.shadcn.com/r/registries.json) (add `"@vllnt": "https://ui.vllnt.ai/r/{name}.json"` to your `components.json` `registries`):
+
+```bash
+pnpm dlx shadcn@latest add @vllnt/button
+```
+
 ## Quick Start
 
 ```tsx

--- a/apps/registry/README.md
+++ b/apps/registry/README.md
@@ -73,11 +73,24 @@ This builds the Next.js app and generates registry JSON files to `public/r/` usi
 ### Usage with shadcn CLI
 
 ```bash
-# Install a component
+# Install directly by URL — works today, no config
 pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json
+```
 
-# Or use the component name directly
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json
+Namespaced install (once `@vllnt` is listed in the [shadcn registry index](https://ui.shadcn.com/r/registries.json)) — add the registry to your app's `components.json`:
+
+```json
+{
+  "registries": {
+    "@vllnt": "https://ui.vllnt.ai/r/{name}.json"
+  }
+}
+```
+
+Then install by namespace:
+
+```bash
+pnpm dlx shadcn@latest add @vllnt/button
 ```
 
 ## Adding Components

--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
-  "name": "vllnt",
+  "name": "@vllnt",
   "homepage": "https://ui.vllnt.ai",
   "items": [
     {

--- a/apps/registry/shadcn-directory-entry.json
+++ b/apps/registry/shadcn-directory-entry.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vllnt",
+  "homepage": "https://ui.vllnt.ai",
+  "url": "https://ui.vllnt.ai/r/{name}.json",
+  "description": "VLLNT UI — 225 accessible React components built on Radix UI, Tailwind CSS, and CVA. Copy-paste, you own the code.",
+  "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'><rect width='128' height='128' rx='28' fill='var(--foreground)'/><text x='64' y='64' text-anchor='middle' dominant-baseline='central' font-family='ui-sans-serif, system-ui, sans-serif' font-size='26' font-weight='700' letter-spacing='-1' fill='var(--background)'>VLLNT</text></svg>"
+}


### PR DESCRIPTION
## What
Prepares the registry to be listed in shadcn's public [registry index](https://ui.shadcn.com/r/registries.json), enabling namespaced installs (`shadcn add @vllnt/button`).

## Changes
- **`apps/registry/registry.json`** — root `name` `vllnt` → `@vllnt` (registry-index validator requires `^@[a-zA-Z0-9][a-zA-Z0-9-_]*$`). Per-item files are keyed by plain item name, so `@vllnt/accordion` still resolves to `/r/accordion.json`. No code reads the root `name`.
- **`apps/registry/shadcn-directory-entry.json`** (new) — the exact 5-field entry (`name/homepage/url/description/logo`) to add to `shadcn-ui/ui` `apps/v4/registry/directory.json`. Validated against their `validate-registries.mts` schema. Logo = theme-aware VLLNT wordmark (`var(--foreground)`/`var(--background)`).
- **READMEs** — document namespaced install alongside the existing direct-URL install.

## Verification
- `registry.json` valid JSON, 225 items, no `content` in index files (correct for index).
- Live `https://ui.vllnt.ai/r/accordion.json` confirmed reachable + valid `registry-item.json`.
- Directory entry passes all validator checks (name regex, homepage URL, `{name}` placeholder, description, logo string).
- Full registry build deferred to CI (changes are JSON metadata + a standalone file + markdown — zero build-graph impact).

## Follow-up
External registration PR to `shadcn-ui/ui` (adds `@vllnt` to their `directory.json`) — opened separately.

Closes #399