### PR TITLE
refactor(registry): generate llms manifests via @vllnt/next-llms

### DIFF
--- a/apps/registry/app/llms-full.txt/route.ts
+++ b/apps/registry/app/llms-full.txt/route.ts
@@ -1,6 +1,12 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
+import {
+  generateLlmsFullText,
+  type LlmsFullPage,
+  type LlmsFullSection,
+} from "@vllnt/next-llms";
+
 import { getLatestReleaseRecords } from "@/lib/changelog";
 import { getDesignGuideMarkdown } from "@/lib/design-guide";
 import { registry, type RegistryComponent } from "@/lib/registry";
@@ -55,151 +61,126 @@ async function readDocumentPage(slug: string): Promise<string> {
   }
 }
 
-function buildIntroLines(
-  items: readonly RegistryComponent[],
-): readonly string[] {
-  return [
-    "# VLLNT UI - Full Reference",
-    "",
-    "> One-fetch, complete agent context for the VLLNT UI registry. " +
-      `${items.length} components, install via shadcn CLI against /r/<name>.json. ` +
-      `Site: ${SITE_URL}`,
-    "",
-  ];
-}
-
-function buildInstallLines(): readonly string[] {
-  return [
-    "## Install",
-    "",
-    "```bash",
-    `pnpm dlx shadcn@latest add ${SITE_URL}/r/<name>.json`,
-    `# Or with npm: npx shadcn@latest add ${SITE_URL}/r/<name>.json`,
-    "```",
-    "",
-  ];
-}
-
-async function buildDocumentLines(): Promise<readonly string[]> {
-  const pageSections = await Promise.all(
-    REFERENCE_PAGES.map(async (page) => {
-      const body = await readDocumentPage(page.slug);
-      if (!body) return [];
-      const source = `${SITE_URL}${page.href}`;
-      return [`## ${page.title}`, "", `Source: ${source}`, "", body, ""];
-    }),
+function buildSummary(items: readonly RegistryComponent[]): string {
+  return (
+    "One-fetch, complete agent context for the VLLNT UI registry. " +
+    `${items.length} components, install via shadcn CLI against /r/<name>.json. ` +
+    `Site: ${SITE_URL}`
   );
-
-  return pageSections.flat();
 }
 
-async function buildDesignLines(): Promise<readonly string[]> {
+const INSTALL_DETAILS = [
+  "## Install",
+  "",
+  "```bash",
+  `pnpm dlx shadcn@latest add ${SITE_URL}/r/<name>.json`,
+  `# Or with npm: npx shadcn@latest add ${SITE_URL}/r/<name>.json`,
+  "```",
+].join("\n");
+
+async function buildGuidePages(): Promise<LlmsFullPage[]> {
+  const entries = await Promise.all(
+    REFERENCE_PAGES.map(async (page) => ({
+      content: await readDocumentPage(page.slug),
+      title: page.title,
+      url: `${SITE_URL}${page.href}`,
+    })),
+  );
+  return entries.filter((entry) => entry.content.length > 0);
+}
+
+async function buildDesignPage(): Promise<LlmsFullPage> {
   const designGuide = await getDesignGuideMarkdown();
-  return [
-    "## Design Guide",
-    "",
-    `Source: ${SITE_URL}/design`,
-    `Raw: ${SITE_URL}/DESIGN.md`,
-    `Tokens: ${SITE_URL}/r/design.json`,
-    "",
-    designGuide,
-    "",
-  ];
+  return {
+    content: [
+      `Raw: ${SITE_URL}/DESIGN.md`,
+      `Tokens: ${SITE_URL}/r/design.json`,
+      "",
+      designGuide,
+    ].join("\n"),
+    title: "Design Guide",
+    url: `${SITE_URL}/design`,
+  };
 }
 
-async function buildReleaseLines(): Promise<readonly string[]> {
+async function buildReleasePages(): Promise<LlmsFullPage[]> {
   const releases = await getLatestReleaseRecords(5);
-  if (releases.length === 0) return [];
-
-  return [
-    "## Latest Release Notes",
-    "",
-    `Full release cards are available at ${SITE_URL}/releases and feeds at ${SITE_URL}/rss.xml or ${SITE_URL}/atom.xml.`,
-    "",
-    ...releases.flatMap((release) => [
-      `### ${release.title}`,
-      "",
+  return releases.map((release) => ({
+    content: [
       `- Version: \`${release.version}\``,
       `- Page: ${SITE_URL}/releases#${release.anchor}`,
       `- GitHub: ${release.url}`,
       ...(release.date ? [`- Date: ${release.date}`] : []),
       "",
       release.notes,
-      "",
-    ]),
-  ];
+    ].join("\n"),
+    title: release.title,
+  }));
 }
 
-function buildTemplateLines(): readonly string[] {
-  if (TEMPLATES.length === 0) return [];
-
-  return [
-    "## Templates",
-    "",
-    "Starter kits pairing complete app shapes with component lists and source paths.",
-    "",
-    ...TEMPLATES.flatMap((template) => [
-      `### ${template.title}`,
-      "",
+function buildTemplatePages(): LlmsFullPage[] {
+  return TEMPLATES.map((template) => ({
+    content: [
       `- Slug: \`${template.slug}\``,
       `- Page: ${SITE_URL}${getTemplatePath(template)}`,
       `- Audience: ${template.audience}`,
       `- Components: ${template.components.join(", ")}`,
-      "",
-    ]),
-  ];
+    ].join("\n"),
+    title: template.title,
+  }));
 }
 
-function buildComponentLines(item: RegistryComponent): readonly string[] {
-  return [
-    `### ${item.title}`,
-    "",
-    `- Slug: \`${item.name}\``,
-    `- Category: \`${item.category ?? ""}\``,
-    `- Description: ${item.description ?? ""}`,
-    `- Page: ${SITE_URL}/components/${item.name}`,
-    `- Schema: ${SITE_URL}/r/${item.name}.json`,
-    ...(item.dependencies?.length
-      ? [`- npm deps: ${item.dependencies.join(", ")}`]
-      : []),
-    ...(item.registryDependencies?.length
-      ? [`- registry deps: ${item.registryDependencies.join(", ")}`]
-      : []),
-    `- Install: \`pnpm dlx shadcn@latest add ${SITE_URL}/r/${item.name}.json\``,
-    "",
-  ];
-}
-
-function buildComponentsReferenceLines(
+function buildComponentPages(
   items: readonly RegistryComponent[],
-): readonly string[] {
-  return [
-    "## Components",
-    "",
-    `${items.length} components total. Each entry links to a machine-readable JSON descriptor at /r/<name>.json.`,
-    "",
-    ...[...items]
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .flatMap(buildComponentLines),
-  ];
+): LlmsFullPage[] {
+  return [...items]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((item) => ({
+      content: [
+        `- Slug: \`${item.name}\``,
+        `- Category: \`${item.category ?? ""}\``,
+        `- Description: ${item.description ?? ""}`,
+        `- Page: ${SITE_URL}/components/${item.name}`,
+        `- Schema: ${SITE_URL}/r/${item.name}.json`,
+        ...(item.dependencies?.length
+          ? [`- npm deps: ${item.dependencies.join(", ")}`]
+          : []),
+        ...(item.registryDependencies?.length
+          ? [`- registry deps: ${item.registryDependencies.join(", ")}`]
+          : []),
+        `- Install: \`pnpm dlx shadcn@latest add ${SITE_URL}/r/${item.name}.json\``,
+      ].join("\n"),
+      title: item.title,
+    }));
 }
 
 async function buildLlmsFullTxt(): Promise<string> {
   const items = getRegistryComponents();
-  const documentLines = await buildDocumentLines();
-  const designLines = await buildDesignLines();
-  const releaseLines = await buildReleaseLines();
-  const templateLines = buildTemplateLines();
+  const [guidePages, designPage, releasePages] = await Promise.all([
+    buildGuidePages(),
+    buildDesignPage(),
+    buildReleasePages(),
+  ]);
+  const templatePages = buildTemplatePages();
 
-  return [
-    ...buildIntroLines(items),
-    ...buildInstallLines(),
-    ...documentLines,
-    ...designLines,
-    ...releaseLines,
-    ...templateLines,
-    ...buildComponentsReferenceLines(items),
-  ].join("\n");
+  const sections: LlmsFullSection[] = [
+    ...(guidePages.length > 0 ? [{ pages: guidePages, title: "Guides" }] : []),
+    { pages: [designPage], title: "Design" },
+    ...(releasePages.length > 0
+      ? [{ pages: releasePages, title: "Latest Release Notes" }]
+      : []),
+    ...(templatePages.length > 0
+      ? [{ pages: templatePages, title: "Templates" }]
+      : []),
+    { pages: buildComponentPages(items), title: "Components" },
+  ];
+
+  return generateLlmsFullText({
+    details: INSTALL_DETAILS,
+    sections,
+    summary: buildSummary(items),
+    title: "VLLNT UI - Full Reference",
+  });
 }
 
 export const dynamic = "force-static";

--- a/apps/registry/app/llms.txt/route.ts
+++ b/apps/registry/app/llms.txt/route.ts
@@ -1,3 +1,9 @@
+import {
+  generateLlmsText,
+  type LlmsLink,
+  type LlmsSection,
+} from "@vllnt/next-llms";
+
 import { registry, type RegistryComponent } from "@/lib/registry";
 
 import { DOCS_PAGES, getDocsPath } from "../../lib/docs-pages";
@@ -41,6 +47,92 @@ const CATEGORY_LABEL = new Map<string, string>([
   ["utility", "Utility"],
 ]);
 
+const INSTALL_DETAILS =
+  "Install any component with the shadcn CLI: " +
+  `\`pnpm dlx shadcn@latest add ${SITE_URL}/r/<name>.json\``;
+
+const DOCS_SECTION: LlmsSection = {
+  links: [
+    {
+      notes: "install and use any component",
+      title: "Get Started",
+      url: `${SITE_URL}/`,
+    },
+    {
+      notes: "theming, registry usage, conventions",
+      title: "Documentation",
+      url: `${SITE_URL}/docs`,
+    },
+    ...DOCS_PAGES.map((page) => ({
+      notes: page.description,
+      title: page.title,
+      url: `${SITE_URL}${getDocsPath(page)}`,
+    })),
+    {
+      notes: "design principles and component patterns",
+      title: "Philosophy",
+      url: `${SITE_URL}/philosophy`,
+    },
+    {
+      notes: "brand, tokens, accessibility, and UI rules",
+      title: "Design guide",
+      url: `${SITE_URL}/design`,
+    },
+    {
+      notes: "browse all components by category",
+      title: "Components index",
+      url: `${SITE_URL}/components`,
+    },
+    {
+      notes: "starter kits for full VLLNT UI apps",
+      title: "Templates",
+      url: `${SITE_URL}/templates`,
+    },
+    {
+      notes: "canonical Keep a Changelog release history",
+      title: "Changelog",
+      url: `${SITE_URL}/changelog`,
+    },
+    {
+      notes: "versioned release cards, GitHub notes, and RSS links",
+      title: "Releases",
+      url: `${SITE_URL}/releases`,
+    },
+    {
+      notes: "release feed for notification and agent polling",
+      title: "RSS feed",
+      url: `${SITE_URL}/rss.xml`,
+    },
+  ],
+  title: "Docs",
+};
+
+const REGISTRY_SECTION: LlmsSection = {
+  links: [
+    {
+      notes: "full machine-readable list of all components",
+      title: "Registry index",
+      url: `${SITE_URL}/r/registry.json`,
+    },
+    {
+      notes: "machine-readable VLLNT UI token contract",
+      title: "Design tokens",
+      url: `${SITE_URL}/r/design.json`,
+    },
+    {
+      notes: "canonical brand and design rules as raw markdown",
+      title: "Design guide (raw)",
+      url: `${SITE_URL}/DESIGN.md`,
+    },
+    {
+      notes: "every public route, refreshed per deploy",
+      title: "Sitemap",
+      url: `${SITE_URL}/sitemap.xml`,
+    },
+  ],
+  title: "Registry API",
+};
+
 function getRegistryComponents(): readonly RegistryComponent[] {
   return registry.items;
 }
@@ -67,89 +159,45 @@ function getSortedCategories(
   ];
 }
 
-function buildIntroLines(
-  items: readonly RegistryComponent[],
-): readonly string[] {
-  return [
-    "# VLLNT UI",
-    "",
-    "> Agent-first React component registry. " +
-      `${items.length} accessible components built on Radix UI, Tailwind CSS, and CVA. ` +
-      "Install via the shadcn CLI against any /r/<name>.json endpoint.",
-    "",
-  ];
-}
-
-function buildDocumentationLines(): readonly string[] {
-  return [
-    "## Docs",
-    "",
-    `- [Get Started](${SITE_URL}/): install and use any component`,
-    `- [Documentation](${SITE_URL}/docs): theming, registry usage, conventions`,
-    ...DOCS_PAGES.map(
-      (page) =>
-        `- [${page.title}](${SITE_URL}${getDocsPath(page)}): ${page.description}`,
-    ),
-    `- [Philosophy](${SITE_URL}/philosophy): design principles and component patterns`,
-    `- [Design guide](${SITE_URL}/design): brand, tokens, accessibility, and UI rules`,
-    `- [Components index](${SITE_URL}/components): browse all components by category`,
-    `- [Templates](${SITE_URL}/templates): starter kits for full VLLNT UI apps`,
-    `- [Changelog](${SITE_URL}/changelog): canonical Keep a Changelog release history`,
-    `- [Releases](${SITE_URL}/releases): versioned release cards, GitHub notes, and RSS links`,
-    `- [RSS feed](${SITE_URL}/rss.xml): release feed for notification and agent polling`,
-    "",
-  ];
-}
-
-function buildRegistryLines(): readonly string[] {
-  return [
-    "## Registry API",
-    "",
-    `- [Registry index](${SITE_URL}/r/registry.json): full machine-readable list of all components`,
-    `- [Design tokens](${SITE_URL}/r/design.json): machine-readable VLLNT UI token contract`,
-    `- [Design guide (raw)](${SITE_URL}/DESIGN.md): canonical brand and design rules as raw markdown`,
-    `- [Sitemap](${SITE_URL}/sitemap.xml): every public route, refreshed per deploy`,
-    "- Install command: `pnpm dlx shadcn@latest add " +
-      `${SITE_URL}/r/<name>.json` +
-      "`",
-    "",
-  ];
-}
-
-function buildCategoryLines(
-  category: string,
-  grouped: ReadonlyMap<string, readonly RegistryComponent[]>,
-): readonly string[] {
-  const bucket = grouped.get(category);
-  if (!bucket || bucket.length === 0) return [];
-  const label = CATEGORY_LABEL.get(category) ?? category;
-  const itemLines = [...bucket]
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .map(
-      (item) =>
-        `- [${item.title}](${SITE_URL}/components/${item.name}): ${item.description ?? ""}`,
-    );
-
-  return [`## Components - ${label}`, "", ...itemLines, ""];
-}
-
-function buildComponentLines(
-  items: readonly RegistryComponent[],
-): readonly string[] {
-  const grouped = groupItems(items);
-  return getSortedCategories(grouped).flatMap((category) =>
-    buildCategoryLines(category, grouped),
+function buildSummary(items: readonly RegistryComponent[]): string {
+  return (
+    "Agent-first React component registry. " +
+    `${items.length} accessible components built on Radix UI, Tailwind CSS, and CVA. ` +
+    "Install via the shadcn CLI against any /r/<name>.json endpoint."
   );
+}
+
+function buildComponentSections(
+  items: readonly RegistryComponent[],
+): readonly LlmsSection[] {
+  const grouped = groupItems(items);
+  return getSortedCategories(grouped).flatMap((category) => {
+    const bucket = grouped.get(category);
+    if (!bucket || bucket.length === 0) return [];
+    const label = CATEGORY_LABEL.get(category) ?? category;
+    const links: LlmsLink[] = [...bucket]
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((item) => ({
+        notes: item.description,
+        title: item.title,
+        url: `${SITE_URL}/components/${item.name}`,
+      }));
+    return [{ links, title: `Components - ${label}` }];
+  });
 }
 
 function buildLlmsTxt(): string {
   const items = getRegistryComponents();
-  return [
-    ...buildIntroLines(items),
-    ...buildDocumentationLines(),
-    ...buildRegistryLines(),
-    ...buildComponentLines(items),
-  ].join("\n");
+  return generateLlmsText({
+    details: INSTALL_DETAILS,
+    sections: [
+      DOCS_SECTION,
+      REGISTRY_SECTION,
+      ...buildComponentSections(items),
+    ],
+    summary: buildSummary(items),
+    title: "VLLNT UI",
+  });
 }
 
 export const dynamic = "force-static";

--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -25,6 +25,7 @@
     "@next/mdx": "16.2.6",
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
+    "@vllnt/next-llms": "canary",
     "@vllnt/ui": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/registry/registry/default/prompt-input/prompt-input.tsx
+++ b/apps/registry/registry/default/prompt-input/prompt-input.tsx
@@ -85,7 +85,7 @@ function usePromptInput({
   isControlled: boolean;
   onSubmit?: (value: string) => void;
   onValueChange?: (value: string) => void;
-  ref: React.Ref<HTMLTextAreaElement> | undefined;
+  ref?: React.Ref<HTMLTextAreaElement>;
   value?: string;
 }) {
   const { assignRef, innerRef } = useMergedRef(ref);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@vercel/speed-insights':
         specifier: ^1.2.0
         version: 1.3.1(next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@vllnt/next-llms':
+        specifier: canary
+        version: 0.1.0-canary.78c9be3
       '@vllnt/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -3462,6 +3465,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@vllnt/next-llms@0.1.0-canary.78c9be3':
+    resolution: {integrity: sha512-KVx3d1Zk3P+Cyn75IBFjIuybv5CKPrzeAT20riKNMBPmh09wjx6NWr0X8qZY3WIl5+/ADasTX8W650lqfCRc2Q==}
+    engines: {node: '>=18'}
 
   '@vllnt/typescript@1.0.0':
     resolution: {integrity: sha512-0hr7yBLLWb6Z5QN3a4IF9TQyU8v8/NoygCAuL5LG64vrHaLdXccIuXzkkOJxBmSVj5dmoxVbJ8IvuCTHC/3IWA==}
@@ -11006,6 +11013,8 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
       - turbo
+
+  '@vllnt/next-llms@0.1.0-canary.78c9be3': {}
 
   '@vllnt/typescript@1.0.0': {}
 


### PR DESCRIPTION
## What

Migrate the registry's `llms.txt` and `llms-full.txt` routes from hand-rolled string builders to the first-party **@vllnt/next-llms** generators (dogfood).

- `app/llms.txt/route.ts` → `generateLlmsText({ title, summary, details, sections })`
- `app/llms-full.txt/route.ts` → `generateLlmsFullText({ title, summary, details, sections })` (package H1→H2→H3 hierarchy)
- `@vllnt/next-llms` added on the `canary` channel (matches the existing `shadcn: "canary"` pattern); lockfile pins the resolved build for reproducible CI.

## Output deltas (intentional, no useful loss)

- Empty-`notes` links drop the trailing `": "` (package omits it) — minor cleanup.
- llms-full's three redundant section-intro lines (releases / templates / components) drop out — the package's section model has no section-prose slot; `rss.xml`/`atom.xml` feeds stay discoverable via the layout `<head>`, the releases page, and `llms.txt`.

## Validation

- `tsc --noEmit` ✓ · `eslint` (changed files) ✓ · `next build` ✓ (both routes prerender static)
- Generated `.next` bodies verified: 309 components, all sections faithful & spec-compliant
- codebase-intelligence: blast radius 0 (leaf route handlers, `riskLevel: LOW`)
- react-doctor: 0 diagnostics

## Scope

Surgical — only the migration files. Unrelated working-tree WIP (browserslist, layout/vs pages) deliberately excluded.

Closes #445