### PR TITLE
feat(registry): add OG images to /vs, /report, and /request-component pages

### DIFF
--- a/apps/registry/app/[locale]/report/page.tsx
+++ b/apps/registry/app/[locale]/report/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { setRequestLocale } from "next-intl/server";
 
 import type { Locale } from "@/i18n/routing";
+import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
@@ -16,16 +17,26 @@ export async function generateMetadata({
   params,
 }: LocaleParams): Promise<Metadata> {
   const { locale } = await params;
+  const ogParameters = {
+    description:
+      "Report a bug in VLLNT UI. The form opens a prefilled GitHub issue — no backend.",
+    title: "Report a bug",
+    type: "page" as const,
+  };
 
   return {
     alternates: {
       canonical: canonical("/report", locale),
       languages: languageAlternates("/report"),
     },
-    description:
-      "Report a bug in VLLNT UI. The form opens a prefilled GitHub issue — no backend.",
+    description: ogParameters.description,
+    openGraph: generateOGMetadata(ogParameters, {
+      locale,
+      pathname: "/report",
+    }),
     robots: { follow: true, index: false },
     title: "Report a bug · VLLNT UI",
+    twitter: generateTwitterMetadata(ogParameters),
   };
 }
 

--- a/apps/registry/app/[locale]/request-component/page.tsx
+++ b/apps/registry/app/[locale]/request-component/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { setRequestLocale } from "next-intl/server";
 
 import type { Locale } from "@/i18n/routing";
+import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
@@ -14,16 +15,26 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
+  const ogParameters = {
+    description:
+      "Request a new VLLNT UI component. The form opens a prefilled GitHub issue — no backend.",
+    title: "Request a component",
+    type: "page" as const,
+  };
 
   return {
     alternates: {
       canonical: canonical("/request-component", locale),
       languages: languageAlternates("/request-component"),
     },
-    description:
-      "Request a new VLLNT UI component. The form opens a prefilled GitHub issue — no backend.",
+    description: ogParameters.description,
+    openGraph: generateOGMetadata(ogParameters, {
+      locale,
+      pathname: "/request-component",
+    }),
     robots: { follow: true, index: false },
     title: "Request a component · VLLNT UI",
+    twitter: generateTwitterMetadata(ogParameters),
   };
 }
 

--- a/apps/registry/app/[locale]/vs/assistant-ui/page.tsx
+++ b/apps/registry/app/[locale]/vs/assistant-ui/page.tsx
@@ -6,6 +6,7 @@ import { setRequestLocale } from "next-intl/server";
 import { Footer } from "@/components/footer/footer";
 import type { Locale } from "@/i18n/routing";
 import { breadcrumbLd, jsonLdScriptAttributes } from "@/lib/jsonld";
+import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
@@ -59,15 +60,25 @@ const ROWS: readonly Row[] = [
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
+  const ogParameters = {
+    description:
+      "VLLNT UI vs assistant-ui: a full AI-first design system you own via the shadcn CLI vs a focused chat-thread library. Honest comparison of scope, install, and theming.",
+    title: "VLLNT UI vs assistant-ui",
+    type: "page" as const,
+  };
 
   return {
     alternates: {
       canonical: canonical(PATHNAME, locale),
       languages: languageAlternates(PATHNAME),
     },
-    description:
-      "VLLNT UI vs assistant-ui: a full AI-first design system you own via the shadcn CLI vs a focused chat-thread library. Honest comparison of scope, install, and theming.",
+    description: ogParameters.description,
+    openGraph: generateOGMetadata(ogParameters, {
+      locale,
+      pathname: PATHNAME,
+    }),
     title: "VLLNT UI vs assistant-ui | VLLNT UI",
+    twitter: generateTwitterMetadata(ogParameters),
   };
 }
 

--- a/apps/registry/app/[locale]/vs/page.tsx
+++ b/apps/registry/app/[locale]/vs/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { setRequestLocale } from "next-intl/server";
 
 import type { Locale } from "@/i18n/routing";
