### PR TITLE
fix(prompt-input): optional ref prop — unblock 0.3.0 canary publish

### DIFF
--- a/packages/ui/src/components/prompt-input/prompt-input.tsx
+++ b/packages/ui/src/components/prompt-input/prompt-input.tsx
@@ -85,7 +85,7 @@ function usePromptInput({
   isControlled: boolean;
   onSubmit?: (value: string) => void;
   onValueChange?: (value: string) => void;
-  ref: React.Ref<HTMLTextAreaElement> | undefined;
+  ref?: React.Ref<HTMLTextAreaElement>;
   value?: string;
 }) {
   const { assignRef, innerRef } = useMergedRef(ref);


### PR DESCRIPTION
Refs #268. The React 19 ref-as-prop codemod left `ref: React.Ref<HTMLTextAreaElement> | undefined` as a property signature in `prompt-input.tsx`, violating the repo's `no-restricted-syntax` rule ("use optional properties instead of unions with undefined"). This was the **single** lint error failing the Publish workflow's Quality Gates → so the canary (`@canary`) was stuck at `0.3.0-canary.00b20d6` (missing React 19 + #271).

Fix: `ref?: React.Ref<HTMLTextAreaElement>`. Verified locally: full `eslint .` exit 0, `@vllnt/ui build` 0 type errors. One-line, behavior-preserving.