### PR TITLE
ci(publish): install npm globally so --provenance can resolve sigstore

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,8 @@ jobs:
           CANARY_VERSION="${BASE_VERSION}-canary.${SHORT_SHA}"
           npm version "$CANARY_VERSION" --no-git-tag-version
           TARBALL=$(pnpm pack --pack-destination /tmp | tail -1)
-          npx --yes npm@latest publish "$TARBALL" --tag canary --provenance --access public
+          npm install -g npm@latest
+          npm publish "$TARBALL" --tag canary --provenance --access public
 
   release:
     name: Publish Release
@@ -169,7 +170,8 @@ jobs:
           sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
           unset NODE_AUTH_TOKEN
           TARBALL=$(pnpm pack --pack-destination /tmp | tail -1)
-          npx --yes npm@latest publish "$TARBALL" --tag latest --provenance --access public
+          npm install -g npm@latest
+          npm publish "$TARBALL" --tag latest --provenance --access public
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## What

Fix the `Publish` workflow so the `--provenance` publish step stops failing with `Cannot find module 'sigstore'`.

## Why

The canary job (and the release job) publish via:

```
npx --yes npm@latest publish "$TARBALL" --provenance --access public
```

`npm@latest` is fetched at run time. The current npm release fails to materialize its bundled `sigstore` dependency in the npx-installed tree, so npm's `--provenance` code path dies:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
npm error - .../npm/node_modules/libnpmpublish/lib/provenance.js
```

Failing run: https://github.com/vllnt/ui/actions/runs/29101065950

Not caused by any repo change — the same workflow last published cleanly on 2026-07-02; only `npm@latest` moved. The token-stripping step uses OIDC trusted publishing (needs npm >= 11.5.1), so dropping back to Node 22's bundled npm is not an option.

## Fix

Install npm globally instead of via npx — a global install correctly includes the bundled `sigstore` — then publish with it. Applied to both the canary and release jobs.

## Verification

- YAML parses (`yaml.safe_load`).
- Full end-to-end proof only happens on merge to main (canary auto-publish). If the current `npm@latest` has since shipped a good release, re-running the failed job would also go green; the global install makes it robust regardless.

Closes #494