+import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
@@ -13,15 +14,22 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
+  const ogParameters = {
+    description:
+      "Honest, evidence-based comparison of VLLNT UI vs shadcn/ui, Radix UI, HeadlessUI, and NextUI.",
+    title: "VLLNT UI vs · Comparisons",
+    type: "page" as const,
+  };
 
   return {
     alternates: {
       canonical: canonical("/vs", locale),
       languages: languageAlternates("/vs"),
     },
-    description:
-      "Honest, evidence-based comparison of VLLNT UI vs shadcn/ui, Radix UI, HeadlessUI, and NextUI.",
-    title: "VLLNT UI vs · Comparisons",
+    description: ogParameters.description,
+    openGraph: generateOGMetadata(ogParameters, { locale, pathname: "/vs" }),
+    title: ogParameters.title,
+    twitter: generateTwitterMetadata(ogParameters),
   };
 }
 

--- a/apps/registry/app/[locale]/vs/shadcn/page.tsx
+++ b/apps/registry/app/[locale]/vs/shadcn/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { setRequestLocale } from "next-intl/server";
 
 import type { Locale } from "@/i18n/routing";
+import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 import { getComponentCount, getLibraryVersion } from "@/lib/stats";
@@ -14,15 +15,25 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
+  const ogParameters = {
+    description:
+      "VLLNT UI vs shadcn/ui — registry format, component count, agent surface, theming, accessibility. Honest comparison.",
+    title: "VLLNT UI vs shadcn/ui",
+    type: "page" as const,
+  };
 
   return {
     alternates: {
       canonical: canonical("/vs/shadcn", locale),
       languages: languageAlternates("/vs/shadcn"),
     },
-    description:
-      "VLLNT UI vs shadcn/ui — registry format, component count, agent surface, theming, accessibility. Honest comparison.",
-    title: "VLLNT UI vs shadcn/ui",
+    description: ogParameters.description,
+    openGraph: generateOGMetadata(ogParameters, {
+      locale,
+      pathname: "/vs/shadcn",
+    }),
+    title: ogParameters.title,
+    twitter: generateTwitterMetadata(ogParameters),
   };
 }
 

--- a/apps/registry/app/[locale]/vs/vercel-ai-sdk/page.tsx
+++ b/apps/registry/app/[locale]/vs/vercel-ai-sdk/page.tsx
@@ -6,6 +6,7 @@ import { setRequestLocale } from "next-intl/server";
 import { Footer } from "@/components/footer/footer";
 import type { Locale } from "@/i18n/routing";
 import { breadcrumbLd, jsonLdScriptAttributes } from "@/lib/jsonld";
+import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
@@ -58,15 +59,25 @@ const ROWS: readonly Row[] = [
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
+  const ogParameters = {
+    description:
+      "VLLNT UI vs the Vercel AI SDK: a UI design system you own vs a model/streaming runtime. They solve different problems and compose together. Honest comparison.",
+    title: "VLLNT UI vs Vercel AI SDK",
+    type: "page" as const,
+  };
 
   return {
     alternates: {
       canonical: canonical(PATHNAME, locale),
       languages: languageAlternates(PATHNAME),
     },
-    description:
-      "VLLNT UI vs the Vercel AI SDK: a UI design system you own vs a model/streaming runtime. They solve different problems and compose together. Honest comparison.",
+    description: ogParameters.description,
+    openGraph: generateOGMetadata(ogParameters, {
+      locale,
+      pathname: PATHNAME,
+    }),
     title: "VLLNT UI vs Vercel AI SDK | VLLNT UI",
+    twitter: generateTwitterMetadata(ogParameters),
   };
 }
 

