### PR TITLE
feat(registry): verify component previews resolve to real stories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,12 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 concurrency:
-  group: ci-${{ github.head_ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   quality:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
         working-directory: packages/ui
         run: pnpm build-storybook
 
+      - name: Verify component previews resolve to real stories
+        run: pnpm -F @vllnt/ui-registry registry:verify-previews
+
   e2e:
     name: E2E (Playwright)
     runs-on: ubuntu-latest

--- a/apps/registry/e2e/preview-embeds.spec.ts
+++ b/apps/registry/e2e/preview-embeds.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Live preview E2E — verify a DEPLOYED registry shows previews wired to the
+ * matching, reachable Storybook instance.
+ *
+ * The build-time guard (scripts/verify-preview-stories.ts) proves metadata IDs
+ * match the Storybook build from the SAME commit. This is the complementary
+ * runtime layer: it hits the actual deployed pages and asserts the embedded
+ * iframe's story ID resolves against the LIVE Storybook the deployment points
+ * at — catching deploy-env issues the static check can't see (wrong
+ * NEXT_PUBLIC_STORYBOOK_URL, registry↔storybook version skew, an unrouted
+ * storybook origin).
+ *
+ * Where it runs (playwright.config.ts reads PLAYWRIGHT_BASE_URL):
+ *   - ntk promote gate — `PLAYWRIGHT_BASE_URL=$NTK_PREVIEW_URL … test:e2e`
+ *     runs this against the live PR preview before a prod promote (ntk.yaml).
+ *   - production — `PLAYWRIGHT_BASE_URL=https://ui.vllnt.ai pnpm -F
+ *     @vllnt/ui-registry test:e2e`.
+ *   - local / GH Actions e2e job — no PLAYWRIGHT_BASE_URL, so it hits the dev
+ *     server whose Storybook origin (localhost:6006) is not running; the live
+ *     assertions self-skip (see below) and only the page↔metadata wiring check
+ *     runs.
+ *
+ * Infra vs code (per the ntk-preview flakiness lessons): a reachable Storybook
+ * that is MISSING a referenced story is a real bug → FAIL. A Storybook origin
+ * that is unreachable (tailnet-only, not provisioned for this PR, transient
+ * 5xx) is infra → SKIP, never a false red that blocks a promote.
+ */
+
+import { readFileSync } from "node:fs";
+
+import { expect, test, type Page } from "@playwright/test";
+
+type ComponentMeta = {
+  defaultStoryId: string;
+  name: string;
+  stories: { id: string; name: string }[];
+};
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:41599";
+
+const metadata = JSON.parse(
+  readFileSync(new URL("../lib/component-metadata.json", import.meta.url), "utf8"),
+) as Record<string, ComponentMeta>;
+
+const components = Object.values(metadata).filter((c) => c.defaultStoryId);
+
+/** A spread of components for the per-page render check, always incl. the one
+ *  that regressed (ai-source-citation). The full set is id-checked in bulk. */
+const renderSample = (() => {
+  const count = Math.min(6, components.length);
+  const step = Math.max(1, Math.floor(components.length / count));
+  const sample = Array.from({ length: count }, (_, i) => components[i * step]!);
+  const regressed = components.find((c) => c.name === "ai-source-citation");
+  if (regressed && !sample.some((c) => c.name === "ai-source-citation")) {
+    sample[0] = regressed;
+  }
+  return sample;
+})();
+
+/** Discovered once per worker: the Storybook origin the deployment embeds, and
+ *  its live story-id set (null when the origin is unreachable = infra). */
+let live: { ids: null | Set<string>; origin: string };
+
+async function readIframeSource(page: Page, slug: string): Promise<string> {
+  await page.goto(`/components/${slug}`);
+  const iframe = page.locator('iframe[src*="/iframe.html"]').first();
+  await iframe.waitFor({ state: "attached", timeout: 30_000 });
+  const source = await iframe.getAttribute("src");
+  if (!source) throw new Error(`no Storybook iframe on /components/${slug}`);
+  return source;
+}
+
+test.beforeAll(async ({ browser }) => {
+  const context = await browser.newContext({ baseURL: BASE_URL });
+  const page = await context.newPage();
+  try {
+    const source = await readIframeSource(page, "ai-source-citation");
+    const origin = new URL(source).origin;
+    let ids: null | Set<string> = null;
+    try {
+      const response = await context.request.get(`${origin}/index.json`, {
+        timeout: 15_000,
+      });
+      if (response.ok()) {
+        const index = (await response.json()) as {
+          entries: Record<string, { type?: string }>;
+        };
+        ids = new Set(
+          Object.entries(index.entries)
+            .filter(([, entry]) => entry.type === "story")
+            .map(([id]) => id),
+        );
+      }
+    } catch {
+      ids = null;
+    }
+    live = { ids, origin };
+  } finally {
+    await context.close();
+  }
+});
+
+test("every deployed preview id resolves to a real story in the live Storybook", async () => {
+  test.skip(
+    live.ids === null,
+    `Storybook origin ${live.origin} unreachable (tailnet/infra or preview not provisioned) — skipping live id assertions`,
+  );
+
+  const missing: string[] = [];
+  for (const component of components) {
+    const referenced = new Set([
+      component.defaultStoryId,
+      ...component.stories.map((story) => story.id),
+    ]);
+    for (const id of referenced) {
+      if (id && !live.ids!.has(id)) missing.push(`${component.name} → ${id}`);
+    }
+  }
+
+  expect(
+    missing,
+    `${missing.length} preview id(s) are not real stories in ${live.origin}/index.json:\n${missing.join("\n")}`,
+  ).toEqual([]);
+});
+
+for (const component of renderSample) {
+  test(`/components/${component.name} embeds its metadata story id`, async ({
+    page,
+  }) => {
+    const source = await readIframeSource(page, component.name);
+    const embeddedId = new URL(source).searchParams.get("id");
+
+    expect(
+      embeddedId,
+      `${component.name}: embedded iframe id must equal its metadata defaultStoryId`,
+    ).toBe(component.defaultStoryId);
+
+    test.skip(
+      live.ids === null,
+      `Storybook origin unreachable — skipping live resolution for ${component.name}`,
+    );
+    expect(
+      live.ids!.has(embeddedId!),
+      `${component.name}: embedded story id "${embeddedId}" is not a real story in ${live.origin}`,
+    ).toBe(true);
+  });
+}

--- a/apps/registry/lib/component-metadata.json
+++ b/apps/registry/lib/component-metadata.json
@@ -14,20 +14,20 @@
   },
   "activity-heatmap": {
     "category": "data",
-    "defaultStoryId": "deploymentactivity--default",
+    "defaultStoryId": "data-activityheatmap--default",
     "description": "Contribution-style grid for visualizing operational activity over time.",
     "name": "activity-heatmap",
     "stories": [
       {
-        "id": "deploymentactivity--default",
+        "id": "data-activityheatmap--default",
         "name": "Default"
       },
       {
-        "id": "deploymentactivity--two-weeks",
+        "id": "data-activityheatmap--two-weeks",
         "name": "Two Weeks"
       },
       {
-        "id": "deploymentactivity--heading-override",
+        "id": "data-activityheatmap--heading-override",
         "name": "Heading Override"
       }
     ],
@@ -35,16 +35,16 @@
   },
   "activity-log": {
     "category": "data",
-    "defaultStoryId": "activitylog--default",
+    "defaultStoryId": "analytics-activitylog--default",
     "description": "Paginated activity feed for audit history and analytics changes.",
     "name": "activity-log",
     "stories": [
       {
-        "id": "activitylog--default",
+        "id": "analytics-activitylog--default",
         "name": "Default"
       },
       {
-        "id": "activitylog--empty",
+        "id": "analytics-activitylog--empty",
         "name": "Empty"
       }
     ],
@@ -77,24 +77,24 @@
   },
   "ai-artifact": {
     "category": "ai",
-    "defaultStoryId": "generatedcomponent--default",
+    "defaultStoryId": "ai-aiartifact--default",
     "description": "Rendered output area for AI-generated content with toolbar, copy/edit/download/fullscreen actions, and version chips.",
     "name": "ai-artifact",
     "stories": [
       {
-        "id": "generatedcomponent--default",
+        "id": "ai-aiartifact--default",
         "name": "Default"
       },
       {
-        "id": "generatedcomponent--read-only",
+        "id": "ai-aiartifact--read-only",
         "name": "Read Only"
       },
       {
-        "id": "generatedcomponent--document",
+        "id": "ai-aiartifact--document",
         "name": "Document"
       },
       {
-        "id": "generatedcomponent--minimal",
+        "id": "ai-aiartifact--minimal",
         "name": "Minimal"
       }
     ],
@@ -161,12 +161,12 @@
   },
   "ai-source-citation": {
     "category": "learning",
-    "defaultStoryId": "designingreadableaiconversations--default",
+    "defaultStoryId": "ai-sourcecitation--default",
     "description": "Compact source reference card for AI answers with a title, origin label, and optional excerpt.",
     "name": "ai-source-citation",
     "stories": [
       {
-        "id": "designingreadableaiconversations--default",
+        "id": "ai-sourcecitation--default",
         "name": "Default"
       }
     ],
@@ -336,16 +336,16 @@
   },
   "animated-testimonials": {
     "category": "content",
-    "defaultStoryId": "engineer--default",
+    "defaultStoryId": "effects-animatedtestimonials--default",
     "description": "Testimonial carousel with animated transitions between quotes.",
     "name": "animated-testimonials",
     "stories": [
       {
-        "id": "engineer--default",
+        "id": "effects-animatedtestimonials--default",
         "name": "Default"
       },
       {
-        "id": "engineer--autoplay",
+        "id": "effects-animatedtestimonials--autoplay",
         "name": "Autoplay"
       }
     ],
@@ -603,12 +603,12 @@
   },
   "blog-card": {
     "category": "content",
-    "defaultStoryId": "exampleblogpost--default",
+    "defaultStoryId": "content-blogcard--default",
     "description": "Card layout for displaying blog post previews.",
     "name": "blog-card",
     "stories": [
       {
-        "id": "exampleblogpost--default",
+        "id": "content-blogcard--default",
         "name": "Default"
       }
     ],
@@ -1002,24 +1002,24 @@
   },
   "chronological-timeline": {
     "category": "data-display",
-    "defaultStoryId": "thespacerace--default",
+    "defaultStoryId": "educational-chronologicaltimeline--default",
     "description": "Media-rich, scroll-driven chronological timeline with alternating cards, image/video/audio media, and a progress strip.",
     "name": "chronological-timeline",
     "stories": [
       {
-        "id": "thespacerace--default",
+        "id": "educational-chronologicaltimeline--default",
         "name": "Default"
       },
       {
-        "id": "thespacerace--with-image-media",
+        "id": "educational-chronologicaltimeline--with-image-media",
         "name": "With Image Media"
       },
       {
-        "id": "thespacerace--compact",
+        "id": "educational-chronologicaltimeline--compact",
         "name": "Compact"
       },
       {
-        "id": "thespacerace--untitled",
+        "id": "educational-chronologicaltimeline--untitled",
         "name": "Untitled"
       }
     ],
@@ -1171,16 +1171,16 @@
   },
   "comparison": {
     "category": "data",
-    "defaultStoryId": "exampletitle--default",
+    "defaultStoryId": "data-comparison--default",
     "description": "Side-by-side comparison layout for content or features.",
     "name": "comparison",
     "stories": [
       {
-        "id": "exampletitle--default",
+        "id": "data-comparison--default",
         "name": "Default"
       },
       {
-        "id": "exampletitle--heading-override",
+        "id": "data-comparison--heading-override",
         "name": "Heading Override"
       }
     ],
@@ -1188,16 +1188,16 @@
   },
   "completion-dialog": {
     "category": "learning",
-    "defaultStoryId": "congratulations--default",
+    "defaultStoryId": "learning-completiondialog--default",
     "description": "Dialog displayed upon completing a task or workflow.",
     "name": "completion-dialog",
     "stories": [
       {
-        "id": "congratulations--default",
+        "id": "learning-completiondialog--default",
         "name": "Default"
       },
       {
-        "id": "congratulations--heading-override",
+        "id": "learning-completiondialog--heading-override",
         "name": "Heading Override"
       }
     ],
@@ -1218,16 +1218,16 @@
   },
   "content-intro": {
     "category": "content",
-    "defaultStoryId": "introduction--default",
+    "defaultStoryId": "content-contentintro--default",
     "description": "Introductory section for content pages with title and description.",
     "name": "content-intro",
     "stories": [
       {
-        "id": "introduction--default",
+        "id": "content-contentintro--default",
         "name": "Default"
       },
       {
-        "id": "introduction--heading-override",
+        "id": "content-contentintro--heading-override",
         "name": "Heading Override"
       }
     ],
@@ -1349,16 +1349,16 @@
   },
   "countdown-timer": {
     "category": "data",
-    "defaultStoryId": "slatimer--default",
+    "defaultStoryId": "data-countdowntimer--default",
     "description": "Countdown and SLA timer for deadlines, escalations, and response windows.",
     "name": "countdown-timer",
     "stories": [
       {
-        "id": "slatimer--default",
+        "id": "data-countdowntimer--default",
         "name": "Default"
       },
       {
-        "id": "slatimer--breached",
+        "id": "data-countdowntimer--breached",
         "name": "Breached"
       }
     ],
@@ -1366,16 +1366,16 @@
   },
   "credit-badge": {
     "category": "content",
-    "defaultStoryId": "accountbilling-creditbadge--default",
+    "defaultStoryId": "account-billing-creditbadge--default",
     "description": "Balance status pill for credits, wallet states, and billing health.",
     "name": "credit-badge",
     "stories": [
       {
-        "id": "accountbilling-creditbadge--default",
+        "id": "account-billing-creditbadge--default",
         "name": "Default"
       },
       {
-        "id": "accountbilling-creditbadge--states",
+        "id": "account-billing-creditbadge--states",
         "name": "States"
       }
     ],
@@ -1383,16 +1383,16 @@
   },
   "curriculum": {
     "category": "learning",
-    "defaultStoryId": "fullstackdevelopment--default",
+    "defaultStoryId": "learning-curriculum--default",
     "description": "Course-layout container for a sequence of lessons or modules with title, progress, optional intro, and a stack of lesson rows.",
     "name": "curriculum",
     "stories": [
       {
-        "id": "fullstackdevelopment--default",
+        "id": "learning-curriculum--default",
         "name": "Default"
       },
       {
-        "id": "fullstackdevelopment--expanded",
+        "id": "learning-curriculum--expanded",
         "name": "Expanded"
       }
     ],
@@ -1524,32 +1524,32 @@
   },
   "document-sibling-nav": {
     "category": "content",
-    "defaultStoryId": "whythinclientsareback--default",
+    "defaultStoryId": "content-documentsiblingnav--default",
     "description": "Newer/older navigator: links to the previous and next item in an ordered series.",
     "name": "document-sibling-nav",
     "stories": [
       {
-        "id": "whythinclientsareback--default",
+        "id": "content-documentsiblingnav--default",
         "name": "Default"
       },
       {
-        "id": "whythinclientsareback--only-previous",
+        "id": "content-documentsiblingnav--only-previous",
         "name": "Only Previous"
       },
       {
-        "id": "whythinclientsareback--only-next",
+        "id": "content-documentsiblingnav--only-next",
         "name": "Only Next"
       },
       {
-        "id": "whythinclientsareback--compact",
+        "id": "content-documentsiblingnav--compact",
         "name": "Compact"
       },
       {
-        "id": "whythinclientsareback--with-meta",
+        "id": "content-documentsiblingnav--with-meta",
         "name": "With Meta"
       },
       {
-        "id": "whythinclientsareback--localized",
+        "id": "content-documentsiblingnav--localized",
         "name": "Localized"
       }
     ],
@@ -1613,24 +1613,24 @@
   },
   "empty-state": {
     "category": "core",
-    "defaultStoryId": "noresultsfound--default",
+    "defaultStoryId": "core-emptystate--default",
     "description": "Centered placeholder for empty lists, tables, and search results with sm/md/lg sizes.",
     "name": "empty-state",
     "stories": [
       {
-        "id": "noresultsfound--default",
+        "id": "core-emptystate--default",
         "name": "Default"
       },
       {
-        "id": "noresultsfound--size-sm",
+        "id": "core-emptystate--size-sm",
         "name": "Size Sm"
       },
       {
-        "id": "noresultsfound--size-lg",
+        "id": "core-emptystate--size-lg",
         "name": "Size Lg"
       },
       {
-        "id": "noresultsfound--with-action",
+        "id": "core-emptystate--with-action",
         "name": "With Action"
       }
     ],
@@ -1659,16 +1659,16 @@
   },
   "exercise": {
     "category": "learning",
-    "defaultStoryId": "reverseastring--default",
+    "defaultStoryId": "learning-exercise--default",
     "description": "Interactive exercise block for learning content.",
     "name": "exercise",
     "stories": [
       {
-        "id": "reverseastring--default",
+        "id": "learning-exercise--default",
         "name": "Default"
       },
       {
-        "id": "reverseastring--heading-override",
+        "id": "learning-exercise--heading-override",
         "name": "Heading Override"
       }
     ],
@@ -1676,12 +1676,12 @@
   },
   "expandable-cards": {
     "category": "content",
-    "defaultStoryId": "gettingstarted--default",
+    "defaultStoryId": "effects-expandablecards--default",
     "description": "Cards that expand on click to reveal additional content.",
     "name": "expandable-cards",
     "stories": [
       {
-        "id": "gettingstarted--default",
+        "id": "effects-expandablecards--default",
         "name": "Default"
       }
     ],
@@ -1770,12 +1770,12 @@
   },
   "flashcard": {
     "category": "learning",
-    "defaultStoryId": "partsofspeech--default",
+    "defaultStoryId": "learning-flashcard--default",
     "description": "Study card for active recall with prompt and answer states.",
     "name": "flashcard",
     "stories": [
       {
-        "id": "partsofspeech--default",
+        "id": "learning-flashcard--default",
         "name": "Default"
       }
     ],
@@ -1881,24 +1881,24 @@
   },
   "gantt-chart": {
     "category": "data",
-    "defaultStoryId": "designsystem--default",
+    "defaultStoryId": "data-ganttchart--default",
     "description": "Project timeline with task bars, progress overlays, milestones, and a today indicator across day/week/month/quarter scales.",
     "name": "gantt-chart",
     "stories": [
       {
-        "id": "designsystem--default",
+        "id": "data-ganttchart--default",
         "name": "Default"
       },
       {
-        "id": "designsystem--quarter-scale",
+        "id": "data-ganttchart--quarter-scale",
         "name": "Quarter Scale"
       },
       {
-        "id": "designsystem--single-group",
+        "id": "data-ganttchart--single-group",
         "name": "Single Group"
       },
       {
-        "id": "designsystem--no-milestones",
+        "id": "data-ganttchart--no-milestones",
         "name": "No Milestones"
       }
     ],
@@ -2121,24 +2121,24 @@
   },
   "historic-timeline": {
     "category": "data-display",
-    "defaultStoryId": "firstolympics--default",
+    "defaultStoryId": "educational-historictimeline--default",
     "description": "Specialized timeline for historical events spanning centuries or millennia, with era bands, period bars, and BCE/CE point markers.",
     "name": "historic-timeline",
     "stories": [
       {
-        "id": "firstolympics--default",
+        "id": "educational-historictimeline--default",
         "name": "Default"
       },
       {
-        "id": "firstolympics--tight-window",
+        "id": "educational-historictimeline--tight-window",
         "name": "Tight Window"
       },
       {
-        "id": "firstolympics--no-categories",
+        "id": "educational-historictimeline--no-categories",
         "name": "No Categories"
       },
       {
-        "id": "firstolympics--periods-only",
+        "id": "educational-historictimeline--periods-only",
         "name": "Periods Only"
       }
     ],
@@ -2146,28 +2146,28 @@
   },
   "historical-figure-card": {
     "category": "educational",
-    "defaultStoryId": "polymath--default",
+    "defaultStoryId": "educational-historicalfigurecard--default",
     "description": "Profile card with portrait, lifespan timeline, fields, works, quote, connections, and an expandable biography section.",
     "name": "historical-figure-card",
     "stories": [
       {
-        "id": "polymath--default",
+        "id": "educational-historicalfigurecard--default",
         "name": "Default"
       },
       {
-        "id": "polymath--with-connections",
+        "id": "educational-historicalfigurecard--with-connections",
         "name": "With Connections"
       },
       {
-        "id": "polymath--with-biography",
+        "id": "educational-historicalfigurecard--with-biography",
         "name": "With Biography"
       },
       {
-        "id": "polymath--antiquity",
+        "id": "educational-historicalfigurecard--antiquity",
         "name": "Antiquity"
       },
       {
-        "id": "polymath--minimal",
+        "id": "educational-historicalfigurecard--minimal",
         "name": "Minimal"
       }
     ],
@@ -2290,24 +2290,24 @@
   },
   "interactive-timeline": {
     "category": "data-display",
-    "defaultStoryId": "v10--default",
+    "defaultStoryId": "timeline-interactivetimeline--default",
     "description": "Zoomable, pannable, multi-track timeline with category filter, today marker, and click-to-select events.",
     "name": "interactive-timeline",
     "stories": [
       {
-        "id": "v10--default",
+        "id": "timeline-interactivetimeline--default",
         "name": "Default"
       },
       {
-        "id": "v10--no-toolbar",
+        "id": "timeline-interactivetimeline--no-toolbar",
         "name": "No Toolbar"
       },
       {
-        "id": "v10--single-track",
+        "id": "timeline-interactivetimeline--single-track",
         "name": "Single Track"
       },
       {
-        "id": "v10--tight-window",
+        "id": "timeline-interactivetimeline--tight-window",
         "name": "Tight Window"
       }
     ],
@@ -2424,20 +2424,20 @@
   },
   "knowledge-check": {
     "category": "educational",
-    "defaultStoryId": "checkyourunderstanding--default",
+    "defaultStoryId": "educational-knowledgecheck--default",
     "description": "Inline knowledge check with multiple-choice / true-false / fill-blank questions, per-answer feedback, and a final score summary.",
     "name": "knowledge-check",
     "stories": [
       {
-        "id": "checkyourunderstanding--default",
+        "id": "educational-knowledgecheck--default",
         "name": "Default"
       },
       {
-        "id": "checkyourunderstanding--single-question",
+        "id": "educational-knowledgecheck--single-question",
         "name": "Single Question"
       },
       {
-        "id": "checkyourunderstanding--multiple-choice-only",
+        "id": "educational-knowledgecheck--multiple-choice-only",
         "name": "Multiple Choice Only"
       }
     ],
@@ -2589,16 +2589,16 @@
   },
   "live-feed": {
     "category": "data",
-    "defaultStoryId": "latencybreachongateway--default",
+    "defaultStoryId": "data-livefeed--default",
     "description": "Rolling activity stream for surfacing incidents, deploys, and operational signals in real time.",
     "name": "live-feed",
     "stories": [
       {
-        "id": "latencybreachongateway--default",
+        "id": "data-livefeed--default",
         "name": "Default"
       },
       {
-        "id": "latencybreachongateway--empty",
+        "id": "data-livefeed--empty",
         "name": "Empty"
       }
     ],
@@ -2796,24 +2796,24 @@
   },
   "metric-cluster": {
     "category": "data",
-    "defaultStoryId": "research2025--default",
+    "defaultStoryId": "canvas-metriccluster--default",
     "description": "Compact stack of related metrics pinned to a canvas object's corner.",
     "name": "metric-cluster",
     "stories": [
       {
-        "id": "research2025--default",
+        "id": "canvas-metriccluster--default",
         "name": "Default"
       },
       {
-        "id": "research2025--untitled",
+        "id": "canvas-metriccluster--untitled",
         "name": "Untitled"
       },
       {
-        "id": "research2025--bottom-left",
+        "id": "canvas-metriccluster--bottom-left",
         "name": "Bottom Left"
       },
       {
-        "id": "research2025--healthy",
+        "id": "canvas-metriccluster--healthy",
         "name": "Healthy"
       }
     ],
@@ -2952,12 +2952,12 @@
   },
   "navbar-saas": {
     "category": "navigation",
-    "defaultStoryId": "home--default",
+    "defaultStoryId": "navigation-navbarsaas--default",
     "description": "SaaS-style navigation bar with branding and links.",
     "name": "navbar-saas",
     "stories": [
       {
-        "id": "home--default",
+        "id": "navigation-navbarsaas--default",
         "name": "Default"
       }
     ],
@@ -3063,24 +3063,24 @@
   },
   "object-inspector": {
     "category": "content",
-    "defaultStoryId": "claude37128kctx--default",
+    "defaultStoryId": "canvas-objectinspector--default",
     "description": "Right-dock detail header — kind chip, status dot, title/subtitle, with property-section slots.",
     "name": "object-inspector",
     "stories": [
       {
-        "id": "claude37128kctx--default",
+        "id": "canvas-objectinspector--default",
         "name": "Default"
       },
       {
-        "id": "claude37128kctx--empty",
+        "id": "canvas-objectinspector--empty",
         "name": "Empty"
       },
       {
-        "id": "claude37128kctx--with-body",
+        "id": "canvas-objectinspector--with-body",
         "name": "With Body"
       },
       {
-        "id": "claude37128kctx--failed",
+        "id": "canvas-objectinspector--failed",
         "name": "Failed"
       }
     ],
@@ -3109,12 +3109,12 @@
   },
   "overview-board": {
     "category": "data",
-    "defaultStoryId": "acompactsummaryboardforthefloatingcanvasshellrightrailoroverviewroute--default",
+    "defaultStoryId": "layout-overviewboard--default",
     "description": "Grid of overview cards for at-a-glance dashboards — a row of headline metrics with consistent spacing and tone.",
     "name": "overview-board",
     "stories": [
       {
-        "id": "acompactsummaryboardforthefloatingcanvasshellrightrailoroverviewroute--default",
+        "id": "layout-overviewboard--default",
         "name": "Default"
       }
     ],
@@ -3152,24 +3152,24 @@
   },
   "parallel-timeline": {
     "category": "educational",
-    "defaultStoryId": "augustusbecomesemperor--default",
+    "defaultStoryId": "educational-paralleltimeline--default",
     "description": "Multi-track timeline with shared time axis, BCE/CE event markers, and optional era bands for comparative history.",
     "name": "parallel-timeline",
     "stories": [
       {
-        "id": "augustusbecomesemperor--default",
+        "id": "educational-paralleltimeline--default",
         "name": "Default"
       },
       {
-        "id": "augustusbecomesemperor--with-era",
+        "id": "educational-paralleltimeline--with-era",
         "name": "With Era"
       },
       {
-        "id": "augustusbecomesemperor--two-tracks",
+        "id": "educational-paralleltimeline--two-tracks",
         "name": "Two Tracks"
       },
       {
-        "id": "augustusbecomesemperor--tight-window",
+        "id": "educational-paralleltimeline--tight-window",
         "name": "Tight Window"
       }
     ],
@@ -3245,20 +3245,20 @@
   },
   "plan-badge": {
     "category": "content",
-    "defaultStoryId": "accountbilling-planbadge--default",
+    "defaultStoryId": "account-billing-planbadge--default",
     "description": "Subscription tier indicator for pricing, billing, and account summaries.",
     "name": "plan-badge",
     "stories": [
       {
-        "id": "accountbilling-planbadge--default",
+        "id": "account-billing-planbadge--default",
         "name": "Default"
       },
       {
-        "id": "accountbilling-planbadge--all-tiers",
+        "id": "account-billing-planbadge--all-tiers",
         "name": "All Tiers"
       },
       {
-        "id": "accountbilling-planbadge--trial",
+        "id": "account-billing-planbadge--trial",
         "name": "Trial"
       }
     ],
@@ -3400,20 +3400,20 @@
   },
   "primary-source-viewer": {
     "category": "data-display",
-    "defaultStoryId": "magnacarta1215--default",
+    "defaultStoryId": "educational-primarysourceviewer--default",
     "description": "Document viewer for historical primary sources with zoom, rotate, region annotations, transcription panel, and metadata footer.",
     "name": "primary-source-viewer",
     "stories": [
       {
-        "id": "magnacarta1215--default",
+        "id": "educational-primarysourceviewer--default",
         "name": "Default"
       },
       {
-        "id": "magnacarta1215--minimal",
+        "id": "educational-primarysourceviewer--minimal",
         "name": "Minimal"
       },
       {
-        "id": "magnacarta1215--no-transcription",
+        "id": "educational-primarysourceviewer--no-transcription",
         "name": "No Transcription"
       }
     ],
@@ -3477,16 +3477,16 @@
   },
   "progress-tracker": {
     "category": "learning",
-    "defaultStoryId": "javascriptbasics--default",
+    "defaultStoryId": "learning-progresstracker--default",
     "description": "Curriculum-level learning dashboard for modules, lessons, exercises, streaks, and earned skills.",
     "name": "progress-tracker",
     "stories": [
       {
-        "id": "javascriptbasics--default",
+        "id": "learning-progresstracker--default",
         "name": "Default"
       },
       {
-        "id": "javascriptbasics--compact-dashboard",
+        "id": "learning-progresstracker--compact-dashboard",
         "name": "Compact Dashboard"
       }
     ],
@@ -3536,24 +3536,24 @@
   },
   "prompt-templates": {
     "category": "ai",
-    "defaultStoryId": "codereview--default",
+    "defaultStoryId": "ai-prompttemplates--default",
     "description": "Searchable prompt template gallery with category filter, variable fill-in form, and onSelect.",
     "name": "prompt-templates",
     "stories": [
       {
-        "id": "codereview--default",
+        "id": "ai-prompttemplates--default",
         "name": "Default"
       },
       {
-        "id": "codereview--no-categories",
+        "id": "ai-prompttemplates--no-categories",
         "name": "No Categories"
       },
       {
-        "id": "codereview--empty",
+        "id": "ai-prompttemplates--empty",
         "name": "Empty"
       },
       {
-        "id": "codereview--custom-labels",
+        "id": "ai-prompttemplates--custom-labels",
         "name": "Custom Labels"
       }
     ],
@@ -3561,24 +3561,24 @@
   },
   "property-section": {
     "category": "content",
-    "defaultStoryId": "layout--default",
+    "defaultStoryId": "canvas-propertysection--default",
     "description": "Compact key/value grid for inspector panels — labels, sublabels, optional collapse.",
     "name": "property-section",
     "stories": [
       {
-        "id": "layout--default",
+        "id": "canvas-propertysection--default",
         "name": "Default"
       },
       {
-        "id": "layout--with-sublabels",
+        "id": "canvas-propertysection--with-sublabels",
         "name": "With Sublabels"
       },
       {
-        "id": "layout--collapsible",
+        "id": "canvas-propertysection--collapsible",
         "name": "Collapsible"
       },
       {
-        "id": "layout--untitled",
+        "id": "canvas-propertysection--untitled",
         "name": "Untitled"
       }
     ],
@@ -3785,16 +3785,16 @@
   },
   "role-badge": {
     "category": "content",
-    "defaultStoryId": "accountbilling-rolebadge--default",
+    "defaultStoryId": "account-billing-rolebadge--default",
     "description": "Account role indicator for owners, admins, members, and billing contacts.",
     "name": "role-badge",
     "stories": [
       {
-        "id": "accountbilling-rolebadge--default",
+        "id": "account-billing-rolebadge--default",
         "name": "Default"
       },
       {
-        "id": "accountbilling-rolebadge--team-roles",
+        "id": "account-billing-rolebadge--team-roles",
         "name": "Team Roles"
       }
     ],
@@ -4263,12 +4263,12 @@
   },
   "sidebar": {
     "category": "navigation",
-    "defaultStoryId": "introduction--default",
+    "defaultStoryId": "navigation-sidebar--default",
     "description": "Collapsible sidebar navigation layout.",
     "name": "sidebar",
     "stories": [
       {
-        "id": "introduction--default",
+        "id": "navigation-sidebar--default",
         "name": "Default"
       }
     ],
@@ -4328,16 +4328,16 @@
   },
   "slideshow": {
     "category": "content",
-    "defaultStoryId": "introduction--default",
+    "defaultStoryId": "content-slideshow--default",
     "description": "Step-through slideshow for presenting content sequentially.",
     "name": "slideshow",
     "stories": [
       {
-        "id": "introduction--default",
+        "id": "content-slideshow--default",
         "name": "Default"
       },
       {
-        "id": "introduction--heading-override",
+        "id": "content-slideshow--heading-override",
         "name": "Heading Override"
       }
     ],
@@ -4485,20 +4485,20 @@
   },
   "status-board": {
     "category": "data",
-    "defaultStoryId": "servicehealth--default",
+    "defaultStoryId": "data-statusboard--default",
     "description": "Service health grid for surfacing infrastructure state, queue pressure, and incidents.",
     "name": "status-board",
     "stories": [
       {
-        "id": "servicehealth--default",
+        "id": "data-statusboard--default",
         "name": "Default"
       },
       {
-        "id": "servicehealth--compact",
+        "id": "data-statusboard--compact",
         "name": "Compact"
       },
       {
-        "id": "servicehealth--heading-override",
+        "id": "data-statusboard--heading-override",
         "name": "Heading Override"
       }
     ],
@@ -4523,12 +4523,12 @@
   },
   "step-by-step": {
     "category": "learning",
-    "defaultStoryId": "gettingstarted--default",
+    "defaultStoryId": "learning-stepbystep--default",
     "description": "Numbered step guide with optional interactive completion tracking.",
     "name": "step-by-step",
     "stories": [
       {
-        "id": "gettingstarted--default",
+        "id": "learning-stepbystep--default",
         "name": "Default"
       }
     ],
@@ -4549,16 +4549,16 @@
   },
   "stepper": {
     "category": "learning",
-    "defaultStoryId": "introduction--default",
+    "defaultStoryId": "learning-stepper--default",
     "description": "Sequenced steps with complete, current, and upcoming states.",
     "name": "stepper",
     "stories": [
       {
-        "id": "introduction--default",
+        "id": "learning-stepper--default",
         "name": "Default"
       },
       {
-        "id": "introduction--vertical",
+        "id": "learning-stepper--vertical",
         "name": "Vertical"
       }
     ],
@@ -4612,16 +4612,16 @@
   },
   "subscription-card": {
     "category": "content",
-    "defaultStoryId": "accountbilling-subscriptioncard--default",
+    "defaultStoryId": "account-billing-subscriptioncard--default",
     "description": "Subscription status and management card for plan, renewal, and usage details.",
     "name": "subscription-card",
     "stories": [
       {
-        "id": "accountbilling-subscriptioncard--default",
+        "id": "account-billing-subscriptioncard--default",
         "name": "Default"
       },
       {
-        "id": "accountbilling-subscriptioncard--trialing",
+        "id": "account-billing-subscriptioncard--trialing",
         "name": "Trialing"
       }
     ],
@@ -4672,16 +4672,16 @@
   },
   "table-of-contents-panel": {
     "category": "utility",
-    "defaultStoryId": "introduction--default",
+    "defaultStoryId": "utility-tableofcontentspanel--default",
     "description": "Side panel rendering a table of contents for page navigation.",
     "name": "table-of-contents-panel",
     "stories": [
       {
-        "id": "introduction--default",
+        "id": "utility-tableofcontentspanel--default",
         "name": "Default"
       },
       {
-        "id": "introduction--heading-override",
+        "id": "utility-tableofcontentspanel--heading-override",
         "name": "Heading Override"
       }
     ],
@@ -4907,24 +4907,24 @@
   },
   "thread-bubble": {
     "category": "utility",
-    "defaultStoryId": "research2025--default",
+    "defaultStoryId": "canvas-threadbubble--default",
     "description": "Expanded discussion bubble for an anchored canvas comment thread.",
     "name": "thread-bubble",
     "stories": [
       {
-        "id": "research2025--default",
+        "id": "canvas-threadbubble--default",
         "name": "Default"
       },
       {
-        "id": "research2025--empty",
+        "id": "canvas-threadbubble--empty",
         "name": "Empty"
       },
       {
-        "id": "research2025--with-footer",
+        "id": "canvas-threadbubble--with-footer",
         "name": "With Footer"
       },
       {
-        "id": "research2025--read-only",
+        "id": "canvas-threadbubble--read-only",
         "name": "Read Only"
       }
     ],
@@ -5186,12 +5186,12 @@
   },
   "tour": {
     "category": "learning",
-    "defaultStoryId": "overview--default",
+    "defaultStoryId": "learning-tour--default",
     "description": "Guided onboarding flow for introducing content or interface patterns.",
     "name": "tour",
     "stories": [
       {
-        "id": "overview--default",
+        "id": "learning-tour--default",
         "name": "Default"
       }
     ],
@@ -5224,24 +5224,24 @@
   },
   "tree-view": {
     "category": "data-display",
-    "defaultStoryId": "datadisplay-treeview--default",
+    "defaultStoryId": "data-display-treeview--default",
     "description": "Hierarchical tree component for nested data with controlled state, single/multi-select, and keyboard navigation.",
     "name": "tree-view",
     "stories": [
       {
-        "id": "datadisplay-treeview--default",
+        "id": "data-display-treeview--default",
         "name": "Default"
       },
       {
-        "id": "datadisplay-treeview--multi-select",
+        "id": "data-display-treeview--multi-select",
         "name": "Multi Select"
       },
       {
-        "id": "datadisplay-treeview--collapsed",
+        "id": "data-display-treeview--collapsed",
         "name": "Collapsed"
       },
       {
-        "id": "datadisplay-treeview--single-level",
+        "id": "data-display-treeview--single-level",
         "name": "Single Level"
       }
     ],
@@ -5262,12 +5262,12 @@
   },
   "tutorial-card": {
     "category": "learning",
-    "defaultStoryId": "exampletitle--default",
+    "defaultStoryId": "learning-tutorialcard--default",
     "description": "Card for displaying tutorial previews with metadata.",
     "name": "tutorial-card",
     "stories": [
       {
-        "id": "exampletitle--default",
+        "id": "learning-tutorialcard--default",
         "name": "Default"
       }
     ],
@@ -5275,16 +5275,16 @@
   },
   "tutorial-complete": {
     "category": "learning",
-    "defaultStoryId": "nextsteps--default",
+    "defaultStoryId": "learning-tutorialcomplete--default",
     "description": "Completion screen displayed when a tutorial is finished.",
     "name": "tutorial-complete",
     "stories": [
       {
-        "id": "nextsteps--default",
+        "id": "learning-tutorialcomplete--default",
         "name": "Default"
       },
       {
-        "id": "nextsteps--heading-override",
+        "id": "learning-tutorialcomplete--heading-override",
         "name": "Heading Override"
       }
     ],
@@ -5305,12 +5305,12 @@
   },
   "tutorial-intro-content": {
     "category": "learning",
-    "defaultStoryId": "reactfundamentals--default",
+    "defaultStoryId": "learning-tutorialintrocontent--default",
     "description": "Introduction section for tutorial pages with overview and prerequisites.",
     "name": "tutorial-intro-content",
     "stories": [
       {
-        "id": "reactfundamentals--default",
+        "id": "learning-tutorialintrocontent--default",
         "name": "Default"
       }
     ],
@@ -5377,20 +5377,20 @@
   },
   "usage-breakdown": {
     "category": "data",
-    "defaultStoryId": "usagebreakdown--default",
+    "defaultStoryId": "analytics-usagebreakdown--default",
     "description": "Ranked resource consumption list with relative share and trend cues.",
     "name": "usage-breakdown",
     "stories": [
       {
-        "id": "usagebreakdown--default",
+        "id": "analytics-usagebreakdown--default",
         "name": "Default"
       },
       {
-        "id": "usagebreakdown--top-two-only",
+        "id": "analytics-usagebreakdown--top-two-only",
         "name": "Top Two Only"
       },
       {
-        "id": "usagebreakdown--empty",
+        "id": "analytics-usagebreakdown--empty",
         "name": "Empty"
       }
     ],
@@ -5398,12 +5398,12 @@
   },
   "video-embed": {
     "category": "content",
-    "defaultStoryId": "tutorialvideo--default",
+    "defaultStoryId": "content-videoembed--default",
     "description": "Responsive video embed for YouTube and other providers.",
     "name": "video-embed",
     "stories": [
       {
-        "id": "tutorialvideo--default",
+        "id": "content-videoembed--default",
         "name": "Default"
       }
     ],
@@ -5449,16 +5449,16 @@
   },
   "wallet-card": {
     "category": "content",
-    "defaultStoryId": "accountbilling-walletcard--default",
+    "defaultStoryId": "account-billing-walletcard--default",
     "description": "Credit balance display card for available, pending, and refresh details.",
     "name": "wallet-card",
     "stories": [
       {
-        "id": "accountbilling-walletcard--default",
+        "id": "account-billing-walletcard--default",
         "name": "Default"
       },
       {
-        "id": "accountbilling-walletcard--depleted",
+        "id": "account-billing-walletcard--depleted",
         "name": "Depleted"
       }
     ],
@@ -5525,20 +5525,20 @@
   },
   "world-clock-bar": {
     "category": "data",
-    "defaultStoryId": "followthesunhandoff--default",
+    "defaultStoryId": "data-worldclockbar--default",
     "description": "Multi-timezone display for follow-the-sun teams and operational handoffs.",
     "name": "world-clock-bar",
     "stories": [
       {
-        "id": "followthesunhandoff--default",
+        "id": "data-worldclockbar--default",
         "name": "Default"
       },
       {
-        "id": "followthesunhandoff--time-only",
+        "id": "data-worldclockbar--time-only",
         "name": "Time Only"
       },
       {
-        "id": "followthesunhandoff--heading-override",
+        "id": "data-worldclockbar--heading-override",
         "name": "Heading Override"
       }
     ],

--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -16,6 +16,7 @@
     "registry:sync-shims": "tsx scripts/inline-component-source.ts",
     "registry:check": "tsx scripts/check-registry-drift.ts",
     "registry:integrity": "tsx scripts/check-registry-integrity.ts",
+    "registry:verify-previews": "tsx scripts/verify-preview-stories.ts",
     "search:index": "pagefind --site .next/server/app --output-path public/_pagefind --root-selector main --force-language en",
     "sync-storybook": "tsx scripts/generate-component-metadata.ts"
   },

