### PR TITLE
fix(lint): enforce stricter jsx-a11y rules, lint registry in CI, fix jsx-a11y minimatch crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Lint
         run: pnpm -F @vllnt/ui lint
 
+      - name: Lint registry
+        run: pnpm -F @vllnt/ui-registry lint
+
       - name: Typecheck
         run: pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json
 

--- a/apps/registry/app/[locale]/changelog/page.tsx
+++ b/apps/registry/app/[locale]/changelog/page.tsx
@@ -3,8 +3,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { setRequestLocale } from "next-intl/server";
 
-import { type ChangelogTypeFilter, getChangelogEntries } from "@/lib/changelog";
 import type { Locale } from "@/i18n/routing";
+import { type ChangelogTypeFilter, getChangelogEntries } from "@/lib/changelog";
 import { breadcrumbLd, jsonLdScript } from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
@@ -18,7 +18,7 @@ type SearchParameters = {
   readonly type?: string;
 };
 
-type LocaleParams = {
+type LocaleParameters = {
   readonly params: Promise<{ locale: Locale }>;
 };
 
@@ -37,7 +37,7 @@ const DESCRIPTION =
 
 export async function generateMetadata({
   params,
-}: LocaleParams): Promise<Metadata> {
+}: LocaleParameters): Promise<Metadata> {
   const { locale } = await params;
 
   return {
@@ -139,7 +139,7 @@ function FilterControls({
 export default async function ChangelogPage({
   params,
   searchParams,
-}: LocaleParams & {
+}: LocaleParameters & {
   readonly searchParams: Promise<SearchParameters>;
 }) {
   const { locale } = await params;

--- a/apps/registry/app/[locale]/docs/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/docs/[slug]/page.tsx
@@ -5,7 +5,6 @@ import { Breadcrumb, MDXContent, Sidebar } from "@vllnt/ui";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Script from "next/script";
-
 import { setRequestLocale } from "next-intl/server";
 
 import { type Locale, routing } from "@/i18n/routing";
@@ -32,7 +31,12 @@ export function generateStaticParams(): { locale: Locale; slug: string }[] {
   );
 }
 
-const ROOT_CHANGELOG_PATH = path.join(process.cwd(), "..", "..", "CHANGELOG.md");
+const ROOT_CHANGELOG_PATH = path.join(
+  process.cwd(),
+  "..",
+  "..",
+  "CHANGELOG.md",
+);
 const PACKAGE_CHANGELOG_PATH = path.join(
   process.cwd(),
   "..",
@@ -44,7 +48,8 @@ const PACKAGE_CHANGELOG_PATH = path.join(
 
 async function readChangelogFile(filePath: string): Promise<string> {
   try {
-    return (await readFile(filePath, "utf8")).trim();
+    const content = await readFile(filePath, "utf8");
+    return content.trim();
   } catch {
     return "";
   }
@@ -149,9 +154,7 @@ export default async function DocsSlugPage(props: Props) {
                 { label: frontmatter.title },
               ]}
             />
-            <h1 className="text-4xl font-semibold mb-4">
-              {frontmatter.title}
-            </h1>
+            <h1 className="text-4xl font-semibold mb-4">{frontmatter.title}</h1>
             <p className="text-muted-foreground text-lg">
               {frontmatter.description}
             </p>

--- a/apps/registry/app/[locale]/docs/page.tsx
+++ b/apps/registry/app/[locale]/docs/page.tsx
@@ -65,7 +65,8 @@ export default async function DocumentationPage({ params }: Props) {
             { name: "Docs", url: `${SITE_URL}/docs` },
           ]),
           techArticleLd({
-            description: "Learn how to use VLLNT UI components in your projects.",
+            description:
+              "Learn how to use VLLNT UI components in your projects.",
             title: "Documentation",
             url: `${SITE_URL}/docs`,
           }),

--- a/apps/registry/app/[locale]/not-found.tsx
+++ b/apps/registry/app/[locale]/not-found.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   title: "Page not found · VLLNT UI",
 };
 
-const POPULAR_COMPONENTS: ReadonlyArray<{ name: string; slug: string }> = [
+const POPULAR_COMPONENTS: readonly { name: string; slug: string }[] = [
   { name: "Button", slug: "button" },
   { name: "DataTable", slug: "data-table" },
   { name: "AI Chat Input", slug: "ai-chat-input" },

--- a/apps/registry/app/[locale]/releases/page.tsx
+++ b/apps/registry/app/[locale]/releases/page.tsx
@@ -3,8 +3,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { setRequestLocale } from "next-intl/server";
 
-import { getReleaseRecords } from "@/lib/changelog";
 import type { Locale } from "@/i18n/routing";
+import { getReleaseRecords } from "@/lib/changelog";
 import { breadcrumbLd, jsonLdScript } from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";

--- a/apps/registry/app/[locale]/report/page.tsx
+++ b/apps/registry/app/[locale]/report/page.tsx
@@ -8,13 +8,13 @@ import { getSidebarSections } from "@/lib/sidebar-sections";
 
 import { ReportBugForm } from "./report-bug-form";
 
-type LocaleParams = {
+type LocaleParameters = {
   readonly params: Promise<{ locale: Locale }>;
 };
 
 export async function generateMetadata({
   params,
-}: LocaleParams): Promise<Metadata> {
+}: LocaleParameters): Promise<Metadata> {
   const { locale } = await params;
 
   return {
@@ -36,7 +36,7 @@ type SearchParameters = {
 export default async function ReportBugPage({
   params,
   searchParams,
-}: LocaleParams & {
+}: LocaleParameters & {
   searchParams: Promise<SearchParameters>;
 }) {
   const { locale } = await params;

--- a/apps/registry/app/[locale]/report/report-bug-form.tsx
+++ b/apps/registry/app/[locale]/report/report-bug-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import type * as React from "react";
 import { useState } from "react";
+
+import type * as React from "react";
 
 const REPO = "vllnt/ui";
 
@@ -44,25 +45,23 @@ function buildIssueUrl({
     .filter(Boolean)
     .join("\n");
 
-  const params = new URLSearchParams({
-    template: "bug_report.yml",
-    title: `${titleSlug}${summary || "bug summary"}`,
+  const parameters = new URLSearchParams({
     body,
     labels: component ? `bug,component:${component}` : "bug",
+    template: "bug_report.yml",
+    title: `${titleSlug}${summary || "bug summary"}`,
   });
 
-  return `https://github.com/${REPO}/issues/new?${params.toString()}`;
+  return `https://github.com/${REPO}/issues/new?${parameters.toString()}`;
 }
 
 function Field({
-  autoFocus,
   label,
   onChange,
   placeholder,
   required,
   value,
 }: {
-  autoFocus?: boolean;
   label: string;
   onChange: (value: string) => void;
   placeholder?: string;
@@ -76,9 +75,10 @@ function Field({
         {required ? <span className="ml-1 text-destructive">*</span> : null}
       </span>
       <input
-        autoFocus={autoFocus}
         className="mt-2 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-        onChange={(event) => onChange(event.target.value)}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
         placeholder={placeholder}
         required={required}
         type="text"
@@ -111,7 +111,9 @@ function TextField({
       </span>
       <textarea
         className="mt-2 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-        onChange={(event) => onChange(event.target.value)}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
         placeholder={placeholder}
         required={required}
         rows={rows}
@@ -132,7 +134,7 @@ export function ReportBugForm({
   const [expected, setExpected] = useState("");
   const [actual, setActual] = useState("");
 
-  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+  function handleSubmit(event: React.SyntheticEvent<HTMLFormElement>) {
     event.preventDefault();
     const url = buildIssueUrl({ actual, component, expected, repro, summary });
     window.open(url, "_blank", "noopener,noreferrer");
@@ -147,7 +149,6 @@ export function ReportBugForm({
         value={component}
       />
       <Field
-        autoFocus
         label="One-line summary"
         onChange={setSummary}
         placeholder="Concise headline for the issue title."

--- a/apps/registry/app/[locale]/request-component/request-component-form.tsx
+++ b/apps/registry/app/[locale]/request-component/request-component-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import type * as React from "react";
 import { useState } from "react";
+
+import type * as React from "react";
 
 const REPO = "vllnt/ui";
 
@@ -26,27 +27,25 @@ function buildIssueUrl({
     .filter(Boolean)
     .join("\n\n");
 
-  const params = new URLSearchParams({
+  const parameters = new URLSearchParams({
+    labels: "enhancement,component",
     template: "feature_request.yml",
     title: `[feat] ${name || "new component"}`,
-    labels: "enhancement,component",
   });
-  if (problem) params.set("problem", problem);
-  if (proposal) params.set("proposal", proposal);
-  if (similar) params.set("alternatives", similar);
+  if (problem) parameters.set("problem", problem);
+  if (proposal) parameters.set("proposal", proposal);
+  if (similar) parameters.set("alternatives", similar);
 
-  return `https://github.com/${REPO}/issues/new?${params.toString()}`;
+  return `https://github.com/${REPO}/issues/new?${parameters.toString()}`;
 }
 
 function Field({
-  autoFocus,
   label,
   onChange,
   placeholder,
   required,
   value,
 }: {
-  autoFocus?: boolean;
   label: string;
   onChange: (value: string) => void;
   placeholder?: string;
@@ -60,9 +59,10 @@ function Field({
         {required ? <span className="ml-1 text-destructive">*</span> : null}
       </span>
       <input
-        autoFocus={autoFocus}
         className="mt-2 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-        onChange={(event) => onChange(event.target.value)}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
         placeholder={placeholder}
         required={required}
         type="text"
@@ -95,7 +95,9 @@ function TextField({
       </span>
       <textarea
         className="mt-2 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-        onChange={(event) => onChange(event.target.value)}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
         placeholder={placeholder}
         required={required}
         rows={rows}
@@ -112,7 +114,7 @@ export function RequestComponentForm() {
   const [useCase, setUseCase] = useState("");
   const [reference, setReference] = useState("");
 
-  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+  function handleSubmit(event: React.SyntheticEvent<HTMLFormElement>) {
     event.preventDefault();
     const url = buildIssueUrl({ name, problem, reference, similar, useCase });
     window.open(url, "_blank", "noopener,noreferrer");
@@ -121,7 +123,6 @@ export function RequestComponentForm() {
   return (
     <form className="space-y-5" onSubmit={handleSubmit}>
       <Field
-        autoFocus
         label="Component name"
         onChange={setName}
         placeholder="e.g. ToastStack"

--- a/apps/registry/app/[locale]/templates/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/templates/[slug]/page.tsx
@@ -1,13 +1,12 @@
 import { Breadcrumb, Sidebar } from "@vllnt/ui";
-import { Github } from "lucide-react";
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import Script from "next/script";
-
 import { setRequestLocale } from "next-intl/server";
 
+import { GitHubMark } from "@/components/github-mark";
 import { type Locale, routing } from "@/i18n/routing";
 import {
   breadcrumbLd,
@@ -191,7 +190,7 @@ export default async function TemplatePage(props: Props) {
                     rel="noreferrer"
                     target="_blank"
                   >
-                    <Github className="size-4" />
+                    <GitHubMark className="size-4" />
                     GitHub source
                   </a>
                 </div>

--- a/apps/registry/app/[locale]/vs/page.tsx
+++ b/apps/registry/app/[locale]/vs/page.tsx
@@ -25,36 +25,36 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-const COMPARISONS: ReadonlyArray<{
-  readonly slug: string;
-  readonly name: string;
-  readonly tagline: string;
+const COMPARISONS: readonly {
   readonly available: boolean;
-}> = [
+  readonly name: string;
+  readonly slug: string;
+  readonly tagline: string;
+}[] = [
   {
-    slug: "shadcn",
+    available: true,
     name: "shadcn/ui",
+    slug: "shadcn",
     tagline:
       "Closest sibling. Same registry format. Different component count and agent surface.",
-    available: true,
   },
   {
-    slug: "radix",
+    available: false,
     name: "Radix UI",
+    slug: "radix",
     tagline: "Accessible primitives — VLLNT UI is built on top of these.",
-    available: false,
   },
   {
-    slug: "headless-ui",
+    available: false,
     name: "HeadlessUI",
+    slug: "headless-ui",
     tagline: "Tailwind Labs primitives — different ecosystem.",
-    available: false,
   },
   {
-    slug: "nextui",
-    name: "NextUI",
-    tagline: "Component library with its own design language.",
     available: false,
+    name: "NextUI",
+    slug: "nextui",
+    tagline: "Component library with its own design language.",
   },
 ];
 
@@ -70,8 +70,8 @@ export default async function VsIndexPage({ params }: Props) {
           <h1 className="text-4xl font-semibold mb-3">VLLNT UI vs the rest</h1>
           <p className="text-muted-foreground text-lg mb-10">
             Honest comparisons. We call out where alternatives are stronger,
-            where VLLNT UI fits better, and where the gap is small enough to
-            not matter.
+            where VLLNT UI fits better, and where the gap is small enough to not
+            matter.
           </p>
 
           <ul className="space-y-3">

--- a/apps/registry/app/[locale]/vs/shadcn/page.tsx
+++ b/apps/registry/app/[locale]/vs/shadcn/page.tsx
@@ -28,9 +28,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 type Row = {
   readonly attribute: string;
-  readonly vllnt: string;
   readonly shadcn: string;
-  readonly winner?: "vllnt" | "shadcn" | "even";
+  readonly vllnt: string;
+  readonly winner?: "even" | "shadcn" | "vllnt";
 };
 
 export default async function VsShadcnPage({ params }: Props) {
@@ -42,110 +42,111 @@ export default async function VsShadcnPage({ params }: Props) {
   const rows: readonly Row[] = [
     {
       attribute: "Component count",
-      vllnt: `${componentCount} components`,
       shadcn: "~50 components",
+      vllnt: `${componentCount} components`,
       winner: "vllnt",
     },
     {
       attribute: "Install model",
-      vllnt: "shadcn CLI against /r/<name>.json",
       shadcn: "shadcn CLI against ui.shadcn.com/r",
+      vllnt: "shadcn CLI against /r/<name>.json",
       winner: "even",
     },
     {
       attribute: "You own the source after install",
-      vllnt: "Yes",
       shadcn: "Yes",
+      vllnt: "Yes",
       winner: "even",
     },
     {
       attribute: "Sibling-component resolution",
-      vllnt: "Hybrid: leaf source + @vllnt/ui peer dep for siblings",
       shadcn: "All source inlined per component",
+      vllnt: "Hybrid: leaf source + @vllnt/ui peer dep for siblings",
       winner: "vllnt",
     },
     {
       attribute: "/llms.txt agent index",
-      vllnt: "Yes — llmstxt.org compliant",
       shadcn: "No",
+      vllnt: "Yes — llmstxt.org compliant",
       winner: "vllnt",
     },
     {
       attribute: "MCP server",
-      vllnt: "Yes — ui.vllnt.ai/mcp (search/get/list tools)",
       shadcn: "No",
+      vllnt: "Yes — ui.vllnt.ai/mcp (search/get/list tools)",
       winner: "vllnt",
     },
     {
       attribute: "Per-component a11y schema in JSON",
-      vllnt: "Yes — keyboard map, ARIA roles, focus model",
       shadcn: "No",
+      vllnt: "Yes — keyboard map, ARIA roles, focus model",
       winner: "vllnt",
     },
     {
       attribute: "Per-component examples in JSON",
-      vllnt: "Yes — code-as-data, agent-readable",
       shadcn: "No",
+      vllnt: "Yes — code-as-data, agent-readable",
       winner: "vllnt",
     },
     {
       attribute: "Per-component props schema in JSON",
-      vllnt: "Yes — TSDoc-shaped",
       shadcn: "No",
+      vllnt: "Yes — TSDoc-shaped",
       winner: "vllnt",
     },
     {
       attribute: "version + stability per component",
-      vllnt: "Yes (stable / beta / experimental / deprecated)",
       shadcn: "No",
+      vllnt: "Yes (stable / beta / experimental / deprecated)",
       winner: "vllnt",
     },
     {
       attribute: "Theming",
-      vllnt: "CSS variables + design tokens (DESIGN.md)",
       shadcn: "CSS variables",
+      vllnt: "CSS variables + design tokens (DESIGN.md)",
       winner: "vllnt",
     },
     {
       attribute: "Accessibility primitives",
-      vllnt: "Radix UI",
       shadcn: "Radix UI",
+      vllnt: "Radix UI",
       winner: "even",
     },
     {
       attribute: "Variant system",
-      vllnt: "CVA",
       shadcn: "CVA",
+      vllnt: "CVA",
       winner: "even",
     },
     {
       attribute: "Community size",
-      vllnt: "Smaller, growing",
       shadcn: "Massive — millions of installs",
+      vllnt: "Smaller, growing",
       winner: "shadcn",
     },
     {
       attribute: "Namespace recognition",
-      vllnt: "@vllnt/ui (newer)",
       shadcn: "shadcn (industry standard)",
+      vllnt: "@vllnt/ui (newer)",
       winner: "shadcn",
     },
     {
       attribute: "Tutorials + content",
-      vllnt: "Limited (young project)",
       shadcn: "Extensive — countless videos, blogs, courses",
+      vllnt: "Limited (young project)",
       winner: "shadcn",
     },
     {
       attribute: "Templates / starter kits",
-      vllnt: "Curated app templates for Next.js, dashboards, SaaS, AI chat, and docs",
       shadcn: "Many official + community templates",
+      vllnt:
+        "Curated app templates for Next.js, dashboards, SaaS, AI chat, and docs",
       winner: "even",
     },
     {
       attribute: "License",
-      vllnt: "MIT",
       shadcn: "MIT",
+      vllnt: "MIT",
       winner: "even",
     },
   ];
@@ -166,8 +167,8 @@ export default async function VsShadcnPage({ params }: Props) {
               shadcn/ui is the industry standard. VLLNT UI is a younger sibling
               that takes the same registry idea further: more components, an
               agent-first surface (<code>/llms.txt</code>, <code>/mcp</code>,
-              richer JSON descriptors), and a hybrid install model that
-              dedupes shared primitives via <code>@vllnt/ui</code>.
+              richer JSON descriptors), and a hybrid install model that dedupes
+              shared primitives via <code>@vllnt/ui</code>.
             </p>
             <p>
               If you want maximum community signal and the largest pool of
@@ -180,8 +181,7 @@ export default async function VsShadcnPage({ params }: Props) {
               <Link href={localizePathname("/templates", locale)}>
                 starter kit gallery
               </Link>{" "}
-              for finished
-              app shells built from the registry.
+              for finished app shells built from the registry.
             </p>
           </div>
 
@@ -227,8 +227,8 @@ export default async function VsShadcnPage({ params }: Props) {
               that benefits from being &ldquo;just shadcn&rdquo;.
             </p>
             <p>
-              <strong>Pick VLLNT UI</strong> when you need components beyond
-              the shadcn core (timelines, maps, AI compounds, runtime overlays,
+              <strong>Pick VLLNT UI</strong> when you need components beyond the
+              shadcn core (timelines, maps, AI compounds, runtime overlays,
               canvas primitives), when AI agents are part of your authoring
               flow, or when you want the registry data structured enough to
               query programmatically.

--- a/apps/registry/app/mcp/route.ts
+++ b/apps/registry/app/mcp/route.ts
@@ -1,14 +1,14 @@
 /**
  * MCP server at ui.vllnt.ai/mcp — Model Context Protocol endpoint.
  *
- * Speaks JSON-RPC 2.0 over POST. Implements the minimum protocol surface
+ * Speaks JSON-RPC 2.0 over POST. Implements the smallest protocol surface
  * an MCP client needs to discover and use VLLNT UI tools:
  *
  *   - initialize      → server capabilities + protocol version
  *   - tools/list      → describe each tool
  *   - tools/call      → invoke a tool by name
  *
- * Tools (UI registry only — see #246 scope decision):
+ * Tools (UI registry scope — see #246 scope decision):
  *   - search_components({ query, category?, limit? })
  *   - get_component({ name })
  *   - list_categories()
@@ -30,23 +30,23 @@ import { NextResponse } from "next/server";
 import registry from "../../registry.json";
 
 type RegistryItem = {
-  readonly name: string;
-  readonly title: string;
-  readonly description?: string;
-  readonly category?: string;
-  readonly registryDependencies?: readonly string[];
-  readonly dependencies?: readonly string[];
-  readonly version?: string;
-  readonly stability?: string;
   readonly a11y?: unknown;
+  readonly category?: string;
+  readonly dependencies?: readonly string[];
+  readonly description?: string;
   readonly examples?: unknown;
+  readonly name: string;
   readonly props?: unknown;
+  readonly registryDependencies?: readonly string[];
+  readonly stability?: string;
+  readonly title: string;
+  readonly version?: string;
 };
 
 type Registry = {
+  readonly generatedAt?: string;
   readonly items: readonly RegistryItem[];
   readonly version?: string;
-  readonly generatedAt?: string;
 };
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
@@ -54,103 +54,108 @@ const REGISTRY = registry as Registry;
 const PROTOCOL_VERSION = "2025-06-18";
 
 type JsonRpcRequest = {
+  id?: null | number | string;
   jsonrpc: "2.0";
-  id?: string | number | null;
   method: string;
   params?: unknown;
 };
 
 type JsonRpcSuccess = {
+  id: null | number | string;
   jsonrpc: "2.0";
-  id: string | number | null;
   result: unknown;
 };
 
 type JsonRpcError = {
+  error: { code: number; data?: unknown; message: string };
+  id: null | number | string;
   jsonrpc: "2.0";
-  id: string | number | null;
-  error: { code: number; message: string; data?: unknown };
 };
 
 const ok = (
-  id: string | number | null | undefined,
+  id: null | number | string | undefined,
   result: unknown,
 ): JsonRpcSuccess => ({
-  jsonrpc: "2.0",
   id: id ?? null,
+  jsonrpc: "2.0",
   result,
 });
 
-const err = (
-  id: string | number | null | undefined,
+const error_ = (
+  id: null | number | string | undefined,
   code: number,
   message: string,
   data?: unknown,
 ): JsonRpcError => ({
-  jsonrpc: "2.0",
+  error: data === undefined ? { code, message } : { code, data, message },
   id: id ?? null,
-  error: data === undefined ? { code, message } : { code, message, data },
+  jsonrpc: "2.0",
 });
 
 const TOOLS = [
   {
-    name: "search_components",
     description:
       "Search VLLNT UI components by name / title / description. Filter by category.",
     inputSchema: {
-      type: "object",
       properties: {
-        query: {
-          type: "string",
-          description:
-            "Free-text query matched against name, title, description (case-insensitive).",
-        },
         category: {
-          type: "string",
           description:
             "Optional filter — one of: ai, billing, content, core, data, data-display, educational, form, learning, navigation, overlay, utility.",
+          type: "string",
         },
         limit: {
-          type: "number",
           description: "Maximum results (default 25, capped at 100).",
+          type: "number",
+        },
+        query: {
+          description:
+            "Free-text query matched against name, title, description (case-insensitive).",
+          type: "string",
         },
       },
+      type: "object",
     },
+    name: "search_components",
   },
   {
-    name: "get_component",
     description:
       "Get the full registry descriptor for one component (name, title, description, deps, version, stability, a11y, examples, props).",
     inputSchema: {
-      type: "object",
-      required: ["name"],
       properties: {
         name: {
-          type: "string",
           description: "Component slug (e.g. 'button', 'data-table').",
+          type: "string",
         },
       },
+      required: ["name"],
+      type: "object",
     },
+    name: "get_component",
   },
   {
+    description: "List the 12 component categories with item counts.",
+    inputSchema: { properties: {}, type: "object" },
     name: "list_categories",
-    description:
-      "List the 12 component categories with item counts.",
-    inputSchema: { type: "object", properties: {} },
   },
 ] as const;
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
-function searchComponents(
-  args: Record<string, unknown>,
-): { items: RegistryItem[]; total: number } {
-  const query = typeof args.query === "string" ? args.query.toLowerCase() : "";
+function searchComponents(arguments_: Record<string, unknown>): {
+  items: RegistryItem[];
+  total: number;
+} {
+  const query =
+    typeof arguments_.query === "string" ? arguments_.query.toLowerCase() : "";
   const category =
-    typeof args.category === "string" ? args.category.toLowerCase() : null;
+    typeof arguments_.category === "string"
+      ? arguments_.category.toLowerCase()
+      : null;
   const requested =
-    typeof args.limit === "number" && args.limit > 0 ? args.limit : 25;
+    typeof arguments_.limit === "number" && arguments_.limit > 0
+      ? arguments_.limit
+      : 25;
   const limit = Math.min(requested, 100);
 
   const items = REGISTRY.items.filter((item) => {
@@ -172,18 +177,23 @@ function searchComponents(
   return { items: items.slice(0, limit), total: items.length };
 }
 
-function getComponent(args: Record<string, unknown>): RegistryItem | null {
-  const name = typeof args.name === "string" ? args.name : null;
+function getComponent(
+  arguments_: Record<string, unknown>,
+): null | RegistryItem {
+  const name = typeof arguments_.name === "string" ? arguments_.name : null;
   if (!name) return null;
   return REGISTRY.items.find((item) => item.name === name) ?? null;
 }
 
-function listCategories(): { category: string; count: number; pageUrl: string }[] {
-  const counts = new Map<string, number>();
-  for (const item of REGISTRY.items) {
+function listCategories(): {
+  category: string;
+  count: number;
+  pageUrl: string;
+}[] {
+  const counts = REGISTRY.items.reduce((accumulator, item) => {
     const category = item.category ?? "uncategorized";
-    counts.set(category, (counts.get(category) ?? 0) + 1);
-  }
+    return accumulator.set(category, (accumulator.get(category) ?? 0) + 1);
+  }, new Map<string, number>());
   return [...counts.entries()]
     .map(([category, count]) => ({
       category,
@@ -195,11 +205,11 @@ function listCategories(): { category: string; count: number; pageUrl: string }[
 
 function callTool(
   name: string,
-  args: Record<string, unknown>,
-): { content: { type: "text"; text: string }[]; isError?: boolean } {
+  arguments_: Record<string, unknown>,
+): { content: { text: string; type: "text" }[]; isError?: boolean } {
   switch (name) {
     case "search_components": {
-      const { items, total } = searchComponents(args);
+      const { items, total } = searchComponents(arguments_);
       const lines = [
         `Found ${total} component(s) matching the query. Showing ${items.length}.`,
         "",
@@ -211,24 +221,24 @@ function callTool(
         ),
       ].filter(Boolean);
       return {
-        content: [{ type: "text", text: lines.join("\n") }],
+        content: [{ text: lines.join("\n"), type: "text" }],
       };
     }
     case "get_component": {
-      const item = getComponent(args);
+      const item = getComponent(arguments_);
       if (!item) {
         return {
           content: [
             {
-              type: "text",
               text: `Component not found. Try search_components first.`,
+              type: "text",
             },
           ],
           isError: true,
         };
       }
       return {
-        content: [{ type: "text", text: JSON.stringify(item, null, 2) }],
+        content: [{ text: JSON.stringify(item, null, 2), type: "text" }],
       };
     }
     case "list_categories": {
@@ -238,29 +248,24 @@ function callTool(
         "",
         ...rows.map((row) => `- ${row.category}: ${row.count}`),
       ];
-      return { content: [{ type: "text", text: lines.join("\n") }] };
+      return { content: [{ text: lines.join("\n"), type: "text" }] };
     }
     default:
       return {
-        content: [{ type: "text", text: `Unknown tool: ${name}` }],
+        content: [{ text: `Unknown tool: ${name}`, type: "text" }],
         isError: true,
       };
   }
 }
 
-function dispatch(req: JsonRpcRequest): JsonRpcSuccess | JsonRpcError {
-  if (req.jsonrpc !== "2.0" || typeof req.method !== "string") {
-    return err(req.id ?? null, -32600, "Invalid Request");
+function dispatch(request: JsonRpcRequest): JsonRpcError | JsonRpcSuccess {
+  if (request.jsonrpc !== "2.0" || typeof request.method !== "string") {
+    return error_(request.id ?? null, -32_600, "Invalid Request");
   }
 
-  switch (req.method) {
+  switch (request.method) {
     case "initialize":
-      return ok(req.id, {
-        protocolVersion: PROTOCOL_VERSION,
-        serverInfo: {
-          name: "vllnt-ui",
-          version: REGISTRY.version ?? "0.0.0",
-        },
+      return ok(request.id, {
         capabilities: {
           tools: { listChanged: false },
         },
@@ -268,31 +273,36 @@ function dispatch(req: JsonRpcRequest): JsonRpcSuccess | JsonRpcError {
           "VLLNT UI registry MCP server. Use search_components / get_component / list_categories to discover and read 225 React components. Source of truth: " +
           SITE_URL +
           "/r/registry.json",
+        protocolVersion: PROTOCOL_VERSION,
+        serverInfo: {
+          name: "vllnt-ui",
+          version: REGISTRY.version ?? "0.0.0",
+        },
       });
 
     case "notifications/initialized":
-      return ok(req.id, {});
+      return ok(request.id, {});
 
     case "tools/list":
-      return ok(req.id, { tools: TOOLS });
+      return ok(request.id, { tools: TOOLS });
 
     case "tools/call": {
-      if (!isObject(req.params)) {
-        return err(req.id, -32602, "Invalid params");
+      if (!isObject(request.params)) {
+        return error_(request.id, -32_602, "Invalid params");
       }
-      const name = req.params.name;
-      const rawArgs = req.params.arguments;
+      const name = request.params.name;
+      const rawArguments = request.params.arguments;
       if (typeof name !== "string") {
-        return err(req.id, -32602, "Missing tool name");
+        return error_(request.id, -32_602, "Missing tool name");
       }
-      const args = isObject(rawArgs) ? rawArgs : {};
+      const arguments_ = isObject(rawArguments) ? rawArguments : {};
       try {
-        const result = callTool(name, args);
-        return ok(req.id, result);
+        const result = callTool(name, arguments_);
+        return ok(request.id, result);
       } catch (error) {
-        return err(
-          req.id,
-          -32603,
+        return error_(
+          request.id,
+          -32_603,
           "Tool execution failed",
           error instanceof Error ? error.message : String(error),
         );
@@ -300,30 +310,34 @@ function dispatch(req: JsonRpcRequest): JsonRpcSuccess | JsonRpcError {
     }
 
     case "ping":
-      return ok(req.id, {});
+      return ok(request.id, {});
 
     default:
-      return err(req.id ?? null, -32601, `Method not found: ${req.method}`);
+      return error_(
+        request.id ?? null,
+        -32_601,
+        `Method not found: ${request.method}`,
+      );
   }
 }
 
 const SERVER_INFO = {
-  name: "vllnt-ui",
-  version: REGISTRY.version ?? "0.0.0",
+  capabilities: { tools: { listChanged: false } },
   description:
     "MCP server for the VLLNT UI component registry. Tools: search_components, get_component, list_categories.",
   endpoint: `${SITE_URL}/mcp`,
+  name: "vllnt-ui",
   protocol: PROTOCOL_VERSION,
-  capabilities: { tools: { listChanged: false } },
   registry: {
-    version: REGISTRY.version ?? "0.0.0",
     generatedAt: REGISTRY.generatedAt ?? null,
     itemCount: REGISTRY.items.length,
+    version: REGISTRY.version ?? "0.0.0",
   },
   tools: TOOLS.map((tool) => ({
-    name: tool.name,
     description: tool.description,
+    name: tool.name,
   })),
+  version: REGISTRY.version ?? "0.0.0",
 };
 
 export const dynamic = "force-static";
@@ -337,18 +351,20 @@ export async function POST(request: Request): Promise<NextResponse> {
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json(err(null, -32700, "Parse error"), { status: 400 });
+    return NextResponse.json(error_(null, -32_700, "Parse error"), {
+      status: 400,
+    });
   }
 
   if (Array.isArray(body)) {
     const responses = body
       .filter((entry): entry is JsonRpcRequest => isObject(entry))
-      .map((entry) => dispatch(entry as JsonRpcRequest));
+      .map((entry) => dispatch(entry));
     return NextResponse.json(responses);
   }
 
   if (!isObject(body)) {
-    return NextResponse.json(err(null, -32600, "Invalid Request"), {
+    return NextResponse.json(error_(null, -32_600, "Invalid Request"), {
       status: 400,
     });
   }

--- a/apps/registry/app/robots.ts
+++ b/apps/registry/app/robots.ts
@@ -18,19 +18,19 @@ const AI_CRAWLERS = [
 
 export default function robots(): MetadataRoute.Robots {
   const aiAllow = AI_CRAWLERS.map((userAgent) => ({
-    userAgent,
     allow: "/",
+    userAgent,
   }));
 
   return {
+    host: SITE_URL,
     rules: [
       {
-        userAgent: "*",
         allow: "/",
+        userAgent: "*",
       },
       ...aiAllow,
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,
-    host: SITE_URL,
   };
 }

--- a/apps/registry/components/theme-editor/export-panel.tsx
+++ b/apps/registry/components/theme-editor/export-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState, useSyncExternalStore } from "react";
 
 import { Button } from "@vllnt/ui";
 
@@ -23,6 +23,17 @@ const TABS: { id: ExportTab; label: string }[] = [
   { id: "json", label: "tokens.json" },
 ];
 
+const unsubscribeNoop = (): void => undefined;
+const subscribeNever = (): (() => void) => unsubscribeNoop;
+
+function useOrigin(): string {
+  return useSyncExternalStore(
+    subscribeNever,
+    () => window.location.origin,
+    () => "https://ui.vllnt.ai",
+  );
+}
+
 function download(filename: string, content: string): void {
   const blob = new Blob([content], { type: "text/plain" });
   const url = URL.createObjectURL(blob);
@@ -39,11 +50,7 @@ function download(filename: string, content: string): void {
 export function ExportPanel({ theme }: ExportPanelProps) {
   const [tab, setTab] = useState<ExportTab>("css");
   const [copied, setCopied] = useState(false);
-  const [origin, setOrigin] = useState("https://ui.vllnt.ai");
-
-  useEffect(() => {
-    setOrigin(window.location.origin);
-  }, []);
+  const origin = useOrigin();
 
   const css = useMemo(() => themeToCss(theme), [theme]);
   const json = useMemo(

--- a/apps/registry/components/theme-editor/theme-editor.tsx
+++ b/apps/registry/components/theme-editor/theme-editor.tsx
@@ -50,6 +50,9 @@ export function ThemeEditor() {
   const [mode, setMode] = useState<ThemeMode>("dark");
   const isFirstRender = useRef(true);
 
+  /* eslint-disable react-hooks/set-state-in-effect -- one-shot init from
+     URL/localStorage after hydration; a lazy useState initializer cannot
+     read window during SSR. */
   useEffect(() => {
     const fromUrl = new URLSearchParams(window.location.search).get("t");
     const urlTheme = fromUrl ? decodeTheme(fromUrl) : undefined;
@@ -63,6 +66,7 @@ export function ThemeEditor() {
       setTheme(restored);
     }
   }, []);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   useEffect(() => {
     if (isFirstRender.current) {

--- a/apps/registry/components/theme-editor/theme-preview.tsx
+++ b/apps/registry/components/theme-editor/theme-preview.tsx
@@ -21,7 +21,7 @@ type ThemePreviewProps = {
   readonly radius: string;
 };
 
-function toCssVars(colors: ThemeColors, radius: string): CSSProperties {
+function toCssVariables(colors: ThemeColors, radius: string): CSSProperties {
   const entries = THEME_TOKENS.map(
     (token) => [token.cssVar, colors[token.name] ?? ""] as const,
   );
@@ -40,7 +40,7 @@ export function ThemePreview({ colors, radius }: ThemePreviewProps) {
   return (
     <div
       className="space-y-6 rounded-lg border border-border bg-background p-6 text-foreground"
-      style={toCssVars(colors, radius)}
+      style={toCssVariables(colors, radius)}
     >
       <div className="space-y-1">
         <h3 className="text-lg font-semibold">The quick brown fox</h3>

--- a/apps/registry/eslint.config.js
+++ b/apps/registry/eslint.config.js
@@ -10,7 +10,113 @@ export default [
       '*.config.*',
       'eslint.config.js',
       'next-env.d.ts',
+      'scripts/**',
+      'e2e/**',
     ],
   },
   ...nextjs,
+  {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+  },
+  {
+    rules: {
+      'jsx-a11y/anchor-ambiguous-text': 'error',
+      'jsx-a11y/interactive-supports-focus': [
+        'error',
+        {
+          tabbable: [
+            'button',
+            'checkbox',
+            'link',
+            'progressbar',
+            'searchbox',
+            'slider',
+            'spinbutton',
+            'switch',
+            'textbox',
+          ],
+        },
+      ],
+      'jsx-a11y/lang': 'error',
+      'jsx-a11y/no-aria-hidden-on-focusable': 'error',
+      'jsx-a11y/no-interactive-element-to-noninteractive-role': 'error',
+      'jsx-a11y/no-noninteractive-element-interactions': [
+        'error',
+        {
+          body: ['onError', 'onLoad'],
+          iframe: ['onError', 'onLoad'],
+          img: ['onError', 'onLoad'],
+        },
+      ],
+      'jsx-a11y/no-noninteractive-tabindex': 'error',
+      'jsx-a11y/no-static-element-interactions': 'error',
+    },
+  },
+  {
+    /* Externally-mandated key shapes: JSON-LD (@context/@type), web app
+       manifest (snake_case members), MCP JSON-RPC protocol fields. */
+    files: ['lib/jsonld.ts', 'lib/seo.ts', 'app/manifest.ts', 'app/mcp/route.ts'],
+    rules: {
+      '@typescript-eslint/naming-convention': 'off',
+    },
+  },
+  {
+    /* MCP route speaks JSON-RPC: null is part of the wire protocol, the
+       error factory mirrors the JSON-RPC error signature, and the switch
+       based dispatchers read better unsplit. */
+    files: ['app/mcp/route.ts'],
+    rules: {
+      'unicorn/no-null': 'off',
+      'max-params': 'off',
+    },
+  },
+  {
+    /* "docs" is the literal name of the /docs site section, not an
+       abbreviation. Options replicate the preset (rule options replace,
+       not merge). */
+    rules: {
+      'unicorn/prevent-abbreviations': [
+        'error',
+        {
+          extendDefaultReplacements: true,
+          replacements: {
+            ctx: false,
+            db: false,
+            docs: false,
+            e: false,
+            fn: false,
+            props: false,
+            ref: false,
+            utils: false,
+          },
+          ignore: [
+            'e2e',
+            'a11y',
+            'i18n',
+            'getInitialProps',
+            'generateStaticParams',
+            'dynamicParams',
+            '.*Ctx$',
+            '.*Ref$',
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: [
+      'app/mcp/route.ts',
+      'app/r/themes/route.ts',
+      'components/header/header.tsx',
+      'components/theme-editor/theme-editor.tsx',
+      'lib/og.ts',
+      'lib/sidebar-sections.ts',
+      'lib/theme-serialize.ts',
+    ],
+    rules: {
+      'max-lines-per-function': 'off',
+    },
+  },
 ]

--- a/apps/registry/lib/changelog.ts
+++ b/apps/registry/lib/changelog.ts
@@ -102,22 +102,12 @@ function extractSummary(notes: string): string {
 }
 
 function countBreakingChangesFromNotes(notes: string): number {
-  const lines = notes.split("\n");
-  let inBreakingSection = false;
-  let count = 0;
-  for (const line of lines) {
-    if (/^###\s+.*breaking/i.test(line)) {
-      inBreakingSection = true;
-      continue;
-    }
-    if (/^###/.test(line)) {
-      inBreakingSection = false;
-      continue;
-    }
-    if (inBreakingSection && line.trim().startsWith("- ")) {
-      count++;
-    }
-  }
+  const count = notes
+    .split(/\n(?=###\s)/)
+    .filter((section) => /^###\s+.*breaking/i.test(section))
+    .flatMap((section) =>
+      section.split("\n").filter((line) => line.trim().startsWith("- ")),
+    ).length;
   if (count > 0) return count;
   return /breaking/i.test(notes) ? 1 : 0;
 }
@@ -154,14 +144,11 @@ function changelogCandidates(): readonly string[] {
 }
 
 async function readChangelog(): Promise<string> {
-  for (const candidate of changelogCandidates()) {
-    try {
-      return await readFile(candidate, "utf8");
-    } catch {
-      // try next candidate
-    }
-  }
-  return "";
+  return changelogCandidates().reduce<Promise<string>>(
+    async (found, candidate) =>
+      (await found) || readFile(candidate, "utf8").catch(() => ""),
+    Promise.resolve(""),
+  );
 }
 
 function parseHeading(line: string): Heading | undefined {
@@ -398,7 +385,7 @@ export function feedUpdatedAt(
 ): string | undefined {
   const firstDated = releases.find((release) => release.date);
   if (firstDated?.date) return new Date(firstDated.date).toISOString();
-  const buildTime = process.env["BUILD_TIME"];
+  const buildTime = process.env.BUILD_TIME;
   return buildTime ? new Date(buildTime).toISOString() : undefined;
 }
 

--- a/apps/registry/lib/jsonld.ts
+++ b/apps/registry/lib/jsonld.ts
@@ -1,14 +1,14 @@
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
 
 type JsonLdValue =
-  | string
-  | number
   | boolean
   | null
+  | number
   | readonly JsonLdValue[]
+  | string
   | { readonly [key: string]: JsonLdValue };
 
-type JsonLdNode = { readonly [key: string]: JsonLdValue };
+type JsonLdNode = Readonly<Record<string, JsonLdValue>>;
 
 export type JsonLdScriptAttributes = {
   readonly dangerouslySetInnerHTML: {
@@ -22,8 +22,8 @@ export function organizationLd(): JsonLdNode {
     "@context": "https://schema.org",
     "@type": "Organization",
     name: "VLLNT",
-    url: SITE_URL,
     sameAs: ["https://github.com/vllnt", "https://github.com/vllnt/ui"],
+    url: SITE_URL,
   };
 }
 
@@ -32,28 +32,28 @@ export function websiteLd(): JsonLdNode {
     "@context": "https://schema.org",
     "@type": "WebSite",
     name: "VLLNT UI",
-    url: SITE_URL,
     publisher: {
       "@type": "Organization",
       name: "VLLNT",
     },
+    url: SITE_URL,
   };
 }
 
 export function softwareSourceCodeLd(component: {
+  readonly description: string;
   readonly name: string;
   readonly title: string;
-  readonly description: string;
 }): JsonLdNode {
   return {
     "@context": "https://schema.org",
     "@type": "SoftwareSourceCode",
-    name: component.title,
-    description: component.description,
     codeRepository: "https://github.com/vllnt/ui",
+    description: component.description,
+    license: "https://opensource.org/license/mit",
+    name: component.title,
     programmingLanguage: "TypeScript",
     runtimePlatform: "React",
-    license: "https://opensource.org/license/mit",
     url: `${SITE_URL}/components/${component.name}`,
   };
 }
@@ -89,18 +89,20 @@ export function softwareApplicationLd(application: {
   return node;
 }
 
-export function breadcrumbLd(trail: ReadonlyArray<{
-  readonly name: string;
-  readonly url: string;
-}>): JsonLdNode {
+export function breadcrumbLd(
+  trail: readonly {
+    readonly name: string;
+    readonly url: string;
+  }[],
+): JsonLdNode {
   return {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     itemListElement: trail.map((step, index) => ({
       "@type": "ListItem",
-      position: index + 1,
-      name: step.name,
       item: step.url,
+      name: step.name,
+      position: index + 1,
     })),
   };
 }
@@ -113,40 +115,40 @@ export function techArticleLd(article: {
   return {
     "@context": "https://schema.org",
     "@type": "TechArticle",
-    headline: article.title,
-    description: article.description,
-    url: article.url,
+    about: "React component library documentation",
     author: {
       "@type": "Organization",
       name: "VLLNT",
       url: SITE_URL,
     },
+    description: article.description,
+    headline: article.title,
+    programmingLanguage: "TypeScript",
     publisher: {
       "@type": "Organization",
       name: "VLLNT",
       url: SITE_URL,
     },
-    programmingLanguage: "TypeScript",
-    about: "React component library documentation",
+    url: article.url,
   };
 }
 
 export function faqPageLd(
-  entries: ReadonlyArray<{
-    readonly question: string;
+  entries: readonly {
     readonly answer: string;
-  }>,
+    readonly question: string;
+  }[],
 ): JsonLdNode {
   return {
     "@context": "https://schema.org",
     "@type": "FAQPage",
     mainEntity: entries.map((entry) => ({
       "@type": "Question",
-      name: entry.question,
       acceptedAnswer: {
         "@type": "Answer",
         text: entry.answer,
       },
+      name: entry.question,
     })),
   };
 }

--- a/apps/registry/lib/oklch.test.ts
+++ b/apps/registry/lib/oklch.test.ts
@@ -31,14 +31,15 @@ describe("oklch", () => {
     expect(oklchChannelsToHex("")).toBe("#000000");
   });
 
-  it("round-trips channels -> hex -> channels within tolerance", () => {
-    for (const sample of ["0.5555 0 0", "0.6368 0.2078 25.326", "0.62 0.17 280"]) {
+  it.each(["0.5555 0 0", "0.6368 0.2078 25.326", "0.62 0.17 280"])(
+    "round-trips %s channels -> hex -> channels within tolerance",
+    (sample) => {
       const back = hexToOklchChannels(oklchChannelsToHex(sample));
       const [l1] = parseOklchChannels(sample);
       const [l2] = parseOklchChannels(back);
       expect(Math.abs(l1 - l2)).toBeLessThan(0.01);
-    }
-  });
+    },
+  );
 
   it("emits an achromatic 'L 0 0' form for greys", () => {
     expect(hexToOklchChannels("#808080")).toMatch(/^[\d.]+ 0 0$/);

--- a/apps/registry/lib/sidebar-sections.ts
+++ b/apps/registry/lib/sidebar-sections.ts
@@ -1,7 +1,7 @@
 import { type Locale, routing } from "@/i18n/routing";
-import registryData from "@/registry.json";
 import { DOCS_PAGES, getDocsPath } from "@/lib/docs-pages";
 import { localizePathname } from "@/lib/seo";
+import registryData from "@/registry.json";
 import type {
   ComponentCategory,
   Registry,

--- a/apps/registry/lib/stats.ts
+++ b/apps/registry/lib/stats.ts
@@ -2,14 +2,14 @@ import packageJson from "../../../packages/ui/package.json";
 import registry from "../registry.json";
 
 type RegistryItem = {
-  readonly name: string;
   readonly category?: string;
+  readonly name: string;
 };
 
 type Registry = {
+  readonly generatedAt?: string;
   readonly items: readonly RegistryItem[];
   readonly version?: string;
-  readonly generatedAt?: string;
 };
 
 const REGISTRY = registry as Registry;
@@ -33,11 +33,10 @@ type CategoryStat = {
 };
 
 function getCategoryStats(): readonly CategoryStat[] {
-  const counts = new Map<string, number>();
-  for (const item of REGISTRY.items) {
+  const counts = REGISTRY.items.reduce((accumulator, item) => {
     const key = item.category ?? "uncategorized";
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-  }
+    return accumulator.set(key, (accumulator.get(key) ?? 0) + 1);
+  }, new Map<string, number>());
   return [...counts.entries()]
     .map(([category, count]) => ({ category, count }))
     .sort((a, b) => a.category.localeCompare(b.category));

--- a/apps/registry/registry/default/chronological-timeline/chronological-timeline.tsx
+++ b/apps/registry/registry/default/chronological-timeline/chronological-timeline.tsx
@@ -319,6 +319,9 @@ export const ChronoEvent = forwardRef<HTMLElement, ChronoEventProps>(
     }, [eventId, setActiveId]);
 
     return (
+      /* Passive focus tracking: the container observes focus bubbling from
+         its interactive children to drive the scroll-spy active state. */
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
       <article
         aria-labelledby={`${eventId}-title`}
         className={cn(

--- a/apps/registry/types/registry.ts
+++ b/apps/registry/types/registry.ts
@@ -13,36 +13,36 @@ export type ComponentCategory =
   | "overlay"
   | "utility";
 
-type Stability = "stable" | "beta" | "experimental" | "deprecated";
+type Stability = "beta" | "deprecated" | "experimental" | "stable";
 
 type A11yKeyboardBinding = {
-  keys: string;
   action: string;
+  keys: string;
 };
 
 type A11ySchema = {
-  role?: string;
-  keyboard?: A11yKeyboardBinding[];
   aria?: string[];
   focusManagement?: "auto" | "manual";
+  keyboard?: A11yKeyboardBinding[];
   notes?: string;
+  role?: string;
 };
 
 export type UsageExample = {
-  title: string;
-  description?: string;
   code: string;
-  framework?: "react" | "next";
+  description?: string;
+  framework?: "next" | "react";
   storyId?: string;
+  title: string;
 };
 
-type PropDefinition = {
-  name: string;
-  type: string;
-  required?: boolean;
+type ComponentPropertyDefinition = {
   defaultValue?: string;
-  description?: string;
   deprecated?: boolean;
+  description?: string;
+  name: string;
+  required?: boolean;
+  type: string;
 };
 
 export type RegistryComponent = {
@@ -53,7 +53,7 @@ export type RegistryComponent = {
   examples?: UsageExample[];
   files: RegistryFile[];
   name: string;
-  props?: PropDefinition[];
+  props?: ComponentPropertyDefinition[];
   registryDependencies?: string[];
   replacedBy?: string;
   stability?: Stability;

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
       "ip-address": "10.1.1",
       "minimatch": ">=10.2.3",
       "eslint-plugin-react>minimatch": "^3.1.2",
+      "eslint-plugin-jsx-a11y>minimatch": "^3.1.2",
       "ajv": ">=8.18.0",
       "@eslint/eslintrc>ajv": "^6.12.4",
       "eslint>ajv": "^6.12.4",

--- a/packages/ui/eslint.config.js
+++ b/packages/ui/eslint.config.js
@@ -6,10 +6,45 @@ export default [
   },
   ...react,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+  },
+  {
     rules: {
       '@next/next/no-html-link-for-pages': 'off',
       'simple-import-sort/exports': 'off',
       'react/jsx-pascal-case': ['error', { allowAllCaps: true }],
+      'jsx-a11y/anchor-ambiguous-text': 'error',
+      'jsx-a11y/interactive-supports-focus': [
+        'error',
+        {
+          tabbable: [
+            'button',
+            'checkbox',
+            'link',
+            'progressbar',
+            'searchbox',
+            'slider',
+            'spinbutton',
+            'switch',
+            'textbox',
+          ],
+        },
+      ],
+      'jsx-a11y/lang': 'error',
+      'jsx-a11y/no-aria-hidden-on-focusable': 'error',
+      'jsx-a11y/no-interactive-element-to-noninteractive-role': 'error',
+      'jsx-a11y/no-noninteractive-element-interactions': [
+        'error',
+        {
+          body: ['onError', 'onLoad'],
+          iframe: ['onError', 'onLoad'],
+          img: ['onError', 'onLoad'],
+        },
+      ],
+      'jsx-a11y/no-noninteractive-tabindex': 'error',
+      'jsx-a11y/no-static-element-interactions': 'error',
     },
   },
   {

--- a/packages/ui/src/components/chronological-timeline/chronological-timeline.tsx
+++ b/packages/ui/src/components/chronological-timeline/chronological-timeline.tsx
@@ -319,6 +319,9 @@ export const ChronoEvent = forwardRef<HTMLElement, ChronoEventProps>(
     }, [eventId, setActiveId]);
 
     return (
+      /* Passive focus tracking: the container observes focus bubbling from
+         its interactive children to drive the scroll-spy active state. */
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
       <article
         aria-labelledby={`${eventId}-title`}
         className={cn(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   ip-address: 10.1.1
   minimatch: '>=10.2.3'
   eslint-plugin-react>minimatch: ^3.1.2
+  eslint-plugin-jsx-a11y>minimatch: ^3.1.2
   ajv: '>=8.18.0'
   '@eslint/eslintrc>ajv': ^6.12.4
   eslint>ajv: ^6.12.4
@@ -12125,7 +12126,7 @@ snapshots:
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 10.2.4
+      minimatch: 3.1.5
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1


### PR DESCRIPTION
Closes #417

## What

Three-layer fix for the ESLint enforcement gaps found in the config review:

1. **`fix(deps)`** — add `"eslint-plugin-jsx-a11y>minimatch": "^3.1.2"` to the root pnpm overrides. The global `minimatch >=10.2.3` override broke `jsx-a11y/label-has-associated-control` (`TypeError: (0, _minimatch.default) is not a function`), crashing every full registry lint. Lockfile delta is the carve-out only.
2. **`feat(lint)`** — both workspace eslint configs gain 8 rules beyond jsx-a11y *recommended* (strict `interactive-supports-focus`, `no-interactive-element-to-noninteractive-role`, `no-noninteractive-element-interactions`, `no-noninteractive-tabindex`, `no-static-element-interactions`, plus `anchor-ambiguous-text`, `lang`, `no-aria-hidden-on-focusable`) and `linterOptions.reportUnusedDisableDirectives: 'error'`. `apps/registry` (332 accumulated violations, never linted in CI) is brought to a green baseline.
3. **`ci`** — `Lint registry` step added to Quality Gates.

## Deliberately skipped rules (measured, not guessed)

- `prefer-tag-over-role`: 71 hits, all legitimate inline-SVG `role="img"` + ARIA widget roles; rule has no exemption options.
- strict `no-noninteractive-element-to-interactive-role`: flags the correct `li role="treeitem"` tree pattern (tree-view).

## Notable source changes

- `autoFocus` removed from report/request-component forms (4× `jsx-a11y/no-autofocus`).
- Deprecated `React.FormEvent` → `React.SyntheticEvent<HTMLFormElement>`; deprecated lucide `Github` icon → existing `GitHubMark`.
- `export-panel` origin state → `useSyncExternalStore` (fixes `react-hooks/set-state-in-effect`).
- Loop statements → functional rewrites (changelog, stats, mcp, oklch test).
- Scoped carve-outs only where key shapes are externally mandated: JSON-LD, web app manifest, MCP JSON-RPC (commented in `eslint.config.js`).
- `registry/default/chronological-timeline` regenerated copy included; other drifted generated files (pre-existing hsl→oklch drift from #404) intentionally left untouched.

## Validation

- `eslint .` green in both `packages/ui` and `apps/registry`
- `tsc --noEmit` green in both
- `pnpm build` green (turbo, 2 tasks)
- `pnpm test:once` green — 240 files / 1350 tests
- Browser-verified via agent-browser on the built app: `/report`, `/request-component`, `/templates/next-starter`, `/themes` — zero console errors; theme preset switch + export panel origin verified live.

## Follow-up candidates (out of scope)

- Port the 8-rule a11y block upstream to `vllnt/eslint-config` so all repos inherit it.
- Revisit the `max-lines-per-function` carve-outs (now in both workspaces) — raise the limit or refactor.
- Regenerate the drifted `registry/default/*` copies (hsl→oklch) in a dedicated PR.