### PR TITLE
ci(publish): pin npm to 11.18.0 for provenance publish (sigstore fix)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,8 +81,7 @@ jobs:
           CANARY_VERSION="${BASE_VERSION}-canary.${SHORT_SHA}"
           npm version "$CANARY_VERSION" --no-git-tag-version
           TARBALL=$(pnpm pack --pack-destination /tmp | tail -1)
-          npm install -g npm@latest
-          npm publish "$TARBALL" --tag canary --provenance --access public
+          npx --yes npm@11.18.0 publish "$TARBALL" --tag canary --provenance --access public
 
   release:
     name: Publish Release
@@ -170,8 +169,7 @@ jobs:
           sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
           unset NODE_AUTH_TOKEN
           TARBALL=$(pnpm pack --pack-destination /tmp | tail -1)
-          npm install -g npm@latest
-          npm publish "$TARBALL" --tag latest --provenance --access public
+          npx --yes npm@11.18.0 publish "$TARBALL" --tag latest --provenance --access public
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## What

Pin npm to `11.18.0` for the `--provenance` publish step, on both the canary and release jobs.

## Why

PR #495 (global `npm install -g`) was **inert** — canary still failed identically ([run 29103166676](https://github.com/vllnt/ui/actions/runs/29103166676)):

```
npm error Cannot find module 'sigstore'
npm error - /opt/hostedtoolcache/node/22.23.1/x64/lib/node_modules/npm/node_modules/libnpmpublish/lib/provenance.js
```

The require stack points at the **globally-installed** npm, proving the install method was never the problem.

Real root cause — verified against the npm registry:

| date | npm@latest | publish result |
|------|-----------|----------------|
| 2026-07-02 | 11.18.0 | success |
| 2026-07-08 | **12.0.0** | — |
| 2026-07-10 | 12.0.0 | **fails: sigstore MODULE_NOT_FOUND** |

npm **12.0.0** (published 2026-07-08) ships broken: `libnpmpublish` requires `sigstore` but it is absent from npm's bundled deps, so `--provenance` dies regardless of npx vs global install. Nothing in the repo changed.

## Fix

Pin to `npm@11.18.0` — the last release that published cleanly and is OIDC-capable (≥ 11.5.1, required by the tokenless trusted-publishing step). Revert to the simple `npx --yes npm@<pinned>` form.

Bump the pin once npm 12.x fixes the bundled `sigstore`.

## Verification

- YAML parses.
- End-to-end proof is the canary auto-publish on merge to main (the failing path). Will confirm the Publish run goes green post-merge.

Closes #494
