### PR TITLE
chore(release): prep 0.3.0 canary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ Release automation can regenerate this file from Conventional Commits with
 
 ## [Unreleased]
 
-> Target version: **`0.3.0`** - canary only; not yet published. See
-> [ROADMAP.md](./ROADMAP.md) for shipping criteria.
+> Target version: **`0.3.0`** - shipping as `0.3.0-canary.<sha>` on the npm
+> `canary` tag on every merge to main. The stable `latest` release is gated on
+> the [ROADMAP.md](./ROADMAP.md) shipping criteria and is not yet published.
 
 ### Added
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap — 0.3.0
 
-> Status: **planning** · Previous release: `v0.2.1` · Current canary: `0.2.1+85 components` · Tracking: [milestone TBD](https://github.com/vllnt/ui/milestones)
+> Status: **planning** · Previous release: `v0.2.1` · Current canary: `0.3.0-canary.<sha>` (+85 components) · Tracking: [milestone TBD](https://github.com/vllnt/ui/milestones)
 
 ## TLDR
 
@@ -219,9 +219,11 @@ Ship only when **all** of the following hold:
 - [ ] Google Rich Results Test: zero errors on `/components/[slug]` and `/design`.
 - [ ] CHANGELOG entry written, `/releases` shows `0.3.0` with notes.
 - [ ] `package.json` versions bumped:
-  - `packages/ui` → `0.3.0`
-  - `apps/registry` → `0.3.0`
-  - root → `0.3.0` (if applicable)
+  - [x] `packages/ui` → `0.3.0` (drives `0.3.0-canary.<sha>` on each merge to main)
+  - [x] `apps/registry` → `0.3.0`
+  - [ ] root → `0.3.0` (optional — private monorepo root, left at `0.1.0`)
+- [ ] At release, flip the registry's shadcn install target off the last published version:
+  - [ ] `PUBLISHED_VERSION` in `apps/registry/scripts/inline-component-source.ts` → `0.3.0` (stamps `@vllnt/ui@^0.3.0` + item/registry `version` into `registry.json`; kept at `0.2.1` during canary so `npx shadcn add` resolves to a published release)
 - [ ] Every closed issue is `Type`-tagged.
 - [ ] PR template in place (linked issue requirement enforced — already shipped via #152).
 

--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vllnt/ui-registry",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/registry/scripts/inline-component-source.ts
+++ b/apps/registry/scripts/inline-component-source.ts
@@ -41,7 +41,6 @@ const repoRoot = join(scriptDir, "../../..");
 const registryJsonPath = join(repoRoot, "apps/registry/registry.json");
 const componentsRoot = join(repoRoot, "packages/ui/src/components");
 const shimsRoot = join(repoRoot, "apps/registry/registry/default");
-const packageJsonPath = join(repoRoot, "packages/ui/package.json");
 
 const PACKAGE_NAME = "@vllnt/ui";
 const RESERVED_REGISTRY_NAMES = new Set([
@@ -121,11 +120,16 @@ type Registry = {
   version?: string;
 };
 
-const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
-  version: string;
-};
-const PACKAGE_VERSION = packageJson.version;
-const PACKAGE_VERSION_RANGE = `^${PACKAGE_VERSION}`;
+// The npm `latest` version external consumers install via shadcn. The registry
+// advertises this everywhere (item `dependencies` range + `version` stamps) so
+// `npx shadcn add` always resolves to a published release. Intentionally
+// decoupled from packages/ui/package.json, which runs ahead as the in-development
+// canary (e.g. 0.3.0-canary.<sha>, published on every merge to main — see
+// .github/workflows/publish.yml). Deriving the range from the canary version
+// would point installs at an unpublished version. Bump this only when a release
+// is published (see the release checklist in ROADMAP.md).
+const PUBLISHED_VERSION = "0.2.1";
+const PACKAGE_VERSION_RANGE = `^${PUBLISHED_VERSION}`;
 const PACKAGE_DEP = `${PACKAGE_NAME}@${PACKAGE_VERSION_RANGE}`;
 
 const readComponentMeta = (name: string): ComponentMeta => {
@@ -240,7 +244,7 @@ for (const item of registry.items) {
   // Defaults to the published @vllnt/ui version + "stable"; per-component
   // overrides come from packages/ui/src/components/<name>/meta.json if present.
   const meta = readComponentMeta(item.name);
-  item.version = PACKAGE_VERSION;
+  item.version = PUBLISHED_VERSION;
   item.stability = meta.stability ?? "stable";
   if (item.stability === "deprecated") {
     if (meta.replacedBy) {
@@ -302,7 +306,7 @@ for (const name of RESERVED_REGISTRY_NAMES) {
 registry.items.sort((a, b) => a.name.localeCompare(b.name));
 
 // Stamp top-level version + generatedAt so agents can detect schema/library changes.
-registry.version = PACKAGE_VERSION;
+registry.version = PUBLISHED_VERSION;
 registry.generatedAt = new Date().toISOString();
 
 // Validate: any deprecated component must declare replacedBy.
@@ -326,4 +330,4 @@ console.log(
 console.log(
   `All siblings/utilities now resolve through ${PACKAGE_NAME}@${PACKAGE_VERSION_RANGE}.`,
 );
-console.log(`Stamped version=${PACKAGE_VERSION} on ${processed} items.`);
+console.log(`Stamped version=${PUBLISHED_VERSION} on ${processed} items.`);

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-> Target version: **`0.3.0`** — canary only; not yet published. See [ROADMAP.md](../../ROADMAP.md) for shipping criteria.
+> Target version: **`0.3.0`** — shipping as `0.3.0-canary.<sha>` on the npm `canary` tag on every merge to main. The stable `latest` release is gated on the [ROADMAP.md](../../ROADMAP.md) shipping criteria and is not yet published.
 
 ### Added
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vllnt/ui",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "React component library — 225 components built on Radix UI, Tailwind CSS, and CVA",
   "license": "MIT",
   "author": "vllnt",


### PR DESCRIPTION
Closes #427

## What

Prep `0.3.0` as a **canary** — no stable release.

- `packages/ui` `0.2.1` → `0.3.0` — merges to `main` now publish `@vllnt/ui@0.3.0-canary.<sha>` on the npm `canary` tag (was mislabeled `0.2.1-canary.<sha>`, which semver-sorts below stable `latest`).
- `apps/registry` `0.1.0` → `0.3.0`.
- **Fix** `apps/registry/scripts/inline-component-source.ts`: decouple the shadcn install target from the in-dev canary version via a `PUBLISHED_VERSION` constant.
- Docs: `ROADMAP.md` status + cut-criteria checklist; `CHANGELOG.md` / `packages/ui/CHANGELOG.md` `[Unreleased]` note now describes the canary channel.

## Why the registry fix is needed

The registry build derives `@vllnt/ui@^<version>` from `packages/ui/package.json`, and the Dockerfile runs it on every deploy. Without the decouple, bumping to `0.3.0` would make the deployed `registry.json` advertise `@vllnt/ui@^0.3.0` — unpublished on `latest` (only `canary`), breaking `npx shadcn add` for external users. `PUBLISHED_VERSION` stays at the last released `0.2.1` until `0.3.0` actually ships.

## Does this break registry CSS?

No. The registry consumes `@vllnt/ui` via `workspace:*` (local source) and imports the CSS files directly — the version string has no effect on rendering. The OKLCH color-space change (#404) was the CSS-risk change and already landed on `main` before this.

## Not in this PR (release-time, gated by ROADMAP cut criteria)

- Rename CHANGELOG `[Unreleased]` → `[0.3.0]`.
- Tag `v0.3.0` / dispatch the Publish workflow.
- Flip `PUBLISHED_VERSION` → `0.3.0` (registry install target).

## Test plan

- [x] Ran `inline-component-source.ts` with `packages/ui` at `0.3.0` → `registry.json` stayed `@vllnt/ui@^0.2.1` / `version 0.2.1` (zero version drift; generated churn reverted).
- [x] Version sanity: `packages/ui` 0.3.0, `apps/registry` 0.3.0, committed `registry.json` install target `^0.2.1`.
- [ ] CI: Quality Gates (lint/typecheck/build/test) green.
