### PR TITLE
chore(registry): rename shadcn namespace @vllnt to @vllnt-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Install individual components with the [shadcn](https://ui.shadcn.com) CLI — n
 pnpm dlx shadcn@latest add https://ui.vllnt.com/r/button.json
 ```
 
-Or by `@vllnt` namespace once it's in the [shadcn registry index](https://ui.shadcn.com/r/registries.json) (add `"@vllnt": "https://ui.vllnt.com/r/{name}.json"` to your `components.json` `registries`):
+Or by `@vllnt-ui` namespace once it's in the [shadcn registry index](https://ui.shadcn.com/r/registries.json) (add `"@vllnt-ui": "https://ui.vllnt.com/r/{name}.json"` to your `components.json` `registries`):
 
 ```bash
-pnpm dlx shadcn@latest add @vllnt/button
+pnpm dlx shadcn@latest add @vllnt-ui/button
 ```
 
 ## Quick Start

--- a/apps/registry/README.md
+++ b/apps/registry/README.md
@@ -77,12 +77,12 @@ This builds the Next.js app and generates registry JSON files to `public/r/` usi
 pnpm dlx shadcn@latest add https://ui.vllnt.com/r/button.json
 ```
 
-Namespaced install (once `@vllnt` is listed in the [shadcn registry index](https://ui.shadcn.com/r/registries.json)) — add the registry to your app's `components.json`:
+Namespaced install (once `@vllnt-ui` is listed in the [shadcn registry index](https://ui.shadcn.com/r/registries.json)) — add the registry to your app's `components.json`:
 
 ```json
 {
   "registries": {
-    "@vllnt": "https://ui.vllnt.com/r/{name}.json"
+    "@vllnt-ui": "https://ui.vllnt.com/r/{name}.json"
   }
 }
 ```
@@ -90,7 +90,7 @@ Namespaced install (once `@vllnt` is listed in the [shadcn registry index](https
 Then install by namespace:
 
 ```bash
-pnpm dlx shadcn@latest add @vllnt/button
+pnpm dlx shadcn@latest add @vllnt-ui/button
 ```
 
 ## Adding Components

--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
-  "name": "@vllnt",
+  "name": "@vllnt-ui",
   "homepage": "https://ui.vllnt.com",
   "items": [
     {

--- a/apps/registry/shadcn-directory-entry.json
+++ b/apps/registry/shadcn-directory-entry.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vllnt",
+  "name": "@vllnt-ui",
   "homepage": "https://ui.vllnt.com",
   "url": "https://ui.vllnt.com/r/{name}.json",
   "description": "VLLNT UI — agent-first React components for AI-native products, from UI primitives to finance and ops domains. Accessible, Radix + Tailwind, you own the code.",


### PR DESCRIPTION
## What

Renames the shadcn **namespace token** `@vllnt` → `@vllnt-ui` across the repo's registry config and install docs, aligning them with the submitted directory PR [shadcn-ui/ui#11132](https://github.com/shadcn-ui/ui/pull/11132). Reserves the bare `@vllnt` for the parent company.

## Files

- `apps/registry/registry.json` — root `name`
- `apps/registry/shadcn-directory-entry.json` — recorded directory entry (mirrors the submitted PR)
- `README.md` — namespace mention, `components.json` registries key, install command
- `apps/registry/README.md` — same

## Not changed (deliberately)

- npm package `@vllnt/ui` (unrelated to the shadcn namespace)
- the `@vllnt` X/Twitter handle in OG metadata (`creator`/`site`)
- `ROADMAP.md` planning references — separate follow-up to avoid churn on a high-traffic file

## Notes

- Domain is already `.com` everywhere (handled by the earlier migration); this PR is namespace-only.
- Install commands resolve publicly only once shadcn-ui/ui#11132 merges; the direct-URL install (`https://ui.vllnt.com/r/button.json`) works today and is unchanged.

Closes #491
