### PR TITLE
feat(components): AI components — reasoning, chain-of-thought, prompt-input (#411)

### DIFF
--- a/apps/registry/lib/component-metadata.json
+++ b/apps/registry/lib/component-metadata.json
@@ -732,6 +732,27 @@
     ],
     "title": "Category Filter"
   },
+  "chain-of-thought": {
+    "category": "ai",
+    "defaultStoryId": "ai-chainofthought--default",
+    "description": "Ordered, status-aware visualization of a model's chain of thought with per-step state.",
+    "name": "chain-of-thought",
+    "stories": [
+      {
+        "id": "ai-chainofthought--default",
+        "name": "Default"
+      },
+      {
+        "id": "ai-chainofthought--with-error",
+        "name": "With Error"
+      },
+      {
+        "id": "ai-chainofthought--all-complete",
+        "name": "All Complete"
+      }
+    ],
+    "title": "Chain of Thought"
+  },
   "chat-dock-section": {
     "category": "ai",
     "defaultStoryId": "layout-chatdocksection--default",
@@ -2791,6 +2812,31 @@
     ],
     "title": "Progress Tracker"
   },
+  "prompt-input": {
+    "category": "ai",
+    "defaultStoryId": "ai-promptinput--default",
+    "description": "Auto-growing prompt textarea with a submit affordance and optional toolbar slot.",
+    "name": "prompt-input",
+    "stories": [
+      {
+        "id": "ai-promptinput--default",
+        "name": "Default"
+      },
+      {
+        "id": "ai-promptinput--loading",
+        "name": "Loading"
+      },
+      {
+        "id": "ai-promptinput--with-toolbar",
+        "name": "With Toolbar"
+      },
+      {
+        "id": "ai-promptinput--disabled",
+        "name": "Disabled"
+      }
+    ],
+    "title": "Prompt Input"
+  },
   "prompt-templates": {
     "category": "ai",
     "defaultStoryId": "codereview--default",
@@ -2887,6 +2933,27 @@
       }
     ],
     "title": "Rating"
+  },
+  "reasoning": {
+    "category": "ai",
+    "defaultStoryId": "ai-reasoning--default",
+    "description": "Collapsible AI reasoning trace with streaming support and ordered or free-form steps.",
+    "name": "reasoning",
+    "stories": [
+      {
+        "id": "ai-reasoning--default",
+        "name": "Default"
+      },
+      {
+        "id": "ai-reasoning--streaming",
+        "name": "Streaming"
+      },
+      {
+        "id": "ai-reasoning--free-form",
+        "name": "Free Form"
+      }
+    ],
+    "title": "Reasoning"
   },
   "relationship-inspector": {
     "category": "content",

--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -819,6 +819,26 @@
       "stability": "stable"
     },
     {
+      "name": "chain-of-thought",
+      "type": "registry:component",
+      "title": "Chain of Thought",
+      "description": "Ordered, status-aware visualization of a model's chain of thought with per-step state.",
+      "files": [
+        {
+          "path": "registry/default/chain-of-thought/chain-of-thought.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1",
+        "lucide-react"
+      ],
+      "category": "ai",
+      "version": "0.2.1",
+      "stability": "stable"
+    },
+    {
       "name": "chat-dock-section",
       "type": "registry:component",
       "title": "Chat Dock Section",
@@ -3095,6 +3115,26 @@
       "stability": "stable"
     },
     {
+      "name": "prompt-input",
+      "type": "registry:component",
+      "title": "Prompt Input",
+      "description": "Auto-growing prompt textarea with a submit affordance and optional toolbar slot.",
+      "files": [
+        {
+          "path": "registry/default/prompt-input/prompt-input.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1",
+        "lucide-react"
+      ],
+      "category": "ai",
+      "version": "0.2.1",
+      "stability": "stable"
+    },
+    {
       "name": "prompt-templates",
       "type": "registry:component",
       "title": "Prompt Templates",
@@ -3187,6 +3227,26 @@
         "@vllnt/ui@^0.2.1"
       ],
       "category": "learning",
+      "version": "0.2.1",
+      "stability": "stable"
+    },
+    {
+      "name": "reasoning",
+      "type": "registry:component",
+      "title": "Reasoning",
+      "description": "Collapsible AI reasoning trace with streaming support and ordered or free-form steps.",
+      "files": [
+        {
+          "path": "registry/default/reasoning/reasoning.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": [],
+      "dependencies": [
+        "@vllnt/ui@^0.2.1",
+        "lucide-react"
+      ],
+      "category": "ai",
       "version": "0.2.1",
       "stability": "stable"
     },
@@ -4773,5 +4833,5 @@
     }
   ],
   "version": "0.2.1",
-  "generatedAt": "2026-06-15T19:29:07.199Z"
+  "generatedAt": "2026-06-17T00:54:55.557Z"
 }

