### PR TITLE
fix(ntk): pin per-host TLS for ui-registry + storybook

### DIFF
--- a/ntk.yaml
+++ b/ntk.yaml
@@ -19,6 +19,14 @@ apps:
     healthcheck: /
     domains:
       production: ui.vllnt.ai
+    tls:
+      # T1 cell (ADR-090e) has no shared *.vllnt.ai wildcard secret;
+      # without this the renderer defaults to the absent
+      # wildcard-vllnt-ai-tls and Traefik serves its default cert
+      # (site DOWN — incident 2026-06-10). Per-host DNS-01 cert,
+      # in-ns + auto-renewing.
+      production:
+        secretName: ui-registry-tls
     visibility:                      # previews are tailnet-only (hostname derived by deployer)
       production: public
       preview:    tailnet
@@ -53,6 +61,14 @@ apps:
     healthcheck: /healthz
     domains:
       production: storybook.vllnt.ai
+    tls:
+      # T1 cell (ADR-090e) has no shared *.vllnt.ai wildcard secret;
+      # without this the renderer defaults to the absent
+      # wildcard-vllnt-ai-tls and Traefik serves its default cert
+      # (site DOWN — incident 2026-06-10). Per-host DNS-01 cert,
+      # in-ns + auto-renewing.
+      production:
+        secretName: storybook-tls
     visibility:
       production: public
       preview:    tailnet


### PR DESCRIPTION
ui.vllnt.ai + storybook.vllnt.ai went DOWN (CERTIFICATE_VERIFY_FAILED, VllntEndpointDown critical) on 2026-06-10: both apps run on the T1 vllnt-apps cell (ADR-090e) which has no shared `*.vllnt.ai` wildcard secret, and ntk.yaml had no `tls:` override, so the renderer defaulted the Ingress to the mgmt-only `wildcard-vllnt-ai-tls` → Traefik served its default cert.

Pins `spec.tls.production.secretName` to the per-host DNS-01 certs (`ui-registry-tls` / `storybook-tls` — cert-manager Ready, in-ns, auto-renewing). Service already restored live via kubectl patch; this makes it durable. Detected + alerted-on going forward by the preview-system contingent plan in vllnt/infra.