### PR TITLE
feat(storybook): 301 storybook.vllnt.ai to canonical storybook.vllnt.com

### DIFF
--- a/apps/storybook/nginx.conf
+++ b/apps/storybook/nginx.conf
@@ -4,6 +4,10 @@ server {
     root         /usr/share/nginx/html;
     index        index.html;
 
+    if ($host = storybook.vllnt.ai) {
+        return 301 https://storybook.vllnt.com$request_uri;
+    }
+
     # Healthcheck endpoint for K8s probes
     location = /healthz {
         access_log off;

--- a/ntk.yaml
+++ b/ntk.yaml
@@ -83,7 +83,7 @@ apps:
     port: 8080
     healthcheck: /healthz
     domains:
-      production: storybook.vllnt.ai
+      production: storybook.vllnt.com
     tls:
       # T1 cell (ADR-090e) has no shared *.vllnt.ai wildcard secret;
       # without this the renderer defaults to the absent
@@ -91,7 +91,7 @@ apps:
       # (site DOWN — incident 2026-06-10). Per-host DNS-01 cert,
       # in-ns + auto-renewing.
       production:
-        secretName: storybook-tls
+        secretName: storybook-vllnt-com-tls
     visibility:
       production: public
       preview:    tailnet


### PR DESCRIPTION
Closes #482

storybook.vllnt.ai 301-redirects to canonical storybook.vllnt.com (ADR-124), done in the app's nginx (`server_name _` + `if ($host = storybook.vllnt.ai)` -> 301, path+query preserved). Preview + .com hosts serve normally. Mirrors the ui-registry redirect (#480). nginx -t OK.

Depends on the .com host being live first (vllnt/infra#387 + DNS storybook.vllnt.com already created) — merge after.

https://claude.ai/code/session_0195ZPRwvoft789Ere1JGB9Z