--- a/apps/registry/registry/default/chain-of-thought/chain-of-thought.tsx
+++ b/apps/registry/registry/default/chain-of-thought/chain-of-thought.tsx
@@ -1,0 +1,130 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { Check, LoaderCircle, X } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+const markerVariants = cva(
+  "flex size-6 shrink-0 items-center justify-center rounded-full border text-xs font-medium",
+  {
+    defaultVariants: {
+      status: "pending",
+    },
+    variants: {
+      status: {
+        active: "border-primary bg-primary/10 text-primary",
+        complete: "border-transparent bg-primary text-primary-foreground",
+        error: "border-transparent bg-destructive text-destructive-foreground",
+        pending: "border-border bg-muted text-muted-foreground",
+      },
+    },
+  },
+);
+
+export type ChainOfThoughtStatus = NonNullable<
+  VariantProps<typeof markerVariants>["status"]
+>;
+
+export type ChainOfThoughtStep = {
+  /** Optional supporting detail shown under the title. */
+  description?: string;
+  /** Current status of the step. Defaults to "pending". */
+  status?: ChainOfThoughtStatus;
+  /** Short step title. */
+  title: string;
+};
+
+export type ChainOfThoughtProps = {
+  className?: string;
+  /** Ref forwarded to the root list element. */
+  ref?: React.Ref<HTMLOListElement>;
+  /** Ordered steps to render. */
+  steps: ChainOfThoughtStep[];
+};
+
+function StepMarkerIcon({
+  index,
+  status,
+}: {
+  index: number;
+  status: ChainOfThoughtStatus;
+}) {
+  if (status === "complete") {
+    return <Check className="size-3.5" />;
+  }
+  if (status === "error") {
+    return <X className="size-3.5" />;
+  }
+  if (status === "active") {
+    return <LoaderCircle className="size-3.5 animate-spin" />;
+  }
+  return <span>{index + 1}</span>;
+}
+
+function ChainOfThoughtItem({
+  index,
+  isLast,
+  step,
+}: {
+  index: number;
+  isLast: boolean;
+  step: ChainOfThoughtStep;
+}) {
+  const status = step.status ?? "pending";
+
+  return (
+    <li className="flex gap-3">
+      <div className="flex flex-col items-center">
+        <span className={markerVariants({ status })}>
+          <StepMarkerIcon index={index} status={status} />
+        </span>
+        {isLast ? null : <span className="my-1 w-px flex-1 bg-border" />}
+      </div>
+      <div className={cn("pb-4", isLast && "pb-0")}>
+        <p
+          className={cn(
+            "text-sm font-medium",
+            status === "pending" ? "text-muted-foreground" : "text-foreground",
+          )}
+        >
+          {step.title}
+        </p>
+        {step.description ? (
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {step.description}
+          </p>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+/**
+ * Ordered, status-aware visualization of a model's chain of thought.
+ *
+ * Renders a numbered vertical step list where each step carries a status
+ * ("pending" | "active" | "complete" | "error") reflected in its marker icon
+ * and color. A vertical rail links the steps.
+ *
+ * @example
+ * <ChainOfThought
+ *   steps={[
+ *     { status: "complete", title: "Read the file" },
+ *     { status: "active", title: "Apply the edit" },
+ *     { title: "Run the tests" },
+ *   ]}
+ * />
+ */
+export function ChainOfThought({ className, ref, steps }: ChainOfThoughtProps) {
+  return (
+    <ol className={cn("flex flex-col", className)} ref={ref}>
+      {steps.map((step, index) => (
+        <ChainOfThoughtItem
+          index={index}
+          isLast={index === steps.length - 1}
+          key={`${index}-${step.title}`}
+          step={step}
+        />
+      ))}
+    </ol>
+  );
+}

--- a/apps/registry/registry/default/chain-of-thought/chain-of-thought.tsx
+++ b/apps/registry/registry/default/chain-of-thought/chain-of-thought.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from "react";
+
 import { cva, type VariantProps } from "class-variance-authority";
 import { Check, LoaderCircle, X } from "lucide-react";
 
@@ -35,8 +37,6 @@ export type ChainOfThoughtStep = {
 
 export type ChainOfThoughtProps = {
   className?: string;
-  /** Ref forwarded to the root list element. */
-  ref?: React.Ref<HTMLOListElement>;
   /** Ordered steps to render. */
   steps: ChainOfThoughtStep[];
 };
@@ -114,8 +114,8 @@ function ChainOfThoughtItem({
  *   ]}
  * />
  */
-export function ChainOfThought({ className, ref, steps }: ChainOfThoughtProps) {
-  return (
+export const ChainOfThought = forwardRef<HTMLOListElement, ChainOfThoughtProps>(
+  ({ className, steps }, ref) => (
     <ol className={cn("flex flex-col", className)} ref={ref}>
       {steps.map((step, index) => (
         <ChainOfThoughtItem
@@ -126,5 +126,6 @@ export function ChainOfThought({ className, ref, steps }: ChainOfThoughtProps) {
         />
       ))}
     </ol>
-  );
-}
+  ),
+);
+ChainOfThought.displayName = "ChainOfThought";

--- a/apps/registry/registry/default/prompt-input/prompt-input.tsx
+++ b/apps/registry/registry/default/prompt-input/prompt-input.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { LoaderCircle, SendHorizontal } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+const SUBMIT_KEY = "Enter";
+const REM_PER_ROW = 1.5;
+
+function autoResize(element: HTMLTextAreaElement | null): void {
+  if (element === null) {
+    return;
+  }
+  element.style.height = "auto";
+  element.style.height = `${element.scrollHeight}px`;
+}
+
+export type PromptInputProps = {
+  className?: string;
+  /** Uncontrolled initial value. */
+  defaultValue?: string;
+  /** Disables editing and sending. */
+  disabled?: boolean;
+  /** Shows a spinner while a request runs. */
+  isLoading?: boolean;
+  /** Row count before the field scrolls. */
+  maxRows?: number;
+  /** Row count at rest; sets the initial height. */
+  minRows?: number;
+  /** Called with the value on submit. */
+  onSubmit?: (value: string) => void;
+  /** Called whenever the value changes. */
+  onValueChange?: (value: string) => void;
+  /** Placeholder text. */
+  placeholder?: string;
+  /** Ref forwarded to the underlying textarea. */
+  ref?: React.Ref<HTMLTextAreaElement>;
+  /** Accessible label for the submit button. */
+  submitLabel?: string;
+  /** Optional controls rendered to the left of the submit button. */
+  toolbar?: React.ReactNode;
+  /** Controlled value. */
+  value?: string;
+};
+
+function applyRef(
+  ref: React.Ref<HTMLTextAreaElement> | undefined,
+  node: HTMLTextAreaElement | null,
+): void {
+  if (typeof ref === "function") {
+    ref(node);
+    return;
+  }
+  if (ref) {
+    ref.current = node;
+  }
+}
+
+function useMergedRef(ref: React.Ref<HTMLTextAreaElement> | undefined): {
+  assignRef: (node: HTMLTextAreaElement | null) => void;
+  innerRef: React.RefObject<HTMLTextAreaElement | null>;
+} {
+  const innerRef = useRef<HTMLTextAreaElement>(null);
+
+  const assignRef = useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      innerRef.current = node;
+      applyRef(ref, node);
+    },
+    [ref],
+  );
+
+  return { assignRef, innerRef };
+}
+
+function usePromptInput({
+  defaultValue,
+  isControlled,
+  onSubmit,
+  onValueChange,
+  ref,
+  value,
+}: {
+  defaultValue: string;
+  isControlled: boolean;
+  onSubmit?: (value: string) => void;
+  onValueChange?: (value: string) => void;
+  ref?: React.Ref<HTMLTextAreaElement>;
+  value?: string;
+}) {
+  const { assignRef, innerRef } = useMergedRef(ref);
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const currentValue = isControlled ? (value ?? "") : internalValue;
+
+  useEffect(() => {
+    autoResize(innerRef.current);
+  }, [currentValue, innerRef]);
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      if (!isControlled) {
+        setInternalValue(event.target.value);
+      }
+      onValueChange?.(event.target.value);
+    },
+    [isControlled, onValueChange],
+  );
+
+  const submit = useCallback(() => {
+    if (currentValue.trim().length === 0) {
+      return;
+    }
+    onSubmit?.(currentValue);
+    if (!isControlled) {
+      setInternalValue("");
+    }
+  }, [currentValue, isControlled, onSubmit]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === SUBMIT_KEY && !event.shiftKey) {
+        event.preventDefault();
+        submit();
+      }
+    },
+    [submit],
+  );
+
+  const handleFormSubmit = useCallback(
+    (event: React.SyntheticEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      submit();
+    },
+    [submit],
+  );
+
+  return {
+    assignRef,
+    currentValue,
+    handleChange,
+    handleFormSubmit,
+    handleKeyDown,
+  };
+}
+
+function PromptInputActions({
+  canSubmit,
+  isLoading,
+  submitLabel,
+  toolbar,
+}: {
+  canSubmit: boolean;
+  isLoading: boolean;
+  submitLabel: string;
+  toolbar?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div className="flex items-center gap-1">{toolbar}</div>
+      <button
+        aria-label={submitLabel}
+        className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-40"
+        disabled={!canSubmit}
+        type="submit"
+      >
+        {isLoading ? (
+          <LoaderCircle className="size-4 animate-spin" />
+        ) : (
+          <SendHorizontal className="size-4" />
+        )}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Auto-growing prompt textarea with a submit affordance and optional toolbar.
+ *
+ * Works controlled (`value` + `onValueChange`) or uncontrolled
+ * (`defaultValue`). The field grows with its content between `minRows` and
+ * `maxRows`, then scrolls. Enter submits; Shift+Enter inserts a newline.
+ *
+ * @example
+ * <PromptInput onSubmit={(text) => send(text)} />
+ */
+export function PromptInput({
+  className,
+  defaultValue = "",
+  disabled = false,
+  isLoading = false,
+  maxRows = 8,
+  minRows = 1,
+  onSubmit,
+  onValueChange,
+  placeholder = "Send a message…",
+  ref,
+  submitLabel = "Send",
+  toolbar,
+  value,
+}: PromptInputProps) {
+  const isControlled = value !== undefined;
+  const {
+    assignRef,
+    currentValue,
+    handleChange,
+    handleFormSubmit,
+    handleKeyDown,
+  } = usePromptInput({
+    defaultValue,
+    isControlled,
+    onSubmit,
+    onValueChange,
+    ref,
+    value,
+  });
+
+  const canSubmit = !disabled && !isLoading && currentValue.trim().length > 0;
+
+  return (
+    <form
+      className={cn(
+        "flex flex-col gap-2 rounded-2xl border border-border bg-background p-2 shadow-sm transition-colors focus-within:ring-1 focus-within:ring-ring",
+        className,
+      )}
+      onSubmit={handleFormSubmit}
+    >
+      <textarea
+        aria-label={placeholder}
+        className="w-full resize-none bg-transparent px-2 py-1.5 text-sm text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={disabled}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        ref={assignRef}
+        style={{
+          maxHeight: `${maxRows * REM_PER_ROW}rem`,
+          minHeight: `${minRows * REM_PER_ROW}rem`,
+          overflowY: "auto",
+        }}
+        value={currentValue}
+      />
+      <PromptInputActions
+        canSubmit={canSubmit}
+        isLoading={isLoading}
+        submitLabel={submitLabel}
+        toolbar={toolbar}
+      />
+    </form>
+  );
+}

--- a/apps/registry/registry/default/prompt-input/prompt-input.tsx
+++ b/apps/registry/registry/default/prompt-input/prompt-input.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
 
 import { LoaderCircle, SendHorizontal } from "lucide-react";
 
@@ -35,8 +35,6 @@ export type PromptInputProps = {
   onValueChange?: (value: string) => void;
   /** Placeholder text. */
   placeholder?: string;
-  /** Ref forwarded to the underlying textarea. */
-  ref?: React.Ref<HTMLTextAreaElement>;
   /** Accessible label for the submit button. */
   submitLabel?: string;
   /** Optional controls rendered to the left of the submit button. */
@@ -46,7 +44,7 @@ export type PromptInputProps = {
 };
 
 function applyRef(
-  ref: React.Ref<HTMLTextAreaElement> | undefined,
+  ref: React.ForwardedRef<HTMLTextAreaElement>,
   node: HTMLTextAreaElement | null,
 ): void {
   if (typeof ref === "function") {
@@ -58,7 +56,7 @@ function applyRef(
   }
 }
 
-function useMergedRef(ref: React.Ref<HTMLTextAreaElement> | undefined): {
+function useMergedRef(ref: React.ForwardedRef<HTMLTextAreaElement>): {
   assignRef: (node: HTMLTextAreaElement | null) => void;
   innerRef: React.RefObject<HTMLTextAreaElement | null>;
 } {
@@ -87,7 +85,7 @@ function usePromptInput({
   isControlled: boolean;
   onSubmit?: (value: string) => void;
   onValueChange?: (value: string) => void;
-  ref?: React.Ref<HTMLTextAreaElement>;
+  ref: React.ForwardedRef<HTMLTextAreaElement>;
   value?: string;
 }) {
   const { assignRef, innerRef } = useMergedRef(ref);
@@ -185,68 +183,73 @@ function PromptInputActions({
  * @example
  * <PromptInput onSubmit={(text) => send(text)} />
  */
-export function PromptInput({
-  className,
-  defaultValue = "",
-  disabled = false,
-  isLoading = false,
-  maxRows = 8,
-  minRows = 1,
-  onSubmit,
-  onValueChange,
-  placeholder = "Send a message…",
-  ref,
-  submitLabel = "Send",
-  toolbar,
-  value,
-}: PromptInputProps) {
-  const isControlled = value !== undefined;
-  const {
-    assignRef,
-    currentValue,
-    handleChange,
-    handleFormSubmit,
-    handleKeyDown,
-  } = usePromptInput({
-    defaultValue,
-    isControlled,
-    onSubmit,
-    onValueChange,
+export const PromptInput = forwardRef<HTMLTextAreaElement, PromptInputProps>(
+  (
+    {
+      className,
+      defaultValue = "",
+      disabled = false,
+      isLoading = false,
+      maxRows = 8,
+      minRows = 1,
+      onSubmit,
+      onValueChange,
+      placeholder = "Send a message…",
+      submitLabel = "Send",
+      toolbar,
+      value,
+    },
     ref,
-    value,
-  });
+  ) => {
+    const isControlled = value !== undefined;
+    const {
+      assignRef,
+      currentValue,
+      handleChange,
+      handleFormSubmit,
+      handleKeyDown,
+    } = usePromptInput({
+      defaultValue,
+      isControlled,
+      onSubmit,
+      onValueChange,
+      ref,
+      value,
+    });
 
-  const canSubmit = !disabled && !isLoading && currentValue.trim().length > 0;
+    const canSubmit = !disabled && !isLoading && currentValue.trim().length > 0;
 
-  return (
-    <form
-      className={cn(
-        "flex flex-col gap-2 rounded-2xl border border-border bg-background p-2 shadow-sm transition-colors focus-within:ring-1 focus-within:ring-ring",
-        className,
-      )}
-      onSubmit={handleFormSubmit}
-    >
-      <textarea
-        aria-label={placeholder}
-        className="w-full resize-none bg-transparent px-2 py-1.5 text-sm text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
-        disabled={disabled}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        placeholder={placeholder}
-        ref={assignRef}
-        style={{
-          maxHeight: `${maxRows * REM_PER_ROW}rem`,
-          minHeight: `${minRows * REM_PER_ROW}rem`,
-          overflowY: "auto",
-        }}
-        value={currentValue}
-      />
-      <PromptInputActions
-        canSubmit={canSubmit}
-        isLoading={isLoading}
-        submitLabel={submitLabel}
-        toolbar={toolbar}
-      />
-    </form>
-  );
-}
+    return (
+      <form
+        className={cn(
+          "flex flex-col gap-2 rounded-2xl border border-border bg-background p-2 shadow-sm transition-colors focus-within:ring-1 focus-within:ring-ring",
+          className,
+        )}
+        onSubmit={handleFormSubmit}
+      >
+        <textarea
+          aria-label={placeholder}
+          className="w-full resize-none bg-transparent px-2 py-1.5 text-sm text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={disabled}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          ref={assignRef}
+          style={{
+            maxHeight: `${maxRows * REM_PER_ROW}rem`,
+            minHeight: `${minRows * REM_PER_ROW}rem`,
+            overflowY: "auto",
+          }}
+          value={currentValue}
+        />
+        <PromptInputActions
+          canSubmit={canSubmit}
+          isLoading={isLoading}
+          submitLabel={submitLabel}
+          toolbar={toolbar}
+        />
+      </form>
+    );
+  },
+);
+PromptInput.displayName = "PromptInput";

--- a/apps/registry/registry/default/reasoning/reasoning.tsx
+++ b/apps/registry/registry/default/reasoning/reasoning.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useId, useState } from "react";
+import { forwardRef, useCallback, useEffect, useId, useState } from "react";
 
 import { Brain, ChevronDown } from "lucide-react";
 
@@ -16,8 +16,6 @@ export type ReasoningProps = {
   isStreaming?: boolean;
   /** Called whenever the expanded state changes. */
   onOpenChange?: (open: boolean) => void;
-  /** Ref forwarded to the root element. */
-  ref?: React.Ref<HTMLDivElement>;
   /** Reasoning steps rendered as an ordered list when expanded. */
   steps?: string[];
 };
@@ -110,55 +108,53 @@ function ReasoningContent({
  * @example
  * <Reasoning duration={4} steps={["Parse the request", "Check the cache"]} />
  */
-export function Reasoning({
-  children,
-  className,
-  duration,
-  isStreaming = false,
-  onOpenChange,
-  ref,
-  steps,
-}: ReasoningProps) {
-  const [isOpen, setIsOpen] = useState(isStreaming);
-  const contentId = useId();
+export const Reasoning = forwardRef<HTMLDivElement, ReasoningProps>(
+  (
+    { children, className, duration, isStreaming = false, onOpenChange, steps },
+    ref,
+  ) => {
+    const [isOpen, setIsOpen] = useState(isStreaming);
+    const contentId = useId();
 
-  useEffect(() => {
-    if (isStreaming) {
-      requestAnimationFrame(() => {
-        setIsOpen(true);
+    useEffect(() => {
+      if (isStreaming) {
+        requestAnimationFrame(() => {
+          setIsOpen(true);
+        });
+      }
+    }, [isStreaming]);
+
+    const handleToggle = useCallback(() => {
+      setIsOpen((previous) => {
+        const next = !previous;
+        onOpenChange?.(next);
+        return next;
       });
-    }
-  }, [isStreaming]);
+    }, [onOpenChange]);
 
-  const handleToggle = useCallback(() => {
-    setIsOpen((previous) => {
-      const next = !previous;
-      onOpenChange?.(next);
-      return next;
-    });
-  }, [onOpenChange]);
-
-  return (
-    <div
-      className={cn("rounded-lg border border-border bg-muted/30", className)}
-      ref={ref}
-    >
-      <ReasoningTrigger
-        contentId={contentId}
-        duration={duration}
-        isOpen={isOpen}
-        isStreaming={isStreaming}
-        onToggle={handleToggle}
-      />
-      {isOpen ? (
-        <ReasoningContent
+    return (
+      <div
+        className={cn("rounded-lg border border-border bg-muted/30", className)}
+        ref={ref}
+      >
+        <ReasoningTrigger
           contentId={contentId}
+          duration={duration}
+          isOpen={isOpen}
           isStreaming={isStreaming}
-          steps={steps}
-        >
-          {children}
-        </ReasoningContent>
-      ) : null}
-    </div>
-  );
-}
+          onToggle={handleToggle}
+        />
+        {isOpen ? (
+          <ReasoningContent
+            contentId={contentId}
+            isStreaming={isStreaming}
+            steps={steps}
+          >
+            {children}
+          </ReasoningContent>
+        ) : null}
+      </div>
+    );
+  },
+);
+Reasoning.displayName = "Reasoning";

--- a/apps/registry/registry/default/reasoning/reasoning.tsx
+++ b/apps/registry/registry/default/reasoning/reasoning.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useCallback, useEffect, useId, useState } from "react";
+
+import { Brain, ChevronDown } from "lucide-react";
+
+import { cn } from "@vllnt/ui";
+
+export type ReasoningProps = {
+  /** Free-form reasoning content; renders when `steps` is absent. */
+  children?: React.ReactNode;
+  className?: string;
+  /** Seconds the model spent reasoning, shown in the header. */
+  duration?: number;
+  /** Whether the reasoning trace is still streaming; auto-expands the panel. */
+  isStreaming?: boolean;
+  /** Called whenever the expanded state changes. */
+  onOpenChange?: (open: boolean) => void;
+  /** Ref forwarded to the root element. */
+  ref?: React.Ref<HTMLDivElement>;
+  /** Reasoning steps rendered as an ordered list when expanded. */
+  steps?: string[];
+};
+
+function ReasoningTrigger({
+  contentId,
+  duration,
+  isOpen,
+  isStreaming,
+  onToggle,
+}: {
+  contentId: string;
+  duration?: number;
+  isOpen: boolean;
+  isStreaming: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      aria-controls={contentId}
+      aria-expanded={isOpen}
+      className="flex w-full items-center gap-2 px-3 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      onClick={onToggle}
+      type="button"
+    >
+      <Brain className="size-4 shrink-0" />
+      <span className="font-medium">
+        {isStreaming ? "Reasoning" : "Reasoned"}
+        {typeof duration === "number" ? ` for ${duration}s` : null}
+      </span>
+      {isStreaming ? <span className="animate-pulse">&hellip;</span> : null}
+      <ChevronDown
+        className={cn(
+          "ml-auto size-4 shrink-0 transition-transform",
+          isOpen ? "rotate-180" : "rotate-0",
+        )}
+      />
+    </button>
+  );
+}
+
+function ReasoningContent({
+  children,
+  contentId,
+  isStreaming,
+  steps,
+}: {
+  children?: React.ReactNode;
+  contentId: string;
+  isStreaming: boolean;
+  steps?: string[];
+}) {
+  const hasSteps = steps !== undefined && steps.length > 0;
+
+  return (
+    <div
+      className="border-t border-border px-3 py-2 text-sm text-muted-foreground"
+      id={contentId}
+    >
+      {hasSteps ? (
+        <ol className="list-decimal space-y-1 pl-4">
+          {steps.map((step, index) => (
+            <li
+              className="whitespace-pre-wrap"
+              key={`${index}-${step.slice(0, 12)}`}
+            >
+              {step}
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <div className="whitespace-pre-wrap">{children}</div>
+      )}
+      {isStreaming ? (
+        <span aria-hidden className="ml-0.5 animate-pulse">
+          &#9611;
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Collapsible AI reasoning trace block.
+ *
+ * Shows a toggleable header ("Reasoning" while streaming, "Reasoned" once
+ * settled) and an expandable body that renders either ordered `steps` or
+ * free-form `children`. Auto-expands while `isStreaming` is true.
+ *
+ * @example
+ * <Reasoning duration={4} steps={["Parse the request", "Check the cache"]} />
+ */
+export function Reasoning({
+  children,
+  className,
+  duration,
+  isStreaming = false,
+  onOpenChange,
+  ref,
+  steps,
+}: ReasoningProps) {
+  const [isOpen, setIsOpen] = useState(isStreaming);
+  const contentId = useId();
+
+  useEffect(() => {
+    if (isStreaming) {
+      requestAnimationFrame(() => {
+        setIsOpen(true);
+      });
+    }
+  }, [isStreaming]);
+
+  const handleToggle = useCallback(() => {
+    setIsOpen((previous) => {
+      const next = !previous;
+      onOpenChange?.(next);
+      return next;
+    });
+  }, [onOpenChange]);
+
+  return (
+    <div
+      className={cn("rounded-lg border border-border bg-muted/30", className)}
+      ref={ref}
+    >
+      <ReasoningTrigger
+        contentId={contentId}
+        duration={duration}
+        isOpen={isOpen}
+        isStreaming={isStreaming}
+        onToggle={handleToggle}
+      />
+      {isOpen ? (
+        <ReasoningContent
+          contentId={contentId}
+          isStreaming={isStreaming}
+          steps={steps}
+        >
+          {children}
+        </ReasoningContent>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/components/chain-of-thought/chain-of-thought.stories.tsx
+++ b/packages/ui/src/components/chain-of-thought/chain-of-thought.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ChainOfThought } from "./chain-of-thought";
+
+const meta = {
+  title: "AI/ChainOfThought",
+  component: ChainOfThought,
+  args: {
+    steps: [
+      { description: "Loaded src/index.ts", status: "complete", title: "Read the file" },
+      { status: "active", title: "Apply the edit" },
+      { title: "Run the test suite" },
+    ],
+  },
+} satisfies Meta<typeof ChainOfThought>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithError: Story = {
+  args: {
+    steps: [
+      { status: "complete", title: "Fetch the dataset" },
+      { description: "Connection timed out", status: "error", title: "Validate rows" },
+      { title: "Write the report" },
+    ],
+  },
+};
+
+export const AllComplete: Story = {
+  args: {
+    steps: [
+      { status: "complete", title: "Plan" },
+      { status: "complete", title: "Build" },
+      { status: "complete", title: "Ship" },
+    ],
+  },
+};

--- a/packages/ui/src/components/chain-of-thought/chain-of-thought.test.tsx
+++ b/packages/ui/src/components/chain-of-thought/chain-of-thought.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ChainOfThought, type ChainOfThoughtStep } from "./chain-of-thought";
+
+const STEPS: ChainOfThoughtStep[] = [
+  { status: "complete", title: "Read the file" },
+  { status: "active", title: "Apply the edit" },
+  { title: "Run the tests" },
+];
+
+describe("ChainOfThought", () => {
+  describe("rendering", () => {
+    it("renders correctly", () => {
+      const { container } = render(<ChainOfThought steps={STEPS} />);
+
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("applies custom className", () => {
+      const { container } = render(
+        <ChainOfThought className="custom-class" steps={STEPS} />,
+      );
+
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+
+    it("renders one list item per step", () => {
+      render(<ChainOfThought steps={STEPS} />);
+
+      expect(screen.getAllByRole("listitem")).toHaveLength(STEPS.length);
+    });
+
+    it("renders titles and descriptions", () => {
+      render(
+        <ChainOfThought
+          steps={[{ description: "loaded index.ts", title: "Read the file" }]}
+        />,
+      );
+
+      expect(screen.getByText("Read the file")).toBeInTheDocument();
+      expect(screen.getByText("loaded index.ts")).toBeInTheDocument();
+    });
+
+    it("numbers pending steps", () => {
+      render(<ChainOfThought steps={[{ title: "Only step" }]} />);
+
+      expect(screen.getByText("1")).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("renders an ordered list", () => {
+      const { container } = render(<ChainOfThought steps={STEPS} />);
+
+      expect(container.querySelector("ol")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/chain-of-thought/chain-of-thought.tsx
+++ b/packages/ui/src/components/chain-of-thought/chain-of-thought.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from "react";
+
 import { cva, type VariantProps } from "class-variance-authority";
 import { Check, LoaderCircle, X } from "lucide-react";
 
@@ -35,8 +37,6 @@ export type ChainOfThoughtStep = {
 
 export type ChainOfThoughtProps = {
   className?: string;
-  /** Ref forwarded to the root list element. */
-  ref?: React.Ref<HTMLOListElement>;
   /** Ordered steps to render. */
   steps: ChainOfThoughtStep[];
 };
@@ -114,8 +114,8 @@ function ChainOfThoughtItem({
  *   ]}
  * />
  */
-export function ChainOfThought({ className, ref, steps }: ChainOfThoughtProps) {
-  return (
+export const ChainOfThought = forwardRef<HTMLOListElement, ChainOfThoughtProps>(
+  ({ className, steps }, ref) => (
     <ol className={cn("flex flex-col", className)} ref={ref}>
       {steps.map((step, index) => (
         <ChainOfThoughtItem
@@ -126,5 +126,6 @@ export function ChainOfThought({ className, ref, steps }: ChainOfThoughtProps) {
         />
       ))}
     </ol>
-  );
-}
+  ),
+);
+ChainOfThought.displayName = "ChainOfThought";

--- a/packages/ui/src/components/chain-of-thought/chain-of-thought.tsx
+++ b/packages/ui/src/components/chain-of-thought/chain-of-thought.tsx
@@ -1,0 +1,130 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { Check, LoaderCircle, X } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+
+const markerVariants = cva(
+  "flex size-6 shrink-0 items-center justify-center rounded-full border text-xs font-medium",
+  {
+    defaultVariants: {
+      status: "pending",
+    },
+    variants: {
+      status: {
+        active: "border-primary bg-primary/10 text-primary",
+        complete: "border-transparent bg-primary text-primary-foreground",
+        error: "border-transparent bg-destructive text-destructive-foreground",
+        pending: "border-border bg-muted text-muted-foreground",
+      },
+    },
+  },
+);
+
+export type ChainOfThoughtStatus = NonNullable<
+  VariantProps<typeof markerVariants>["status"]
+>;
+
+export type ChainOfThoughtStep = {
+  /** Optional supporting detail shown under the title. */
+  description?: string;
+  /** Current status of the step. Defaults to "pending". */
+  status?: ChainOfThoughtStatus;
+  /** Short step title. */
+  title: string;
+};
+
+export type ChainOfThoughtProps = {
+  className?: string;
+  /** Ref forwarded to the root list element. */
+  ref?: React.Ref<HTMLOListElement>;
+  /** Ordered steps to render. */
+  steps: ChainOfThoughtStep[];
+};
+
+function StepMarkerIcon({
+  index,
+  status,
+}: {
+  index: number;
+  status: ChainOfThoughtStatus;
+}) {
+  if (status === "complete") {
+    return <Check className="size-3.5" />;
+  }
+  if (status === "error") {
+    return <X className="size-3.5" />;
+  }
+  if (status === "active") {
+    return <LoaderCircle className="size-3.5 animate-spin" />;
+  }
+  return <span>{index + 1}</span>;
+}
+
+function ChainOfThoughtItem({
+  index,
+  isLast,
+  step,
+}: {
+  index: number;
+  isLast: boolean;
+  step: ChainOfThoughtStep;
+}) {
+  const status = step.status ?? "pending";
+
+  return (
+    <li className="flex gap-3">
+      <div className="flex flex-col items-center">
+        <span className={markerVariants({ status })}>
+          <StepMarkerIcon index={index} status={status} />
+        </span>
+        {isLast ? null : <span className="my-1 w-px flex-1 bg-border" />}
+      </div>
+      <div className={cn("pb-4", isLast && "pb-0")}>
+        <p
+          className={cn(
+            "text-sm font-medium",
+            status === "pending" ? "text-muted-foreground" : "text-foreground",
+          )}
+        >
+          {step.title}
+        </p>
+        {step.description ? (
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {step.description}
+          </p>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+/**
+ * Ordered, status-aware visualization of a model's chain of thought.
+ *
+ * Renders a numbered vertical step list where each step carries a status
+ * ("pending" | "active" | "complete" | "error") reflected in its marker icon
+ * and color. A vertical rail links the steps.
+ *
+ * @example
+ * <ChainOfThought
+ *   steps={[
+ *     { status: "complete", title: "Read the file" },
+ *     { status: "active", title: "Apply the edit" },
+ *     { title: "Run the tests" },
+ *   ]}
+ * />
+ */
+export function ChainOfThought({ className, ref, steps }: ChainOfThoughtProps) {
+  return (
+    <ol className={cn("flex flex-col", className)} ref={ref}>
+      {steps.map((step, index) => (
+        <ChainOfThoughtItem
+          index={index}
+          isLast={index === steps.length - 1}
+          key={`${index}-${step.title}`}
+          step={step}
+        />
+      ))}
+    </ol>
+  );
+}

--- a/packages/ui/src/components/chain-of-thought/index.ts
+++ b/packages/ui/src/components/chain-of-thought/index.ts
@@ -1,0 +1,6 @@
+export {
+  ChainOfThought,
+  type ChainOfThoughtProps,
+  type ChainOfThoughtStatus,
+  type ChainOfThoughtStep,
+} from "./chain-of-thought";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1361,3 +1361,11 @@ export {
 } from "./model-selector";
 export { SidebarToggle, type SidebarToggleProps } from "./sidebar-toggle";
 export { ThinkingBlock, type ThinkingBlockProps } from "./thinking-block";
+export { Reasoning, type ReasoningProps } from "./reasoning";
+export {
+  ChainOfThought,
+  type ChainOfThoughtProps,
+  type ChainOfThoughtStatus,
+  type ChainOfThoughtStep,
+} from "./chain-of-thought";
+export { PromptInput, type PromptInputProps } from "./prompt-input";

--- a/packages/ui/src/components/prompt-input/index.ts
+++ b/packages/ui/src/components/prompt-input/index.ts
@@ -1,0 +1,1 @@
+export { PromptInput, type PromptInputProps } from "./prompt-input";

--- a/packages/ui/src/components/prompt-input/prompt-input.stories.tsx
+++ b/packages/ui/src/components/prompt-input/prompt-input.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PromptInput } from "./prompt-input";
+
+const meta = {
+  args: {
+    placeholder: "Ask anything…",
+  },
+  component: PromptInput,
+  title: "AI/PromptInput",
+} satisfies Meta<typeof PromptInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Loading: Story = {
+  args: {
+    isLoading: true,
+    value: "Generating a response",
+  },
+};
+
+export const WithToolbar: Story = {
+  args: {
+    toolbar: (
+      <button
+        className="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground"
+        type="button"
+      >
+        Attach
+      </button>
+    ),
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    value: "Read-only prompt",
+  },
+};

--- a/packages/ui/src/components/prompt-input/prompt-input.test.tsx
+++ b/packages/ui/src/components/prompt-input/prompt-input.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PromptInput } from "./prompt-input";
+
+describe("PromptInput", () => {
+  describe("rendering", () => {
+    it("renders correctly", () => {
+      const { container } = render(<PromptInput />);
+
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("applies custom className", () => {
+      const { container } = render(<PromptInput className="custom-class" />);
+
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+
+    it("renders the toolbar slot", () => {
+      render(<PromptInput toolbar={<span>Attach</span>} />);
+
+      expect(screen.getByText("Attach")).toBeInTheDocument();
+    });
+  });
+
+  describe("interactions", () => {
+    it("updates the value as the user types (uncontrolled)", () => {
+      render(<PromptInput />);
+      const textarea = screen.getByRole("textbox");
+
+      fireEvent.change(textarea, { target: { value: "hello" } });
+
+      expect(textarea).toHaveValue("hello");
+    });
+
+    it("calls onValueChange when typing", () => {
+      const onValueChange = vi.fn();
+      render(<PromptInput onValueChange={onValueChange} />);
+
+      fireEvent.change(screen.getByRole("textbox"), {
+        target: { value: "hi" },
+      });
+
+      expect(onValueChange).toHaveBeenCalledWith("hi");
+    });
+
+    it("submits on Enter without Shift", () => {
+      const onSubmit = vi.fn();
+      render(<PromptInput onSubmit={onSubmit} />);
+      const textarea = screen.getByRole("textbox");
+
+      fireEvent.change(textarea, { target: { value: "send me" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+
+      expect(onSubmit).toHaveBeenCalledWith("send me");
+    });
+
+    it("does not submit on Shift+Enter", () => {
+      const onSubmit = vi.fn();
+      render(<PromptInput onSubmit={onSubmit} />);
+      const textarea = screen.getByRole("textbox");
+
+      fireEvent.change(textarea, { target: { value: "draft" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("does not submit when empty", () => {
+      const onSubmit = vi.fn();
+      render(<PromptInput onSubmit={onSubmit} />);
+
+      fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("disables the submit button when empty", () => {
+      render(<PromptInput submitLabel="Send" />);
+
+      expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+    });
+
+    it("forwards a ref to the textarea", () => {
+      const ref = { current: null as HTMLTextAreaElement | null };
+      render(<PromptInput ref={ref} />);
+
+      expect(ref.current).toBeInstanceOf(HTMLTextAreaElement);
+    });
+  });
+});

--- a/packages/ui/src/components/prompt-input/prompt-input.tsx
+++ b/packages/ui/src/components/prompt-input/prompt-input.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { LoaderCircle, SendHorizontal } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+
+const SUBMIT_KEY = "Enter";
+const REM_PER_ROW = 1.5;
+
+function autoResize(element: HTMLTextAreaElement | null): void {
+  if (element === null) {
+    return;
+  }
+  element.style.height = "auto";
+  element.style.height = `${element.scrollHeight}px`;
+}
+
+export type PromptInputProps = {
+  className?: string;
+  /** Uncontrolled initial value. */
+  defaultValue?: string;
+  /** Disables editing and sending. */
+  disabled?: boolean;
+  /** Shows a spinner while a request runs. */
+  isLoading?: boolean;
+  /** Row count before the field scrolls. */
+  maxRows?: number;
+  /** Row count at rest; sets the initial height. */
+  minRows?: number;
+  /** Called with the value on submit. */
+  onSubmit?: (value: string) => void;
+  /** Called whenever the value changes. */
+  onValueChange?: (value: string) => void;
+  /** Placeholder text. */
+  placeholder?: string;
+  /** Ref forwarded to the underlying textarea. */
+  ref?: React.Ref<HTMLTextAreaElement>;
+  /** Accessible label for the submit button. */
+  submitLabel?: string;
+  /** Optional controls rendered to the left of the submit button. */
+  toolbar?: React.ReactNode;
+  /** Controlled value. */
+  value?: string;
+};
+
+function applyRef(
+  ref: React.Ref<HTMLTextAreaElement> | undefined,
+  node: HTMLTextAreaElement | null,
+): void {
+  if (typeof ref === "function") {
+    ref(node);
+    return;
+  }
+  if (ref) {
+    ref.current = node;
+  }
+}
+
+function useMergedRef(ref: React.Ref<HTMLTextAreaElement> | undefined): {
+  assignRef: (node: HTMLTextAreaElement | null) => void;
+  innerRef: React.RefObject<HTMLTextAreaElement | null>;
+} {
+  const innerRef = useRef<HTMLTextAreaElement>(null);
+
+  const assignRef = useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      innerRef.current = node;
+      applyRef(ref, node);
+    },
+    [ref],
+  );
+
+  return { assignRef, innerRef };
+}
+
+function usePromptInput({
+  defaultValue,
+  isControlled,
+  onSubmit,
+  onValueChange,
+  ref,
+  value,
+}: {
+  defaultValue: string;
+  isControlled: boolean;
+  onSubmit?: (value: string) => void;
+  onValueChange?: (value: string) => void;
+  ref?: React.Ref<HTMLTextAreaElement>;
+  value?: string;
+}) {
+  const { assignRef, innerRef } = useMergedRef(ref);
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const currentValue = isControlled ? (value ?? "") : internalValue;
+
+  useEffect(() => {
+    autoResize(innerRef.current);
+  }, [currentValue, innerRef]);
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      if (!isControlled) {
+        setInternalValue(event.target.value);
+      }
+      onValueChange?.(event.target.value);
+    },
+    [isControlled, onValueChange],
+  );
+
+  const submit = useCallback(() => {
+    if (currentValue.trim().length === 0) {
+      return;
+    }
+    onSubmit?.(currentValue);
+    if (!isControlled) {
+      setInternalValue("");
+    }
+  }, [currentValue, isControlled, onSubmit]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === SUBMIT_KEY && !event.shiftKey) {
+        event.preventDefault();
+        submit();
+      }
+    },
+    [submit],
+  );
+
+  const handleFormSubmit = useCallback(
+    (event: React.SyntheticEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      submit();
+    },
+    [submit],
+  );
+
+  return {
+    assignRef,
+    currentValue,
+    handleChange,
+    handleFormSubmit,
+    handleKeyDown,
+  };
+}
+
+function PromptInputActions({
+  canSubmit,
+  isLoading,
+  submitLabel,
+  toolbar,
+}: {
+  canSubmit: boolean;
+  isLoading: boolean;
+  submitLabel: string;
+  toolbar?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div className="flex items-center gap-1">{toolbar}</div>
+      <button
+        aria-label={submitLabel}
+        className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-40"
+        disabled={!canSubmit}
+        type="submit"
+      >
+        {isLoading ? (
+          <LoaderCircle className="size-4 animate-spin" />
+        ) : (
+          <SendHorizontal className="size-4" />
+        )}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Auto-growing prompt textarea with a submit affordance and optional toolbar.
+ *
+ * Works controlled (`value` + `onValueChange`) or uncontrolled
+ * (`defaultValue`). The field grows with its content between `minRows` and
+ * `maxRows`, then scrolls. Enter submits; Shift+Enter inserts a newline.
+ *
+ * @example
+ * <PromptInput onSubmit={(text) => send(text)} />
+ */
+export function PromptInput({
+  className,
+  defaultValue = "",
+  disabled = false,
+  isLoading = false,
+  maxRows = 8,
+  minRows = 1,
+  onSubmit,
+  onValueChange,
+  placeholder = "Send a message…",
+  ref,
+  submitLabel = "Send",
+  toolbar,
+  value,
+}: PromptInputProps) {
+  const isControlled = value !== undefined;
+  const {
+    assignRef,
+    currentValue,
+    handleChange,
+    handleFormSubmit,
+    handleKeyDown,
+  } = usePromptInput({
+    defaultValue,
+    isControlled,
+    onSubmit,
+    onValueChange,
+    ref,
+    value,
+  });
+
+  const canSubmit = !disabled && !isLoading && currentValue.trim().length > 0;
+
+  return (
+    <form
+      className={cn(
+        "flex flex-col gap-2 rounded-2xl border border-border bg-background p-2 shadow-sm transition-colors focus-within:ring-1 focus-within:ring-ring",
+        className,
+      )}
+      onSubmit={handleFormSubmit}
+    >
+      <textarea
+        aria-label={placeholder}
+        className="w-full resize-none bg-transparent px-2 py-1.5 text-sm text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={disabled}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        ref={assignRef}
+        style={{
+          maxHeight: `${maxRows * REM_PER_ROW}rem`,
+          minHeight: `${minRows * REM_PER_ROW}rem`,
+          overflowY: "auto",
+        }}
+        value={currentValue}
+      />
+      <PromptInputActions
+        canSubmit={canSubmit}
+        isLoading={isLoading}
+        submitLabel={submitLabel}
+        toolbar={toolbar}
+      />
+    </form>
+  );
+}

--- a/packages/ui/src/components/prompt-input/prompt-input.tsx
+++ b/packages/ui/src/components/prompt-input/prompt-input.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
 
 import { LoaderCircle, SendHorizontal } from "lucide-react";
 
@@ -35,8 +35,6 @@ export type PromptInputProps = {
   onValueChange?: (value: string) => void;
   /** Placeholder text. */
   placeholder?: string;
-  /** Ref forwarded to the underlying textarea. */
-  ref?: React.Ref<HTMLTextAreaElement>;
   /** Accessible label for the submit button. */
   submitLabel?: string;
   /** Optional controls rendered to the left of the submit button. */
@@ -46,7 +44,7 @@ export type PromptInputProps = {
 };
 
 function applyRef(
-  ref: React.Ref<HTMLTextAreaElement> | undefined,
+  ref: React.ForwardedRef<HTMLTextAreaElement>,
   node: HTMLTextAreaElement | null,
 ): void {
   if (typeof ref === "function") {
@@ -58,7 +56,7 @@ function applyRef(
   }
 }
 
-function useMergedRef(ref: React.Ref<HTMLTextAreaElement> | undefined): {
+function useMergedRef(ref: React.ForwardedRef<HTMLTextAreaElement>): {
   assignRef: (node: HTMLTextAreaElement | null) => void;
   innerRef: React.RefObject<HTMLTextAreaElement | null>;
 } {
@@ -87,7 +85,7 @@ function usePromptInput({
   isControlled: boolean;
   onSubmit?: (value: string) => void;
   onValueChange?: (value: string) => void;
-  ref?: React.Ref<HTMLTextAreaElement>;
+  ref: React.ForwardedRef<HTMLTextAreaElement>;
   value?: string;
 }) {
   const { assignRef, innerRef } = useMergedRef(ref);
@@ -185,68 +183,73 @@ function PromptInputActions({
  * @example
  * <PromptInput onSubmit={(text) => send(text)} />
  */
-export function PromptInput({
-  className,
-  defaultValue = "",
-  disabled = false,
-  isLoading = false,
-  maxRows = 8,
-  minRows = 1,
-  onSubmit,
-  onValueChange,
-  placeholder = "Send a message…",
-  ref,
-  submitLabel = "Send",
-  toolbar,
-  value,
-}: PromptInputProps) {
-  const isControlled = value !== undefined;
-  const {
-    assignRef,
-    currentValue,
-    handleChange,
-    handleFormSubmit,
-    handleKeyDown,
-  } = usePromptInput({
-    defaultValue,
-    isControlled,
-    onSubmit,
-    onValueChange,
+export const PromptInput = forwardRef<HTMLTextAreaElement, PromptInputProps>(
+  (
+    {
+      className,
+      defaultValue = "",
+      disabled = false,
+      isLoading = false,
+      maxRows = 8,
+      minRows = 1,
+      onSubmit,
+      onValueChange,
+      placeholder = "Send a message…",
+      submitLabel = "Send",
+      toolbar,
+      value,
+    },
     ref,
-    value,
-  });
+  ) => {
+    const isControlled = value !== undefined;
+    const {
+      assignRef,
+      currentValue,
+      handleChange,
+      handleFormSubmit,
+      handleKeyDown,
+    } = usePromptInput({
+      defaultValue,
+      isControlled,
+      onSubmit,
+      onValueChange,
+      ref,
+      value,
+    });
 
-  const canSubmit = !disabled && !isLoading && currentValue.trim().length > 0;
+    const canSubmit = !disabled && !isLoading && currentValue.trim().length > 0;
 
-  return (
-    <form
-      className={cn(
-        "flex flex-col gap-2 rounded-2xl border border-border bg-background p-2 shadow-sm transition-colors focus-within:ring-1 focus-within:ring-ring",
-        className,
-      )}
-      onSubmit={handleFormSubmit}
-    >
-      <textarea
-        aria-label={placeholder}
-        className="w-full resize-none bg-transparent px-2 py-1.5 text-sm text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
-        disabled={disabled}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        placeholder={placeholder}
-        ref={assignRef}
-        style={{
-          maxHeight: `${maxRows * REM_PER_ROW}rem`,
-          minHeight: `${minRows * REM_PER_ROW}rem`,
-          overflowY: "auto",
-        }}
-        value={currentValue}
-      />
-      <PromptInputActions
-        canSubmit={canSubmit}
-        isLoading={isLoading}
-        submitLabel={submitLabel}
-        toolbar={toolbar}
-      />
-    </form>
-  );
-}
+    return (
+      <form
+        className={cn(
+          "flex flex-col gap-2 rounded-2xl border border-border bg-background p-2 shadow-sm transition-colors focus-within:ring-1 focus-within:ring-ring",
+          className,
+        )}
+        onSubmit={handleFormSubmit}
+      >
+        <textarea
+          aria-label={placeholder}
+          className="w-full resize-none bg-transparent px-2 py-1.5 text-sm text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={disabled}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          ref={assignRef}
+          style={{
+            maxHeight: `${maxRows * REM_PER_ROW}rem`,
+            minHeight: `${minRows * REM_PER_ROW}rem`,
+            overflowY: "auto",
+          }}
+          value={currentValue}
+        />
+        <PromptInputActions
+          canSubmit={canSubmit}
+          isLoading={isLoading}
+          submitLabel={submitLabel}
+          toolbar={toolbar}
+        />
+      </form>
+    );
+  },
+);
+PromptInput.displayName = "PromptInput";

--- a/packages/ui/src/components/reasoning/index.ts
+++ b/packages/ui/src/components/reasoning/index.ts
@@ -1,0 +1,1 @@
+export { Reasoning, type ReasoningProps } from "./reasoning";

--- a/packages/ui/src/components/reasoning/reasoning.stories.tsx
+++ b/packages/ui/src/components/reasoning/reasoning.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Reasoning } from "./reasoning";
+
+const meta = {
+  args: {
+    duration: 4,
+    steps: [
+      "Parse the user request and identify the goal.",
+      "Check the cache for a recent matching answer.",
+      "Compose the final response from the retrieved context.",
+    ],
+  },
+  component: Reasoning,
+  title: "AI/Reasoning",
+} satisfies Meta<typeof Reasoning>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Streaming: Story = {
+  args: {
+    isStreaming: true,
+    steps: ["Parse the user request and identify the goal."],
+  },
+};
+
+export const FreeForm: Story = {
+  args: {
+    children:
+      "I weighed two approaches and chose the simpler one because it avoids an extra dependency.",
+    steps: undefined,
+  },
+};

--- a/packages/ui/src/components/reasoning/reasoning.test.tsx
+++ b/packages/ui/src/components/reasoning/reasoning.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Reasoning } from "./reasoning";
+
+describe("Reasoning", () => {
+  describe("rendering", () => {
+    it("renders correctly", () => {
+      const { container } = render(<Reasoning steps={["Step one"]} />);
+
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("applies custom className", () => {
+      const { container } = render(
+        <Reasoning className="custom-class" steps={["Step one"]} />,
+      );
+
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+  });
+
+  describe("interactions", () => {
+    it("is collapsed by default and expands on toggle", () => {
+      render(<Reasoning steps={["Parse the request"]} />);
+
+      expect(screen.queryByText("Parse the request")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button"));
+
+      expect(screen.getByText("Parse the request")).toBeInTheDocument();
+    });
+
+    it("calls onOpenChange when toggled", () => {
+      const onOpenChange = vi.fn();
+      render(<Reasoning onOpenChange={onOpenChange} steps={["Parse"]} />);
+
+      fireEvent.click(screen.getByRole("button"));
+
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+
+    it("auto-expands while streaming", () => {
+      render(<Reasoning isStreaming steps={["Thinking hard"]} />);
+
+      expect(screen.getByText("Thinking hard")).toBeInTheDocument();
+      expect(screen.getByRole("button")).toHaveAttribute(
+        "aria-expanded",
+        "true",
+      );
+    });
+  });
+
+  describe("content modes", () => {
+    it("renders free-form children when no steps are provided", () => {
+      render(<Reasoning isStreaming>Free-form reasoning text</Reasoning>);
+
+      expect(screen.getByText("Free-form reasoning text")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/reasoning/reasoning.tsx
+++ b/packages/ui/src/components/reasoning/reasoning.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useId, useState } from "react";
+import { forwardRef, useCallback, useEffect, useId, useState } from "react";
 
 import { Brain, ChevronDown } from "lucide-react";
 
@@ -16,8 +16,6 @@ export type ReasoningProps = {
   isStreaming?: boolean;
   /** Called whenever the expanded state changes. */
   onOpenChange?: (open: boolean) => void;
-  /** Ref forwarded to the root element. */
-  ref?: React.Ref<HTMLDivElement>;
   /** Reasoning steps rendered as an ordered list when expanded. */
   steps?: string[];
 };
@@ -110,55 +108,53 @@ function ReasoningContent({
  * @example
  * <Reasoning duration={4} steps={["Parse the request", "Check the cache"]} />
  */
-export function Reasoning({
-  children,
-  className,
-  duration,
-  isStreaming = false,
-  onOpenChange,
-  ref,
-  steps,
-}: ReasoningProps) {
-  const [isOpen, setIsOpen] = useState(isStreaming);
-  const contentId = useId();
+export const Reasoning = forwardRef<HTMLDivElement, ReasoningProps>(
+  (
+    { children, className, duration, isStreaming = false, onOpenChange, steps },
+    ref,
+  ) => {
+    const [isOpen, setIsOpen] = useState(isStreaming);
+    const contentId = useId();
 
-  useEffect(() => {
-    if (isStreaming) {
-      requestAnimationFrame(() => {
-        setIsOpen(true);
+    useEffect(() => {
+      if (isStreaming) {
+        requestAnimationFrame(() => {
+          setIsOpen(true);
+        });
+      }
+    }, [isStreaming]);
+
+    const handleToggle = useCallback(() => {
+      setIsOpen((previous) => {
+        const next = !previous;
+        onOpenChange?.(next);
+        return next;
       });
-    }
-  }, [isStreaming]);
+    }, [onOpenChange]);
 
-  const handleToggle = useCallback(() => {
-    setIsOpen((previous) => {
-      const next = !previous;
-      onOpenChange?.(next);
-      return next;
-    });
-  }, [onOpenChange]);
-
-  return (
-    <div
-      className={cn("rounded-lg border border-border bg-muted/30", className)}
-      ref={ref}
-    >
-      <ReasoningTrigger
-        contentId={contentId}
-        duration={duration}
-        isOpen={isOpen}
-        isStreaming={isStreaming}
-        onToggle={handleToggle}
-      />
-      {isOpen ? (
-        <ReasoningContent
+    return (
+      <div
+        className={cn("rounded-lg border border-border bg-muted/30", className)}
+        ref={ref}
+      >
+        <ReasoningTrigger
           contentId={contentId}
+          duration={duration}
+          isOpen={isOpen}
           isStreaming={isStreaming}
-          steps={steps}
-        >
-          {children}
-        </ReasoningContent>
-      ) : null}
-    </div>
-  );
-}
+          onToggle={handleToggle}
+        />
+        {isOpen ? (
+          <ReasoningContent
+            contentId={contentId}
+            isStreaming={isStreaming}
+            steps={steps}
+          >
+            {children}
+          </ReasoningContent>
+        ) : null}
+      </div>
+    );
+  },
+);
+Reasoning.displayName = "Reasoning";

--- a/packages/ui/src/components/reasoning/reasoning.tsx
+++ b/packages/ui/src/components/reasoning/reasoning.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useCallback, useEffect, useId, useState } from "react";
+
+import { Brain, ChevronDown } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+
+export type ReasoningProps = {
+  /** Free-form reasoning content; renders when `steps` is absent. */
+  children?: React.ReactNode;
+  className?: string;
+  /** Seconds the model spent reasoning, shown in the header. */
+  duration?: number;
+  /** Whether the reasoning trace is still streaming; auto-expands the panel. */
+  isStreaming?: boolean;
+  /** Called whenever the expanded state changes. */
+  onOpenChange?: (open: boolean) => void;
+  /** Ref forwarded to the root element. */
+  ref?: React.Ref<HTMLDivElement>;
+  /** Reasoning steps rendered as an ordered list when expanded. */
+  steps?: string[];
+};
+
+function ReasoningTrigger({
+  contentId,
+  duration,
+  isOpen,
+  isStreaming,
+  onToggle,
+}: {
+  contentId: string;
+  duration?: number;
+  isOpen: boolean;
+  isStreaming: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      aria-controls={contentId}
+      aria-expanded={isOpen}
+      className="flex w-full items-center gap-2 px-3 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      onClick={onToggle}
+      type="button"
+    >
+      <Brain className="size-4 shrink-0" />
+      <span className="font-medium">
+        {isStreaming ? "Reasoning" : "Reasoned"}
+        {typeof duration === "number" ? ` for ${duration}s` : null}
+      </span>
+      {isStreaming ? <span className="animate-pulse">&hellip;</span> : null}
+      <ChevronDown
+        className={cn(
+          "ml-auto size-4 shrink-0 transition-transform",
+          isOpen ? "rotate-180" : "rotate-0",
+        )}
+      />
+    </button>
+  );
+}
+
+function ReasoningContent({
+  children,
+  contentId,
+  isStreaming,
+  steps,
+}: {
+  children?: React.ReactNode;
+  contentId: string;
+  isStreaming: boolean;
+  steps?: string[];
+}) {
+  const hasSteps = steps !== undefined && steps.length > 0;
+
+  return (
+    <div
+      className="border-t border-border px-3 py-2 text-sm text-muted-foreground"
+      id={contentId}
+    >
+      {hasSteps ? (
+        <ol className="list-decimal space-y-1 pl-4">
+          {steps.map((step, index) => (
+            <li
+              className="whitespace-pre-wrap"
+              key={`${index}-${step.slice(0, 12)}`}
+            >
+              {step}
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <div className="whitespace-pre-wrap">{children}</div>
+      )}
+      {isStreaming ? (
+        <span aria-hidden className="ml-0.5 animate-pulse">
+          &#9611;
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Collapsible AI reasoning trace block.
+ *
+ * Shows a toggleable header ("Reasoning" while streaming, "Reasoned" once
+ * settled) and an expandable body that renders either ordered `steps` or
+ * free-form `children`. Auto-expands while `isStreaming` is true.
+ *
+ * @example
+ * <Reasoning duration={4} steps={["Parse the request", "Check the cache"]} />
+ */
+export function Reasoning({
+  children,
+  className,
+  duration,
+  isStreaming = false,
+  onOpenChange,
+  ref,
+  steps,
+}: ReasoningProps) {
+  const [isOpen, setIsOpen] = useState(isStreaming);
+  const contentId = useId();
+
+  useEffect(() => {
+    if (isStreaming) {
+      requestAnimationFrame(() => {
+        setIsOpen(true);
+      });
+    }
+  }, [isStreaming]);
+
+  const handleToggle = useCallback(() => {
+    setIsOpen((previous) => {
+      const next = !previous;
+      onOpenChange?.(next);
+      return next;
+    });
+  }, [onOpenChange]);
+
+  return (
+    <div
+      className={cn("rounded-lg border border-border bg-muted/30", className)}
+      ref={ref}
+    >
+      <ReasoningTrigger
+        contentId={contentId}
+        duration={duration}
+        isOpen={isOpen}
+        isStreaming={isStreaming}
+        onToggle={handleToggle}
+      />
+      {isOpen ? (
+        <ReasoningContent
+          contentId={contentId}
+          isStreaming={isStreaming}
+          steps={steps}
+        >
+          {children}
+        </ReasoningContent>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds 3 new `@vllnt/ui` AI components for #411 ("Missing AI components"):

- [x] **reasoning** — collapsible AI reasoning / "thinking" trace block. Toggleable header ("Reasoning"/"Reasoned for Ns"), expandable body rendering ordered `steps` or free-form `children`, auto-expands while `isStreaming`.
- [x] **chain-of-thought** — ordered, status-aware step list. Numbered vertical rail with per-step status (`pending` | `active` | `complete` | `error`) reflected in the marker icon and color.
- [x] **prompt-input** — auto-growing prompt textarea with submit affordance + optional `toolbar` slot. Controlled or uncontrolled, Enter submits / Shift+Enter newline, grows between `minRows`/`maxRows`.

## Conventions

- React 19 ref-as-prop (no `forwardRef`); design tokens only (no hardcoded colors); `"use client"` on hook-using files; explicit exported prop types + TSDoc.
- Each component ships `.tsx`, `.stories.tsx` (CSF3), `.test.tsx` (Vitest + Testing Library), `index.ts`.
- Barrel updated (`packages/ui/src/components/index.ts`); `registry.json` + `registry/default/*` regenerated via `pnpm registry:build` (category `ai`).

## Validation

- `pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json` — PASS
- `pnpm -F @vllnt/ui build` (tsup) — PASS
- `pnpm -F @vllnt/ui exec vitest run` (new components) — 22 passed
- lint (`eslint --fix` on changed files) — clean
- `check:use-client`, `check:stories`, `verify-stories`, `registry:integrity` — PASS

Closes #411
