### PR TITLE
feat(registry): 301 ui.vllnt.ai to canonical ui.vllnt.com

### DIFF
--- a/apps/registry/lib/legacy-host-redirect.test.ts
+++ b/apps/registry/lib/legacy-host-redirect.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CANONICAL_HOST,
+  LEGACY_HOST,
+  legacyHostRedirectUrl,
+} from "./legacy-host-redirect";
+
+describe("legacyHostRedirectUrl", () => {
+  it("redirects the legacy host to canonical, preserving path and query", () => {
+    expect(
+      legacyHostRedirectUrl(LEGACY_HOST, "/components/button", "?tab=code"),
+    ).toBe(`https://${CANONICAL_HOST}/components/button?tab=code`);
+  });
+
+  it("redirects the root path", () => {
+    expect(legacyHostRedirectUrl(LEGACY_HOST, "/", "")).toBe(
+      `https://${CANONICAL_HOST}/`,
+    );
+  });
+
+  it("is case-insensitive and ignores a port on the host", () => {
+    expect(legacyHostRedirectUrl("UI.VLLNT.AI:443", "/x", "")).toBe(
+      `https://${CANONICAL_HOST}/x`,
+    );
+  });
+
+  it("does not redirect the canonical host", () => {
+    expect(legacyHostRedirectUrl(CANONICAL_HOST, "/", "")).toBeUndefined();
+  });
+
+  it("does not redirect preview or localhost hosts", () => {
+    expect(
+      legacyHostRedirectUrl("pr-42-ui-registry.preview.vllnt.ai", "/", ""),
+    ).toBeUndefined();
+    expect(legacyHostRedirectUrl("localhost:3000", "/", "")).toBeUndefined();
+  });
+
+  it("does not redirect when the host is missing", () => {
+    expect(legacyHostRedirectUrl(undefined, "/", "")).toBeUndefined();
+  });
+});

--- a/apps/registry/lib/legacy-host-redirect.ts
+++ b/apps/registry/lib/legacy-host-redirect.ts
@@ -1,0 +1,15 @@
+export const LEGACY_HOST = "ui.vllnt.ai";
+export const CANONICAL_HOST = "ui.vllnt.com";
+
+export function legacyHostRedirectUrl(
+  host: string | undefined,
+  pathname: string,
+  search: string,
+): string | undefined {
+  const hostname = (host ?? "").toLowerCase().split(":")[0];
+  if (hostname !== LEGACY_HOST) {
+    return undefined;
+  }
+
+  return `https://${CANONICAL_HOST}${pathname}${search}`;
+}

--- a/apps/registry/middleware.ts
+++ b/apps/registry/middleware.ts
@@ -2,10 +2,22 @@ import { type NextRequest, NextResponse } from "next/server";
 import createMiddleware from "next-intl/middleware";
 
 import { routing } from "@/i18n/routing";
+import { legacyHostRedirectUrl } from "@/lib/legacy-host-redirect";
 
 const intlMiddleware = createMiddleware(routing);
 
 export default function middleware(request: NextRequest): NextResponse {
+  const canonicalUrl = legacyHostRedirectUrl(
+    request.headers.get("x-forwarded-host") ??
+      request.headers.get("host") ??
+      undefined,
+    request.nextUrl.pathname,
+    request.nextUrl.search,
+  );
+  if (canonicalUrl) {
+    return NextResponse.redirect(canonicalUrl, 301);
+  }
+
   const { pathname } = request.nextUrl;
 
   // Case-sensitive redirect for the lowercase guess of the design guide.

--- a/ntk.yaml
+++ b/ntk.yaml
@@ -47,8 +47,8 @@ apps:
       limits:   { cpu: 1000m, memory: 1024Mi }
     env:
       production:
-        SITE_URL: https://ui.vllnt.ai
-        NEXT_PUBLIC_SITE_URL: https://ui.vllnt.ai
+        SITE_URL: https://ui.vllnt.com
+        NEXT_PUBLIC_SITE_URL: https://ui.vllnt.com
     build:
       dockerfile: Dockerfile         # repo-root Dockerfile builds @vllnt/ui-registry
       context: .


### PR DESCRIPTION
Closes #481

## What

`ui.vllnt.ai` 301-redirects to the first-party canonical `ui.vllnt.com` (ADR-124), done **in the app** (registry middleware), not at the edge — both hosts route to the same pod; the app decides.

- `apps/registry/lib/legacy-host-redirect.ts` — pure `legacyHostRedirectUrl(host, pathname, search)` (host-exact `ui.vllnt.ai`, preserves path+query, ignores port/case); previews (`*.preview.vllnt.ai`) + localhost untouched.
- `middleware.ts` — 301 before intl routing.
- `ntk.yaml` — production `SITE_URL`/`NEXT_PUBLIC_SITE_URL` → `https://ui.vllnt.com` (OG/canonical/sitemap).

## Test

`lib/legacy-host-redirect.test.ts` — 6 cases (path/query preserve, root, port+case, canonical/preview/localhost/missing no-op). Lint + vitest green.

## Depends on

The `.com` host must be live first (infra PR vllnt/infra#386 + DNS `ui.vllnt.com A 145.239.36.22`) — **merge this after**, else `.ai` 301s to a dead `.com`.

https://claude.ai/code/session_0195ZPRwvoft789Ere1JGB9Z