### PR TITLE
docs(registry): future-proof + sharpen @vllnt directory description

### DIFF
--- a/apps/registry/shadcn-directory-entry.json
+++ b/apps/registry/shadcn-directory-entry.json
@@ -2,6 +2,6 @@
   "name": "@vllnt",
   "homepage": "https://ui.vllnt.ai",
   "url": "https://ui.vllnt.ai/r/{name}.json",
-  "description": "VLLNT UI — 225 accessible React components built on Radix UI, Tailwind CSS, and CVA. Copy-paste, you own the code.",
+  "description": "VLLNT UI — agent-first React components for AI-native products, from UI primitives to finance and ops domains. Accessible, Radix + Tailwind, you own the code.",
   "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'><rect width='128' height='128' rx='28' fill='var(--foreground)'/><text x='64' y='64' text-anchor='middle' dominant-baseline='central' font-family='ui-sans-serif, system-ui, sans-serif' font-size='26' font-weight='700' letter-spacing='-1' fill='var(--background)'>VLLNT</text></svg>"
 }


### PR DESCRIPTION
Drops the hardcoded `225` count (future-proof as components grow) and leads with agent-first / AI-native + domain-breadth positioning to differentiate `@vllnt` in the shadcn [registry directory](https://ui.shadcn.com/r/registries.json).

Before: `VLLNT UI — 225 accessible React components built on Radix UI, Tailwind CSS, and CVA. Copy-paste, you own the code.`
After: `VLLNT UI — agent-first React components for AI-native products, from UI primitives to finance and ops domains. Accessible, Radix + Tailwind, you own the code.`

Mirrors the live copy in shadcn-ui/ui#10869 (already updated + signed).

Closes #405