### PR TITLE
docs(skills): inject vllnt _shared contracts into vllnt-ui skill

### DIFF
--- a/skills/vllnt-ui/SKILL.md
+++ b/skills/vllnt-ui/SKILL.md
@@ -20,6 +20,10 @@ allowed-tools:
 
 # VLLNT UI — usage + design system
 
+**Core values**: @_shared/vllnt-core-values.md
+**Operating principles**: @_shared/vllnt-operating-principles.md
+**Web quality**: @_shared/web-quality.md
+
 `@vllnt/ui` (brand name **VLLNT UI**, always two words) is a React component
 library: 200+ accessible components built on **Radix UI** primitives,
 **Tailwind CSS**, and **CVA** (class-variance-authority). Shipped on public npm
@@ -223,6 +227,11 @@ Keyboard-reachable interactions; visible focus ring (`--ring`, never bare
 `outline-none`); inputs labelled (`<label>`/`aria-label`); live regions for async
 state (`aria-live="polite"` toasts, `assertive` errors); color is never the only
 signal — pair with icon/text.
+
+The **enforcement gate** for consuming apps — axe-core zero violations + a
+keyboard-only pass + the Lighthouse a11y score — is owned by the `accessibility`
+skill (`@_shared/web-quality.md` → Accessibility). VLLNT UI ships accessible
+primitives; that skill verifies the app keeps them accessible in use.
 
 ### Copy / voice
 


### PR DESCRIPTION
## What

Adds the vllnt `@_shared` injection block to the `vllnt-ui` skill and routes the accessibility enforcement gate to the `accessibility` skill.

- **Injection lines** (after the title): `Core values`, `Operating principles`, `Web quality` (`@_shared/*.md`). These resolve at runtime via the flat-linked `_shared` shared by all linked skills.
- **Accessibility section**: a pointer that the consuming-app a11y gate (axe-core zero violations + keyboard-only pass + Lighthouse a11y score) is owned by the `accessibility` skill. VLLNT UI ships accessible primitives; that skill verifies apps keep them accessible in use.

## Why

Part of the Lighthouse best-practices enforcement sweep in `vllnt/agent-skills` (new `_shared/web-quality.md` contract + `accessibility` skill). This makes `vllnt-ui` consistent with the four-category web-quality contract.

## Scope

One file (`skills/vllnt-ui/SKILL.md`, +9 lines). No component or registry changes.

> Note: the live deployed copy (`~/.agents/skills/vllnt-ui`) is out of sync with this source copy independently of this PR.

https://claude.ai/code/session_018ec25ydFU2MCdi938uSJeB