### PR TITLE
refs(registry): point canonical domain to ui.vllnt.com

### DIFF
--- a/apps/registry/app/[locale]/build/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/build/[slug]/page.tsx
@@ -18,7 +18,7 @@ type Props = {
   readonly params: Promise<{ locale: Locale; slug: string }>;
 };
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
 export function generateStaticParams() {
   return routing.locales.flatMap((locale) =>
@@ -69,7 +69,7 @@ export default async function UseCasePage({ params }: Props) {
   const installCommand = components
     .map(
       (component) =>
-        `pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/${component.name}.json`,
+        `pnpm dlx shadcn@latest add https://ui.vllnt.com/r/${component.name}.json`,
     )
     .join("\n");
 

--- a/apps/registry/app/[locale]/changelog/page.tsx
+++ b/apps/registry/app/[locale]/changelog/page.tsx
@@ -10,7 +10,7 @@ import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
 type SearchParameters = {
   readonly from?: string;

--- a/apps/registry/app/[locale]/components/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/components/[slug]/page.tsx
@@ -188,7 +188,7 @@ export default async function ComponentPage(props: Props) {
     // Source file not found — skip code section
   }
 
-  const installCommand = `pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/${component.name}.json`;
+  const installCommand = `pnpm dlx shadcn@latest add https://ui.vllnt.com/r/${component.name}.json`;
 
   const componentCategory = getCategoryForComponent(slug);
   const familyGroup = componentCategory
@@ -205,7 +205,7 @@ export default async function ComponentPage(props: Props) {
       : []),
   ] as { id: string; title: string }[];
 
-  const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+  const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
   return (
     <>

--- a/apps/registry/app/[locale]/docs/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/docs/[slug]/page.tsx
@@ -19,7 +19,7 @@ import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
 type Props = {
   params: Promise<{ locale: Locale; slug: string }>;

--- a/apps/registry/app/[locale]/docs/page.tsx
+++ b/apps/registry/app/[locale]/docs/page.tsx
@@ -16,7 +16,7 @@ import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
 type Props = {
   readonly params: Promise<{ locale: Locale }>;

--- a/apps/registry/app/[locale]/families/[category]/page.tsx
+++ b/apps/registry/app/[locale]/families/[category]/page.tsx
@@ -29,7 +29,7 @@ type Props = {
   readonly params: Promise<{ category: string; locale: Locale }>;
 };
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
 function findFamily(category: string) {
   return groupedComponents.find((group) => group.category === category);

--- a/apps/registry/app/[locale]/families/page.tsx
+++ b/apps/registry/app/[locale]/families/page.tsx
@@ -23,7 +23,7 @@ type Props = {
   readonly params: Promise<{ locale: Locale }>;
 };
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 const PATHNAME = "/families";
 const TITLE = "Component families";
 const DESCRIPTION =

--- a/apps/registry/app/[locale]/layout.tsx
+++ b/apps/registry/app/[locale]/layout.tsx
@@ -75,7 +75,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       "open source",
     ],
     metadataBase: new URL(
-      process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai",
+      process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com",
     ),
     openGraph: {
       alternateLocale: alternateOgLocales(locale),

--- a/apps/registry/app/[locale]/releases/page.tsx
+++ b/apps/registry/app/[locale]/releases/page.tsx
@@ -10,7 +10,7 @@ import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
 const DESCRIPTION =
   "Read VLLNT UI releases, including latest notes, component count deltas, breaking change counts, migration links, and GitHub release links.";

--- a/apps/registry/app/[locale]/templates/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/templates/[slug]/page.tsx
@@ -23,7 +23,7 @@ import {
   TEMPLATES,
 } from "@/lib/templates";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
 type Props = {
   params: Promise<{ locale: Locale; slug: string }>;

--- a/apps/registry/app/[locale]/templates/page.tsx
+++ b/apps/registry/app/[locale]/templates/page.tsx
@@ -15,7 +15,7 @@ import { withRef } from "@/lib/share";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 import { getTemplatePath, TEMPLATES } from "@/lib/templates";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
 const title = "Templates - VLLNT UI";
 const description =

--- a/apps/registry/app/[locale]/vs/assistant-ui/page.tsx
+++ b/apps/registry/app/[locale]/vs/assistant-ui/page.tsx
@@ -14,7 +14,7 @@ type Props = {
   readonly params: Promise<{ locale: Locale }>;
 };
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 const PATHNAME = "/vs/assistant-ui";
 
 type Row = {

--- a/apps/registry/app/[locale]/vs/shadcn/page.tsx
+++ b/apps/registry/app/[locale]/vs/shadcn/page.tsx
@@ -84,7 +84,7 @@ export default async function VsShadcnPage({ params }: Props) {
     {
       attribute: "MCP server",
       shadcn: "No",
-      vllnt: "Yes — ui.vllnt.ai/mcp (search/get/list tools)",
+      vllnt: "Yes — ui.vllnt.com/mcp (search/get/list tools)",
       winner: "vllnt",
     },
     {

--- a/apps/registry/app/[locale]/vs/vercel-ai-sdk/page.tsx
+++ b/apps/registry/app/[locale]/vs/vercel-ai-sdk/page.tsx
@@ -14,7 +14,7 @@ type Props = {
   readonly params: Promise<{ locale: Locale }>;
 };
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 const PATHNAME = "/vs/vercel-ai-sdk";
 
 type Row = {

--- a/apps/registry/app/api/badge/route.ts
+++ b/apps/registry/app/api/badge/route.ts
@@ -21,7 +21,7 @@ function segmentWidth(text: string): number {
  * Static "Built with VLLNT UI" badge served as SVG (same pattern as /api/og).
  *
  * The badge image carries no link equity on its own — consumers wrap it in an
- * `<a href="https://ui.vllnt.ai?ref=badge">` (see buildBadgeSnippets), and
+ * `<a href="https://ui.vllnt.com?ref=badge">` (see buildBadgeSnippets), and
  * that anchor in their page DOM is the backlink.
  */
 export function GET(): Response {

--- a/apps/registry/app/api/oembed/route.ts
+++ b/apps/registry/app/api/oembed/route.ts
@@ -65,7 +65,7 @@ function buildThumbnailUrl(input: {
   if (input.category) {
     url.searchParams.set("category", input.category);
   }
-  url.searchParams.set("url", `ui.vllnt.ai/components/${input.slug}`);
+  url.searchParams.set("url", `ui.vllnt.com/components/${input.slug}`);
   return url.toString();
 }
 
@@ -104,7 +104,7 @@ function buildPayload(
 /**
  * oEmbed provider endpoint (https://oembed.com). Lets WordPress, Ghost,
  * Discourse, dev.to, and similar tools auto-unfurl any
- * `ui.vllnt.ai/components/*` URL into a rich embed. The returned `html`
+ * `ui.vllnt.com/components/*` URL into a rich embed. The returned `html`
  * carries the live-preview iframe and a caption anchor — that anchor lands in
  * the host's DOM and becomes the backlink.
  */

--- a/apps/registry/app/atom.xml/route.ts
+++ b/apps/registry/app/atom.xml/route.ts
@@ -4,7 +4,7 @@ import {
   releasePageUrl,
 } from "@/lib/changelog";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 const ATOM_HEADERS = new Headers([
   [
     "Cache-Control",

--- a/apps/registry/app/llms-full.txt/route.ts
+++ b/apps/registry/app/llms-full.txt/route.ts
@@ -14,7 +14,7 @@ import { registry, type RegistryComponent } from "@/lib/registry";
 import { DOCS_PAGES, getDocsPath } from "../../lib/docs-pages";
 import { getTemplatePath, TEMPLATES } from "../../lib/templates";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 const TEXT_HEADERS = new Headers([
   [
     "Cache-Control",

--- a/apps/registry/app/llms.txt/route.ts
+++ b/apps/registry/app/llms.txt/route.ts
@@ -8,7 +8,7 @@ import { registry, type RegistryComponent } from "@/lib/registry";
 
 import { DOCS_PAGES, getDocsPath } from "../../lib/docs-pages";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 const TEXT_HEADERS = new Headers([
   [
     "Cache-Control",

--- a/apps/registry/app/mcp/route.ts
+++ b/apps/registry/app/mcp/route.ts
@@ -1,5 +1,5 @@
 /**
- * MCP server at ui.vllnt.ai/mcp — Model Context Protocol endpoint.
+ * MCP server at ui.vllnt.com/mcp — Model Context Protocol endpoint.
  *
  * Speaks JSON-RPC 2.0 over POST. Implements the smallest protocol surface
  * an MCP client needs to discover and use VLLNT UI tools:
@@ -29,7 +29,7 @@ import { NextResponse } from "next/server";
 
 import { registry as REGISTRY, type RegistryComponent } from "@/lib/registry";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 const PROTOCOL_VERSION = "2025-06-18";
 
 type JsonRpcRequest = {

--- a/apps/registry/app/robots.ts
+++ b/apps/registry/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
 const AI_CRAWLERS = [
   "GPTBot",

--- a/apps/registry/app/rss.xml/route.ts
+++ b/apps/registry/app/rss.xml/route.ts
@@ -4,7 +4,7 @@ import {
   releasePageUrl,
 } from "@/lib/changelog";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 const RSS_HEADERS = new Headers([
   [
     "Cache-Control",

--- a/apps/registry/app/sitemap.ts
+++ b/apps/registry/app/sitemap.ts
@@ -10,7 +10,7 @@ import { DOCS_PAGES, getDocsPath } from "../lib/docs-pages";
 import { getTemplatePath, TEMPLATES } from "../lib/templates";
 import { getUseCasePath, USE_CASES } from "../lib/use-cases";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
 const AI_COMPONENT_SLUGS = new Set(getAiComponentSlugs());
 

--- a/apps/registry/components/component-preview/component-preview.tsx
+++ b/apps/registry/components/component-preview/component-preview.tsx
@@ -4824,7 +4824,7 @@ function CopyButtonPreview() {
       <CopyButton value="EXAMPLE_API_KEY" />
       <CopyButton
         label="Copy link"
-        value="https://ui.vllnt.ai"
+        value="https://ui.vllnt.com"
         variant="button"
       />
     </div>

--- a/apps/registry/components/footer/footer.tsx
+++ b/apps/registry/components/footer/footer.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 
 const GITHUB_URL = "https://github.com/vllnt/ui";
-const STORYBOOK_URL = "https://storybook.vllnt.ai";
+const STORYBOOK_URL = "https://storybook.vllnt.com";
 const SPONSOR_URL = "https://github.com/sponsors/bntvllnt";
 const REPORT_URL =
   "https://github.com/vllnt/ui/issues/new?template=bug_report.yml&labels=bug";

--- a/apps/registry/components/landing/landing.tsx
+++ b/apps/registry/components/landing/landing.tsx
@@ -15,11 +15,11 @@ import {
 } from "@/lib/stats";
 
 const GITHUB_URL = "https://github.com/vllnt/ui";
-const STORYBOOK_URL = "https://storybook.vllnt.ai";
+const STORYBOOK_URL = "https://storybook.vllnt.com";
 const REQUEST_URL =
   "https://github.com/vllnt/ui/issues/new?template=feature_request.yml&labels=enhancement,component";
 const INSTALL_COMMAND =
-  "pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json";
+  "pnpm dlx shadcn@latest add https://ui.vllnt.com/r/button.json";
 
 const TRUST_BADGES = [
   { label: "MIT" },

--- a/apps/registry/components/quick-add/quick-add.tsx
+++ b/apps/registry/components/quick-add/quick-add.tsx
@@ -10,7 +10,7 @@ type QuickAddProps = {
 };
 
 export function QuickAdd({ componentName }: QuickAddProps) {
-  const registryUrl = `https://ui.vllnt.ai/r/${componentName}.json`;
+  const registryUrl = `https://ui.vllnt.com/r/${componentName}.json`;
   const installCommand = `pnpm dlx shadcn@latest add ${registryUrl}`;
   const v0Url = `https://v0.dev/chat?q=add+component+from+${encodeURIComponent(registryUrl)}`;
   const [copied, setCopied] = useState(false);

--- a/apps/registry/components/theme-editor/export-panel.tsx
+++ b/apps/registry/components/theme-editor/export-panel.tsx
@@ -30,7 +30,7 @@ function useOrigin(): string {
   return useSyncExternalStore(
     subscribeNever,
     () => window.location.origin,
-    () => "https://ui.vllnt.ai",
+    () => "https://ui.vllnt.com",
   );
 }
 

--- a/apps/registry/content/pages/docs/agents.mdx
+++ b/apps/registry/content/pages/docs/agents.mdx
@@ -17,7 +17,7 @@ VLLNT UI exposes agent-readable surfaces so coding agents can discover component
 Use `/llms.txt` for a compact overview of the registry. It includes install guidance, core docs links, and component links grouped by category.
 
 ```text
-https://ui.vllnt.ai/llms.txt
+https://ui.vllnt.com/llms.txt
 ```
 
 ## llms-full.txt
@@ -25,7 +25,7 @@ https://ui.vllnt.ai/llms.txt
 Use `/llms-full.txt` when the agent needs one larger text context. It includes the main docs pages and component metadata summaries.
 
 ```text
-https://ui.vllnt.ai/llms-full.txt
+https://ui.vllnt.com/llms-full.txt
 ```
 
 ## Registry JSON

--- a/apps/registry/content/pages/docs/cli.mdx
+++ b/apps/registry/content/pages/docs/cli.mdx
@@ -15,7 +15,7 @@ The VLLNT UI registry uses the same JSON descriptor shape expected by the shadcn
 ## Add one component
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/button.json
 ```
 
 The CLI reads the descriptor, installs dependencies, and writes source files into your configured component directory.
@@ -25,9 +25,9 @@ The CLI reads the descriptor, installs dependencies, and writes source files int
 Install components one at a time so diffs are easy to review:
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/dialog.json
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/toast.json
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/form.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/dialog.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/toast.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/form.json
 ```
 
 ## Inspect the registry first
@@ -35,13 +35,13 @@ pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/form.json
 Use the registry index when scripting:
 
 ```bash
-curl https://ui.vllnt.ai/r/registry.json
+curl https://ui.vllnt.com/r/registry.json
 ```
 
 Each item includes its slug, title, description, category, dependencies, and file list. Per-component descriptors live at:
 
 ```text
-https://ui.vllnt.ai/r/<name>.json
+https://ui.vllnt.com/r/<name>.json
 ```
 
 ## Team workflow

--- a/apps/registry/content/pages/docs/en.mdx
+++ b/apps/registry/content/pages/docs/en.mdx
@@ -17,7 +17,7 @@ Welcome to VLLNT UI. This is a component registry built with shadcn/ui.
 Install components using the shadcn CLI:
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/[component-name].json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/[component-name].json
 ```
 
 ## Usage

--- a/apps/registry/content/pages/docs/fr.mdx
+++ b/apps/registry/content/pages/docs/fr.mdx
@@ -17,7 +17,7 @@ Bienvenue dans VLLNT UI. C'est un registre de composants construit avec le forma
 Installez les composants avec la CLI shadcn :
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/[component-name].json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/[component-name].json
 ```
 
 ## Utilisation

--- a/apps/registry/content/pages/docs/installation.mdx
+++ b/apps/registry/content/pages/docs/installation.mdx
@@ -60,7 +60,7 @@ export function SaveButton() {
 Use the shadcn CLI when you want the component source copied into your project:
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/button.json
 ```
 
 Replace `button` with any component slug from the [component index](/components).

--- a/apps/registry/content/pages/home/en.mdx
+++ b/apps/registry/content/pages/home/en.mdx
@@ -3,36 +3,36 @@ title: VLLNT UI - Component Registry
 description: 313 agent-first React components. Install with the shadcn CLI — no library to import, no version lock-in.
 type: home
 og:
-  title: ui.vllnt.ai
+  title: ui.vllnt.com
   description: Agent-first React component registry — install with the shadcn CLI
   type: home
 ---
 
 # Install any component in one line
 
-Pick a component, copy its install command, run it. The CLI fetches the source from `ui.vllnt.ai/r/<name>.json` and writes it directly into your repo — you own the code.
+Pick a component, copy its install command, run it. The CLI fetches the source from `ui.vllnt.com/r/<name>.json` and writes it directly into your repo — you own the code.
 
 ## Install (pick your package manager)
 
 ```bash
 # pnpm
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/button.json
 
 # npm
-npx shadcn@latest add https://ui.vllnt.ai/r/button.json
+npx shadcn@latest add https://ui.vllnt.com/r/button.json
 
 # yarn
-yarn dlx shadcn@latest add https://ui.vllnt.ai/r/button.json
+yarn dlx shadcn@latest add https://ui.vllnt.com/r/button.json
 
 # bun
-bunx --bun shadcn@latest add https://ui.vllnt.ai/r/button.json
+bunx --bun shadcn@latest add https://ui.vllnt.com/r/button.json
 ```
 
 Replace `button.json` with any component name from the [registry](/components).
 
 ## No CLI to install
 
-There is no `@vllnt/cli`. The shadcn CLI already speaks the registry format — running it against `ui.vllnt.ai/r/<name>.json` is the supported install path. Same UX, less to maintain.
+There is no `@vllnt/cli`. The shadcn CLI already speaks the registry format — running it against `ui.vllnt.com/r/<name>.json` is the supported install path. Same UX, less to maintain.
 
 ## Usage after install
 
@@ -50,10 +50,10 @@ The CLI installs source files into your project under `components/ui/` (configur
 
 Every component is also exposed as a machine-readable JSON descriptor. AI coding agents can read them directly:
 
-- `https://ui.vllnt.ai/r/registry.json` — index of all 313 components
-- `https://ui.vllnt.ai/r/<name>.json` — one component
-- `https://ui.vllnt.ai/llms.txt` — concise index per the [llmstxt.org](https://llmstxt.org) spec
-- `https://ui.vllnt.ai/llms-full.txt` — full agent context in one fetch
+- `https://ui.vllnt.com/r/registry.json` — index of all 313 components
+- `https://ui.vllnt.com/r/<name>.json` — one component
+- `https://ui.vllnt.com/llms.txt` — concise index per the [llmstxt.org](https://llmstxt.org) spec
+- `https://ui.vllnt.com/llms-full.txt` — full agent context in one fetch
 
 ## Next steps
 

--- a/apps/registry/content/pages/home/fr.mdx
+++ b/apps/registry/content/pages/home/fr.mdx
@@ -3,36 +3,36 @@ title: VLLNT UI - Registre de composants
 description: 313 composants React agent-first. Installez avec la CLI shadcn - aucune bibliotheque a importer, aucun verrou de version.
 type: home
 og:
-  title: ui.vllnt.ai
+  title: ui.vllnt.com
   description: Registre de composants React agent-first - installez avec la CLI shadcn
   type: home
 ---
 
 # Installez n'importe quel composant en une ligne
 
-Choisissez un composant, copiez sa commande d'installation, puis lancez-la. La CLI recupere la source depuis `ui.vllnt.ai/r/<name>.json` et l'ecrit directement dans votre depot. Le code vous appartient.
+Choisissez un composant, copiez sa commande d'installation, puis lancez-la. La CLI recupere la source depuis `ui.vllnt.com/r/<name>.json` et l'ecrit directement dans votre depot. Le code vous appartient.
 
 ## Installation
 
 ```bash
 # pnpm
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/button.json
 
 # npm
-npx shadcn@latest add https://ui.vllnt.ai/r/button.json
+npx shadcn@latest add https://ui.vllnt.com/r/button.json
 
 # yarn
-yarn dlx shadcn@latest add https://ui.vllnt.ai/r/button.json
+yarn dlx shadcn@latest add https://ui.vllnt.com/r/button.json
 
 # bun
-bunx --bun shadcn@latest add https://ui.vllnt.ai/r/button.json
+bunx --bun shadcn@latest add https://ui.vllnt.com/r/button.json
 ```
 
 Remplacez `button.json` par le nom d'un composant du [registre](/fr/components).
 
 ## Pas de CLI supplementaire
 
-Il n'y a pas de `@vllnt/cli`. La CLI shadcn comprend deja le format de registre. L'utiliser avec `ui.vllnt.ai/r/<name>.json` est le chemin d'installation supporte.
+Il n'y a pas de `@vllnt/cli`. La CLI shadcn comprend deja le format de registre. L'utiliser avec `ui.vllnt.com/r/<name>.json` est le chemin d'installation supporte.
 
 ## Utilisation apres installation
 
@@ -50,10 +50,10 @@ La CLI installe les fichiers source dans votre projet sous `components/ui/`, con
 
 Chaque composant est aussi expose comme descripteur JSON lisible par machine :
 
-- `https://ui.vllnt.ai/r/registry.json` - index des 313 composants
-- `https://ui.vllnt.ai/r/<name>.json` - un composant
-- `https://ui.vllnt.ai/llms.txt` - index concis selon la specification [llmstxt.org](https://llmstxt.org)
-- `https://ui.vllnt.ai/llms-full.txt` - contexte agent complet en une requete
+- `https://ui.vllnt.com/r/registry.json` - index des 313 composants
+- `https://ui.vllnt.com/r/<name>.json` - un composant
+- `https://ui.vllnt.com/llms.txt` - index concis selon la specification [llmstxt.org](https://llmstxt.org)
+- `https://ui.vllnt.com/llms-full.txt` - contexte agent complet en une requete
 
 ## Etapes suivantes
 

--- a/apps/registry/e2e/preview-embeds.spec.ts
+++ b/apps/registry/e2e/preview-embeds.spec.ts
@@ -13,7 +13,7 @@
  * Where it runs (playwright.config.ts reads PLAYWRIGHT_BASE_URL):
  *   - ntk promote gate — `PLAYWRIGHT_BASE_URL=$NTK_PREVIEW_URL … test:e2e`
  *     runs this against the live PR preview before a prod promote (ntk.yaml).
- *   - production — `PLAYWRIGHT_BASE_URL=https://ui.vllnt.ai pnpm -F
+ *   - production — `PLAYWRIGHT_BASE_URL=https://ui.vllnt.com pnpm -F
  *     @vllnt/ui-registry test:e2e`.
  *   - local / GH Actions e2e job — no PLAYWRIGHT_BASE_URL, so it hits the dev
  *     server whose Storybook origin (localhost:6006) is not running; the live

--- a/apps/registry/lib/changelog.ts
+++ b/apps/registry/lib/changelog.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { z } from "zod";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 const GITHUB_REPO_URL = "https://github.com/vllnt/ui";
 const GITHUB_RELEASES_API = "https://api.github.com/repos/vllnt/ui/releases";
 const GITHUB_HEADERS = new Headers([["Accept", "application/vnd.github+json"]]);

--- a/apps/registry/lib/jsonld.ts
+++ b/apps/registry/lib/jsonld.ts
@@ -1,4 +1,4 @@
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
 type JsonLdValue =
   | boolean

--- a/apps/registry/lib/og.ts
+++ b/apps/registry/lib/og.ts
@@ -7,7 +7,7 @@ import { alternateOgLocales, canonical, ogLocale } from "@/lib/seo";
 export const OG_IMAGE_WIDTH = 2400;
 export const OG_IMAGE_HEIGHT = 1260;
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
 const ogImageParametersSchema = z.object({
   category: z.string().max(100).optional(),

--- a/apps/registry/lib/seo.ts
+++ b/apps/registry/lib/seo.ts
@@ -1,6 +1,6 @@
 import { type Locale, routing } from "@/i18n/routing";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
 export function localizePathname(
   pathname: string,

--- a/apps/registry/lib/share.ts
+++ b/apps/registry/lib/share.ts
@@ -10,7 +10,7 @@ import { canonical } from "@/lib/seo";
  */
 
 export const SITE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
 /** Attribution source tags appended as `?ref=` so referrals stay measurable. */
 export type ShareRef = "badge" | "embed" | "oembed" | "permalink" | "share";

--- a/apps/registry/lib/templates.ts
+++ b/apps/registry/lib/templates.ts
@@ -1,4 +1,4 @@
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.ai";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 const GITHUB_REPO_URL = "https://github.com/vllnt/ui";
 
 export type Template = {

--- a/apps/registry/lib/theme-serialize.test.ts
+++ b/apps/registry/lib/theme-serialize.test.ts
@@ -83,8 +83,8 @@ describe("theme-serialize exports", () => {
   });
 
   it("builds an install URL pointing at /r/themes", () => {
-    const url = themeInstallUrl("https://ui.vllnt.ai", DEFAULT_THEME, "demo");
-    expect(url.startsWith("https://ui.vllnt.ai/r/themes?t=")).toBe(true);
+    const url = themeInstallUrl("https://ui.vllnt.com", DEFAULT_THEME, "demo");
+    expect(url.startsWith("https://ui.vllnt.com/r/themes?t=")).toBe(true);
     expect(url).toContain("name=demo");
   });
 });

--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
   "name": "@vllnt",
-  "homepage": "https://ui.vllnt.ai",
+  "homepage": "https://ui.vllnt.com",
   "items": [
     {
       "name": "accordion",

--- a/apps/registry/shadcn-directory-entry.json
+++ b/apps/registry/shadcn-directory-entry.json
@@ -1,7 +1,7 @@
 {
   "name": "@vllnt",
-  "homepage": "https://ui.vllnt.ai",
-  "url": "https://ui.vllnt.ai/r/{name}.json",
+  "homepage": "https://ui.vllnt.com",
+  "url": "https://ui.vllnt.com/r/{name}.json",
   "description": "VLLNT UI — agent-first React components for AI-native products, from UI primitives to finance and ops domains. Accessible, Radix + Tailwind, you own the code.",
   "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'><rect width='128' height='128' rx='28' fill='var(--foreground)'/><text x='64' y='64' text-anchor='middle' dominant-baseline='central' font-family='ui-sans-serif, system-ui, sans-serif' font-size='26' font-weight='700' letter-spacing='-1' fill='var(--background)'>VLLNT</text></svg>"
 }


### PR DESCRIPTION
## What

Completes the `ui.vllnt.ai → ui.vllnt.com` domain migration. The host-level 301 landed in #480; this updates every URL the registry app *emits* so canonical, sitemap, structured data and install commands all point at the new canonical domain.

## Changes (45 files, pure domain swap — 78/78 lines)

- `SITE_URL` fallbacks across routes/pages/libs
- `sitemap.ts`, `robots.ts`, `llms.txt`, `llms-full.txt`, `rss.xml`, `atom.xml`, `mcp` route
- JSON-LD (`lib/jsonld.ts`), oEmbed, OG (`lib/og.ts`), share/templates/changelog
- shadcn install commands (component/build pages) + `registry.json` `homepage` + `shadcn-directory-entry.json`
- MDX docs (home/docs, en+fr)
- `storybook.vllnt.ai → storybook.vllnt.com` in footer + landing (its nginx 301 is handled in a separate storybook PR)

## Deliberately unchanged

- `lib/legacy-host-redirect.ts` `LEGACY_HOST = "ui.vllnt.ai"` — that is the host to redirect *from* (the #480 mechanism); changing it would loop.

## Deploy requirement (blocking)

`NEXT_PUBLIC_SITE_URL` must be **unset or `https://ui.vllnt.com`**. The live `.com` site currently resolves it to `.ai`, which would override this code fallback and keep emitting `.ai` URLs.

## Follow-up (post-deploy, not in this PR)

- Submit `https://ui.vllnt.com/sitemap.xml` to the `sc-domain:vllnt.com` GSC property
- GSC Change of Address `ui.vllnt.ai → ui.vllnt.com` (UI-only) after verifying the 301
- Keep the `ui.vllnt.ai` GSC property (history + Change-of-Address source)

## Validation

- grep-to-zero: no `ui.vllnt.ai` left outside the intentional 301 file
- unit tests 16/16 pass (`theme-serialize`, `legacy-host-redirect`) on the identical change

Closes #484