--- a/apps/registry/lib/og.test.ts
+++ b/apps/registry/lib/og.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+// @/i18n/routing pulls next-intl/navigation, which cannot load in the node
+// test environment; the module under test needs nothing beyond locale constants.
+vi.mock("@/i18n/routing", () => ({
+  routing: { defaultLocale: "en", locales: ["en", "fr"] },
+}));
+
+import { generateTwitterMetadata } from "./og";
+
+describe("generateTwitterMetadata", () => {
+  it("keeps the site-wide attribution that pages lose when they override the layout twitter metadata", () => {
+    const twitter = generateTwitterMetadata({
+      description: "Honest comparison.",
+      title: "VLLNT UI vs shadcn/ui",
+      type: "page",
+    });
+
+    expect(twitter).toMatchObject({
+      card: "summary_large_image",
+      creator: "@vllnt",
+      site: "@vllnt",
+    });
+  });
+
+  it("returns an /api/og image for the given parameters", () => {
+    const twitter = generateTwitterMetadata({
+      title: "Report a bug",
+      type: "page",
+    });
+
+    const images = twitter && "images" in twitter ? twitter.images : undefined;
+    expect(images).toEqual([
+      expect.stringContaining("/api/og?title=Report+a+bug"),
+    ]);
+  });
+});

--- a/apps/registry/lib/og.ts
+++ b/apps/registry/lib/og.ts
@@ -80,8 +80,10 @@ export function generateTwitterMetadata(
 
   return {
     card: "summary_large_image",
+    creator: "@vllnt",
     description: validated.description,
     images: [ogImageURL],
+    site: "@vllnt",
     title: validated.title,
   };
 }


### PR DESCRIPTION
Closes #415

## What

Adds `next/og` OG images (via the existing `/api/og` pipeline) to the 6 public pages that lacked them:

- `/vs`, `/vs/shadcn`, `/vs/assistant-ui`, `/vs/vercel-ai-sdk`
- `/report`, `/request-component`

Each page builds an `ogParameters` const and passes it to `generateOGMetadata` + `generateTwitterMetadata` from `@/lib/og` — same idiom as `ai/page.tsx`. No new infra.

Follow-up commit (review finding): page-level `twitter` metadata replaces the locale layout's `twitter` object (Next.js shallow merge), which silently dropped `twitter:site`/`twitter:creator` on every page using `generateTwitterMetadata`. `lib/og.ts` now supplies `site: "@vllnt"` + `creator: "@vllnt"` itself, with a regression test (`lib/og.test.ts`, red before / green after).

## Why

The `/vs` comparison pages are indexed marketing pages — exactly what gets shared on X/HN — and rendered imageless cards: the locale layout fallback declares `twitter:card: summary_large_image` but provides no image. `/report` and `/request-component` are noindex but public, so shared links also rendered imageless.

This completes OG coverage for all rendered public pages. Excluded by design: `/docs/changelog` (permanent redirect), `/embed/[slug]` (noindex+nofollow iframe surface).

## Validation (on head 8506fc3)

- `tsc --noEmit` clean; vitest `25/25` passing incl. 2 new `lib/og.test.ts` regression tests
- ESLint: zero violations on added lines
- Preview (`pr-416-ui-registry.preview.vllnt.ai`): all 6 routes emit `og:image` + `twitter:image` pointing at `/api/og` with correct params — verified in real browser via agent-browser:

```
/vs            og:image=https://ui.vllnt.ai/api/og?title=VLLNT+UI+vs+%C2%B7+Comparisons&type=page&…
/vs/shadcn     og:image=https://ui.vllnt.ai/api/og?title=VLLNT+UI+vs+shadcn%2Fui&type=page&…
/vs/assistant-ui, /vs/vercel-ai-sdk, /report, /request-component — same shape, per-page params
```

- Prod `/api/og` already renders the new params (2400×1260 card verified in browser)
- Empirical before/after for the twitter fix: prod `/vs` (layout fallback) serves `twitter:site=@vllnt`; pre-fix preview served `null` — fix restores it from the helper