--- a/apps/registry/scripts/generate-component-metadata.ts
+++ b/apps/registry/scripts/generate-component-metadata.ts
@@ -66,32 +66,111 @@ const outputPath = join(
   "component-metadata.json",
 );
 
-const TITLE_PATTERN = /title\s*:\s*["'`]([^"'`]+)["'`]/;
 const NAMED_EXPORT_PATTERN = /^export\s+const\s+([A-Z][\w$]*)\s*[:=]/gm;
+const TITLE_KEY_PATTERN = /^["']?title["']?\s*:\s*["'`]([^"'`]*)["'`]/;
+const META_OBJECT_PATTERN = /\b(?:const|let|var)\s+meta\b[^=]*=\s*\{/;
 
-function slugifyTitleSegment(segment: string): string {
-  return segment
+/**
+ * Mirror of Storybook's `sanitize` (from @storybook/csf): lowercase, collapse
+ * every run of non-alphanumerics to a single "-", trim leading/trailing "-".
+ * Storybook derives story IDs from the title + story name with this exact rule,
+ * so the metadata IDs must be produced the same way or the preview iframe 404s
+ * ("Couldn't find story matching …"). verify-preview-stories.ts cross-checks the
+ * result against the real built index.json — the authoritative guard for any
+ * exotic title Storybook happens to slug differently.
+ */
+function sanitize(input: string): string {
+  return input
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "")
-    .replace(/^-+|-+$/g, "");
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "");
 }
 
-function titleToStoryIdPrefix(title: string): string {
-  const segments: string[] = [];
-  for (const segment of title.split("/")) {
-    const slug = slugifyTitleSegment(segment);
-    if (slug) {
-      segments.push(slug);
+/**
+ * Split a PascalCase story export into words the way Storybook's
+ * `storyNameFromExport` (lodash startCase) does, then sanitize — so
+ * `WithLongText` → `with-long-text` matches the built story id.
+ */
+function exportNameToStorySlug(exportName: string): string {
+  const spaced = exportName
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2");
+  return sanitize(spaced);
+}
+
+function skipStringLiteral(source: string, start: number): number {
+  const quote = source[start];
+  let index = start + 1;
+  while (index < source.length) {
+    const char = source[index];
+    if (char === "\\") {
+      index += 2;
+      continue;
     }
+    if (char === quote) return index + 1;
+    index += 1;
   }
-  return segments.join("-");
+  return source.length;
 }
 
-function exportNameToSlug(exportName: string): string {
-  return exportName
-    .replace(/([a-z])([A-Z])/g, "$1-$2")
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
-    .toLowerCase();
+function isWordBoundaryBefore(source: string, index: number): boolean {
+  return index === 0 || !/[\w$]/.test(source[index - 1]!);
+}
+
+/**
+ * Extract the Storybook meta `title` — the object's OWN top-level property.
+ * A naive `title:` regex matches the first occurrence, which is frequently a
+ * nested `args.title` (sample content), producing a bogus story id such as
+ * `designingreadableaiconversations--default`. This walks the `const meta = {}`
+ * object literal and only reads `title:` at brace depth 1, skipping strings and
+ * comments so nested braces/quotes never confuse the depth count.
+ */
+function extractMetaTitle(source: string): string | undefined {
+  const declaration = META_OBJECT_PATTERN.exec(source);
+  const openBraceIndex = declaration
+    ? declaration.index + declaration[0].length - 1
+    : source.indexOf("{", source.indexOf("export default"));
+  if (openBraceIndex < 0) return undefined;
+
+  let depth = 0;
+  let index = openBraceIndex;
+  while (index < source.length) {
+    const char = source[index];
+
+    if (char === "/" && source[index + 1] === "/") {
+      const newline = source.indexOf("\n", index);
+      index = newline === -1 ? source.length : newline;
+      continue;
+    }
+    if (char === "/" && source[index + 1] === "*") {
+      const end = source.indexOf("*/", index + 2);
+      index = end === -1 ? source.length : end + 2;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") {
+      index = skipStringLiteral(source, index);
+      continue;
+    }
+    if (char === "{") {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+    if (char === "}") {
+      depth -= 1;
+      index += 1;
+      if (depth === 0) break;
+      continue;
+    }
+    if (depth === 1 && isWordBoundaryBefore(source, index)) {
+      const keyValue = TITLE_KEY_PATTERN.exec(source.slice(index));
+      if (keyValue?.[1] !== undefined) return keyValue[1];
+    }
+    index += 1;
+  }
+
+  return undefined;
 }
 
 function findStoryFile(componentName: string): string | undefined {
@@ -110,10 +189,9 @@ function parseStoriesFromFile(
   filePath: string,
 ): { title: string; exportNames: string[] } | undefined {
   const source = readFileSync(filePath, "utf8");
-  const titleMatch = TITLE_PATTERN.exec(source);
-  if (!titleMatch?.[1]) return;
+  const title = extractMetaTitle(source);
+  if (!title) return;
 
-  const title = titleMatch[1];
   const exportNames: string[] = [];
   let match: RegExpExecArray | null;
 
@@ -132,10 +210,10 @@ function buildEntries(
   componentName: string,
   parsed: { title: string; exportNames: string[] },
 ): { defaultStoryId: string; stories: StoryEntry[] } {
-  const prefix = titleToStoryIdPrefix(parsed.title);
+  const prefix = sanitize(parsed.title);
 
   const stories: StoryEntry[] = parsed.exportNames.map((exportName) => ({
-    id: `${prefix}--${exportNameToSlug(exportName)}`,
+    id: `${prefix}--${exportNameToStorySlug(exportName)}`,
     name: exportName.replace(/([a-z])([A-Z])/g, "$1 $2"),
   }));
 

--- a/apps/registry/scripts/verify-preview-stories.ts
+++ b/apps/registry/scripts/verify-preview-stories.ts
@@ -1,0 +1,155 @@
+/**
+ * Verify every component preview resolves to a real Storybook story.
+ *
+ * The registry site embeds a Storybook iframe using the story IDs recorded in
+ * apps/registry/lib/component-metadata.json (`defaultStoryId` + `stories[].id`).
+ * If any of those IDs is absent from the actual Storybook build, the iframe
+ * renders "Couldn't find story matching '<id>'" and the preview is blank.
+ *
+ * This loads the authoritative story index produced by `pnpm build-storybook`
+ * (packages/ui/storybook-static/index.json) and asserts that:
+ *
+ *   1. BROKEN — every metadata story ID exists as a real `story` entry, and
+ *   2. MISSING — every component that has a real story also has a non-empty
+ *      `defaultStoryId` (otherwise its preview is silently hidden).
+ *
+ * Exits non-zero on any mismatch. This is the authoritative guard: it holds
+ * regardless of how the metadata is generated, so it catches the args.title
+ * regex bug, slug-algorithm drift, renamed stories, and stale metadata alike.
+ *
+ * Run: pnpm -F @vllnt/ui-registry registry:verify-previews
+ * Requires a fresh Storybook build first (CI builds it in the same job).
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDirectory, "..", "..", "..");
+
+const metadataPath = join(
+  repoRoot,
+  "apps",
+  "registry",
+  "lib",
+  "component-metadata.json",
+);
+const storybookIndexPath = join(
+  repoRoot,
+  "packages",
+  "ui",
+  "storybook-static",
+  "index.json",
+);
+
+type ComponentMetadata = {
+  defaultStoryId: string;
+  name: string;
+  stories: { id: string; name: string }[];
+};
+
+type StorybookIndexEntry = {
+  importPath: string;
+  type: string;
+};
+
+type StorybookIndex = {
+  entries: Record<string, StorybookIndexEntry>;
+};
+
+type Failure = {
+  component: string;
+  detail: string;
+  kind: "broken" | "missing";
+};
+
+function fail(message: string): never {
+  console.error(`✗ ${message}`);
+  process.exit(1);
+}
+
+if (!existsSync(storybookIndexPath)) {
+  fail(
+    `Storybook index not found at ${storybookIndexPath}.\n` +
+      `  Build it first: pnpm -F @vllnt/ui build-storybook`,
+  );
+}
+
+const metadata = JSON.parse(readFileSync(metadataPath, "utf8")) as Record<
+  string,
+  ComponentMetadata
+>;
+const storybookIndex = JSON.parse(
+  readFileSync(storybookIndexPath, "utf8"),
+) as StorybookIndex;
+
+const storyEntries = Object.entries(storybookIndex.entries).filter(
+  ([, entry]) => entry.type === "story",
+);
+const validStoryIds = new Set(storyEntries.map(([id]) => id));
+
+/** Story IDs that belong to a given component folder, for actionable hints. */
+function storyIdsForComponent(componentName: string): string[] {
+  const marker = `/components/${componentName}/`;
+  return storyEntries
+    .filter(([, entry]) => entry.importPath.includes(marker))
+    .map(([id]) => id);
+}
+
+const failures: Failure[] = [];
+
+for (const component of Object.values(metadata)) {
+  const referencedIds = new Set<string>();
+  if (component.defaultStoryId) referencedIds.add(component.defaultStoryId);
+  for (const story of component.stories) referencedIds.add(story.id);
+
+  for (const id of referencedIds) {
+    if (!validStoryIds.has(id)) {
+      const available = storyIdsForComponent(component.name);
+      const hint =
+        available.length > 0
+          ? `available: ${available.join(", ")}`
+          : "no stories found for this component in the Storybook build";
+      failures.push({
+        component: component.name,
+        detail: `references "${id}" which is not a built story (${hint})`,
+        kind: "broken",
+      });
+    }
+  }
+
+  if (!component.defaultStoryId) {
+    const available = storyIdsForComponent(component.name);
+    if (available.length > 0) {
+      failures.push({
+        component: component.name,
+        detail: `has no defaultStoryId but Storybook has ${available.join(", ")} — preview is hidden`,
+        kind: "missing",
+      });
+    }
+  }
+}
+
+const componentCount = Object.keys(metadata).length;
+
+if (failures.length === 0) {
+  console.info(
+    `✓ All ${componentCount} component previews resolve to real Storybook stories ` +
+      `(${validStoryIds.size} stories indexed).`,
+  );
+  process.exit(0);
+}
+
+console.error(
+  `✗ ${failures.length} component preview(s) reference stories that do not exist:\n`,
+);
+for (const failure of failures) {
+  const label = failure.kind === "broken" ? "BROKEN" : "MISSING";
+  console.error(`  [${label}] ${failure.component}: ${failure.detail}`);
+}
+console.error(
+  `\nRegenerate metadata (pnpm -F @vllnt/ui-registry sync-storybook) and rebuild ` +
+    `Storybook so preview IDs match, then re-run this check.`,
+);
+process.exit(1);


### PR DESCRIPTION
Closes #466

## What

Fixes blank component previews (e.g. `/components/ai-source-citation` showing "Couldn't find story matching 'designingreadableaiconversations--default'") and adds layered verification so this class of bug can never ship again — at build time, on main, and against the live deployed preview.

## Root cause

`generate-component-metadata.ts` extracted the Storybook `title` with a regex that matched the **first** `title:` in a story file — frequently a nested `args.title` (sample content) rather than the meta `title:`. That produced story IDs absent from the built Storybook, so the iframe 404s. **104 of 309 components** had a broken `defaultStoryId`. A secondary bug: the custom slug diverged from Storybook's `sanitize` for titles with spaces/specials (e.g. `Data Display/...`).

## Changes

**Fix**
- `generate-component-metadata.ts` — extract the meta object's own top-level `title` (brace-depth aware scanner that skips strings/comments) and slug it with Storybook's exact `sanitize` rule so IDs match the built index.
- `component-metadata.json` — regenerated; 184 corrected story IDs (diff touches only `id`/`defaultStoryId`).

**Guard — 3 layers**
1. **Build-time (every PR + main)** — `scripts/verify-preview-stories.ts` asserts every metadata story ID exists as a real `story` in the freshly-built `packages/ui/storybook-static/index.json`. Wired into CI Quality Gates right after `build-storybook`.
2. **Gate main directly** — `ci.yml` now also triggers `on: push:[main]`, so the build-time verify runs on main itself, not only transitively via each PR (closes the direct-push / admin-merge-past-red hole).
3. **Live deployed preview (promote gate + production)** — `e2e/preview-embeds.spec.ts` visits the DEPLOYED `/components/*` pages and asserts each embedded iframe story ID resolves in the LIVE Storybook the deployment points at (fetched from the iframe's own origin `/index.json`). **Fails** on a reachable-but-missing story (wrong `NEXT_PUBLIC_STORYBOOK_URL`, registry↔storybook version skew); **skips** when the Storybook origin is unreachable (tailnet/infra) so it never false-reds a promote. Runs automatically at the ntk promote gate (`ntk.yaml` already invokes `test:e2e` with `PLAYWRIGHT_BASE_URL=$NTK_PREVIEW_URL`) and can target production.

## Verification

- Build-time script: **PASS** on fixed metadata (309/309 resolve, 761 stories indexed); **FAIL** on old metadata (132 broken references caught, incl. the exact `ai-source-citation` error).
- Live E2E, storybook reachable: **7/7 passed** against a real registry+storybook pair (all ids resolve; 6 sampled pages embed the correct id).
- Live E2E, storybook unreachable: **skipped, not failed** (infra-safety property — won't block a promote on tailnet/infra flakiness).
- Real browser: fixed id renders the component card; broken id reproduces "Couldn't find story…".
- `tsc` clean; generator deterministic.

## Coverage

| Surface | Guarded |
|---|---|
| PR (metadata ↔ storybook index, build-time) | yes |
| main (build-time, direct) | yes |
| Deployed preview → live storybook (promote gate) | yes |
| Production (`ui.vllnt.ai`) — run same spec w/ `PLAYWRIGHT_BASE_URL` | yes (on demand / promote) |

https://claude.ai/code/session_01QbNR2Vi8hFyvxYbuWRXUu9