### PR TITLE
refs: point remaining ui.vllnt.ai references to ui.vllnt.com

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://github.com/vllnt/ui/security/advisories/new
     about: Report security issues privately (do NOT open a public issue).
   - name: Documentation
-    url: https://ui.vllnt.ai
+    url: https://ui.vllnt.com
     about: Component docs + registry.
   - name: Storybook
     url: https://storybook.vllnt.ai

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ This file is the **index**. Detailed rules live in [`docs/agents/`](./docs/agent
 | Path | Purpose | Published |
 |------|---------|-----------|
 | `packages/ui/` | `@vllnt/ui` component library | npm (public) |
-| `apps/registry/` | `ui.vllnt.ai` — Next.js registry + docs site | deployed (Vercel) |
+| `apps/registry/` | `ui.vllnt.com` — Next.js registry + docs site | deployed (Vercel) |
 | `skills/` | Agent skills (e.g. `vllnt-ui` — how to consume `@vllnt/ui` + the design system) | — |
 | `.github/workflows/` | CI: `ci.yml`, `publish.yml`, `storybook.yml`, `pr-issue-link.yml` | — |
 
@@ -101,7 +101,7 @@ Repository-wide docs (audience = contributors, not just agents):
 
 The most-violated rules in PR review history:
 
-0. **Design rules are mandatory for UI work.** Any UI suggestion or component/site change must follow [`DESIGN.md`](./DESIGN.md) (live at `https://ui.vllnt.ai/DESIGN.md`) and the machine-readable tokens in [`packages/design/tokens.json`](./packages/design/tokens.json). List any intentional deviation in the PR body.
+0. **Design rules are mandatory for UI work.** Any UI suggestion or component/site change must follow [`DESIGN.md`](./DESIGN.md) (live at `https://ui.vllnt.com/DESIGN.md`) and the machine-readable tokens in [`packages/design/tokens.json`](./packages/design/tokens.json). List any intentional deviation in the PR body.
 1. **Workspace gates green at HEAD** ([R6](./docs/agents/RULES.md#r6--workspace-gates-green-at-head)). Touched-file passes alone are not ship-OK. Run `pnpm -F @vllnt/ui lint && pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json && pnpm build && pnpm test:once` — all must be green.
 2. **PR body matches HEAD** ([R3](./docs/agents/RULES.md#r3--pr-body-matches-head)). After every push, rewrite the body to match the current head. Stale claims block ship.
 3. **Linked issue required** ([R5](./docs/agents/RULES.md#r5--linked-issue-required)). Every PR must reference a GitHub issue. Accepted keywords: `close` / `closes` / `closed`, `fix` / `fixes` / `fixed`, `resolve` / `resolves` / `resolved`, or repo phrases `Part of` / `Related to` — all case-insensitive, optional colon — followed by `#123` or `owner/repo#123`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,7 +216,7 @@ Release automation can regenerate this file from Conventional Commits with
 
 ### Changed
 
-- Documentation domain moved to `ui.vllnt.ai` / `storybook.vllnt.ai`.
+- Documentation domain moved to `ui.vllnt.com` / `storybook.vllnt.ai`.
 - Default package registry is the public npm registry (no longer GitHub
   Packages).
 - README component tables expanded to cover all 144 components organized by

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for wanting to contribute. This repo welcomes issues, bug reports, and PR
 - Be respectful. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 - Security-sensitive reports go through [SECURITY.md](SECURITY.md), **not** public issues.
 - Every change keeps the repo shippable: lint, typecheck, tests, and build pass on `main`.
-- UI changes must follow [DESIGN.md](DESIGN.md) (live at <https://ui.vllnt.ai/DESIGN.md>) and the token contract in [packages/design/tokens.json](packages/design/tokens.json). Document intentional deviations in the PR body.
+- UI changes must follow [DESIGN.md](DESIGN.md) (live at <https://ui.vllnt.com/DESIGN.md>) and the token contract in [packages/design/tokens.json](packages/design/tokens.json). Document intentional deviations in the PR body.
 
 ## Development setup
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,9 +6,9 @@
 This is the **canonical** brand & design guideline for the library. Read it on
 the web at three public surfaces, all generated from this one file:
 
-- [`/DESIGN.md`](https://ui.vllnt.ai/DESIGN.md) — this file as raw markdown (canonical for agents).
-- [`/design`](https://ui.vllnt.ai/design) — human-browsable rendering with a contents nav.
-- [`/r/design.json`](https://ui.vllnt.ai/r/design.json) — machine-readable token set.
+- [`/DESIGN.md`](https://ui.vllnt.com/DESIGN.md) — this file as raw markdown (canonical for agents).
+- [`/design`](https://ui.vllnt.com/design) — human-browsable rendering with a contents nav.
+- [`/r/design.json`](https://ui.vllnt.com/r/design.json) — machine-readable token set.
 
 The full token set lives in `packages/design/tokens.json` and is documented in
 `packages/design/README.md`.
@@ -273,9 +273,9 @@ No coloured shadows. No multi-layered glow effects.
 This document is the **v1 brand baseline** for VLLNT UI. It ships on these
 surfaces today:
 
-- [`/DESIGN.md`](https://ui.vllnt.ai/DESIGN.md) — this file as raw markdown.
-- [`/design`](https://ui.vllnt.ai/design) — human-browsable rendering with a contents nav.
-- [`/r/design.json`](https://ui.vllnt.ai/r/design.json) — JSON token set, mirroring `packages/design/tokens.json`.
+- [`/DESIGN.md`](https://ui.vllnt.com/DESIGN.md) — this file as raw markdown.
+- [`/design`](https://ui.vllnt.com/design) — human-browsable rendering with a contents nav.
+- [`/r/design.json`](https://ui.vllnt.com/r/design.json) — JSON token set, mirroring `packages/design/tokens.json`.
 
 Still planned:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# ui.vllnt.ai — component registry/docs site (standalone output).
+# ui.vllnt.com — component registry/docs site (standalone output).
 # Built from vllnt/ui monorepo, app: apps/registry. Workspace dep: @vllnt/ui.
 
 FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS builder

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org)
 [![npm](https://img.shields.io/npm/v/@vllnt/ui)](https://www.npmjs.com/package/@vllnt/ui)
 
-[Documentation](https://ui.vllnt.ai) · [Storybook](https://storybook.vllnt.ai) · [Registry](https://ui.vllnt.ai/components) · [GitHub](https://github.com/vllnt/ui)
+[Documentation](https://ui.vllnt.com) · [Storybook](https://storybook.vllnt.ai) · [Registry](https://ui.vllnt.com/components) · [GitHub](https://github.com/vllnt/ui)
 
 </div>
 
@@ -36,10 +36,10 @@ pnpm add @vllnt/ui
 Install individual components with the [shadcn](https://ui.shadcn.com) CLI — no package dependency, you own the code:
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/button.json
 ```
 
-Or by `@vllnt` namespace once it's in the [shadcn registry index](https://ui.shadcn.com/r/registries.json) (add `"@vllnt": "https://ui.vllnt.ai/r/{name}.json"` to your `components.json` `registries`):
+Or by `@vllnt` namespace once it's in the [shadcn registry index](https://ui.shadcn.com/r/registries.json) (add `"@vllnt": "https://ui.vllnt.com/r/{name}.json"` to your `components.json` `registries`):
 
 ```bash
 pnpm dlx shadcn@latest add @vllnt/button
@@ -78,7 +78,7 @@ export default {
 Install individual components directly:
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/button.json
 ```
 
 ## Development
@@ -134,7 +134,7 @@ Override CSS variables after importing styles:
 
 ## AI agents
 
-Building with an AI coding agent? Install the [`vllnt-ui` skill](skills/vllnt-ui/SKILL.md) — it gives agents the component set, design tokens, and usage patterns, pointing to the live registry and [`DESIGN.md`](https://ui.vllnt.ai/DESIGN.md) for current detail. Agents working *in this repo* should read [AGENTS.md](AGENTS.md).
+Building with an AI coding agent? Install the [`vllnt-ui` skill](skills/vllnt-ui/SKILL.md) — it gives agents the component set, design tokens, and usage patterns, pointing to the live registry and [`DESIGN.md`](https://ui.vllnt.com/DESIGN.md) for current detail. Agents working *in this repo* should read [AGENTS.md](AGENTS.md).
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,25 +68,25 @@ Single-pane drill-down (chosen over accordion-single-open and a two-pane family 
 
 ## native-parity [PLANNED]
 
-**Goal:** Make all 309 @vllnt/ui components iso web↔native — install once from the single `ui.vllnt.ai` registry, one import, platform-correct render — with no second registry.
-**Exit criteria:** Every component ships a `<c>.native.tsx` twin + a shared `<c>.variants.ts`; one `npx shadcn add @vllnt/<c>` from `ui.vllnt.ai/r/<c>.json` installs both files; each renders correctly on a Next.js web app AND an Expo device; each is stamped `parity: full|api-only` in `meta.json` with the badge shown on the site.
+**Goal:** Make all 309 @vllnt/ui components iso web↔native — install once from the single `ui.vllnt.com` registry, one import, platform-correct render — with no second registry.
+**Exit criteria:** Every component ships a `<c>.native.tsx` twin + a shared `<c>.variants.ts`; one `npx shadcn add @vllnt/<c>` from `ui.vllnt.com/r/<c>.json` installs both files; each renders correctly on a Next.js web app AND an Expo device; each is stamped `parity: full|api-only` in `meta.json` with the badge shown on the site.
 **Verify:** a consumer dev runs `npx shadcn add @vllnt/button` once → `import { Button }` renders on web (Radix/DOM) and on an Expo device (rn-primitives) with an identical variant API across all 12 families; the overlay family is documented `api-only` where Portal/keyboard can't map. Personas: consumer dev (web + Expo device, keyboard), maintainer (adds a native twin + variants contract), agent (reads `parity` from the registry JSON).
 
 **Gated by:** a confirmed Expo/RN consumer (`native-parity.1`) — **Horizon** until resolved (flagged since 2026-06; still open).
 
-One registry, not two — platform is resolved by the bundler (Metro picks `<c>.native.tsx`, web picks `<c>.tsx`), so `ui.vllnt.ai` stays the single source. Stack maps 1:1: Radix → @rn-primitives, Tailwind `className` → NativeWind, CVA + `cn()` unchanged, lucide-react → lucide-react-native. Only the render body forks; `<c>.variants.ts` (CVA + a platform-neutral prop contract) is shared. Iso *API* is always achievable; iso *visual result* is a per-component property (the `parity` badge) — overlays / hover / keyboard degrade to api-only. Proven prior art: **react-native-reusables** (@rn-primitives + NativeWind, 8.4k★, active 2026) already publishes a shadcn-format `registry.json` for RN — one schema spans web+native, validating the single-registry bet. Open gate: a confirmed Expo consumer (`.1`); OKLCH-on-native is resolved — NativeWind v4 (stable) has no on-device `oklch()`, so an HSL fallback is required (`.2`).
+One registry, not two — platform is resolved by the bundler (Metro picks `<c>.native.tsx`, web picks `<c>.tsx`), so `ui.vllnt.com` stays the single source. Stack maps 1:1: Radix → @rn-primitives, Tailwind `className` → NativeWind, CVA + `cn()` unchanged, lucide-react → lucide-react-native. Only the render body forks; `<c>.variants.ts` (CVA + a platform-neutral prop contract) is shared. Iso *API* is always achievable; iso *visual result* is a per-component property (the `parity` badge) — overlays / hover / keyboard degrade to api-only. Proven prior art: **react-native-reusables** (@rn-primitives + NativeWind, 8.4k★, active 2026) already publishes a shadcn-format `registry.json` for RN — one schema spans web+native, validating the single-registry bet. Open gate: a confirmed Expo consumer (`.1`); OKLCH-on-native is resolved — NativeWind v4 (stable) has no on-device `oklch()`, so an HSL fallback is required (`.2`).
 
 - [ ] native-parity.1 Decide: confirm an Expo/RN consumer app + the native stack (NativeWind + @rn-primitives + lucide-react-native)
 - [ ] native-parity.2 Emit an HSL fallback channel for the native theme (RESEARCHED 2026-07): NativeWind v4 (stable) has no on-device `oklch()` — RNR themes in HSL; native OKLCH is gated on NativeWind v5 (preview). Spike confirms the down-convert on a device; tweakcn already exports OKLCH+HSL from one source
-- [ ] native-parity.3 Decide: one registry, multi-file items (`<c>.tsx` + `<c>.native.tsx`, bundler-resolved) — single `ui.vllnt.ai`, no second namespace
+- [ ] native-parity.3 Decide: one registry, multi-file items (`<c>.tsx` + `<c>.native.tsx`, bundler-resolved) — single `ui.vllnt.com`, no second namespace
 - [ ] native-parity.4 Token codegen: emit the RN/NativeWind theme from `tokens.json` alongside the web CSS vars (single source)
 - [ ] native-parity.5 Establish the iso pattern: extract `<c>.variants.ts` (CVA + platform-neutral prop contract) + ship a 5-component reference set (button, input, card, badge, dialog)
-- [ ] native-parity.6 Extend `apps/registry/scripts/inline-component-source.ts` to emit `<c>.native.tsx` + the shared variants per registry item; stamp `parity: full|api-only` in `meta.json`; surface the badge on `ui.vllnt.ai`
+- [ ] native-parity.6 Extend `apps/registry/scripts/inline-component-source.ts` to emit `<c>.native.tsx` + the shared variants per registry item; stamp `parity: full|api-only` in `meta.json`; surface the badge on `ui.vllnt.com`
 - [ ] native-parity.7 Port core + form + utility families (115) to native twins
 - [ ] native-parity.8 Port data + data-display + content families (109) to native twins
 - [ ] native-parity.9 Port navigation + learning + educational + billing + ai families (70) to native twins
 - [ ] native-parity.10 Port overlay family (15) — api-only parity where Portal/keyboard can't map; document the degradation
-- [ ] native-parity.11 Validate native-parity.5–10: one `shadcn add @vllnt/<c>` from `ui.vllnt.ai` → identical import renders on Next web + Expo device across all 12 families; parity badges accurate (E2E)
+- [ ] native-parity.11 Validate native-parity.5–10: one `shadcn add @vllnt/<c>` from `ui.vllnt.com` → identical import renders on Next web + Expo device across all 12 families; parity badges accurate (E2E)
 - [ ] native-parity.12 Validate native-parity.4: an off-token native color fails; `tokens.json` stays the sole source across web CSS + RN theme (E2E)
 
 ## typography-primitives [DONE 2026-07]
@@ -213,24 +213,24 @@ Falls out of API-first (`studio.11`) — registration is just another API — pl
 ## search-consolidation [PLANNED]
 
 **Goal:** Stop the silent ranking leaks — kill the dead-domain cannibalization and fix the canonical / schema / analytics gaps capping the already-indexed pages.
-**Exit criteria:** `ui.vllnt.com/*` 301s to `ui.vllnt.ai/*`; GSC shows `.com` pages dropping and `.ai` positions rising; every localized page self-canonicals to its resolved (non-307) URL; zero console errors on load; Rich Results clean for BreadcrumbList + SoftwareApplication.
+**Exit criteria:** `ui.vllnt.com/*` 301s to `ui.vllnt.com/*`; GSC shows `.com` pages dropping and `.ai` positions rising; every localized page self-canonicals to its resolved (non-307) URL; zero console errors on load; Rich Results clean for BreadcrumbList + SoftwareApplication.
 **Verify:** a visitor landing on a stale `ui.vllnt.com/components/*` URL is 301'd to the live `.ai` page; Google Rich Results Test passes on `/components/[slug]` (Breadcrumb) and `/` (SoftwareApplication); DevTools console is clean on `/` + `/components/[slug]`. Personas: search visitor on a stale URL; Googlebot recrawling duplicates.
 
-- [ ] search-consolidation.1 301-redirect all `ui.vllnt.com/*` → `ui.vllnt.ai/*` at the host/DNS edge (restore the subdomain only to serve the redirect) (cmd: `curl -sI https://ui.vllnt.com/components/calendar | grep -Ei '301|location: https://ui.vllnt.ai'`)
-- [ ] search-consolidation.2 Self-referencing canonical + hreflang per locale in `apps/registry/app/[locale]/layout.tsx` + `lib/seo.ts` — canonical targets the resolved URL, not the 307 (cmd: `curl -s https://ui.vllnt.ai/components/button | grep -c 'rel="canonical".*/components/button'`)
+- [ ] search-consolidation.1 301-redirect all `ui.vllnt.com/*` → `ui.vllnt.com/*` at the host/DNS edge (restore the subdomain only to serve the redirect) (cmd: `curl -sI https://ui.vllnt.com/components/calendar | grep -Ei '301|location: https://ui.vllnt.com'`)
+- [ ] search-consolidation.2 Self-referencing canonical + hreflang per locale in `apps/registry/app/[locale]/layout.tsx` + `lib/seo.ts` — canonical targets the resolved URL, not the 307 (cmd: `curl -s https://ui.vllnt.com/components/button | grep -c 'rel="canonical".*/components/button'`)
 - [ ] search-consolidation.3 Replace the `@vercel/analytics` + `@vercel/speed-insights` 404s in `layout.tsx` with a portable web-vitals beacon (cmd: agent-browser `/` → 0 console errors, no `/_vercel/insights` 404)
 - [ ] search-consolidation.4 Add `BreadcrumbList` JSON-LD to `/components/[slug]` + `/docs/[slug]`, `SoftwareApplication` `featureList` on `/`, and a `blogPostingLd()` helper in `lib/jsonld.ts` (cmd: Rich Results Test clean on `/components/button`)
-- [ ] search-consolidation.5 Exclude 307/redirecting locale URLs from `sitemap.ts` + request re-index of the AI-wedge pages in GSC (cmd: `python3 gsc.py query --site sc-domain:ui.vllnt.ai --dimensions page --filter 'page contains /components/ai-'`)
+- [ ] search-consolidation.5 Exclude 307/redirecting locale URLs from `sitemap.ts` + request re-index of the AI-wedge pages in GSC (cmd: `python3 gsc.py query --site sc-domain:ui.vllnt.com --dimensions page --filter 'page contains /components/ai-'`)
 - [ ] search-consolidation.6 Validate search-consolidation.1–5: E2E — stale `.com` URL 301s to `.ai`; Rich Results clean (Breadcrumb + SoftwareApplication); console clean; canonical resolves (E2E: `pnpm test:e2e seo-consolidation`)
 
 ## ai-toolchain-registration [PLANNED]
 
 **Goal:** Make VLLNT UI installable by name inside AI coding tools — register the registry, MCP server, and docs in the indexes agents actually query. Highest-ROI, do-first (converts the DONE `agent-surface` infra into installs).
-**Exit criteria:** `@vllnt` resolves in `ui.shadcn.com/r/registries.json`; a shadcn-MCP-connected agent installs `@vllnt/ai-chat-input` by name; Context7 serves `ui.vllnt.ai` docs; `@vllnt/mcp` is on npm + the official MCP Registry; the GitHub repo carries the AI topics.
-**Verify:** in a fresh app with `"@vllnt": "https://ui.vllnt.ai/r/{name}"` in `components.json`, an agent prompted "add an AI chat thread" installs a VLLNT component; Context7 returns VLLNT docs for a Cursor query. Personas: dev scaffolding in Cursor/Claude Code/v0; agent resolving a component by name.
+**Exit criteria:** `@vllnt` resolves in `ui.shadcn.com/r/registries.json`; a shadcn-MCP-connected agent installs `@vllnt/ai-chat-input` by name; Context7 serves `ui.vllnt.com` docs; `@vllnt/mcp` is on npm + the official MCP Registry; the GitHub repo carries the AI topics.
+**Verify:** in a fresh app with `"@vllnt": "https://ui.vllnt.com/r/{name}"` in `components.json`, an agent prompted "add an AI chat thread" installs a VLLNT component; Context7 returns VLLNT docs for a Cursor query. Personas: dev scaffolding in Cursor/Claude Code/v0; agent resolving a component by name.
 
 - [ ] ai-toolchain-registration.1 PR `@vllnt` into the shadcn registry directory (`apps/v4/registry/directory.json`) + verify the earlier index PR is live in `registries.json` (cmd: `curl -s https://ui.shadcn.com/r/registries.json | grep -c '@vllnt'`)
-- [ ] ai-toolchain-registration.2 Submit `ui.vllnt.ai` to Context7 + add `context7.json` to repo root (cmd: `curl -s https://context7.com/vllnt/ui | grep -ci vllnt`)
+- [ ] ai-toolchain-registration.2 Submit `ui.vllnt.com` to Context7 + add `context7.json` to repo root (cmd: `curl -s https://context7.com/vllnt/ui | grep -ci vllnt`)
 - [ ] ai-toolchain-registration.3 Publish a distributable `@vllnt/mcp` stdio bridge (wrapping the hosted `/mcp`) to npm (cmd: `npm view @vllnt/mcp version`)
 - [ ] ai-toolchain-registration.4 Register the MCP server in the official MCP Registry (`mcp-publisher`) + Registry Discovery MCP (cmd: `curl -s https://registry.modelcontextprotocol.io/v0/servers | grep -ci vllnt`)
 - [ ] ai-toolchain-registration.5 Add GitHub topics `ai, ai-agents, llm, generative-ui, shadcn, shadcn-registry` + document the `components.json` `@vllnt` snippet in `/docs/installation` (cmd: `gh repo view vllnt/ui --json repositoryTopics | grep -E 'ai-agents|shadcn-registry'`)
@@ -245,7 +245,7 @@ Falls out of API-first (`studio.11`) — registration is just another API — pl
 - [ ] visibility-measurement.1 Configure the GA4 AI-Assistant channel + a referrer/UTM filter `chatgpt.com|perplexity.ai|claude.ai|gemini.google.com|copilot.microsoft.com` (cmd: GA4 realtime shows the channel on a test referral)
 - [ ] visibility-measurement.2 Stand up a share-of-voice tracker (Profound/Otterly/Peec/Ahrefs Brand Radar) on the AI-UI prompt set (cmd: tracker dashboard returns a baseline mention rate)
 - [ ] visibility-measurement.3 Add server-log crawler monitoring for GPTBot/ClaudeBot/Claude-Code/PerplexityBot/OAI-SearchBot — proves llms.txt consumption (cmd: `grep -Ec 'GPTBot|ClaudeBot|Claude-Code' access.log`)
-- [ ] visibility-measurement.4 Script a recurring GSC position/impressions review via `gsc.py` (cmd: `python3 gsc.py query --site sc-domain:ui.vllnt.ai --dimensions query --days 28`)
+- [ ] visibility-measurement.4 Script a recurring GSC position/impressions review via `gsc.py` (cmd: `python3 gsc.py query --site sc-domain:ui.vllnt.com --dimensions query --days 28`)
 
 ## seo-content-engine [PLANNED]
 
@@ -254,12 +254,12 @@ Falls out of API-first (`studio.11`) — registration is just another API — pl
 **Verify:** a dev searching "how to build a chat ui with the vercel ai sdk" finds a VLLNT guide; `/alternatives/assistant-ui` renders a comparison table; a blog post shows correct BlogPosting rich data. Personas: dev in organic search; dev comparing libraries; AI answer engine extracting a table. (needs: search-consolidation done first)
 
 - [ ] seo-content-engine.1 Add the MDX blog: `content/blog/{slug}/{locale}.mdx` + `lib/blog.ts` (Content Collections `@content-collections/mdx`, Zod frontmatter — NOT Contentlayer; Velite fallback) mirroring `lib/content.ts` (needs: search-consolidation.4) → docs/specs/blog-system.md
-- [ ] seo-content-engine.2 Routes `/blog` + `/blog/[slug]` with `generateMetadata` + BlogPosting/Breadcrumb JSON-LD + Shiki build-time highlighting + per-post OG via `ImageResponse` (cmd: `curl -s https://ui.vllnt.ai/blog/<post> | grep -c '"@type":"BlogPosting"'`)
-- [ ] seo-content-engine.3 Blog RSS + sitemap + llms.txt entries (extend `app/rss.xml`, `sitemap.ts`, `llms.txt/route.ts`) (cmd: `curl -s https://ui.vllnt.ai/sitemap.xml | grep -c /blog/`)
-- [ ] seo-content-engine.4 Programmatic `/integrations/{tool}` pages (vercel-ai-sdk, langgraph, convex, openai, anthropic), data-driven like `lib/use-cases.ts` (cmd: `curl -sI https://ui.vllnt.ai/integrations/vercel-ai-sdk | grep -c 200`)
-- [ ] seo-content-engine.5 Programmatic `/alternatives/{competitor}` pages (assistant-ui, copilotkit, ai-elements) with a comparison table + FAQPage LD (cmd: `curl -s https://ui.vllnt.ai/alternatives/assistant-ui | grep -c '<table'`)
+- [ ] seo-content-engine.2 Routes `/blog` + `/blog/[slug]` with `generateMetadata` + BlogPosting/Breadcrumb JSON-LD + Shiki build-time highlighting + per-post OG via `ImageResponse` (cmd: `curl -s https://ui.vllnt.com/blog/<post> | grep -c '"@type":"BlogPosting"'`)
+- [ ] seo-content-engine.3 Blog RSS + sitemap + llms.txt entries (extend `app/rss.xml`, `sitemap.ts`, `llms.txt/route.ts`) (cmd: `curl -s https://ui.vllnt.com/sitemap.xml | grep -c /blog/`)
+- [ ] seo-content-engine.4 Programmatic `/integrations/{tool}` pages (vercel-ai-sdk, langgraph, convex, openai, anthropic), data-driven like `lib/use-cases.ts` (cmd: `curl -sI https://ui.vllnt.com/integrations/vercel-ai-sdk | grep -c 200`)
+- [ ] seo-content-engine.5 Programmatic `/alternatives/{competitor}` pages (assistant-ui, copilotkit, ai-elements) with a comparison table + FAQPage LD (cmd: `curl -s https://ui.vllnt.com/alternatives/assistant-ui | grep -c '<table'`)
 - [ ] seo-content-engine.6 Per-component uniqueness pass: unique copy + live demo + install command on each `/components/[slug]` → docs/specs/component-page-uniqueness.md
-- [ ] seo-content-engine.7 Publish 3 flagship guides (best react components for AI agents; assistant-ui vs ai-elements vs vllnt; render tool calls in react) — answer-first, stats + tables, TechArticle LD (cmd: `curl -s https://ui.vllnt.ai/blog/best-react-components-for-ai-agents | grep -c '<table'`)
+- [ ] seo-content-engine.7 Publish 3 flagship guides (best react components for AI agents; assistant-ui vs ai-elements vs vllnt; render tool calls in react) — answer-first, stats + tables, TechArticle LD (cmd: `curl -s https://ui.vllnt.com/blog/best-react-components-for-ai-agents | grep -c '<table'`)
 - [ ] seo-content-engine.8 Validate seo-content-engine.1–7: E2E — blog post renders with BlogPosting rich data; integration + alternative pages return 200 with tables; component page shows demo + install; RSS/sitemap include blog (E2E: `pnpm test:e2e content-engine`)
 
 ## backlink-authority [PLANNED]
@@ -271,10 +271,10 @@ Falls out of API-first (`studio.11`) — registration is just another API — pl
 - [ ] backlink-authority.1 PRs to awesome-shadcn-ui + awesome-react-components + awesome-nextjs + awesome-generative-ui (cmd: PR merged + entry visible in the list README)
 - [ ] backlink-authority.2 Show HN launch + Product Hunt launch (cmd: live HN + PH post URLs)
 - [ ] backlink-authority.3 Submit to OSS aggregators: OpenAlternative, LibHunt, AlternativeTo, SaaSHub, DevHunt (cmd: listing URLs live)
-- [ ] backlink-authority.4 Syndicate 3 guides to dev.to/Hashnode with `canonical` → ui.vllnt.ai (needs: seo-content-engine.7) (cmd: syndicated post `rel=canonical` points home)
+- [ ] backlink-authority.4 Syndicate 3 guides to dev.to/Hashnode with `canonical` → ui.vllnt.com (needs: seo-content-engine.7) (cmd: syndicated post `rel=canonical` points home)
 - [ ] backlink-authority.5 Newsletter sponsorship (React Status / Bytes / JS Weekly) timed to the magnet (cmd: placement confirmed live)
 - [ ] backlink-authority.6 Ship one original-data link magnet: AI chat UI benchmark or "State of AI UI 2026" survey (needs: seo-content-engine.1) → docs/specs/link-magnet.md
-- [ ] backlink-authority.7 Validate backlink-authority.1–6: GSC Links report shows ≥3 new referring domains to the magnet + ≥5 directory/list entries live (cmd: `python3 gsc.py query --site sc-domain:ui.vllnt.ai --dimensions page --filter 'page contains /blog/'` + GSC Links export)
+- [ ] backlink-authority.7 Validate backlink-authority.1–6: GSC Links report shows ≥3 new referring domains to the magnet + ≥5 directory/list entries live (cmd: `python3 gsc.py query --site sc-domain:ui.vllnt.com --dimensions page --filter 'page contains /blog/'` + GSC Links export)
 
 ---
 
@@ -561,7 +561,7 @@ Full task detail for completed phases — collapsed above to keep the active roa
 - [x] agent-surface.3 `/llms.txt` + `/llms-full.txt` — #235, #236
 - [x] agent-surface.4 JSON-LD (Organization, WebSite, SoftwareSourceCode, ItemList, BreadcrumbList) + manifest + custom 404 + breadcrumbs — #238, #239, #240, #251
 - [x] agent-surface.5 Release-intelligence surface: `/changelog`, `/releases`, `/rss.xml`, `/atom.xml` — #260
-- [x] agent-surface.6 `@vllnt/mcp` server at `ui.vllnt.ai/mcp` — #246
+- [x] agent-surface.6 `@vllnt/mcp` server at `ui.vllnt.com/mcp` — #246
 - [x] agent-surface.7 Community paths: footer, header GitHub icon, `/request-component`, `/report`, FUNDING, shadcn-CLI install path — #243–#247, #261, #265
 - [x] agent-surface.8 Brand: DESIGN.md + `/design` + `design.tokens.json` — #250
 - [x] agent-surface.9 Landing rebuild to OSS-library best practices — #264

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,7 +38,7 @@ In scope:
 
 - The published `@vllnt/ui` package on the public npm registry.
 - Source in `packages/ui/` and `apps/registry/`.
-- The published registry API (`https://ui.vllnt.ai/r/*.json`).
+- The published registry API (`https://ui.vllnt.com/r/*.json`).
 - CI workflows that touch publishing or release provenance.
 
 Out of scope:

--- a/apps/registry/README.md
+++ b/apps/registry/README.md
@@ -74,7 +74,7 @@ This builds the Next.js app and generates registry JSON files to `public/r/` usi
 
 ```bash
 # Install directly by URL — works today, no config
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/button.json
 ```
 
 Namespaced install (once `@vllnt` is listed in the [shadcn registry index](https://ui.shadcn.com/r/registries.json)) — add the registry to your app's `components.json`:
@@ -82,7 +82,7 @@ Namespaced install (once `@vllnt` is listed in the [shadcn registry index](https
 ```json
 {
   "registries": {
-    "@vllnt": "https://ui.vllnt.ai/r/{name}.json"
+    "@vllnt": "https://ui.vllnt.com/r/{name}.json"
   }
 }
 ```
@@ -171,7 +171,7 @@ The registry follows the shadcn/ui registry schema:
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
   "name": "vllnt",
-  "homepage": "https://ui.vllnt.ai",
+  "homepage": "https://ui.vllnt.com",
   "items": [
     {
       "name": "component-name",

--- a/apps/registry/SEO-AI-POSITIONING.md
+++ b/apps/registry/SEO-AI-POSITIONING.md
@@ -1,4 +1,4 @@
-# SEO: repositioning ui.vllnt.ai as the UI design system for AI agents
+# SEO: repositioning ui.vllnt.com as the UI design system for AI agents
 
 GSC-grounded change set that shifts the site from "agent-readable shadcn clone"
 (unwinnable on generic component terms) to category owner of **UI for AI agents
@@ -32,7 +32,7 @@ These are off-platform / require account access:
    - Track a saved query group filtering `chat|ai|agent|tool|citation|streaming`.
 2. **Off-page / authority**
    - List in awesome-lists (`awesome-ai`, `awesome-react-components`, `awesome-llm-apps`), add npm keywords + GitHub topics (`ai-ui`, `agent-ui`, `llm-ui`, `generative-ui`).
-   - Cross-post guides (dev.to / Hashnode) with canonical back to ui.vllnt.ai; Show HN / r/reactjs launch with the AI-UI angle.
+   - Cross-post guides (dev.to / Hashnode) with canonical back to ui.vllnt.com; Show HN / r/reactjs launch with the AI-UI angle.
 3. **Deploy note**: the storybook noindex only takes effect after `apps/storybook` is rebuilt/redeployed.
 
 ## KPIs to watch

--- a/apps/storybook/Dockerfile
+++ b/apps/storybook/Dockerfile
@@ -1,4 +1,4 @@
-# Storybook static build for ui.vllnt.ai monorepo.
+# Storybook static build for ui.vllnt.com monorepo.
 # Build from repo root so pnpm workspace links resolve.
 # Final image: nginx-unprivileged serving the static export.
 

--- a/apps/storybook/nginx.conf
+++ b/apps/storybook/nginx.conf
@@ -16,7 +16,7 @@ server {
     }
 
     # Keep Storybook out of search indexes — the canonical component docs live
-    # at ui.vllnt.ai/components/*. Indexing storybook.vllnt.ai cannibalizes them.
+    # at ui.vllnt.com/components/*. Indexing storybook.vllnt.ai cannibalizes them.
     location = /robots.txt {
         access_log off;
         add_header Content-Type text/plain;
@@ -39,7 +39,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
-        # Do not index Storybook — canonical docs are on ui.vllnt.ai/components/*
+        # Do not index Storybook — canonical docs are on ui.vllnt.com/components/*
         add_header X-Robots-Tag "noindex, nofollow" always;
     }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,7 @@ vllnt/ui/
 │       ├── styles.css
 │       └── themes/
 ├── apps/
-│   └── registry/             # Next.js site at ui.vllnt.ai
+│   └── registry/             # Next.js site at ui.vllnt.com
 │       ├── app/              # app-router routes (components/[slug], etc.)
 │       ├── content/          # MDX pages
 │       ├── lib/              # registry + OG utilities
@@ -30,7 +30,7 @@ vllnt/ui/
 | Package | Purpose | Published |
 |---------|---------|-----------|
 | `@vllnt/ui` | Component library | Yes, public npm |
-| `@vllnt/ui-registry` (registry app) | Docs + shadcn registry | No, deployed to `ui.vllnt.ai` |
+| `@vllnt/ui-registry` (registry app) | Docs + shadcn registry | No, deployed to `ui.vllnt.com` |
 
 External shared configs consumed as dev deps from npm:
 
@@ -91,4 +91,4 @@ Beyond light/dark, a runtime **preset** layer (`themes/presets.css`) applies nam
 
 ## Registry feed
 
-The shadcn-compatible registry at `https://ui.vllnt.ai/r/{component}.json` is generated from `apps/registry/registry.ts` and served by the Next.js app. Each component resolves to a JSON payload consumable by `shadcn add`.
+The shadcn-compatible registry at `https://ui.vllnt.com/r/{component}.json` is generated from `apps/registry/registry.ts` and served by the Next.js app. Each component resolves to a JSON payload consumable by `shadcn add`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-This folder contains in-repo documentation for `@vllnt/ui` contributors and downstream maintainers. Component-level documentation for users lives at [ui.vllnt.ai](https://ui.vllnt.ai) and in [Storybook](https://storybook.vllnt.ai).
+This folder contains in-repo documentation for `@vllnt/ui` contributors and downstream maintainers. Component-level documentation for users lives at [ui.vllnt.com](https://ui.vllnt.com) and in [Storybook](https://storybook.vllnt.ai).
 
 ## Index
 
@@ -11,7 +11,7 @@ This folder contains in-repo documentation for `@vllnt/ui` contributors and down
 
 ## External destinations
 
-- **Component docs:** https://ui.vllnt.ai
+- **Component docs:** https://ui.vllnt.com
 - **Storybook:** https://storybook.vllnt.ai
 - **Package on npm:** https://www.npmjs.com/package/@vllnt/ui
 - **Changelog:** [`packages/ui/CHANGELOG.md`](../packages/ui/CHANGELOG.md)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -62,7 +62,7 @@ The `registry:check` and `registry:integrity` CI guards confirm the regenerated 
 
 - `CHANGELOG.md` has an `[Unreleased]` section describing user-facing changes. Use `cliff.toml` with git-cliff if you need to regenerate it from Conventional Commits.
 - The canary built from the same commit passes and lists the expected components (check logs for the tarball manifest).
-- Docs are in sync: component count in `README.md`, family tables in `packages/ui/README.md`, domain references (`ui.vllnt.ai` / `storybook.vllnt.ai`).
+- Docs are in sync: component count in `README.md`, family tables in `packages/ui/README.md`, domain references (`ui.vllnt.com` / `storybook.vllnt.ai`).
 
 ## Post-release verification
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,6 +1,6 @@
 # @vllnt/ui — full reference for AI consumption
 
-> React component library — 144 accessible components built on Radix UI primitives, Tailwind CSS, and CVA. Distributed via the public npm registry with OIDC-signed provenance, and via a shadcn-compatible registry at https://ui.vllnt.ai/r.
+> React component library — 144 accessible components built on Radix UI primitives, Tailwind CSS, and CVA. Distributed via the public npm registry with OIDC-signed provenance, and via a shadcn-compatible registry at https://ui.vllnt.com/r.
 
 ---
 
@@ -14,9 +14,9 @@
 - **Runtime targets:** React 18+, Tailwind CSS 3+
 - **Distribution:**
   - Public npm: https://www.npmjs.com/package/@vllnt/ui
-  - shadcn registry: https://ui.vllnt.ai/r
-  - Docs: https://ui.vllnt.ai
-  - Design system: https://ui.vllnt.ai/DESIGN.md
+  - shadcn registry: https://ui.vllnt.com/r
+  - Docs: https://ui.vllnt.com
+  - Design system: https://ui.vllnt.com/DESIGN.md
   - Storybook: https://storybook.vllnt.ai
 
 ## Install
@@ -196,7 +196,7 @@ import { cn } from "@vllnt/ui";
 ```
 vllnt/ui/
   packages/ui/                # @vllnt/ui source
-  apps/registry/              # Next.js registry at ui.vllnt.ai
+  apps/registry/              # Next.js registry at ui.vllnt.com
   .github/workflows/          # CI, publish, storybook
   AGENTS.md                   # canonical agent instructions
   CONTRIBUTING.md             # contributor guide
@@ -211,7 +211,7 @@ vllnt/ui/
 
 ## References
 
-- Project homepage — https://ui.vllnt.ai
+- Project homepage — https://ui.vllnt.com
 - Storybook — https://storybook.vllnt.ai
 - Changelog — https://github.com/vllnt/ui/blob/main/packages/ui/CHANGELOG.md
 - Contributing — https://github.com/vllnt/ui/blob/main/CONTRIBUTING.md

--- a/llms.txt
+++ b/llms.txt
@@ -1,13 +1,13 @@
 # @vllnt/ui
 
 > React component library — 144 accessible components built on Radix UI primitives, Tailwind CSS, and CVA.
-> Distributed via the public npm registry and a shadcn-compatible registry at https://ui.vllnt.ai/r.
+> Distributed via the public npm registry and a shadcn-compatible registry at https://ui.vllnt.com/r.
 
 ## Package
 
 - npm: https://www.npmjs.com/package/@vllnt/ui
 - Source: https://github.com/vllnt/ui/tree/main/packages/ui
-- Docs: https://ui.vllnt.ai
+- Docs: https://ui.vllnt.com
 - Storybook: https://storybook.vllnt.ai
 
 ## Install
@@ -33,7 +33,7 @@ import { Button } from "@vllnt/ui";
 ## Key docs
 
 - [Root README](https://github.com/vllnt/ui/blob/main/README.md) — overview + component index
-- [DESIGN](https://ui.vllnt.ai/DESIGN.md) — canonical brand, tokens, and design system rules
+- [DESIGN](https://ui.vllnt.com/DESIGN.md) — canonical brand, tokens, and design system rules
 - [Package README](https://github.com/vllnt/ui/blob/main/packages/ui/README.md) — setup, theming, full component tables
 - [CHANGELOG](https://github.com/vllnt/ui/blob/main/packages/ui/CHANGELOG.md) — version history
 - [CONTRIBUTING](https://github.com/vllnt/ui/blob/main/CONTRIBUTING.md) — dev + PR workflow
@@ -62,5 +62,5 @@ import { Button } from "@vllnt/ui";
 Install a single component:
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/{component}.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/{component}.json
 ```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vllnt/ui-monorepo",
   "private": true,
   "version": "0.1.0",
-  "homepage": "https://ui.vllnt.ai",
+  "homepage": "https://ui.vllnt.com",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/vllnt/ui.git"

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -83,7 +83,7 @@ _Nothing yet._
 
 ### Changed
 
-- Documentation domain moved to `ui.vllnt.ai` / `storybook.vllnt.ai`.
+- Documentation domain moved to `ui.vllnt.com` / `storybook.vllnt.ai`.
 - Default package registry is the public npm registry (no longer GitHub Packages).
 - README component tables expanded to cover all 144 components organized by family.
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -134,7 +134,7 @@ which set `data-theme` on the document root. Render `<ThemePresetProvider />`
 once near the root to restore the saved preset before paint.
 
 To design and export your own theme, use the visual editor at
-[`/themes`](https://ui.vllnt.ai/themes) — it exports a CSS block, a
+[`/themes`](https://ui.vllnt.com/themes) — it exports a CSS block, a
 `npx shadcn add` command, or design tokens.
 
 ## Component Patterns

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,7 +4,7 @@
   "description": "React component library — 309 components built on Radix UI, Tailwind CSS, and CVA",
   "license": "MIT",
   "author": "vllnt",
-  "homepage": "https://ui.vllnt.ai",
+  "homepage": "https://ui.vllnt.com",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/vllnt/ui.git",

--- a/packages/ui/scripts/generate-docs.ts
+++ b/packages/ui/scripts/generate-docs.ts
@@ -770,7 +770,7 @@ function generateMdx(component: ComponentMeta): string {
   lines.push(`## Installation`)
   lines.push('')
   lines.push('```bash')
-  lines.push(`pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/${dirName}.json`)
+  lines.push(`pnpm dlx shadcn@latest add https://ui.vllnt.com/r/${dirName}.json`)
   lines.push('```')
   lines.push('')
 

--- a/packages/ui/src/components/accordion/accordion.mdx
+++ b/packages/ui/src/components/accordion/accordion.mdx
@@ -12,7 +12,7 @@ Collapsible content sections supporting single or multiple open items.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/accordion.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/accordion.json
 ```
 
 ## Import

--- a/packages/ui/src/components/activity-heatmap/activity-heatmap.mdx
+++ b/packages/ui/src/components/activity-heatmap/activity-heatmap.mdx
@@ -14,7 +14,7 @@ Distinct from \`HeatOverlay\` (free-form canvas heatmap): this primitive is a fi
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/activity-heatmap.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/activity-heatmap.json
 ```
 
 ## Import

--- a/packages/ui/src/components/activity-log/activity-log.mdx
+++ b/packages/ui/src/components/activity-log/activity-log.mdx
@@ -14,7 +14,7 @@ Distinct from \`LiveFeed\` (full-height live event stream) and \`BottomActivityS
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/activity-log.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/activity-log.json
 ```
 
 ## Import

--- a/packages/ui/src/components/agent-activity/agent-activity.mdx
+++ b/packages/ui/src/components/agent-activity/agent-activity.mdx
@@ -19,7 +19,7 @@ A compound component family:
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/agent-activity.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/agent-activity.json
 ```
 
 ## Import

--- a/packages/ui/src/components/ai-artifact/ai-artifact.mdx
+++ b/packages/ui/src/components/ai-artifact/ai-artifact.mdx
@@ -22,7 +22,7 @@ A compound family driven by an internal context:
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ai-artifact.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/ai-artifact.json
 ```
 
 ## Import

--- a/packages/ui/src/components/ai-chat-input/ai-chat-input.mdx
+++ b/packages/ui/src/components/ai-chat-input/ai-chat-input.mdx
@@ -12,7 +12,7 @@ Composer for AI chat surfaces — multi-line text area with submit affordance, o
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ai-chat-input.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/ai-chat-input.json
 ```
 
 ## Import

--- a/packages/ui/src/components/ai-message-bubble/ai-message-bubble.mdx
+++ b/packages/ui/src/components/ai-message-bubble/ai-message-bubble.mdx
@@ -12,7 +12,7 @@ Single chat message bubble — \`user\` / \`assistant\` / \`system\` roles, time
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ai-message-bubble.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/ai-message-bubble.json
 ```
 
 ## Import

--- a/packages/ui/src/components/ai-sidebar/ai-sidebar.mdx
+++ b/packages/ui/src/components/ai-sidebar/ai-sidebar.mdx
@@ -22,7 +22,7 @@ A compound family driven by `AISidebarProvider`:
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ai-sidebar.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/ai-sidebar.json
 ```
 
 ## Import

--- a/packages/ui/src/components/ai-source-citation/ai-source-citation.mdx
+++ b/packages/ui/src/components/ai-source-citation/ai-source-citation.mdx
@@ -12,7 +12,7 @@ Inline citation chip linking to the source the AI used for a claim. Renders as a
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ai-source-citation.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/ai-source-citation.json
 ```
 
 ## Import

--- a/packages/ui/src/components/ai-streaming-text/ai-streaming-text.mdx
+++ b/packages/ui/src/components/ai-streaming-text/ai-streaming-text.mdx
@@ -12,7 +12,7 @@ Live-streaming text container with a calm caret affordance for the actively-typi
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ai-streaming-text.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/ai-streaming-text.json
 ```
 
 ## Import

--- a/packages/ui/src/components/ai-tool-call-display/ai-tool-call-display.mdx
+++ b/packages/ui/src/components/ai-tool-call-display/ai-tool-call-display.mdx
@@ -12,7 +12,7 @@ Inline tool-call summary rendered inside an assistant message — tool name, sta
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ai-tool-call-display.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/ai-tool-call-display.json
 ```
 
 ## Import

--- a/packages/ui/src/components/alert-dialog/alert-dialog.mdx
+++ b/packages/ui/src/components/alert-dialog/alert-dialog.mdx
@@ -12,7 +12,7 @@ Modal dialog for confirming destructive or important actions.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/alert-dialog.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/alert-dialog.json
 ```
 
 ## Import

--- a/packages/ui/src/components/alert-pulse/alert-pulse.mdx
+++ b/packages/ui/src/components/alert-pulse/alert-pulse.mdx
@@ -14,7 +14,7 @@ Render inside a \`position: relative\` parent that shares the canvas pixel coord
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/alert-pulse.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/alert-pulse.json
 ```
 
 ## Import

--- a/packages/ui/src/components/alert/alert.mdx
+++ b/packages/ui/src/components/alert/alert.mdx
@@ -12,7 +12,7 @@ Displays an alert message to the user.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/alert.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/alert.json
 ```
 
 ## Import

--- a/packages/ui/src/components/anchor-port/anchor-port.mdx
+++ b/packages/ui/src/components/anchor-port/anchor-port.mdx
@@ -12,7 +12,7 @@ Connection-point marker rendered on the edge of an \`ObjectCard\` for inputs, ou
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/anchor-port.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/anchor-port.json
 ```
 
 ## Import

--- a/packages/ui/src/components/animated-text/animated-text.mdx
+++ b/packages/ui/src/components/animated-text/animated-text.mdx
@@ -12,7 +12,7 @@ Animated text container that types in characters, fades in words, or rolls betwe
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/animated-text.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/animated-text.json
 ```
 
 ## Import

--- a/packages/ui/src/components/annotation/annotation.mdx
+++ b/packages/ui/src/components/annotation/annotation.mdx
@@ -14,7 +14,7 @@ Distinct from \`Tooltip\` (transient hover) and \`CommentPin\` (canvas-anchored 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/annotation.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/annotation.json
 ```
 
 ## Import

--- a/packages/ui/src/components/aspect-ratio/aspect-ratio.mdx
+++ b/packages/ui/src/components/aspect-ratio/aspect-ratio.mdx
@@ -12,7 +12,7 @@ Constrains content to a specified aspect ratio.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/aspect-ratio.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/aspect-ratio.json
 ```
 
 ## Import

--- a/packages/ui/src/components/auto-reload/auto-reload.mdx
+++ b/packages/ui/src/components/auto-reload/auto-reload.mdx
@@ -14,7 +14,7 @@ Values flow through in **minor units** (cents). The inputs display the correspon
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/auto-reload.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/auto-reload.json
 ```
 
 ## Import

--- a/packages/ui/src/components/avatar-group/avatar-group.mdx
+++ b/packages/ui/src/components/avatar-group/avatar-group.mdx
@@ -14,7 +14,7 @@ Distinct from \`PresenceStack\` (live status + colors): \`AvatarGroup\` is the d
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/avatar-group.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/avatar-group.json
 ```
 
 ## Import

--- a/packages/ui/src/components/avatar/avatar.mdx
+++ b/packages/ui/src/components/avatar/avatar.mdx
@@ -12,7 +12,7 @@ Displays a user avatar image with fallback initials.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/avatar.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/avatar.json
 ```
 
 ## Import

--- a/packages/ui/src/components/badge/badge.mdx
+++ b/packages/ui/src/components/badge/badge.mdx
@@ -12,7 +12,7 @@ Small status label with variant styles.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/badge.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/badge.json
 ```
 
 ## Import

--- a/packages/ui/src/components/banner/banner.mdx
+++ b/packages/ui/src/components/banner/banner.mdx
@@ -12,7 +12,7 @@ Full-width announcement bar for trial warnings, maintenance notices, and upgrade
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/banner.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/banner.json
 ```
 
 ## Import

--- a/packages/ui/src/components/blog-card/blog-card.mdx
+++ b/packages/ui/src/components/blog-card/blog-card.mdx
@@ -12,7 +12,7 @@ Card layout for displaying blog post previews.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/blog-card.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/blog-card.json
 ```
 
 ## Import

--- a/packages/ui/src/components/border-beam/border-beam.mdx
+++ b/packages/ui/src/components/border-beam/border-beam.mdx
@@ -12,7 +12,7 @@ Animated accent beam that travels around the border of a highlighted surface —
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/border-beam.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/border-beam.json
 ```
 
 ## Import

--- a/packages/ui/src/components/bottom-activity-strip/bottom-activity-strip.mdx
+++ b/packages/ui/src/components/bottom-activity-strip/bottom-activity-strip.mdx
@@ -16,7 +16,7 @@ Distinct from \`ActivityLog\` (vertical, persistent) and \`LiveFeed\` (full-heig
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/bottom-activity-strip.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/bottom-activity-strip.json
 ```
 
 ## Import

--- a/packages/ui/src/components/bottom-bar/bottom-bar.mdx
+++ b/packages/ui/src/components/bottom-bar/bottom-bar.mdx
@@ -14,7 +14,7 @@ Pair with \`BottomActivityStrip\` for the live event chips, \`PresenceSyncIndica
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/bottom-bar.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/bottom-bar.json
 ```
 
 ## Import

--- a/packages/ui/src/components/breadcrumb/breadcrumb.mdx
+++ b/packages/ui/src/components/breadcrumb/breadcrumb.mdx
@@ -12,7 +12,7 @@ Navigation breadcrumb trail showing the current page hierarchy.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/breadcrumb.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/breadcrumb.json
 ```
 
 ## Import

--- a/packages/ui/src/components/button/button.mdx
+++ b/packages/ui/src/components/button/button.mdx
@@ -12,7 +12,7 @@ Interactive button with multiple variants and sizes.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/button.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/button.json
 ```
 
 ## Import

--- a/packages/ui/src/components/calendar/calendar.mdx
+++ b/packages/ui/src/components/calendar/calendar.mdx
@@ -12,7 +12,7 @@ Date picker calendar for selecting dates.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/calendar.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/calendar.json
 ```
 
 ## Import

--- a/packages/ui/src/components/callout/callout.mdx
+++ b/packages/ui/src/components/callout/callout.mdx
@@ -12,7 +12,7 @@ Highlighted content block with variant styles for info, warning, danger, and mor
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/callout.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/callout.json
 ```
 
 ## Import

--- a/packages/ui/src/components/candlestick-chart/candlestick-chart.mdx
+++ b/packages/ui/src/components/candlestick-chart/candlestick-chart.mdx
@@ -12,7 +12,7 @@ OHLC candlestick chart — open / high / low / close per period, color-coded by 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/candlestick-chart.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/candlestick-chart.json
 ```
 
 ## Import

--- a/packages/ui/src/components/canvas-shell/canvas-shell.mdx
+++ b/packages/ui/src/components/canvas-shell/canvas-shell.mdx
@@ -14,7 +14,7 @@ Pair with \`TopBar\`, \`LeftRail\`, \`RightDock\`, \`BottomBar\`, and \`CanvasVi
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/canvas-shell.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/canvas-shell.json
 ```
 
 ## Import

--- a/packages/ui/src/components/canvas-view/canvas-view.mdx
+++ b/packages/ui/src/components/canvas-view/canvas-view.mdx
@@ -14,7 +14,7 @@ Pair with \`InfinitePlane\` for the dotted backdrop, \`MiniMapPanel\` for the ov
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/canvas-view.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/canvas-view.json
 ```
 
 ## Import

--- a/packages/ui/src/components/card/card.mdx
+++ b/packages/ui/src/components/card/card.mdx
@@ -12,7 +12,7 @@ Container with header, content, and footer sections.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/card.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/card.json
 ```
 
 ## Import

--- a/packages/ui/src/components/carousel/carousel.mdx
+++ b/packages/ui/src/components/carousel/carousel.mdx
@@ -12,7 +12,7 @@ Scrollable content carousel with navigation controls.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/carousel.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/carousel.json
 ```
 
 ## Import

--- a/packages/ui/src/components/category-filter/category-filter.mdx
+++ b/packages/ui/src/components/category-filter/category-filter.mdx
@@ -12,7 +12,7 @@ Filterable category selection for content lists.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/category-filter.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/category-filter.json
 ```
 
 ## Import

--- a/packages/ui/src/components/chart/area-chart.mdx
+++ b/packages/ui/src/components/chart/area-chart.mdx
@@ -10,7 +10,7 @@ import * as Stories from './area-chart.stories'
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/chart.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/chart.json
 ```
 
 ## Import

--- a/packages/ui/src/components/chat-dock-section/chat-dock-section.mdx
+++ b/packages/ui/src/components/chat-dock-section/chat-dock-section.mdx
@@ -14,7 +14,7 @@ Distinct from full chat surfaces — \`ChatDockSection\` is intentionally narrow
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/chat-dock-section.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/chat-dock-section.json
 ```
 
 ## Import

--- a/packages/ui/src/components/checkbox/checkbox.mdx
+++ b/packages/ui/src/components/checkbox/checkbox.mdx
@@ -12,7 +12,7 @@ Toggle control for boolean input.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/checkbox.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/checkbox.json
 ```
 
 ## Import

--- a/packages/ui/src/components/checklist/checklist.mdx
+++ b/packages/ui/src/components/checklist/checklist.mdx
@@ -12,7 +12,7 @@ Interactive checklist with progress tracking and toggleable items.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/checklist.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/checklist.json
 ```
 
 ## Import

--- a/packages/ui/src/components/choropleth-map/choropleth-map.mdx
+++ b/packages/ui/src/components/choropleth-map/choropleth-map.mdx
@@ -12,7 +12,7 @@ Region-colored data map. Standalone SVG primitive — no external map library or
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/choropleth-map.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/choropleth-map.json
 ```
 
 ## Import

--- a/packages/ui/src/components/chronological-timeline/chronological-timeline.mdx
+++ b/packages/ui/src/components/chronological-timeline/chronological-timeline.mdx
@@ -14,7 +14,7 @@ The active event is tracked via `IntersectionObserver`; the progress strip at th
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/chronological-timeline.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/chronological-timeline.json
 ```
 
 ## Import

--- a/packages/ui/src/components/civilization-card/civilization-card.mdx
+++ b/packages/ui/src/components/civilization-card/civilization-card.mdx
@@ -12,7 +12,7 @@ Overview card for historical civilizations: hero band with optional image + colo
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/civilization-card.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/civilization-card.json
 ```
 
 ## Import

--- a/packages/ui/src/components/code-block/code-block.mdx
+++ b/packages/ui/src/components/code-block/code-block.mdx
@@ -12,7 +12,7 @@ Syntax-highlighted code display with copy support.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/code-block.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/code-block.json
 ```
 
 ## Import

--- a/packages/ui/src/components/code-playground/code-playground.mdx
+++ b/packages/ui/src/components/code-playground/code-playground.mdx
@@ -12,7 +12,7 @@ Interactive code editor with live preview.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/code-playground.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/code-playground.json
 ```
 
 ## Import

--- a/packages/ui/src/components/collapsible/collapsible.mdx
+++ b/packages/ui/src/components/collapsible/collapsible.mdx
@@ -12,7 +12,7 @@ Expandable and collapsible content section.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/collapsible.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/collapsible.json
 ```
 
 ## Import

--- a/packages/ui/src/components/combobox/combobox.mdx
+++ b/packages/ui/src/components/combobox/combobox.mdx
@@ -14,7 +14,7 @@ Distinct from \`Select\` (native dropdown) and \`MultiSelect\` (multi-value pick
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/combobox.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/combobox.json
 ```
 
 ## Import

--- a/packages/ui/src/components/command/command.mdx
+++ b/packages/ui/src/components/command/command.mdx
@@ -12,7 +12,7 @@ Command palette with search, groups, and keyboard navigation.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/command.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/command.json
 ```
 
 ## Import

--- a/packages/ui/src/components/comment-pin/comment-pin.mdx
+++ b/packages/ui/src/components/comment-pin/comment-pin.mdx
@@ -14,7 +14,7 @@ Pure presentation; the host owns the thread store + supplies the unread count an
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/comment-pin.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/comment-pin.json
 ```
 
 ## Import

--- a/packages/ui/src/components/comparison/comparison.mdx
+++ b/packages/ui/src/components/comparison/comparison.mdx
@@ -12,7 +12,7 @@ Side-by-side comparison layout for content or features.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/comparison.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/comparison.json
 ```
 
 ## Import

--- a/packages/ui/src/components/completion-dialog/completion-dialog.mdx
+++ b/packages/ui/src/components/completion-dialog/completion-dialog.mdx
@@ -12,7 +12,7 @@ Dialog displayed upon completing a task or workflow.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/completion-dialog.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/completion-dialog.json
 ```
 
 ## Import

--- a/packages/ui/src/components/connector-edge/connector-edge.mdx
+++ b/packages/ui/src/components/connector-edge/connector-edge.mdx
@@ -14,7 +14,7 @@ Distinct from \`FlowDiagram\` (generic node-edge graph primitive): this edge is 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/connector-edge.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/connector-edge.json
 ```
 
 ## Import

--- a/packages/ui/src/components/content-intro/content-intro.mdx
+++ b/packages/ui/src/components/content-intro/content-intro.mdx
@@ -12,7 +12,7 @@ Introductory section for content pages with title and description.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/content-intro.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/content-intro.json
 ```
 
 ## Import

--- a/packages/ui/src/components/context-lens/context-lens.mdx
+++ b/packages/ui/src/components/context-lens/context-lens.mdx
@@ -14,7 +14,7 @@ The lens is \`pointer-events: none\` — host gestures pass through.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/context-lens.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/context-lens.json
 ```
 
 ## Import

--- a/packages/ui/src/components/context-menu/context-menu.mdx
+++ b/packages/ui/src/components/context-menu/context-menu.mdx
@@ -12,7 +12,7 @@ Right-click context menu with items and submenus.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/context-menu.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/context-menu.json
 ```
 
 ## Import

--- a/packages/ui/src/components/cookie-consent/cookie-consent.mdx
+++ b/packages/ui/src/components/cookie-consent/cookie-consent.mdx
@@ -10,7 +10,7 @@ import * as Stories from './cookie-consent.stories'
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/cookie-consent.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/cookie-consent.json
 ```
 
 ## Import

--- a/packages/ui/src/components/copy-button/copy-button.mdx
+++ b/packages/ui/src/components/copy-button/copy-button.mdx
@@ -12,7 +12,7 @@ Click-to-copy utility with confirmation feedback. Copies `value` to the clipboar
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/copy-button.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/copy-button.json
 ```
 
 ## Import

--- a/packages/ui/src/components/copy-button/copy-button.stories.tsx
+++ b/packages/ui/src/components/copy-button/copy-button.stories.tsx
@@ -37,7 +37,7 @@ export const Inline: Story = {
 export const ButtonVariant: Story = {
   args: {
     label: "Copy link",
-    value: "https://ui.vllnt.ai",
+    value: "https://ui.vllnt.com",
     variant: "button",
   },
 };

--- a/packages/ui/src/components/copy-button/copy-button.visual.tsx
+++ b/packages/ui/src/components/copy-button/copy-button.visual.tsx
@@ -17,7 +17,7 @@ test.describe("CopyButton Visual", () => {
 
   test("variant-button", async ({ mount }) => {
     const component = await mount(
-      <CopyButton label="Copy link" value="https://ui.vllnt.ai" variant="button" />,
+      <CopyButton label="Copy link" value="https://ui.vllnt.com" variant="button" />,
     );
     await expect(component).toHaveScreenshot("copy-button-variant-button.png");
   });

--- a/packages/ui/src/components/countdown-timer/countdown-timer.mdx
+++ b/packages/ui/src/components/countdown-timer/countdown-timer.mdx
@@ -12,7 +12,7 @@ Live countdown to a target timestamp — renders days / hours / minutes / second
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/countdown-timer.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/countdown-timer.json
 ```
 
 ## Import

--- a/packages/ui/src/components/credit-badge/credit-badge.mdx
+++ b/packages/ui/src/components/credit-badge/credit-badge.mdx
@@ -12,7 +12,7 @@ Compact pill that surfaces a user's available / pending credit balance. Pure pre
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/credit-badge.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/credit-badge.json
 ```
 
 ## Import

--- a/packages/ui/src/components/curriculum/curriculum.mdx
+++ b/packages/ui/src/components/curriculum/curriculum.mdx
@@ -12,7 +12,7 @@ Course-layout container for a sequence of lessons or modules — title, progress
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/curriculum.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/curriculum.json
 ```
 
 ## Import

--- a/packages/ui/src/components/data-list/data-list.mdx
+++ b/packages/ui/src/components/data-list/data-list.mdx
@@ -14,7 +14,7 @@ Distinct from \`PropertySection\` (canvas inspector): \`DataList\` is the dashbo
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/data-list.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/data-list.json
 ```
 
 ## Import

--- a/packages/ui/src/components/data-table/data-table.mdx
+++ b/packages/ui/src/components/data-table/data-table.mdx
@@ -14,7 +14,7 @@ Distinct from \`Table\` (the unstyled HTML primitive): \`DataTable\` adds the ca
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/data-table.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/data-table.json
 ```
 
 ## Import

--- a/packages/ui/src/components/date-picker/date-picker.mdx
+++ b/packages/ui/src/components/date-picker/date-picker.mdx
@@ -14,7 +14,7 @@ Pair with \`Calendar\` (the underlying month grid) for embedded calendar UI with
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/date-picker.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/date-picker.json
 ```
 
 ## Import

--- a/packages/ui/src/components/dialog/dialog.mdx
+++ b/packages/ui/src/components/dialog/dialog.mdx
@@ -12,7 +12,7 @@ Modal dialog overlay for focused content and actions.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/dialog.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/dialog.json
 ```
 
 ## Import

--- a/packages/ui/src/components/document-sibling-nav/document-sibling-nav.mdx
+++ b/packages/ui/src/components/document-sibling-nav/document-sibling-nav.mdx
@@ -14,7 +14,7 @@ This is **not** `Pagination` — `Pagination` handles page numbers for paginated
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/document-sibling-nav.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/document-sibling-nav.json
 ```
 
 ## Import

--- a/packages/ui/src/components/drawer/drawer.mdx
+++ b/packages/ui/src/components/drawer/drawer.mdx
@@ -12,7 +12,7 @@ Slide-out panel anchored to the screen edge.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/drawer.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/drawer.json
 ```
 
 ## Import

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu.mdx
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu.mdx
@@ -12,7 +12,7 @@ Accessible dropdown menu with items, checkboxes, radio groups, and submenus.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/dropdown-menu.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/dropdown-menu.json
 ```
 
 ## Import

--- a/packages/ui/src/components/edge-label/edge-label.mdx
+++ b/packages/ui/src/components/edge-label/edge-label.mdx
@@ -12,7 +12,7 @@ Inline label rendered along a \`ConnectorEdge\` to communicate relation type, th
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/edge-label.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/edge-label.json
 ```
 
 ## Import

--- a/packages/ui/src/components/empty-state/empty-state.mdx
+++ b/packages/ui/src/components/empty-state/empty-state.mdx
@@ -12,7 +12,7 @@ Placeholder for empty lists, tables, and search results. Composes a centered ico
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/empty-state.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/empty-state.json
 ```
 
 ## Import

--- a/packages/ui/src/components/era-comparison/era-comparison.mdx
+++ b/packages/ui/src/components/era-comparison/era-comparison.mdx
@@ -21,7 +21,7 @@ A compound family:
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/era-comparison.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/era-comparison.json
 ```
 
 ## Import

--- a/packages/ui/src/components/exercise/exercise.mdx
+++ b/packages/ui/src/components/exercise/exercise.mdx
@@ -12,7 +12,7 @@ Interactive exercise block for learning content.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/exercise.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/exercise.json
 ```
 
 ## Import

--- a/packages/ui/src/components/faq/faq.mdx
+++ b/packages/ui/src/components/faq/faq.mdx
@@ -12,7 +12,7 @@ Frequently asked questions section with expandable answers.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/faq.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/faq.json
 ```
 
 ## Import

--- a/packages/ui/src/components/file-upload/file-upload.mdx
+++ b/packages/ui/src/components/file-upload/file-upload.mdx
@@ -12,7 +12,7 @@ Drag-and-drop or click-to-browse file input with preview thumbnails and per-file
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/file-upload.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/file-upload.json
 ```
 
 ## Import

--- a/packages/ui/src/components/filter-bar/filter-bar.mdx
+++ b/packages/ui/src/components/filter-bar/filter-bar.mdx
@@ -12,7 +12,7 @@ Horizontal bar with filter controls for content lists.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/filter-bar.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/filter-bar.json
 ```
 
 ## Import

--- a/packages/ui/src/components/flashcard/flashcard.mdx
+++ b/packages/ui/src/components/flashcard/flashcard.mdx
@@ -12,7 +12,7 @@ Two-sided card for spaced-repetition review — front holds the prompt, back hol
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/flashcard.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/flashcard.json
 ```
 
 ## Import

--- a/packages/ui/src/components/floating-action-button/floating-action-button.mdx
+++ b/packages/ui/src/components/floating-action-button/floating-action-button.mdx
@@ -12,7 +12,7 @@ Fixed-position action button for primary actions.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/floating-action-button.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/floating-action-button.json
 ```
 
 ## Import

--- a/packages/ui/src/components/floating-toolbar/floating-toolbar.mdx
+++ b/packages/ui/src/components/floating-toolbar/floating-toolbar.mdx
@@ -12,7 +12,7 @@ Compact action bar that floats above a selection. Pair with `SelectionHalo` — 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/floating-toolbar.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/floating-toolbar.json
 ```
 
 ## Import

--- a/packages/ui/src/components/flow-diagram/flow-diagram.mdx
+++ b/packages/ui/src/components/flow-diagram/flow-diagram.mdx
@@ -12,7 +12,7 @@ Interactive flow diagram with nodes, edges, and controls.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/flow-diagram.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/flow-diagram.json
 ```
 
 ## Import

--- a/packages/ui/src/components/follow-mode/follow-mode.mdx
+++ b/packages/ui/src/components/follow-mode/follow-mode.mdx
@@ -12,7 +12,7 @@ Follow-mode chrome. Wrap any region (typically the whole canvas) to outline it w
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/follow-mode.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/follow-mode.json
 ```
 
 ## Import

--- a/packages/ui/src/components/gantt-chart/gantt-chart.mdx
+++ b/packages/ui/src/components/gantt-chart/gantt-chart.mdx
@@ -14,7 +14,7 @@ Pass data as a `groups: GanttGroup[]` array. The component handles layout, scali
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/gantt-chart.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/gantt-chart.json
 ```
 
 ## Import

--- a/packages/ui/src/components/geography-quiz-map/geography-quiz-map.mdx
+++ b/packages/ui/src/components/geography-quiz-map/geography-quiz-map.mdx
@@ -14,7 +14,7 @@ Standalone SVG primitive — no external map library required.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/geography-quiz-map.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/geography-quiz-map.json
 ```
 
 ## Import

--- a/packages/ui/src/components/glass-panel/glass-panel.mdx
+++ b/packages/ui/src/components/glass-panel/glass-panel.mdx
@@ -12,7 +12,7 @@ Frosted-glass surface for floating chrome that sits on top of the canvas — doc
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/glass-panel.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/glass-panel.json
 ```
 
 ## Import

--- a/packages/ui/src/components/globe-3d/globe-3d.mdx
+++ b/packages/ui/src/components/globe-3d/globe-3d.mdx
@@ -12,7 +12,7 @@ Standalone SVG pseudo-3D globe. Renders a unit sphere with orthographic projecti
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/globe-3d.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/globe-3d.json
 ```
 
 ## Import

--- a/packages/ui/src/components/group-hull/group-hull.mdx
+++ b/packages/ui/src/components/group-hull/group-hull.mdx
@@ -14,7 +14,7 @@ Distinct from \`ContextLens\` (transient focus vignette) and \`SelectionPresence
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/group-hull.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/group-hull.json
 ```
 
 ## Import

--- a/packages/ui/src/components/handoff-beacon/handoff-beacon.mdx
+++ b/packages/ui/src/components/handoff-beacon/handoff-beacon.mdx
@@ -12,7 +12,7 @@ Attention-routing beacon. Drop a beacon at the position a remote participant wan
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/handoff-beacon.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/handoff-beacon.json
 ```
 
 ## Import

--- a/packages/ui/src/components/heat-map-overlay/heat-map-overlay.mdx
+++ b/packages/ui/src/components/heat-map-overlay/heat-map-overlay.mdx
@@ -14,7 +14,7 @@ Use for troop concentrations, population density, event / incident hotspots, arc
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/heat-map-overlay.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/heat-map-overlay.json
 ```
 
 ## Import

--- a/packages/ui/src/components/heat-overlay/heat-overlay.mdx
+++ b/packages/ui/src/components/heat-overlay/heat-overlay.mdx
@@ -16,7 +16,7 @@ Distinct from \`ActivityHeatmap\`: that primitive is a calendar-style fixed grid
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/heat-overlay.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/heat-overlay.json
 ```
 
 ## Import

--- a/packages/ui/src/components/historic-timeline/historic-timeline.mdx
+++ b/packages/ui/src/components/historic-timeline/historic-timeline.mdx
@@ -14,7 +14,7 @@ Data-driven — pass `eras`, `periods`, `events`, and an optional `categories` l
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/historic-timeline.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/historic-timeline.json
 ```
 
 ## Import

--- a/packages/ui/src/components/historical-figure-card/historical-figure-card.mdx
+++ b/packages/ui/src/components/historical-figure-card/historical-figure-card.mdx
@@ -12,7 +12,7 @@ Profile card for historical figures with portrait, lifespan timeline, fields / w
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/historical-figure-card.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/historical-figure-card.json
 ```
 
 ## Import

--- a/packages/ui/src/components/horizontal-scroll-row/horizontal-scroll-row.mdx
+++ b/packages/ui/src/components/horizontal-scroll-row/horizontal-scroll-row.mdx
@@ -12,7 +12,7 @@ Horizontal scroll container with snap scrolling, chevron navigation, and hidden 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/horizontal-scroll-row.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/horizontal-scroll-row.json
 ```
 
 ## Import

--- a/packages/ui/src/components/hover-card/hover-card.mdx
+++ b/packages/ui/src/components/hover-card/hover-card.mdx
@@ -12,7 +12,7 @@ Card that appears on hover for previewing content.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/hover-card.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/hover-card.json
 ```
 
 ## Import

--- a/packages/ui/src/components/infinite-plane/infinite-plane.mdx
+++ b/packages/ui/src/components/infinite-plane/infinite-plane.mdx
@@ -14,7 +14,7 @@ Pure presentation; the host owns the viewport transform and supplies \`translate
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/infinite-plane.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/infinite-plane.json
 ```
 
 ## Import

--- a/packages/ui/src/components/inline-input/inline-input.mdx
+++ b/packages/ui/src/components/inline-input/inline-input.mdx
@@ -12,7 +12,7 @@ Inline text input with keyboard commit and cancel support.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/inline-input.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/inline-input.json
 ```
 
 ## Import

--- a/packages/ui/src/components/input-otp/input-otp.mdx
+++ b/packages/ui/src/components/input-otp/input-otp.mdx
@@ -12,7 +12,7 @@ One-time password input with segmented fields.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/input-otp.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/input-otp.json
 ```
 
 ## Import

--- a/packages/ui/src/components/input/input.mdx
+++ b/packages/ui/src/components/input/input.mdx
@@ -12,7 +12,7 @@ Text input field for forms.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/input.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/input.json
 ```
 
 ## Import

--- a/packages/ui/src/components/interactive-timeline/interactive-timeline.mdx
+++ b/packages/ui/src/components/interactive-timeline/interactive-timeline.mdx
@@ -14,7 +14,7 @@ Compound family: `InteractiveTimeline` + `InteractiveTimelineToolbar`, `Interact
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/interactive-timeline.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/interactive-timeline.json
 ```
 
 ## Import

--- a/packages/ui/src/components/jarvis-dock/jarvis-dock.mdx
+++ b/packages/ui/src/components/jarvis-dock/jarvis-dock.mdx
@@ -14,7 +14,7 @@ Pairs with the right-dock inspector primitives (\`ObjectInspector\`, \`PropertyS
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/jarvis-dock.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/jarvis-dock.json
 ```
 
 ## Import

--- a/packages/ui/src/components/kbd/kbd.mdx
+++ b/packages/ui/src/components/kbd/kbd.mdx
@@ -12,7 +12,7 @@ Keyboard key indicator for displaying shortcuts. Pass a single child for one key
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/kbd.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/kbd.json
 ```
 
 ## Import

--- a/packages/ui/src/components/key-concept/key-concept.mdx
+++ b/packages/ui/src/components/key-concept/key-concept.mdx
@@ -12,7 +12,7 @@ Highlighted definition block for key terms and a glossary list.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/key-concept.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/key-concept.json
 ```
 
 ## Import

--- a/packages/ui/src/components/keyboard-shortcuts-help/keyboard-shortcuts-help.mdx
+++ b/packages/ui/src/components/keyboard-shortcuts-help/keyboard-shortcuts-help.mdx
@@ -12,7 +12,7 @@ Displays available keyboard shortcuts to the user.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/keyboard-shortcuts-help.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/keyboard-shortcuts-help.json
 ```
 
 ## Import

--- a/packages/ui/src/components/knowledge-check/knowledge-check.mdx
+++ b/packages/ui/src/components/knowledge-check/knowledge-check.mdx
@@ -14,7 +14,7 @@ Question state lives inside the component. Drive analytics or persistence from t
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/knowledge-check.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/knowledge-check.json
 ```
 
 ## Import

--- a/packages/ui/src/components/label/label.mdx
+++ b/packages/ui/src/components/label/label.mdx
@@ -10,7 +10,7 @@ import * as Stories from './label.stories'
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/label.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/label.json
 ```
 
 ## Import

--- a/packages/ui/src/components/lang-provider/lang-provider.mdx
+++ b/packages/ui/src/components/lang-provider/lang-provider.mdx
@@ -12,7 +12,7 @@ Context provider for language and internationalization.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/lang-provider.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/lang-provider.json
 ```
 
 ## Import

--- a/packages/ui/src/components/learning-objectives/learning-objectives.mdx
+++ b/packages/ui/src/components/learning-objectives/learning-objectives.mdx
@@ -12,7 +12,7 @@ Lists learning goals for educational content.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/learning-objectives.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/learning-objectives.json
 ```
 
 ## Import

--- a/packages/ui/src/components/left-rail/left-rail.mdx
+++ b/packages/ui/src/components/left-rail/left-rail.mdx
@@ -14,7 +14,7 @@ Distinct from \`Sidebar\` (document chrome) and \`NavbarSaas\` (marketing chrome
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/left-rail.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/left-rail.json
 ```
 
 ## Import

--- a/packages/ui/src/components/live-cursor/live-cursor.mdx
+++ b/packages/ui/src/components/live-cursor/live-cursor.mdx
@@ -14,7 +14,7 @@ The wrapper is \`pointer-events: none\` so host gestures pass through.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/live-cursor.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/live-cursor.json
 ```
 
 ## Import

--- a/packages/ui/src/components/live-feed/live-feed.mdx
+++ b/packages/ui/src/components/live-feed/live-feed.mdx
@@ -14,7 +14,7 @@ Distinct from \`ActivityLog\` (durable persistent list) and \`BottomActivityStri
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/live-feed.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/live-feed.json
 ```
 
 ## Import

--- a/packages/ui/src/components/map-2d/map-2d.mdx
+++ b/packages/ui/src/components/map-2d/map-2d.mdx
@@ -14,7 +14,7 @@ No external map library required — the component is self-contained and ships w
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/map-2d.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/map-2d.json
 ```
 
 ## Import

--- a/packages/ui/src/components/map-timeline/map-timeline.mdx
+++ b/packages/ui/src/components/map-timeline/map-timeline.mdx
@@ -14,7 +14,7 @@ Standalone SVG primitive — no external map library required.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/map-timeline.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/map-timeline.json
 ```
 
 ## Import

--- a/packages/ui/src/components/market-treemap/market-treemap.mdx
+++ b/packages/ui/src/components/market-treemap/market-treemap.mdx
@@ -12,7 +12,7 @@ Treemap-style heatmap of market constituents — each cell sized by weight (mark
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/market-treemap.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/market-treemap.json
 ```
 
 ## Import

--- a/packages/ui/src/components/marquee/marquee.mdx
+++ b/packages/ui/src/components/marquee/marquee.mdx
@@ -12,7 +12,7 @@ Continuous-scroll horizontal strip — wraps any children and loops them across 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/marquee.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/marquee.json
 ```
 
 ## Import

--- a/packages/ui/src/components/mdx-content/mdx-content.mdx
+++ b/packages/ui/src/components/mdx-content/mdx-content.mdx
@@ -12,7 +12,7 @@ Renders MDX content with component mapping.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/mdx-content.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/mdx-content.json
 ```
 
 ## Import

--- a/packages/ui/src/components/menubar/menubar.mdx
+++ b/packages/ui/src/components/menubar/menubar.mdx
@@ -12,7 +12,7 @@ Horizontal menu bar with dropdown menus.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/menubar.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/menubar.json
 ```
 
 ## Import

--- a/packages/ui/src/components/metric-cluster/metric-cluster.mdx
+++ b/packages/ui/src/components/metric-cluster/metric-cluster.mdx
@@ -14,7 +14,7 @@ The wrapper is \`pointer-events: none\` — host gestures pass through.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/metric-cluster.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/metric-cluster.json
 ```
 
 ## Import

--- a/packages/ui/src/components/metric-gauge/metric-gauge.mdx
+++ b/packages/ui/src/components/metric-gauge/metric-gauge.mdx
@@ -14,7 +14,7 @@ Distinct from \`ThresholdRing\` (compact canvas overlay): \`MetricGauge\` is a d
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/metric-gauge.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/metric-gauge.json
 ```
 
 ## Import

--- a/packages/ui/src/components/mini-map-panel/mini-map-panel.mdx
+++ b/packages/ui/src/components/mini-map-panel/mini-map-panel.mdx
@@ -12,7 +12,7 @@ Birdseye overview of a \`CanvasView\` — a scaled rendering of the world with a
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/mini-map-panel.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/mini-map-panel.json
 ```
 
 ## Import

--- a/packages/ui/src/components/model-comparison/model-comparison.mdx
+++ b/packages/ui/src/components/model-comparison/model-comparison.mdx
@@ -19,7 +19,7 @@ A compound component family:
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/model-comparison.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/model-comparison.json
 ```
 
 ## Import

--- a/packages/ui/src/components/model-selector/model-selector.mdx
+++ b/packages/ui/src/components/model-selector/model-selector.mdx
@@ -12,7 +12,7 @@ Dropdown selector for choosing AI models.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/model-selector.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/model-selector.json
 ```
 
 ## Import

--- a/packages/ui/src/components/multi-select-lasso/multi-select-lasso.mdx
+++ b/packages/ui/src/components/multi-select-lasso/multi-select-lasso.mdx
@@ -14,7 +14,7 @@ Negative-direction drags are normalized automatically — pass the raw delta and
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/multi-select-lasso.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/multi-select-lasso.json
 ```
 
 ## Import

--- a/packages/ui/src/components/navbar-saas/navbar-saas.mdx
+++ b/packages/ui/src/components/navbar-saas/navbar-saas.mdx
@@ -12,7 +12,7 @@ SaaS-style navigation bar with branding and links.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/navbar-saas.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/navbar-saas.json
 ```
 
 ## Import

--- a/packages/ui/src/components/navigation-menu/navigation-menu.mdx
+++ b/packages/ui/src/components/navigation-menu/navigation-menu.mdx
@@ -12,7 +12,7 @@ Accessible navigation menu with links and sub-navigation.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/navigation-menu.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/navigation-menu.json
 ```
 
 ## Import

--- a/packages/ui/src/components/newsletter-signup/newsletter-signup.mdx
+++ b/packages/ui/src/components/newsletter-signup/newsletter-signup.mdx
@@ -14,7 +14,7 @@ The consumer owns the submission promise — works with any provider (Resend, Co
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/newsletter-signup.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/newsletter-signup.json
 ```
 
 ## Import

--- a/packages/ui/src/components/number-input/number-input.mdx
+++ b/packages/ui/src/components/number-input/number-input.mdx
@@ -12,7 +12,7 @@ Numeric input with increment / decrement buttons, min / max clamping, and option
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/number-input.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/number-input.json
 ```
 
 ## Import

--- a/packages/ui/src/components/number-ticker/number-ticker.mdx
+++ b/packages/ui/src/components/number-ticker/number-ticker.mdx
@@ -12,7 +12,7 @@ Animated numeric value that rolls between updates — useful for live counters (
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/number-ticker.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/number-ticker.json
 ```
 
 ## Import

--- a/packages/ui/src/components/object-card/object-card.mdx
+++ b/packages/ui/src/components/object-card/object-card.mdx
@@ -14,7 +14,7 @@ Distinct from \`Card\` (generic content card) and \`StatCard\` (KPI tile): this 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/object-card.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/object-card.json
 ```
 
 ## Import

--- a/packages/ui/src/components/object-handle/object-handle.mdx
+++ b/packages/ui/src/components/object-handle/object-handle.mdx
@@ -12,7 +12,7 @@ Drag affordance for an \`ObjectCard\` — a calm grab target that signals "this 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/object-handle.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/object-handle.json
 ```
 
 ## Import

--- a/packages/ui/src/components/object-inspector/object-inspector.mdx
+++ b/packages/ui/src/components/object-inspector/object-inspector.mdx
@@ -14,7 +14,7 @@ Distinct from `ObjectCard`: \`ObjectCard\` is the **on-canvas** representation o
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/object-inspector.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/object-inspector.json
 ```
 
 ## Import

--- a/packages/ui/src/components/order-book/order-book.mdx
+++ b/packages/ui/src/components/order-book/order-book.mdx
@@ -12,7 +12,7 @@ Level-II bid / ask depth ladder with cumulative size bars and a spread readout. 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/order-book.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/order-book.json
 ```
 
 ## Import

--- a/packages/ui/src/components/overview-board/overview-board.mdx
+++ b/packages/ui/src/components/overview-board/overview-board.mdx
@@ -12,7 +12,7 @@ Grid of \`OverviewCard\` cells for at-a-glance dashboards — typically a row of
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/overview-board.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/overview-board.json
 ```
 
 ## Import

--- a/packages/ui/src/components/pagination/pagination.mdx
+++ b/packages/ui/src/components/pagination/pagination.mdx
@@ -12,7 +12,7 @@ Page navigation controls with previous, next, and page links.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/pagination.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/pagination.json
 ```
 
 ## Import

--- a/packages/ui/src/components/parallel-timeline/parallel-timeline.mdx
+++ b/packages/ui/src/components/parallel-timeline/parallel-timeline.mdx
@@ -14,7 +14,7 @@ Data-driven — pass `tracks: ParallelTimelineTrack[]` and the visible window vi
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/parallel-timeline.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/parallel-timeline.json
 ```
 
 ## Import

--- a/packages/ui/src/components/password-input/password-input.mdx
+++ b/packages/ui/src/components/password-input/password-input.mdx
@@ -12,7 +12,7 @@ Password input with a show / hide toggle. Pure presentation; the host owns the v
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/password-input.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/password-input.json
 ```
 
 ## Import

--- a/packages/ui/src/components/plan-badge/plan-badge.mdx
+++ b/packages/ui/src/components/plan-badge/plan-badge.mdx
@@ -12,7 +12,7 @@ Subscription-tier indicator pill — \`free\` / \`pro\` / \`team\` / \`enterpris
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/plan-badge.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/plan-badge.json
 ```
 
 ## Import

--- a/packages/ui/src/components/playback-ghost/playback-ghost.mdx
+++ b/packages/ui/src/components/playback-ghost/playback-ghost.mdx
@@ -16,7 +16,7 @@ The wrapper is \`pointer-events: none\` so host gestures pass through.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/playback-ghost.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/playback-ghost.json
 ```
 
 ## Import

--- a/packages/ui/src/components/policy-delivery-panel/policy-delivery-panel.mdx
+++ b/packages/ui/src/components/policy-delivery-panel/policy-delivery-panel.mdx
@@ -12,7 +12,7 @@ Right-dock panel listing the policies / guardrails that apply to the active rout
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/policy-delivery-panel.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/policy-delivery-panel.json
 ```
 
 ## Import

--- a/packages/ui/src/components/popover/popover.mdx
+++ b/packages/ui/src/components/popover/popover.mdx
@@ -12,7 +12,7 @@ Floating content panel anchored to a trigger element.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/popover.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/popover.json
 ```
 
 ## Import

--- a/packages/ui/src/components/presence-stack/presence-stack.mdx
+++ b/packages/ui/src/components/presence-stack/presence-stack.mdx
@@ -14,7 +14,7 @@ Pure presentation; the host owns the websocket roster + maps user ids to colors.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/presence-stack.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/presence-stack.json
 ```
 
 ## Import

--- a/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.mdx
+++ b/packages/ui/src/components/presence-sync-indicator/presence-sync-indicator.mdx
@@ -14,7 +14,7 @@ Pure presentation; the host owns the websocket / CRDT loop and maps its diagnost
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/presence-sync-indicator.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/presence-sync-indicator.json
 ```
 
 ## Import

--- a/packages/ui/src/components/pricing-table/pricing-table.mdx
+++ b/packages/ui/src/components/pricing-table/pricing-table.mdx
@@ -12,7 +12,7 @@ Plan comparison table with feature checklist, tier highlighting, and CTA buttons
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/pricing-table.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/pricing-table.json
 ```
 
 ## Import

--- a/packages/ui/src/components/primary-source-viewer/primary-source-viewer.mdx
+++ b/packages/ui/src/components/primary-source-viewer/primary-source-viewer.mdx
@@ -12,7 +12,7 @@ Document viewer for historical primary sources — manuscripts, charters, artwor
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/primary-source-viewer.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/primary-source-viewer.json
 ```
 
 ## Import

--- a/packages/ui/src/components/pro-tip/pro-tip.mdx
+++ b/packages/ui/src/components/pro-tip/pro-tip.mdx
@@ -12,7 +12,7 @@ Highlighted tip block with variants for tips, best practices, gotchas, and more.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/pro-tip.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/pro-tip.json
 ```
 
 ## Import

--- a/packages/ui/src/components/profile-section/profile-section.mdx
+++ b/packages/ui/src/components/profile-section/profile-section.mdx
@@ -12,7 +12,7 @@ User profile display section with avatar and details.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/profile-section.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/profile-section.json
 ```
 
 ## Import

--- a/packages/ui/src/components/progress-bar/progress-bar.mdx
+++ b/packages/ui/src/components/progress-bar/progress-bar.mdx
@@ -12,7 +12,7 @@ Visual progress indicator with labels and completion state.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/progress-bar.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/progress-bar.json
 ```
 
 ## Import

--- a/packages/ui/src/components/progress-card/progress-card.mdx
+++ b/packages/ui/src/components/progress-card/progress-card.mdx
@@ -12,7 +12,7 @@ Card displaying progress metrics and status.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/progress-card.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/progress-card.json
 ```
 
 ## Import

--- a/packages/ui/src/components/prompt-templates/prompt-templates.mdx
+++ b/packages/ui/src/components/prompt-templates/prompt-templates.mdx
@@ -14,7 +14,7 @@ The component is data-driven — pass a `templates` array. Variables in the temp
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/prompt-templates.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/prompt-templates.json
 ```
 
 ## Import

--- a/packages/ui/src/components/property-section/property-section.mdx
+++ b/packages/ui/src/components/property-section/property-section.mdx
@@ -12,7 +12,7 @@ Compact key / value grid for an inspector panel. Use one `PropertySection` per l
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/property-section.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/property-section.json
 ```
 
 ## Import

--- a/packages/ui/src/components/quiz/quiz.mdx
+++ b/packages/ui/src/components/quiz/quiz.mdx
@@ -12,7 +12,7 @@ Interactive multiple-choice quiz with hints, explanations, and scoring.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/quiz.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/quiz.json
 ```
 
 ## Import

--- a/packages/ui/src/components/radio-group/radio-group.mdx
+++ b/packages/ui/src/components/radio-group/radio-group.mdx
@@ -12,7 +12,7 @@ Group of radio buttons for single-selection input.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/radio-group.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/radio-group.json
 ```
 
 ## Import

--- a/packages/ui/src/components/rating/rating.mdx
+++ b/packages/ui/src/components/rating/rating.mdx
@@ -12,7 +12,7 @@ Inline star rating — display-only or interactive (read-only summary or live in
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/rating.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/rating.json
 ```
 
 ## Import

--- a/packages/ui/src/components/relationship-inspector/relationship-inspector.mdx
+++ b/packages/ui/src/components/relationship-inspector/relationship-inspector.mdx
@@ -14,7 +14,7 @@ Pairs with \`ObjectInspector\` and \`PropertySection\` to form the right-dock de
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/relationship-inspector.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/relationship-inspector.json
 ```
 
 ## Import

--- a/packages/ui/src/components/resizable/resizable.mdx
+++ b/packages/ui/src/components/resizable/resizable.mdx
@@ -12,7 +12,7 @@ Resizable panel layout with draggable handles.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/resizable.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/resizable.json
 ```
 
 ## Import

--- a/packages/ui/src/components/right-dock/right-dock.mdx
+++ b/packages/ui/src/components/right-dock/right-dock.mdx
@@ -12,7 +12,7 @@ Vertical chrome dock pinned to the right of \`CanvasShell\` — host for inspect
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/right-dock.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/right-dock.json
 ```
 
 ## Import

--- a/packages/ui/src/components/role-badge/role-badge.mdx
+++ b/packages/ui/src/components/role-badge/role-badge.mdx
@@ -12,7 +12,7 @@ Account-role pill — \`owner\` / \`admin\` / \`member\` / \`billing\`. Used in 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/role-badge.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/role-badge.json
 ```
 
 ## Import

--- a/packages/ui/src/components/route-map/route-map.mdx
+++ b/packages/ui/src/components/route-map/route-map.mdx
@@ -12,7 +12,7 @@ Map for animated route paths, waypoints, and journey progression. Use for trade 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/route-map.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/route-map.json
 ```
 
 ## Import

--- a/packages/ui/src/components/routing-assignment-panel/routing-assignment-panel.mdx
+++ b/packages/ui/src/components/routing-assignment-panel/routing-assignment-panel.mdx
@@ -12,7 +12,7 @@ Right-dock panel listing the agent slots the active route dispatches to: primary
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/routing-assignment-panel.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/routing-assignment-panel.json
 ```
 
 ## Import

--- a/packages/ui/src/components/run-timeline/run-timeline.mdx
+++ b/packages/ui/src/components/run-timeline/run-timeline.mdx
@@ -16,7 +16,7 @@ Distinct from \`MapTimeline\` (geo-aware), \`Stepper\` (sequential steps), and t
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/run-timeline.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/run-timeline.json
 ```
 
 ## Import

--- a/packages/ui/src/components/runtime-overview-panel/runtime-overview-panel.mdx
+++ b/packages/ui/src/components/runtime-overview-panel/runtime-overview-panel.mdx
@@ -14,7 +14,7 @@ Pairs with \`ObjectInspector\`: when a canvas object becomes the focus, swap to 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/runtime-overview-panel.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/runtime-overview-panel.json
 ```
 
 ## Import

--- a/packages/ui/src/components/scope-selector/scope-selector.mdx
+++ b/packages/ui/src/components/scope-selector/scope-selector.mdx
@@ -12,7 +12,7 @@ Multi-level scope picker for nested environments, teams, or targets. Renders as 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/scope-selector.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/scope-selector.json
 ```
 
 ## Import

--- a/packages/ui/src/components/scroll-area/scroll-area.mdx
+++ b/packages/ui/src/components/scroll-area/scroll-area.mdx
@@ -12,7 +12,7 @@ Custom scrollable area with styled scrollbars.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/scroll-area.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/scroll-area.json
 ```
 
 ## Import

--- a/packages/ui/src/components/search-bar/search-bar.mdx
+++ b/packages/ui/src/components/search-bar/search-bar.mdx
@@ -12,7 +12,7 @@ Text search input with icon and clear functionality.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/search-bar.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/search-bar.json
 ```
 
 ## Import

--- a/packages/ui/src/components/search-dialog/search-dialog.mdx
+++ b/packages/ui/src/components/search-dialog/search-dialog.mdx
@@ -12,7 +12,7 @@ Full-screen search dialog with keyboard navigation.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/search-dialog.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/search-dialog.json
 ```
 
 ## Import

--- a/packages/ui/src/components/select/select.mdx
+++ b/packages/ui/src/components/select/select.mdx
@@ -12,7 +12,7 @@ Dropdown select input for choosing from a list of options.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/select.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/select.json
 ```
 
 ## Import

--- a/packages/ui/src/components/selection-halo/selection-halo.mdx
+++ b/packages/ui/src/components/selection-halo/selection-halo.mdx
@@ -14,7 +14,7 @@ Distinct from `SelectionPresence`: this halo represents the **local** user's sel
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/selection-halo.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/selection-halo.json
 ```
 
 ## Import

--- a/packages/ui/src/components/selection-presence/selection-presence.mdx
+++ b/packages/ui/src/components/selection-presence/selection-presence.mdx
@@ -14,7 +14,7 @@ The wrapper is \`pointer-events: none\` so host gestures pass through.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/selection-presence.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/selection-presence.json
 ```
 
 ## Import

--- a/packages/ui/src/components/separator/separator.mdx
+++ b/packages/ui/src/components/separator/separator.mdx
@@ -12,7 +12,7 @@ Visual divider between content sections.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/separator.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/separator.json
 ```
 
 ## Import

--- a/packages/ui/src/components/severity-badge/severity-badge.mdx
+++ b/packages/ui/src/components/severity-badge/severity-badge.mdx
@@ -12,7 +12,7 @@ Incident-severity pill — \`info\` / \`warn\` / \`error\` / \`critical\`. Used 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/severity-badge.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/severity-badge.json
 ```
 
 ## Import

--- a/packages/ui/src/components/share-dialog/share-dialog.mdx
+++ b/packages/ui/src/components/share-dialog/share-dialog.mdx
@@ -10,7 +10,7 @@ import * as Stories from './share-dialog.stories'
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/share-dialog.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/share-dialog.json
 ```
 
 ## Import

--- a/packages/ui/src/components/share-section/share-section.mdx
+++ b/packages/ui/src/components/share-section/share-section.mdx
@@ -12,7 +12,7 @@ Social sharing buttons and link copy section.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/share-section.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/share-section.json
 ```
 
 ## Import

--- a/packages/ui/src/components/sheet/sheet.mdx
+++ b/packages/ui/src/components/sheet/sheet.mdx
@@ -12,7 +12,7 @@ Slide-over panel from the edge of the screen.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/sheet.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/sheet.json
 ```
 
 ## Import

--- a/packages/ui/src/components/sidebar-provider/sidebar-provider.mdx
+++ b/packages/ui/src/components/sidebar-provider/sidebar-provider.mdx
@@ -12,7 +12,7 @@ Context provider for managing sidebar open/close state.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/sidebar-provider.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/sidebar-provider.json
 ```
 
 ## Import

--- a/packages/ui/src/components/sidebar-toggle/sidebar-toggle.mdx
+++ b/packages/ui/src/components/sidebar-toggle/sidebar-toggle.mdx
@@ -12,7 +12,7 @@ Responsive toggle button for opening and closing the sidebar.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/sidebar-toggle.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/sidebar-toggle.json
 ```
 
 ## Import

--- a/packages/ui/src/components/sidebar/sidebar.mdx
+++ b/packages/ui/src/components/sidebar/sidebar.mdx
@@ -12,7 +12,7 @@ Collapsible sidebar navigation layout.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/sidebar.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/sidebar.json
 ```
 
 ## Import

--- a/packages/ui/src/components/skeleton/skeleton.mdx
+++ b/packages/ui/src/components/skeleton/skeleton.mdx
@@ -12,7 +12,7 @@ Placeholder loading animation for content.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/skeleton.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/skeleton.json
 ```
 
 ## Import

--- a/packages/ui/src/components/slider/slider.mdx
+++ b/packages/ui/src/components/slider/slider.mdx
@@ -12,7 +12,7 @@ Range slider input for selecting numeric values.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/slider.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/slider.json
 ```
 
 ## Import

--- a/packages/ui/src/components/slideshow/slideshow.mdx
+++ b/packages/ui/src/components/slideshow/slideshow.mdx
@@ -12,7 +12,7 @@ Step-through slideshow for presenting content sequentially.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/slideshow.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/slideshow.json
 ```
 
 ## Import

--- a/packages/ui/src/components/snap-guides/snap-guides.mdx
+++ b/packages/ui/src/components/snap-guides/snap-guides.mdx
@@ -12,7 +12,7 @@ Alignment guide overlay for a canvas. Renders dashed lines at the `x` / `y` coor
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/snap-guides.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/snap-guides.json
 ```
 
 ## Import

--- a/packages/ui/src/components/social-fab/social-fab.mdx
+++ b/packages/ui/src/components/social-fab/social-fab.mdx
@@ -10,7 +10,7 @@ import * as Stories from './social-fab.stories'
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/social-fab.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/social-fab.json
 ```
 
 ## Import

--- a/packages/ui/src/components/sparkline-grid/sparkline-grid.mdx
+++ b/packages/ui/src/components/sparkline-grid/sparkline-grid.mdx
@@ -12,7 +12,7 @@ Grid of compact sparkline charts — one mini line chart per row showing recent 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/sparkline-grid.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/sparkline-grid.json
 ```
 
 ## Import

--- a/packages/ui/src/components/spinner/spinner.mdx
+++ b/packages/ui/src/components/spinner/spinner.mdx
@@ -12,7 +12,7 @@ Animated loading spinner indicator.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/spinner.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/spinner.json
 ```
 
 ## Import

--- a/packages/ui/src/components/stat-card/stat-card.mdx
+++ b/packages/ui/src/components/stat-card/stat-card.mdx
@@ -14,7 +14,7 @@ Distinct from \`ObjectCard\` (canvas runtime object) and \`OverviewCard\` (overv
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/stat-card.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/stat-card.json
 ```
 
 ## Import

--- a/packages/ui/src/components/state-badge-overlay/state-badge-overlay.mdx
+++ b/packages/ui/src/components/state-badge-overlay/state-badge-overlay.mdx
@@ -14,7 +14,7 @@ The wrapper is \`pointer-events: none\` — host gestures pass through.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/state-badge-overlay.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/state-badge-overlay.json
 ```
 
 ## Import

--- a/packages/ui/src/components/status-board/status-board.mdx
+++ b/packages/ui/src/components/status-board/status-board.mdx
@@ -12,7 +12,7 @@ Service-health grid surfacing infrastructure state, queue pressure, and incident
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/status-board.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/status-board.json
 ```
 
 ## Import

--- a/packages/ui/src/components/status-indicator/status-indicator.mdx
+++ b/packages/ui/src/components/status-indicator/status-indicator.mdx
@@ -12,7 +12,7 @@ Live system-state dot + label — \`operational\` / \`degraded\` / \`outage\` / 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/status-indicator.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/status-indicator.json
 ```
 
 ## Import

--- a/packages/ui/src/components/step-by-step/step-by-step.mdx
+++ b/packages/ui/src/components/step-by-step/step-by-step.mdx
@@ -12,7 +12,7 @@ Numbered step guide with optional interactive completion tracking.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/step-by-step.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/step-by-step.json
 ```
 
 ## Import

--- a/packages/ui/src/components/step-navigation/step-navigation.mdx
+++ b/packages/ui/src/components/step-navigation/step-navigation.mdx
@@ -12,7 +12,7 @@ Navigation controls for stepping through multi-page content.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/step-navigation.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/step-navigation.json
 ```
 
 ## Import

--- a/packages/ui/src/components/stepper/stepper.mdx
+++ b/packages/ui/src/components/stepper/stepper.mdx
@@ -14,7 +14,7 @@ Distinct from \`StepNavigation\` (free-form step list) and \`StepByStep\` (tutor
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/stepper.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/stepper.json
 ```
 
 ## Import

--- a/packages/ui/src/components/sticky-metric/sticky-metric.mdx
+++ b/packages/ui/src/components/sticky-metric/sticky-metric.mdx
@@ -14,7 +14,7 @@ The wrapper is \`pointer-events: none\` — host gestures pass through.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/sticky-metric.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/sticky-metric.json
 ```
 
 ## Import

--- a/packages/ui/src/components/story-map/story-map.mdx
+++ b/packages/ui/src/components/story-map/story-map.mdx
@@ -12,7 +12,7 @@ Scroll-driven narrative map. Place `StoryMapChapter` children in the narrative c
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/story-map.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/story-map.json
 ```
 
 ## Import

--- a/packages/ui/src/components/subscription-card/subscription-card.mdx
+++ b/packages/ui/src/components/subscription-card/subscription-card.mdx
@@ -12,7 +12,7 @@ Subscription summary tile — current plan, renewal date, billing cycle, and a p
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/subscription-card.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/subscription-card.json
 ```
 
 ## Import

--- a/packages/ui/src/components/switch/switch.mdx
+++ b/packages/ui/src/components/switch/switch.mdx
@@ -10,7 +10,7 @@ import * as Stories from './switch.stories'
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/switch.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/switch.json
 ```
 
 ## Import

--- a/packages/ui/src/components/table-of-contents-panel/table-of-contents-panel.mdx
+++ b/packages/ui/src/components/table-of-contents-panel/table-of-contents-panel.mdx
@@ -12,7 +12,7 @@ Side panel rendering a table of contents for page navigation.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/table-of-contents-panel.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/table-of-contents-panel.json
 ```
 
 ## Import

--- a/packages/ui/src/components/table-of-contents/table-of-contents.mdx
+++ b/packages/ui/src/components/table-of-contents/table-of-contents.mdx
@@ -12,7 +12,7 @@ Auto-generated table of contents from page headings.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/table-of-contents.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/table-of-contents.json
 ```
 
 ## Import

--- a/packages/ui/src/components/table/table.mdx
+++ b/packages/ui/src/components/table/table.mdx
@@ -12,7 +12,7 @@ Styled data table with header, body, and footer sections.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/table.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/table.json
 ```
 
 ## Import

--- a/packages/ui/src/components/tabs/tabs.mdx
+++ b/packages/ui/src/components/tabs/tabs.mdx
@@ -12,7 +12,7 @@ Tabbed content panels with keyboard-accessible tab triggers.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/tabs.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/tabs.json
 ```
 
 ## Import

--- a/packages/ui/src/components/terminal/terminal.mdx
+++ b/packages/ui/src/components/terminal/terminal.mdx
@@ -12,7 +12,7 @@ Terminal-style display for command output.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/terminal.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/terminal.json
 ```
 
 ## Import

--- a/packages/ui/src/components/textarea/textarea.mdx
+++ b/packages/ui/src/components/textarea/textarea.mdx
@@ -12,7 +12,7 @@ Multi-line text input field.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/textarea.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/textarea.json
 ```
 
 ## Import

--- a/packages/ui/src/components/theme-preset-provider/theme-preset-provider.mdx
+++ b/packages/ui/src/components/theme-preset-provider/theme-preset-provider.mdx
@@ -12,7 +12,7 @@ Restores the persisted theme preset before paint to avoid a flash, and optionall
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/theme-preset-provider.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/theme-preset-provider.json
 ```
 
 ## Import

--- a/packages/ui/src/components/theme-provider/theme-provider.mdx
+++ b/packages/ui/src/components/theme-provider/theme-provider.mdx
@@ -12,7 +12,7 @@ Context provider for light/dark theme switching.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/theme-provider.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/theme-provider.json
 ```
 
 ## Import

--- a/packages/ui/src/components/theme-switcher/theme-switcher.mdx
+++ b/packages/ui/src/components/theme-switcher/theme-switcher.mdx
@@ -12,7 +12,7 @@ Compact swatch row for switching between built-in theme presets. Reads and write
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/theme-switcher.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/theme-switcher.json
 ```
 
 ## Import

--- a/packages/ui/src/components/theme-toggle/theme-toggle.mdx
+++ b/packages/ui/src/components/theme-toggle/theme-toggle.mdx
@@ -12,7 +12,7 @@ Button to toggle between light and dark themes.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/theme-toggle.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/theme-toggle.json
 ```
 
 ## Import

--- a/packages/ui/src/components/thinking-block/thinking-block.mdx
+++ b/packages/ui/src/components/thinking-block/thinking-block.mdx
@@ -12,7 +12,7 @@ Collapsible block showing AI thinking/reasoning with streaming support.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/thinking-block.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/thinking-block.json
 ```
 
 ## Import

--- a/packages/ui/src/components/thread-bubble/thread-bubble.mdx
+++ b/packages/ui/src/components/thread-bubble/thread-bubble.mdx
@@ -14,7 +14,7 @@ Pure presentation; the host owns the message store + supplies the resolve handle
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/thread-bubble.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/thread-bubble.json
 ```
 
 ## Import

--- a/packages/ui/src/components/threshold-ring/threshold-ring.mdx
+++ b/packages/ui/src/components/threshold-ring/threshold-ring.mdx
@@ -14,7 +14,7 @@ Distinct from \`MetricGauge\`: this primitive is small, headless, and meant to a
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/threshold-ring.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/threshold-ring.json
 ```
 
 ## Import

--- a/packages/ui/src/components/ticker-tape/ticker-tape.mdx
+++ b/packages/ui/src/components/ticker-tape/ticker-tape.mdx
@@ -12,7 +12,7 @@ Marquee-style scrolling symbol tape with price + change badges. Pure presentatio
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/ticker-tape.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/ticker-tape.json
 ```
 
 ## Import

--- a/packages/ui/src/components/timeline-scrubber/timeline-scrubber.mdx
+++ b/packages/ui/src/components/timeline-scrubber/timeline-scrubber.mdx
@@ -14,7 +14,7 @@ Pure presentation; the host owns the value + drives playback in its own loop. Pa
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/timeline-scrubber.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/timeline-scrubber.json
 ```
 
 ## Import

--- a/packages/ui/src/components/timeline/timeline.mdx
+++ b/packages/ui/src/components/timeline/timeline.mdx
@@ -18,7 +18,7 @@ A small compound family:
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/timeline.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/timeline.json
 ```
 
 ## Import

--- a/packages/ui/src/components/tldr-section/tldr-section.mdx
+++ b/packages/ui/src/components/tldr-section/tldr-section.mdx
@@ -12,7 +12,7 @@ Summary section for quick content overview.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/tldr-section.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/tldr-section.json
 ```
 
 ## Import

--- a/packages/ui/src/components/toast/toast.mdx
+++ b/packages/ui/src/components/toast/toast.mdx
@@ -12,7 +12,7 @@ Temporary notification messages with action support.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/toast.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/toast.json
 ```
 
 ## Import

--- a/packages/ui/src/components/toggle-group/toggle-group.mdx
+++ b/packages/ui/src/components/toggle-group/toggle-group.mdx
@@ -12,7 +12,7 @@ Group of toggle buttons for single or multiple selection.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/toggle-group.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/toggle-group.json
 ```
 
 ## Import

--- a/packages/ui/src/components/toggle/toggle.mdx
+++ b/packages/ui/src/components/toggle/toggle.mdx
@@ -12,7 +12,7 @@ Two-state toggle button.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/toggle.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/toggle.json
 ```
 
 ## Import

--- a/packages/ui/src/components/tooltip/tooltip.mdx
+++ b/packages/ui/src/components/tooltip/tooltip.mdx
@@ -12,7 +12,7 @@ Informational popup displayed on hover or focus.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/tooltip.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/tooltip.json
 ```
 
 ## Import

--- a/packages/ui/src/components/top-bar/top-bar.mdx
+++ b/packages/ui/src/components/top-bar/top-bar.mdx
@@ -14,7 +14,7 @@ Distinct from \`NavbarSaas\` (marketing nav) and \`Sidebar\` (document chrome): 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/top-bar.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/top-bar.json
 ```
 
 ## Import

--- a/packages/ui/src/components/tour/tour.mdx
+++ b/packages/ui/src/components/tour/tour.mdx
@@ -12,7 +12,7 @@ Guided product tour — sequence of anchored tooltips highlighting key UI elemen
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/tour.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/tour.json
 ```
 
 ## Import

--- a/packages/ui/src/components/transaction-list/transaction-list.mdx
+++ b/packages/ui/src/components/transaction-list/transaction-list.mdx
@@ -23,7 +23,7 @@ The component also exports two helper functions for callers that want to format 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/transaction-list.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/transaction-list.json
 ```
 
 ## Import

--- a/packages/ui/src/components/tree-view/tree-view.mdx
+++ b/packages/ui/src/components/tree-view/tree-view.mdx
@@ -12,7 +12,7 @@ Hierarchical tree component for nested data — file systems, categories, taxono
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/tree-view.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/tree-view.json
 ```
 
 ## Import

--- a/packages/ui/src/components/truncated-text/truncated-text.mdx
+++ b/packages/ui/src/components/truncated-text/truncated-text.mdx
@@ -10,7 +10,7 @@ import * as Stories from './truncated-text.stories'
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/truncated-text.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/truncated-text.json
 ```
 
 ## Import

--- a/packages/ui/src/components/tutorial-card/tutorial-card.mdx
+++ b/packages/ui/src/components/tutorial-card/tutorial-card.mdx
@@ -12,7 +12,7 @@ Card for displaying tutorial previews with metadata.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/tutorial-card.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/tutorial-card.json
 ```
 
 ## Import

--- a/packages/ui/src/components/tutorial-complete/tutorial-complete.mdx
+++ b/packages/ui/src/components/tutorial-complete/tutorial-complete.mdx
@@ -12,7 +12,7 @@ Completion screen displayed when a tutorial is finished.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/tutorial-complete.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/tutorial-complete.json
 ```
 
 ## Import

--- a/packages/ui/src/components/tutorial-filters/tutorial-filters.mdx
+++ b/packages/ui/src/components/tutorial-filters/tutorial-filters.mdx
@@ -12,7 +12,7 @@ Filter controls for browsing tutorials by category or difficulty.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/tutorial-filters.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/tutorial-filters.json
 ```
 
 ## Import

--- a/packages/ui/src/components/tutorial-intro-content/tutorial-intro-content.mdx
+++ b/packages/ui/src/components/tutorial-intro-content/tutorial-intro-content.mdx
@@ -12,7 +12,7 @@ Introduction section for tutorial pages with overview and prerequisites.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/tutorial-intro-content.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/tutorial-intro-content.json
 ```
 
 ## Import

--- a/packages/ui/src/components/tutorial-mdx/tutorial-mdx.mdx
+++ b/packages/ui/src/components/tutorial-mdx/tutorial-mdx.mdx
@@ -12,7 +12,7 @@ MDX renderer tailored for tutorial content with custom components.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/tutorial-mdx.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/tutorial-mdx.json
 ```
 
 ## Import

--- a/packages/ui/src/components/usage-breakdown/usage-breakdown.mdx
+++ b/packages/ui/src/components/usage-breakdown/usage-breakdown.mdx
@@ -12,7 +12,7 @@ Stacked horizontal bar showing how a usage budget breaks down across categories 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/usage-breakdown.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/usage-breakdown.json
 ```
 
 ## Import

--- a/packages/ui/src/components/video-embed/video-embed.mdx
+++ b/packages/ui/src/components/video-embed/video-embed.mdx
@@ -12,7 +12,7 @@ Responsive video embed for YouTube and other providers.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/video-embed.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/video-embed.json
 ```
 
 ## Import

--- a/packages/ui/src/components/view-switcher/view-switcher.mdx
+++ b/packages/ui/src/components/view-switcher/view-switcher.mdx
@@ -12,7 +12,7 @@ URL param-based toggle between named views with pill/tab styling.
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/view-switcher.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/view-switcher.json
 ```
 
 ## Import

--- a/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.mdx
+++ b/packages/ui/src/components/viewport-bookmarks/viewport-bookmarks.mdx
@@ -12,7 +12,7 @@ Saved-view list for the canvas — the spatial equivalent of a tab bar's pinned 
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/viewport-bookmarks.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/viewport-bookmarks.json
 ```
 
 ## Import

--- a/packages/ui/src/components/wallet-card/wallet-card.mdx
+++ b/packages/ui/src/components/wallet-card/wallet-card.mdx
@@ -12,7 +12,7 @@ Credit-balance tile showing available, pending, and last-refreshed details for a
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/wallet-card.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/wallet-card.json
 ```
 
 ## Import

--- a/packages/ui/src/components/watchlist/watchlist.mdx
+++ b/packages/ui/src/components/watchlist/watchlist.mdx
@@ -12,7 +12,7 @@ Compact list of pinned symbols / objects — one row per item with a leading gly
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/watchlist.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/watchlist.json
 ```
 
 ## Import

--- a/packages/ui/src/components/workspace-switcher/workspace-switcher.mdx
+++ b/packages/ui/src/components/workspace-switcher/workspace-switcher.mdx
@@ -12,7 +12,7 @@ Segmented workspace picker for switching between canvas views and operational co
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/workspace-switcher.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/workspace-switcher.json
 ```
 
 ## Import

--- a/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.mdx
+++ b/packages/ui/src/components/world-breadcrumbs/world-breadcrumbs.mdx
@@ -14,7 +14,7 @@ Pure presentation; the host computes the trail from the active viewport target a
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/world-breadcrumbs.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/world-breadcrumbs.json
 ```
 
 ## Import

--- a/packages/ui/src/components/world-clock-bar/world-clock-bar.mdx
+++ b/packages/ui/src/components/world-clock-bar/world-clock-bar.mdx
@@ -14,7 +14,7 @@ Distinct from \`WorldBreadcrumbs\` (spatial canvas trail): this primitive is a c
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/world-clock-bar.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/world-clock-bar.json
 ```
 
 ## Import

--- a/packages/ui/src/components/zoom-hud/zoom-hud.mdx
+++ b/packages/ui/src/components/zoom-hud/zoom-hud.mdx
@@ -12,7 +12,7 @@ Compact zoom affordance for \`CanvasView\` â€” current zoom percentage with +, â
 ## Installation
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/zoom-hud.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/zoom-hud.json
 ```
 
 ## Import

--- a/skills/vllnt-ui/SKILL.md
+++ b/skills/vllnt-ui/SKILL.md
@@ -23,9 +23,9 @@ allowed-tools:
 `@vllnt/ui` (brand name **VLLNT UI**, always two words) is a React component
 library: 200+ accessible components built on **Radix UI** primitives,
 **Tailwind CSS**, and **CVA** (class-variance-authority). Shipped on public npm
-and as a shadcn-compatible registry at `https://ui.vllnt.ai/r`.
+and as a shadcn-compatible registry at `https://ui.vllnt.com/r`.
 
-- Docs: https://ui.vllnt.ai · Storybook: https://storybook.vllnt.ai
+- Docs: https://ui.vllnt.com · Storybook: https://storybook.vllnt.ai
 - npm: https://www.npmjs.com/package/@vllnt/ui
 - Machine docs: `llms.txt` / `llms-full.txt` at repo root
 
@@ -42,19 +42,19 @@ The component set changes; the design rules don't. Hardcoded lists go stale —
 
 | Need | URL | Form |
 |------|-----|------|
-| Full component list / TOC | `https://ui.vllnt.ai/r/registry.json` | JSON — `items[]` with `name`, `title`, `description` |
-| Browse a component (props, demos) | `https://ui.vllnt.ai/components` · `…/components/{slug}` | HTML |
-| Install one component | `https://ui.vllnt.ai/r/{name}.json` | JSON (shadcn) |
-| Design system (canonical) | `https://ui.vllnt.ai/DESIGN.md` | Markdown (raw) |
-| AI orientation (short) | `https://ui.vllnt.ai/llms.txt` | text |
-| AI deep reference (full) | `https://ui.vllnt.ai/llms-full.txt` | text |
+| Full component list / TOC | `https://ui.vllnt.com/r/registry.json` | JSON — `items[]` with `name`, `title`, `description` |
+| Browse a component (props, demos) | `https://ui.vllnt.com/components` · `…/components/{slug}` | HTML |
+| Install one component | `https://ui.vllnt.com/r/{name}.json` | JSON (shadcn) |
+| Design system (canonical) | `https://ui.vllnt.com/DESIGN.md` | Markdown (raw) |
+| AI orientation (short) | `https://ui.vllnt.com/llms.txt` | text |
+| AI deep reference (full) | `https://ui.vllnt.com/llms-full.txt` | text |
 
 Rules:
 - "What components exist?" / "is there an X component?" → fetch `/r/registry.json`
   and read `items[].name`. **Do not answer the component list from memory.**
 - Need exact props / a11y map / examples → fetch the component page or its `.tsx`.
-- Need a design decision not covered below → fetch `https://ui.vllnt.ai/DESIGN.md`.
-- For human-readable browsing use `https://ui.vllnt.ai/design`. If `/DESIGN.md` is
+- Need a design decision not covered below → fetch `https://ui.vllnt.com/DESIGN.md`.
+- For human-readable browsing use `https://ui.vllnt.com/design`. If `/DESIGN.md` is
   unreachable, fall back to `https://raw.githubusercontent.com/vllnt/ui/main/DESIGN.md`.
 
 ---
@@ -168,7 +168,7 @@ Pick by intent, not by looks (from `DESIGN.md` §10):
 | Empty state | `EmptyState` |
 
 This table is the **common picks**, not the full set — fetch
-`https://ui.vllnt.ai/r/registry.json` (`items[].name`) for everything. Families:
+`https://ui.vllnt.com/r/registry.json` (`items[].name`) for everything. Families:
 Primitives, Layout, Forms, Feedback, Navigation, Data/Charts, AI, Financial,
 Ops/Status, Billing & Plans, Animation, Content, Tutorial/Educational, App Shell.
 
@@ -235,7 +235,7 @@ in shipped UI.
 ## shadcn registry (copy a single component)
 
 ```bash
-pnpm dlx shadcn@latest add https://ui.vllnt.ai/r/{component}.json
+pnpm dlx shadcn@latest add https://ui.vllnt.com/r/{component}.json
 ```
 
 Copy-paste model: you own the resulting file. Still obey the design tokens above.

--- a/templates/ai-chat/README.md
+++ b/templates/ai-chat/README.md
@@ -18,6 +18,6 @@ This template is published as source in the VLLNT UI repository. Copy or adapt t
 
 ## Demo and assets
 
-- Demo: https://ui.vllnt.ai/templates/ai-chat
+- Demo: https://ui.vllnt.com/templates/ai-chat
 - Screenshot: ./screenshots/preview.svg
 - Source path: templates/ai-chat

--- a/templates/ai-chat/template.json
+++ b/templates/ai-chat/template.json
@@ -1,7 +1,7 @@
 {
   "slug": "ai-chat",
   "title": "AI Chat",
-  "demoUrl": "https://ui.vllnt.ai/templates/ai-chat",
+  "demoUrl": "https://ui.vllnt.com/templates/ai-chat",
   "screenshots": [
     "screenshots/preview.svg"
   ],

--- a/templates/dashboard/README.md
+++ b/templates/dashboard/README.md
@@ -18,6 +18,6 @@ This template is published as source in the VLLNT UI repository. Copy or adapt t
 
 ## Demo and assets
 
-- Demo: https://ui.vllnt.ai/templates/dashboard
+- Demo: https://ui.vllnt.com/templates/dashboard
 - Screenshot: ./screenshots/preview.svg
 - Source path: templates/dashboard

--- a/templates/dashboard/template.json
+++ b/templates/dashboard/template.json
@@ -1,7 +1,7 @@
 {
   "slug": "dashboard",
   "title": "Dashboard",
-  "demoUrl": "https://ui.vllnt.ai/templates/dashboard",
+  "demoUrl": "https://ui.vllnt.com/templates/dashboard",
   "screenshots": [
     "screenshots/preview.svg"
   ],

--- a/templates/docs-site/README.md
+++ b/templates/docs-site/README.md
@@ -18,6 +18,6 @@ This template is published as source in the VLLNT UI repository. Copy or adapt t
 
 ## Demo and assets
 
-- Demo: https://ui.vllnt.ai/templates/docs-site
+- Demo: https://ui.vllnt.com/templates/docs-site
 - Screenshot: ./screenshots/preview.svg
 - Source path: templates/docs-site

--- a/templates/docs-site/template.json
+++ b/templates/docs-site/template.json
@@ -1,7 +1,7 @@
 {
   "slug": "docs-site",
   "title": "Docs Site",
-  "demoUrl": "https://ui.vllnt.ai/templates/docs-site",
+  "demoUrl": "https://ui.vllnt.com/templates/docs-site",
   "screenshots": [
     "screenshots/preview.svg"
   ],

--- a/templates/next-starter/README.md
+++ b/templates/next-starter/README.md
@@ -18,6 +18,6 @@ This template is published as source in the VLLNT UI repository. Copy or adapt t
 
 ## Demo and assets
 
-- Demo: https://ui.vllnt.ai/templates/next-starter
+- Demo: https://ui.vllnt.com/templates/next-starter
 - Screenshot: ./screenshots/preview.svg
 - Source path: templates/next-starter

--- a/templates/next-starter/template.json
+++ b/templates/next-starter/template.json
@@ -1,7 +1,7 @@
 {
   "slug": "next-starter",
   "title": "Next Starter",
-  "demoUrl": "https://ui.vllnt.ai/templates/next-starter",
+  "demoUrl": "https://ui.vllnt.com/templates/next-starter",
   "screenshots": [
     "screenshots/preview.svg"
   ],

--- a/templates/saas/README.md
+++ b/templates/saas/README.md
@@ -18,6 +18,6 @@ This template is published as source in the VLLNT UI repository. Copy or adapt t
 
 ## Demo and assets
 
-- Demo: https://ui.vllnt.ai/templates/saas
+- Demo: https://ui.vllnt.com/templates/saas
 - Screenshot: ./screenshots/preview.svg
 - Source path: templates/saas

--- a/templates/saas/template.json
+++ b/templates/saas/template.json
@@ -1,7 +1,7 @@
 {
   "slug": "saas",
   "title": "SaaS",
-  "demoUrl": "https://ui.vllnt.ai/templates/saas",
+  "demoUrl": "https://ui.vllnt.com/templates/saas",
   "screenshots": [
     "screenshots/preview.svg"
   ],


### PR DESCRIPTION
## What

PR #485 swept `ui.vllnt.ai → ui.vllnt.com` only in `apps/registry`. This covers everywhere else — **268 files, pure domain swap (325/325 lines)**.

## Changes

- **232 generated component `.mdx`** install commands (`packages/ui/src/components/*/*.mdx`) **and** `packages/ui/scripts/generate-docs.ts:773` (the template that emits them) — swept together so they stay consistent; no docs-drift check exists, and a full regen would only add noise.
- **Markdown**: README, AGENTS, ROADMAP, CONTRIBUTING, SECURITY, DESIGN, `docs/*.md`, `apps/registry/README.md` + `SEO-AI-POSITIONING.md`, template READMEs, `skills/vllnt-ui/SKILL.md`.
- **Config/other**: root `llms.txt` / `llms-full.txt`, `package.json` + `packages/ui/package.json` homepages, `templates/*/template.json`, Dockerfile + `nginx.conf` comments, `.github/ISSUE_TEMPLATE/config.yml`, two `copy-button` story/visual files.

## Deliberately left `.ai`

- `apps/registry/lib/legacy-host-redirect.ts` `LEGACY_HOST = "ui.vllnt.ai"` — the host the #480 middleware redirects **from**.
- Every `storybook.vllnt.ai` (14 files) — its own domain, redirected by #483.
- `*.vllnt.ai` wildcard-cert notes in `ntk.yaml`.

## Excluded — needs an infra decision (not in this PR)

`ntk.yaml:30` `production: ui.vllnt.ai` is the **live deploy domain**. Flipping it to `ui.vllnt.com` is a deployment/routing change coupled to the 301 (the app must still receive `.ai` traffic to redirect it). Left for a deliberate infra call.

## Validation

- Diff is 100% `ui.vllnt.ai → ui.vllnt.com` (zero non-domain lines).
- All touched JSON re-parses; generator updated to emit `.com`.

Closes #488
