### PR TITLE
fix(registry): derive component count from registry, drop hardcoded 225

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ Release automation can regenerate this file from Conventional Commits with
   `ContextLens`.
 - **Time navigation** - `TimelineScrubber`, `PlaybackGhost`,
   `BottomActivityStrip`, and `RunTimeline`.
-- Total component count: **225** (up from 140).
+- Total component count: **309** (up from 140).
 - **OKLCH theming system** - color tokens migrated to the OKLCH color space, with
   13 runtime theme presets, a `/themes` web theme editor route, and a `/r/themes`
   endpoint. New public theme exports from `@vllnt/ui` (`THEME_PRESETS`,

--- a/apps/registry/app/manifest.ts
+++ b/apps/registry/app/manifest.ts
@@ -1,11 +1,12 @@
 import type { MetadataRoute } from "next";
 
+import { getComponentCount } from "@/lib/stats";
+
 export default function manifest(): MetadataRoute.Manifest {
   return {
     background_color: "#0a0a0a",
     categories: ["developer", "productivity", "design"],
-    description:
-      "Agent-first React component registry. 225 accessible components built on Radix UI, Tailwind CSS, and CVA.",
+    description: `Agent-first React component registry. ${getComponentCount()} accessible components built on Radix UI, Tailwind CSS, and CVA.`,
     display: "standalone",
     name: "VLLNT UI",
     orientation: "any",

--- a/apps/registry/app/mcp/route.ts
+++ b/apps/registry/app/mcp/route.ts
@@ -249,7 +249,7 @@ function dispatch(request: JsonRpcRequest): JsonRpcError | JsonRpcSuccess {
           tools: { listChanged: false },
         },
         instructions:
-          "VLLNT UI registry MCP server. Use search_components / get_component / list_categories to discover and read 225 React components. Source of truth: " +
+          `VLLNT UI registry MCP server. Use search_components / get_component / list_categories to discover and read ${REGISTRY.items.length} React components. Source of truth: ` +
           SITE_URL +
           "/r/registry.json",
         protocolVersion: PROTOCOL_VERSION,

--- a/apps/registry/content/pages/home/en.mdx
+++ b/apps/registry/content/pages/home/en.mdx
@@ -1,6 +1,6 @@
 ---
 title: VLLNT UI - Component Registry
-description: 225 agent-first React components. Install with the shadcn CLI — no library to import, no version lock-in.
+description: 309 agent-first React components. Install with the shadcn CLI — no library to import, no version lock-in.
 type: home
 og:
   title: ui.vllnt.ai
@@ -50,13 +50,13 @@ The CLI installs source files into your project under `components/ui/` (configur
 
 Every component is also exposed as a machine-readable JSON descriptor. AI coding agents can read them directly:
 
-- `https://ui.vllnt.ai/r/registry.json` — index of all 225 components
+- `https://ui.vllnt.ai/r/registry.json` — index of all 309 components
 - `https://ui.vllnt.ai/r/<name>.json` — one component
 - `https://ui.vllnt.ai/llms.txt` — concise index per the [llmstxt.org](https://llmstxt.org) spec
 - `https://ui.vllnt.ai/llms-full.txt` — full agent context in one fetch
 
 ## Next steps
 
-- Browse [all 225 components](/components)
+- Browse [all 309 components](/components)
 - Read the [philosophy](/philosophy) behind the library
 - Read the [docs](/docs)

--- a/apps/registry/content/pages/home/fr.mdx
+++ b/apps/registry/content/pages/home/fr.mdx
@@ -1,6 +1,6 @@
 ---
 title: VLLNT UI - Registre de composants
-description: 225 composants React agent-first. Installez avec la CLI shadcn - aucune bibliotheque a importer, aucun verrou de version.
+description: 309 composants React agent-first. Installez avec la CLI shadcn - aucune bibliotheque a importer, aucun verrou de version.
 type: home
 og:
   title: ui.vllnt.ai
@@ -50,13 +50,13 @@ La CLI installe les fichiers source dans votre projet sous `components/ui/`, con
 
 Chaque composant est aussi expose comme descripteur JSON lisible par machine :
 
-- `https://ui.vllnt.ai/r/registry.json` - index des 225 composants
+- `https://ui.vllnt.ai/r/registry.json` - index des 309 composants
 - `https://ui.vllnt.ai/r/<name>.json` - un composant
 - `https://ui.vllnt.ai/llms.txt` - index concis selon la specification [llmstxt.org](https://llmstxt.org)
 - `https://ui.vllnt.ai/llms-full.txt` - contexte agent complet en une requete
 
 ## Etapes suivantes
 
-- Parcourir [les 225 composants](/fr/components)
+- Parcourir [les 309 composants](/fr/components)
 - Lire la [philosophie](/fr/philosophy) de la bibliotheque
 - Lire la [documentation](/fr/docs)

--- a/apps/registry/lib/component-count.test.ts
+++ b/apps/registry/lib/component-count.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import manifest from "@/app/manifest";
+import { registry } from "@/lib/registry";
+
+/**
+ * Regression guard for component-count drift.
+ *
+ * `registry.items.length` is the single source of truth for the number of
+ * shipped components. Three human-maintained surfaces restate it as prose: the
+ * changelog snapshot and the localized home copy (en and fr). They drifted to a
+ * stale 225 while the registry grew to 309 — the homepage read the live count,
+ * the prose did not. These tests fail the moment a restated count diverges from
+ * the registry, so adding a component also updates the copy.
+ *
+ * The code surfaces (app/manifest.ts and app/mcp/route.ts) now derive the count
+ * from the registry and cannot drift; this test pins the manifest to lock it in.
+ */
+
+const liveCount = registry.items.length;
+
+const repoRoot = path.join(process.cwd(), "..", "..");
+const homeDirectory = path.join(process.cwd(), "content", "pages", "home");
+
+function read(filePath: string): string {
+  return readFileSync(filePath, "utf8");
+}
+
+describe("component count stays consistent with the registry", () => {
+  it("the CHANGELOG [Unreleased] snapshot matches the live count", () => {
+    const changelog = read(path.join(repoRoot, "CHANGELOG.md"));
+    const unreleased = changelog
+      .split(/^## \[/m)
+      .find((section) => section.startsWith("Unreleased]"));
+    expect(
+      unreleased,
+      "CHANGELOG.md has no [Unreleased] section",
+    ).toBeDefined();
+
+    const match = /total component count:\s*\*\*(\d+)\*\*/i.exec(
+      unreleased ?? "",
+    );
+    expect(
+      match,
+      "[Unreleased] section is missing a 'Total component count' line",
+    ).not.toBeNull();
+    expect(Number(match?.[1])).toBe(liveCount);
+  });
+
+  it.each(["en", "fr"])(
+    "every count claim in home/%s.mdx matches the live count",
+    (locale) => {
+      const mdx = read(path.join(homeDirectory, `${locale}.mdx`));
+      const claims = [
+        ...mdx.matchAll(/(\d+)(?=[^\n]{0,30}(?:components|composants))/g),
+      ].map((entry) => Number(entry[1]));
+
+      expect(
+        claims.length,
+        `home/${locale}.mdx has no detectable component-count claim`,
+      ).toBeGreaterThan(0);
+      claims.forEach((claim) => {
+        expect(claim).toBe(liveCount);
+      });
+    },
+  );
+
+  it("the PWA manifest description states the live count", () => {
+    expect(manifest().description).toContain(String(liveCount));
+  });
+});

--- a/apps/registry/registry/default/prompt-input/prompt-input.tsx
+++ b/apps/registry/registry/default/prompt-input/prompt-input.tsx
@@ -85,7 +85,7 @@ function usePromptInput({
   isControlled: boolean;
   onSubmit?: (value: string) => void;
   onValueChange?: (value: string) => void;
-  ref: React.Ref<HTMLTextAreaElement> | undefined;
+  ref?: React.Ref<HTMLTextAreaElement>;
   value?: string;
 }) {
   const { assignRef, innerRef } = useMergedRef(ref);


### PR DESCRIPTION
## Why

The site reported two different component counts:

| Surface | Count | Source |
|---|---|---|
| Homepage hero/stats, page metadata, `/ai`, `/vs/shadcn`, `llms.txt`, `llms-full.txt` | **309** | live — `getComponentCount()` = `registry.items.length` |
| Changelog `[Unreleased]`, PWA manifest, MCP server instructions, `home/{en,fr}.mdx` | **225** | hardcoded literal, last accurate ~PR #386 |

**Root cause:** two sources of truth. The live count auto-updates from `registry.json`; the hardcoded `225` is copy-pasted prose that drifted as ~84 components were added.

## What changed

- **`app/manifest.ts`, `app/mcp/route.ts`** — derive the count from the registry (`getComponentCount()` / `REGISTRY.items.length`). These can no longer drift.
- **`CHANGELOG.md` `[Unreleased]`, `home/{en,fr}.mdx`** — bump `225` → `309`. The changelog snapshot is intentionally a release-time value (parsed by `lib/changelog.ts` as a "up from N" stat), so it stays a literal but is now guarded.
- **`apps/registry/lib/component-count.test.ts`** — regression guard: fails when the changelog `[Unreleased]` count, either home MDX, or the manifest description diverges from `registry.items.length`. Verified it goes red on the stale `225` and green on `309`.

## Notes / out of scope

- `content/pages/home/{en,fr}.mdx` appear **orphaned** — the locale homepage renders `<Landing/>` (React), not this MDX, and `/llms-full.txt` reads a non-existent `content/pages/home.mdx`. Updated in place rather than deleted (Chesterton's fence); orphan cleanup can be a follow-up.
- The pre-existing `(up from 140)` delta in the changelog is left untouched.

## Validation

- `vitest run` — 34/34 pass (incl. new guard); RED proof confirmed on stale value
- `tsc --noEmit` — clean
- `eslint` (changed files) — clean

Closes #449