### PR TITLE
fix(code-block): lazy-load react-syntax-highlighter out of the barrel

### DIFF
--- a/packages/ui/src/components/code-block/code-block.test.tsx
+++ b/packages/ui/src/components/code-block/code-block.test.tsx
@@ -16,6 +16,12 @@ describe("CodeBlock", () => {
 
       expect(container.firstChild).toHaveClass("custom-class");
     });
+
+    it("shows the raw code in the fallback before the highlighter loads", () => {
+      const { container } = render(<CodeBlock>const answer = 42;</CodeBlock>);
+
+      expect(container.textContent).toContain("const answer = 42;");
+    });
   });
 
   describe("accessibility", () => {

--- a/packages/ui/src/components/code-block/code-block.tsx
+++ b/packages/ui/src/components/code-block/code-block.tsx
@@ -1,17 +1,27 @@
 "use client";
 
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import {
+  type ComponentType,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { Check, Copy } from "lucide-react";
 import { useTheme } from "next-themes";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import {
-  oneDark,
-  oneLight,
-} from "react-syntax-highlighter/dist/esm/styles/prism";
+import type { SyntaxHighlighterProps } from "react-syntax-highlighter";
 
 import { cn } from "../../lib/utils";
 import { Button } from "../button/button";
+
+type PrismStyle = SyntaxHighlighterProps["style"];
+
+type LoadedHighlighter = {
+  oneDark: PrismStyle;
+  oneLight: PrismStyle;
+  SyntaxHighlighter: ComponentType<SyntaxHighlighterProps>;
+};
 
 type CodeBlockProps = {
   children: ReactNode;
@@ -58,14 +68,37 @@ export function CodeBlock({
   showLanguage = false,
 }: CodeBlockProps) {
   const [copied, setCopied] = useState(false);
+  // react-syntax-highlighter (~10MB) is dynamic-imported on mount so the
+  // @vllnt/ui barrel's static graph never reaches it — barrel consumers that
+  // never render a CodeBlock ship zero bytes of it. Null until the chunk loads.
+  const [highlighter, setHighlighter] = useState<LoadedHighlighter | null>(
+    null,
+  );
   const { systemTheme, theme } = useTheme();
 
   const resolvedTheme = theme === "system" ? systemTheme : theme;
   const isDark = resolvedTheme !== "light";
-  const codeStyle = isDark ? oneDark : oneLight;
   const code = extractTextFromChildren(children);
 
   const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let active = true;
+    void Promise.all([
+      import("react-syntax-highlighter"),
+      import("react-syntax-highlighter/dist/esm/styles/prism"),
+    ]).then(([module_, styles]) => {
+      if (!active) return;
+      setHighlighter({
+        oneDark: styles.oneDark,
+        oneLight: styles.oneLight,
+        SyntaxHighlighter: module_.Prism,
+      });
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   useEffect(() => {
     const element = scrollRef.current;
@@ -94,6 +127,9 @@ export function CodeBlock({
     }, 2000);
   };
 
+  const SyntaxHighlighter = highlighter?.SyntaxHighlighter;
+  const codeStyle = isDark ? highlighter?.oneDark : highlighter?.oneLight;
+
   return (
     <div
       className={cn(
@@ -105,27 +141,33 @@ export function CodeBlock({
         className="relative overflow-x-auto overflow-y-hidden touch-pan-y"
         ref={scrollRef}
       >
-        <SyntaxHighlighter
-          codeTagProps={{
-            className: "font-mono text-sm",
-            style: {
-              background: "transparent",
-              display: "block",
-            },
-          }}
-          customStyle={{
-            background: "oklch(var(--background))",
-            fontSize: "0.875rem",
-            margin: 0,
-            minWidth: "fit-content",
-            overflowY: "hidden",
-            padding: "1rem",
-          }}
-          language={language}
-          style={codeStyle}
-        >
-          {code}
-        </SyntaxHighlighter>
+        {SyntaxHighlighter ? (
+          <SyntaxHighlighter
+            codeTagProps={{
+              className: "font-mono text-sm",
+              style: {
+                background: "transparent",
+                display: "block",
+              },
+            }}
+            customStyle={{
+              background: "oklch(var(--background))",
+              fontSize: "0.875rem",
+              margin: 0,
+              minWidth: "fit-content",
+              overflowY: "hidden",
+              padding: "1rem",
+            }}
+            language={language}
+            style={codeStyle}
+          >
+            {code}
+          </SyntaxHighlighter>
+        ) : (
+          <pre className="m-0 min-w-fit overflow-y-hidden p-4 font-mono text-sm">
+            <code className="block bg-transparent">{code}</code>
+          </pre>
+        )}
         <div className="absolute right-2 top-2 flex items-center gap-2">
           {showLanguage ? (
             <span className="text-xs font-mono text-muted-foreground uppercase tracking-wider">


### PR DESCRIPTION
## Problem

`CodeBlock` statically imported `react-syntax-highlighter` (~10MB). Because it's re-exported from the `@vllnt/ui` barrel, every consumer importing **any** component pulled the highlighter into their bundle — even when `CodeBlock` is never rendered. Next.js `optimizePackageImports` / tree-shaking did not drop it in practice (`bundle: false` dist preserves the static per-file import).

## Fix

Lazy-load the highlighter (proposed fix #1). `CodeBlock` now dynamic-`import()`s `react-syntax-highlighter` + its prism styles on mount; a plain `<pre>` shows the raw code until the chunk loads, then swaps to highlighted output. The barrel API (`import { CodeBlock } from "@vllnt/ui"`) is unchanged — non-breaking.

Kept self-contained in `code-block.tsx` (no new sibling file) on purpose: the registry generator emits only `<name>.tsx` per shadcn item, so a sibling would ship a broken `npx shadcn add @vllnt/code-block` copy.

## Proof (acceptance criteria)

Built `dist/components/code-block/code-block.js`:

- **0** static `from "react-syntax-highlighter"` imports
- **2** dynamic `import("react-syntax-highlighter…")` calls → separate async chunk

→ barrel consumers that never render a `CodeBlock` ship **zero bytes** of `react-syntax-highlighter`. `bntvllnt.com` can drop its `patches/@vllnt__ui.patch` code-block hunk.

## Validation

- lint (changed files) ✓ · `tsc --noEmit` ✓ · tsup build (ESM + DTS) ✓ · vitest 4/4 ✓
- Playwright CT visual (Chromium): pixel-identical to the existing baseline → zero visual regression
- Added regression test: raw code visible in the fallback before the highlighter loads

## Notes

- `static-code` (server component) also imports the highlighter, but renders server-side and was confirmed not to leak via the barrel (the reporter only needed to patch `code-block.js`) — left untouched.
- The issue's adjacent ask (ship `ProfileSection` `as` prop in a stable release) is a separate release-cut concern, out of scope here.

Closes #419
