### PR TITLE
fix(registry): locale-correct JSON-LD + schema on all public pages

### DIFF
--- a/apps/registry/app/[locale]/build/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/build/[slug]/page.tsx
@@ -8,7 +8,11 @@ import { setRequestLocale } from "next-intl/server";
 import { Footer } from "@/components/footer/footer";
 import { type Locale, routing } from "@/i18n/routing";
 import { resolveAiComponent } from "@/lib/ai-seo";
-import { breadcrumbLd, faqPageLd, jsonLdScriptAttributes } from "@/lib/jsonld";
+import {
+  breadcrumbTrailLd,
+  faqPageLd,
+  jsonLdScriptAttributes,
+} from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
@@ -75,13 +79,9 @@ export default async function UseCasePage({ params }: Props) {
     <>
       <script
         {...jsonLdScriptAttributes([
-          breadcrumbLd([
-            { name: "Home", url: canonical("/", locale) },
-            { name: "AI components", url: canonical("/ai", locale) },
-            {
-              name: useCase.title,
-              url: canonical(`/build/${useCase.slug}`, locale),
-            },
+          breadcrumbTrailLd(locale, [
+            { name: "AI components", path: "/ai" },
+            { name: useCase.title, path: `/build/${useCase.slug}` },
           ]),
           faqPageLd(useCase.faq),
         ])}

--- a/apps/registry/app/[locale]/build/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/build/[slug]/page.tsx
@@ -18,8 +18,6 @@ type Props = {
   readonly params: Promise<{ locale: Locale; slug: string }>;
 };
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
-
 export function generateStaticParams() {
   return routing.locales.flatMap((locale) =>
     USE_CASES.map((useCase) => ({ locale, slug: useCase.slug })),
@@ -78,11 +76,11 @@ export default async function UseCasePage({ params }: Props) {
       <script
         {...jsonLdScriptAttributes([
           breadcrumbLd([
-            { name: "Home", url: SITE_URL },
-            { name: "AI components", url: `${SITE_URL}/ai` },
+            { name: "Home", url: canonical("/", locale) },
+            { name: "AI components", url: canonical("/ai", locale) },
             {
               name: useCase.title,
-              url: `${SITE_URL}/build/${useCase.slug}`,
+              url: canonical(`/build/${useCase.slug}`, locale),
             },
           ]),
           faqPageLd(useCase.faq),

--- a/apps/registry/app/[locale]/changelog/page.tsx
+++ b/apps/registry/app/[locale]/changelog/page.tsx
@@ -5,7 +5,7 @@ import { setRequestLocale } from "next-intl/server";
 
 import type { Locale } from "@/i18n/routing";
 import { type ChangelogTypeFilter, getChangelogEntries } from "@/lib/changelog";
-import { breadcrumbLd, jsonLdScript } from "@/lib/jsonld";
+import { breadcrumbTrailLd, jsonLdScript } from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
@@ -156,9 +156,8 @@ export default async function ChangelogPage({
       <script
         dangerouslySetInnerHTML={{
           __html: jsonLdScript([
-            breadcrumbLd([
-              { name: "Home", url: canonical("/", locale) },
-              { name: "Changelog", url: canonical("/changelog", locale) },
+            breadcrumbTrailLd(locale, [
+              { name: "Changelog", path: "/changelog" },
             ]),
             {
               "@context": "https://schema.org",

--- a/apps/registry/app/[locale]/changelog/page.tsx
+++ b/apps/registry/app/[locale]/changelog/page.tsx
@@ -10,8 +10,6 @@ import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
-
 type SearchParameters = {
   readonly from?: string;
   readonly to?: string;
@@ -159,8 +157,8 @@ export default async function ChangelogPage({
         dangerouslySetInnerHTML={{
           __html: jsonLdScript([
             breadcrumbLd([
-              { name: "Home", url: SITE_URL },
-              { name: "Changelog", url: `${SITE_URL}/changelog` },
+              { name: "Home", url: canonical("/", locale) },
+              { name: "Changelog", url: canonical("/changelog", locale) },
             ]),
             {
               "@context": "https://schema.org",
@@ -170,7 +168,7 @@ export default async function ChangelogPage({
                 : {}),
               description: DESCRIPTION,
               headline: "VLLNT UI Changelog",
-              mainEntityOfPage: `${SITE_URL}/changelog`,
+              mainEntityOfPage: canonical("/changelog", locale),
               publisher: {
                 "@type": "Organization",
                 name: "VLLNT",

--- a/apps/registry/app/[locale]/components/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/components/[slug]/page.tsx
@@ -22,7 +22,7 @@ import { getAiSeo } from "@/lib/ai-seo";
 import componentMetadata from "@/lib/component-metadata.json";
 import { getComponentSeo } from "@/lib/component-seo";
 import {
-  breadcrumbLd,
+  breadcrumbTrailLd,
   faqPageLd,
   jsonLdScriptAttributes,
   softwareSourceCodeLd,
@@ -246,13 +246,9 @@ export default async function ComponentPage(props: Props) {
             name: component.name,
             title: displayTitle,
           }),
-          breadcrumbLd([
-            { name: "Home", url: canonical("/", locale) },
-            { name: "Components", url: canonical("/components", locale) },
-            {
-              name: displayTitle,
-              url: canonical(`/components/${component.name}`, locale),
-            },
+          breadcrumbTrailLd(locale, [
+            { name: "Components", path: "/components" },
+            { name: displayTitle, path: `/components/${component.name}` },
           ]),
           ...(componentSeo?.faqs.length ? [faqPageLd(componentSeo.faqs)] : []),
         ])}

--- a/apps/registry/app/[locale]/components/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/components/[slug]/page.tsx
@@ -237,8 +237,6 @@ export default async function ComponentPage(props: Props) {
       : []),
   ] as { id: string; title: string }[];
 
-  const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
-
   return (
     <>
       <script
@@ -249,11 +247,11 @@ export default async function ComponentPage(props: Props) {
             title: displayTitle,
           }),
           breadcrumbLd([
-            { name: "Home", url: SITE_URL },
-            { name: "Components", url: `${SITE_URL}/components` },
+            { name: "Home", url: canonical("/", locale) },
+            { name: "Components", url: canonical("/components", locale) },
             {
               name: displayTitle,
-              url: `${SITE_URL}/components/${component.name}`,
+              url: canonical(`/components/${component.name}`, locale),
             },
           ]),
           ...(componentSeo?.faqs.length ? [faqPageLd(componentSeo.faqs)] : []),

--- a/apps/registry/app/[locale]/components/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/components/[slug]/page.tsx
@@ -243,6 +243,7 @@ export default async function ComponentPage(props: Props) {
         {...jsonLdScriptAttributes([
           softwareSourceCodeLd({
             description: displayDescription,
+            locale,
             name: component.name,
             title: displayTitle,
           }),

--- a/apps/registry/app/[locale]/components/[slug]/playground/page.tsx
+++ b/apps/registry/app/[locale]/components/[slug]/playground/page.tsx
@@ -8,7 +8,7 @@ import { PlaygroundCodePanel } from "@/components/playground";
 import { StorybookEmbed } from "@/components/storybook-embed";
 import { type Locale, routing } from "@/i18n/routing";
 import componentMetadata from "@/lib/component-metadata.json";
-import { breadcrumbLd, jsonLdScriptAttributes } from "@/lib/jsonld";
+import { breadcrumbTrailLd, jsonLdScriptAttributes } from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import {
   getPlaygroundExample,
@@ -114,19 +114,12 @@ export default async function ComponentPlaygroundPage(props: Props) {
     <>
       <script
         {...jsonLdScriptAttributes(
-          breadcrumbLd([
-            { name: "Home", url: canonical("/", locale) },
-            { name: "Components", url: canonical("/components", locale) },
-            {
-              name: displayTitle,
-              url: canonical(`/components/${component.name}`, locale),
-            },
+          breadcrumbTrailLd(locale, [
+            { name: "Components", path: "/components" },
+            { name: displayTitle, path: `/components/${component.name}` },
             {
               name: "Playground",
-              url: canonical(
-                `/components/${component.name}/playground`,
-                locale,
-              ),
+              path: `/components/${component.name}/playground`,
             },
           ]),
         )}

--- a/apps/registry/app/[locale]/components/[slug]/playground/page.tsx
+++ b/apps/registry/app/[locale]/components/[slug]/playground/page.tsx
@@ -8,6 +8,7 @@ import { PlaygroundCodePanel } from "@/components/playground";
 import { StorybookEmbed } from "@/components/storybook-embed";
 import { type Locale, routing } from "@/i18n/routing";
 import componentMetadata from "@/lib/component-metadata.json";
+import { breadcrumbLd, jsonLdScriptAttributes } from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import {
   getPlaygroundExample,
@@ -111,6 +112,25 @@ export default async function ComponentPlaygroundPage(props: Props) {
 
   return (
     <>
+      <script
+        {...jsonLdScriptAttributes(
+          breadcrumbLd([
+            { name: "Home", url: canonical("/", locale) },
+            { name: "Components", url: canonical("/components", locale) },
+            {
+              name: displayTitle,
+              url: canonical(`/components/${component.name}`, locale),
+            },
+            {
+              name: "Playground",
+              url: canonical(
+                `/components/${component.name}/playground`,
+                locale,
+              ),
+            },
+          ]),
+        )}
+      />
       <Sidebar
         sections={getSidebarSections(getCategoryForComponent(slug), locale)}
       />

--- a/apps/registry/app/[locale]/components/page.tsx
+++ b/apps/registry/app/[locale]/components/page.tsx
@@ -6,6 +6,11 @@ import { setRequestLocale } from "next-intl/server";
 import { ComponentCard } from "@/components/component-card";
 import type { Locale } from "@/i18n/routing";
 import { getPageContent } from "@/lib/content";
+import {
+  breadcrumbLd,
+  collectionPageLd,
+  jsonLdScriptAttributes,
+} from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import {
@@ -53,6 +58,25 @@ export default async function ComponentsPage({ params }: Props) {
 
   return (
     <>
+      <script
+        {...jsonLdScriptAttributes([
+          breadcrumbLd([
+            { name: "Home", url: canonical("/", locale) },
+            { name: "Components", url: canonical("/components", locale) },
+          ]),
+          collectionPageLd({
+            description: `Browse all ${components.length} accessible React components in VLLNT UI — installable with the shadcn CLI.`,
+            items: groupedComponents.flatMap((group) =>
+              group.items.map((item) => ({
+                name: item.title,
+                url: canonical(`/components/${item.name}`, locale),
+              })),
+            ),
+            title: "Components",
+            url: canonical("/components", locale),
+          }),
+        ])}
+      />
       <Sidebar sections={getSidebarSections(undefined, locale)} />
       <main className="flex-1 overflow-y-auto bg-background">
         <div className="container mx-auto px-4 py-16 lg:px-8">

--- a/apps/registry/app/[locale]/components/page.tsx
+++ b/apps/registry/app/[locale]/components/page.tsx
@@ -7,7 +7,7 @@ import { ComponentCard } from "@/components/component-card";
 import type { Locale } from "@/i18n/routing";
 import { getPageContent } from "@/lib/content";
 import {
-  breadcrumbLd,
+  breadcrumbTrailLd,
   collectionPageLd,
   jsonLdScriptAttributes,
 } from "@/lib/jsonld";
@@ -60,9 +60,8 @@ export default async function ComponentsPage({ params }: Props) {
     <>
       <script
         {...jsonLdScriptAttributes([
-          breadcrumbLd([
-            { name: "Home", url: canonical("/", locale) },
-            { name: "Components", url: canonical("/components", locale) },
+          breadcrumbTrailLd(locale, [
+            { name: "Components", path: "/components" },
           ]),
           collectionPageLd({
             description: `Browse all ${components.length} accessible React components in VLLNT UI — installable with the shadcn CLI.`,

--- a/apps/registry/app/[locale]/docs/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/docs/[slug]/page.tsx
@@ -19,8 +19,6 @@ import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
-
 type Props = {
   params: Promise<{ locale: Locale; slug: string }>;
 };
@@ -123,7 +121,7 @@ export default async function DocsSlugPage(props: Props) {
     docsPage.slug === "changelog"
       ? `${content}\n\n${await readChangelog()}`
       : content;
-  const pageUrl = `${SITE_URL}${getDocsPath(docsPage)}`;
+  const pageUrl = canonical(getDocsPath(docsPage), locale);
 
   return (
     <>
@@ -131,8 +129,8 @@ export default async function DocsSlugPage(props: Props) {
         id={`docs-${docsPage.slug}-json-ld`}
         {...jsonLdScriptAttributes([
           breadcrumbLd([
-            { name: "Home", url: SITE_URL },
-            { name: "Docs", url: `${SITE_URL}/docs` },
+            { name: "Home", url: canonical("/", locale) },
+            { name: "Docs", url: canonical("/docs", locale) },
             { name: frontmatter.title, url: pageUrl },
           ]),
           techArticleLd({

--- a/apps/registry/app/[locale]/docs/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/docs/[slug]/page.tsx
@@ -11,7 +11,7 @@ import { type Locale, routing } from "@/i18n/routing";
 import { getPageContent } from "@/lib/content";
 import { DOCS_PAGES, getDocsPage, getDocsPath } from "@/lib/docs-pages";
 import {
-  breadcrumbLd,
+  breadcrumbTrailLd,
   jsonLdScriptAttributes,
   techArticleLd,
 } from "@/lib/jsonld";
@@ -128,10 +128,9 @@ export default async function DocsSlugPage(props: Props) {
       <Script
         id={`docs-${docsPage.slug}-json-ld`}
         {...jsonLdScriptAttributes([
-          breadcrumbLd([
-            { name: "Home", url: canonical("/", locale) },
-            { name: "Docs", url: canonical("/docs", locale) },
-            { name: frontmatter.title, url: pageUrl },
+          breadcrumbTrailLd(locale, [
+            { name: "Docs", path: "/docs" },
+            { name: frontmatter.title, path: getDocsPath(docsPage) },
           ]),
           techArticleLd({
             description: frontmatter.description,

--- a/apps/registry/app/[locale]/docs/page.tsx
+++ b/apps/registry/app/[locale]/docs/page.tsx
@@ -16,8 +16,6 @@ import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
-
 type Props = {
   readonly params: Promise<{ locale: Locale }>;
 };
@@ -61,14 +59,14 @@ export default async function DocumentationPage({ params }: Props) {
         id="docs-json-ld"
         {...jsonLdScriptAttributes([
           breadcrumbLd([
-            { name: "Home", url: SITE_URL },
-            { name: "Docs", url: `${SITE_URL}/docs` },
+            { name: "Home", url: canonical("/", locale) },
+            { name: "Docs", url: canonical("/docs", locale) },
           ]),
           techArticleLd({
             description:
               "Learn how to use VLLNT UI components in your projects.",
             title: "Documentation",
-            url: `${SITE_URL}/docs`,
+            url: canonical("/docs", locale),
           }),
         ])}
       />

--- a/apps/registry/app/[locale]/docs/page.tsx
+++ b/apps/registry/app/[locale]/docs/page.tsx
@@ -8,7 +8,7 @@ import type { Locale } from "@/i18n/routing";
 import { getPageContent } from "@/lib/content";
 import { DOCS_PAGES, getDocsPath } from "@/lib/docs-pages";
 import {
-  breadcrumbLd,
+  breadcrumbTrailLd,
   jsonLdScriptAttributes,
   techArticleLd,
 } from "@/lib/jsonld";
@@ -58,10 +58,7 @@ export default async function DocumentationPage({ params }: Props) {
       <Script
         id="docs-json-ld"
         {...jsonLdScriptAttributes([
-          breadcrumbLd([
-            { name: "Home", url: canonical("/", locale) },
-            { name: "Docs", url: canonical("/docs", locale) },
-          ]),
+          breadcrumbTrailLd(locale, [{ name: "Docs", path: "/docs" }]),
           techArticleLd({
             description:
               "Learn how to use VLLNT UI components in your projects.",

--- a/apps/registry/app/[locale]/families/[category]/page.tsx
+++ b/apps/registry/app/[locale]/families/[category]/page.tsx
@@ -29,8 +29,6 @@ type Props = {
   readonly params: Promise<{ category: string; locale: Locale }>;
 };
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
-
 function findFamily(category: string) {
   return groupedComponents.find((group) => group.category === category);
 }
@@ -110,18 +108,18 @@ export default async function FamilyPage({ params }: Props) {
       <script
         {...jsonLdScriptAttributes([
           breadcrumbLd([
-            { name: "Home", url: SITE_URL },
-            { name: "Components", url: `${SITE_URL}/components` },
-            { name: group.label, url: `${SITE_URL}${pathname}` },
+            { name: "Home", url: canonical("/", locale) },
+            { name: "Components", url: canonical("/components", locale) },
+            { name: group.label, url: canonical(pathname, locale) },
           ]),
           collectionPageLd({
             description,
             items: group.items.map((item) => ({
               name: item.title,
-              url: `${SITE_URL}/components/${item.name}`,
+              url: canonical(`/components/${item.name}`, locale),
             })),
             title: `${group.label} components`,
-            url: `${SITE_URL}${pathname}`,
+            url: canonical(pathname, locale),
           }),
           ...(copy && copy.faq.length > 0 ? [faqPageLd(copy.faq)] : []),
         ])}

--- a/apps/registry/app/[locale]/families/[category]/page.tsx
+++ b/apps/registry/app/[locale]/families/[category]/page.tsx
@@ -11,7 +11,7 @@ import { type Locale, routing } from "@/i18n/routing";
 import { getFamilyCopy } from "@/lib/family-copy";
 import { getFamilyGroups } from "@/lib/family-groups";
 import {
-  breadcrumbLd,
+  breadcrumbTrailLd,
   collectionPageLd,
   faqPageLd,
   jsonLdScriptAttributes,
@@ -107,10 +107,9 @@ export default async function FamilyPage({ params }: Props) {
     <>
       <script
         {...jsonLdScriptAttributes([
-          breadcrumbLd([
-            { name: "Home", url: canonical("/", locale) },
-            { name: "Components", url: canonical("/components", locale) },
-            { name: group.label, url: canonical(pathname, locale) },
+          breadcrumbTrailLd(locale, [
+            { name: "Components", path: "/components" },
+            { name: group.label, path: pathname },
           ]),
           collectionPageLd({
             description,

--- a/apps/registry/app/[locale]/families/page.tsx
+++ b/apps/registry/app/[locale]/families/page.tsx
@@ -23,7 +23,6 @@ type Props = {
   readonly params: Promise<{ locale: Locale }>;
 };
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 const PATHNAME = "/families";
 const TITLE = "Component families";
 const DESCRIPTION =
@@ -60,18 +59,18 @@ export default async function FamiliesPage({ params }: Props) {
       <script
         {...jsonLdScriptAttributes([
           breadcrumbLd([
-            { name: "Home", url: SITE_URL },
-            { name: "Components", url: `${SITE_URL}/components` },
-            { name: "Families", url: `${SITE_URL}${PATHNAME}` },
+            { name: "Home", url: canonical("/", locale) },
+            { name: "Components", url: canonical("/components", locale) },
+            { name: "Families", url: canonical(PATHNAME, locale) },
           ]),
           collectionPageLd({
             description: DESCRIPTION,
             items: groupedComponents.map((group) => ({
               name: `${group.label} components`,
-              url: `${SITE_URL}${familyPath(group.category)}`,
+              url: canonical(familyPath(group.category), locale),
             })),
             title: TITLE,
-            url: `${SITE_URL}${PATHNAME}`,
+            url: canonical(PATHNAME, locale),
           }),
         ])}
       />

--- a/apps/registry/app/[locale]/families/page.tsx
+++ b/apps/registry/app/[locale]/families/page.tsx
@@ -6,7 +6,7 @@ import { setRequestLocale } from "next-intl/server";
 import { Footer } from "@/components/footer/footer";
 import type { Locale } from "@/i18n/routing";
 import {
-  breadcrumbLd,
+  breadcrumbTrailLd,
   collectionPageLd,
   jsonLdScriptAttributes,
 } from "@/lib/jsonld";
@@ -58,10 +58,9 @@ export default async function FamiliesPage({ params }: Props) {
     <>
       <script
         {...jsonLdScriptAttributes([
-          breadcrumbLd([
-            { name: "Home", url: canonical("/", locale) },
-            { name: "Components", url: canonical("/components", locale) },
-            { name: "Families", url: canonical(PATHNAME, locale) },
+          breadcrumbTrailLd(locale, [
+            { name: "Components", path: "/components" },
+            { name: "Families", path: PATHNAME },
           ]),
           collectionPageLd({
             description: DESCRIPTION,

--- a/apps/registry/app/[locale]/page.tsx
+++ b/apps/registry/app/[locale]/page.tsx
@@ -4,6 +4,7 @@ import { setRequestLocale } from "next-intl/server";
 
 import { Landing } from "@/components/landing/landing";
 import type { Locale } from "@/i18n/routing";
+import { jsonLdScriptAttributes, softwareApplicationLd } from "@/lib/jsonld";
 import { getNpmDistributionTags } from "@/lib/npm-version";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates } from "@/lib/seo";
@@ -43,9 +44,19 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function HomePage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
+  const componentCount = getComponentCount();
 
   return (
     <>
+      <script
+        {...jsonLdScriptAttributes(
+          softwareApplicationLd({
+            description: `Open-source React UI components and design system for building AI apps — ${componentCount} accessible components installable with the shadcn CLI and readable by AI agents via llms.txt.`,
+            name: "VLLNT UI",
+            url: canonical("/", locale),
+          }),
+        )}
+      />
       <Sidebar sections={getSidebarSections(undefined, locale)} />
       <main className="flex-1 overflow-y-auto bg-background">
         <Landing />

--- a/apps/registry/app/[locale]/philosophy/page.tsx
+++ b/apps/registry/app/[locale]/philosophy/page.tsx
@@ -4,6 +4,11 @@ import { setRequestLocale } from "next-intl/server";
 
 import type { Locale } from "@/i18n/routing";
 import { getPageContent } from "@/lib/content";
+import {
+  breadcrumbLd,
+  jsonLdScriptAttributes,
+  techArticleLd,
+} from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
@@ -43,10 +48,23 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function PhilosophyPage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
-  const { content } = await getPageContent("philosophy", locale);
+  const { content, frontmatter } = await getPageContent("philosophy", locale);
 
   return (
     <>
+      <script
+        {...jsonLdScriptAttributes([
+          breadcrumbLd([
+            { name: "Home", url: canonical("/", locale) },
+            { name: "Philosophy", url: canonical("/philosophy", locale) },
+          ]),
+          techArticleLd({
+            description: frontmatter.description,
+            title: frontmatter.title,
+            url: canonical("/philosophy", locale),
+          }),
+        ])}
+      />
       <Sidebar sections={getSidebarSections(undefined, locale)} />
       <main className="flex-1 overflow-y-auto bg-background">
         <div className="container mx-auto px-4 py-16 lg:px-8">

--- a/apps/registry/app/[locale]/philosophy/page.tsx
+++ b/apps/registry/app/[locale]/philosophy/page.tsx
@@ -5,7 +5,7 @@ import { setRequestLocale } from "next-intl/server";
 import type { Locale } from "@/i18n/routing";
 import { getPageContent } from "@/lib/content";
 import {
-  breadcrumbLd,
+  breadcrumbTrailLd,
   jsonLdScriptAttributes,
   techArticleLd,
 } from "@/lib/jsonld";
@@ -54,9 +54,8 @@ export default async function PhilosophyPage({ params }: Props) {
     <>
       <script
         {...jsonLdScriptAttributes([
-          breadcrumbLd([
-            { name: "Home", url: canonical("/", locale) },
-            { name: "Philosophy", url: canonical("/philosophy", locale) },
+          breadcrumbTrailLd(locale, [
+            { name: "Philosophy", path: "/philosophy" },
           ]),
           techArticleLd({
             description: frontmatter.description,

--- a/apps/registry/app/[locale]/releases/page.tsx
+++ b/apps/registry/app/[locale]/releases/page.tsx
@@ -5,7 +5,7 @@ import { setRequestLocale } from "next-intl/server";
 
 import type { Locale } from "@/i18n/routing";
 import { getReleaseRecords } from "@/lib/changelog";
-import { breadcrumbLd, jsonLdScript } from "@/lib/jsonld";
+import { breadcrumbTrailLd, jsonLdScript } from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
@@ -171,9 +171,8 @@ export default async function ReleasesPage({ params }: Props) {
       <script
         dangerouslySetInnerHTML={{
           __html: jsonLdScript([
-            breadcrumbLd([
-              { name: "Home", url: canonical("/", locale) },
-              { name: "Releases", url: canonical("/releases", locale) },
+            breadcrumbTrailLd(locale, [
+              { name: "Releases", path: "/releases" },
             ]),
             {
               "@context": "https://schema.org",

--- a/apps/registry/app/[locale]/releases/page.tsx
+++ b/apps/registry/app/[locale]/releases/page.tsx
@@ -10,8 +10,6 @@ import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
-
 const DESCRIPTION =
   "Read VLLNT UI releases, including latest notes, component count deltas, breaking change counts, migration links, and GitHub release links.";
 
@@ -146,6 +144,7 @@ function ReleaseCard({
 function releaseJsonLdItem(
   release: Awaited<ReturnType<typeof getReleaseRecords>>[number],
   index: number,
+  locale: Locale,
 ) {
   return {
     "@type": "ListItem",
@@ -156,7 +155,7 @@ function releaseJsonLdItem(
       name: release.version,
       programmingLanguage: "TypeScript",
       runtimePlatform: "React",
-      url: `${SITE_URL}/releases#${release.anchor}`,
+      url: `${canonical("/releases", locale)}#${release.anchor}`,
     },
     position: index + 1,
   };
@@ -173,13 +172,15 @@ export default async function ReleasesPage({ params }: Props) {
         dangerouslySetInnerHTML={{
           __html: jsonLdScript([
             breadcrumbLd([
-              { name: "Home", url: SITE_URL },
-              { name: "Releases", url: `${SITE_URL}/releases` },
+              { name: "Home", url: canonical("/", locale) },
+              { name: "Releases", url: canonical("/releases", locale) },
             ]),
             {
               "@context": "https://schema.org",
               "@type": "ItemList",
-              itemListElement: releases.map(releaseJsonLdItem),
+              itemListElement: releases.map((release, index) =>
+                releaseJsonLdItem(release, index, locale),
+              ),
               name: "VLLNT UI Releases",
               numberOfItems: releases.length,
             },

--- a/apps/registry/app/[locale]/templates/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/templates/[slug]/page.tsx
@@ -9,7 +9,7 @@ import { setRequestLocale } from "next-intl/server";
 import { GitHubMark } from "@/components/github-mark";
 import { type Locale, routing } from "@/i18n/routing";
 import {
-  breadcrumbLd,
+  breadcrumbTrailLd,
   jsonLdScriptAttributes,
   softwareApplicationLd,
 } from "@/lib/jsonld";
@@ -87,10 +87,9 @@ export default async function TemplatePage(props: Props) {
       <Script
         id={`template-${template.slug}-json-ld`}
         {...jsonLdScriptAttributes([
-          breadcrumbLd([
-            { name: "Home", url: canonical("/", locale) },
-            { name: "Templates", url: canonical("/templates", locale) },
-            { name: template.title, url: templateUrl },
+          breadcrumbTrailLd(locale, [
+            { name: "Templates", path: "/templates" },
+            { name: template.title, path: templatePath },
           ]),
           softwareApplicationLd({
             description: template.description,

--- a/apps/registry/app/[locale]/templates/[slug]/page.tsx
+++ b/apps/registry/app/[locale]/templates/[slug]/page.tsx
@@ -23,8 +23,6 @@ import {
   TEMPLATES,
 } from "@/lib/templates";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
-
 type Props = {
   params: Promise<{ locale: Locale; slug: string }>;
 };
@@ -81,7 +79,7 @@ export default async function TemplatePage(props: Props) {
   }
 
   const templatePath = getTemplatePath(template);
-  const templateUrl = `${SITE_URL}${templatePath}`;
+  const templateUrl = canonical(templatePath, locale);
   const githubUrl = getTemplateGithubUrl(template);
 
   return (
@@ -90,8 +88,8 @@ export default async function TemplatePage(props: Props) {
         id={`template-${template.slug}-json-ld`}
         {...jsonLdScriptAttributes([
           breadcrumbLd([
-            { name: "Home", url: SITE_URL },
-            { name: "Templates", url: `${SITE_URL}/templates` },
+            { name: "Home", url: canonical("/", locale) },
+            { name: "Templates", url: canonical("/templates", locale) },
             { name: template.title, url: templateUrl },
           ]),
           softwareApplicationLd({

--- a/apps/registry/app/[locale]/templates/page.tsx
+++ b/apps/registry/app/[locale]/templates/page.tsx
@@ -15,8 +15,6 @@ import { withRef } from "@/lib/share";
 import { getSidebarSections } from "@/lib/sidebar-sections";
 import { getTemplatePath, TEMPLATES } from "@/lib/templates";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
-
 const title = "Templates - VLLNT UI";
 const description =
   "Starter kits for Next.js apps, dashboards, SaaS products, AI chat, and documentation sites built with VLLNT UI.";
@@ -64,7 +62,7 @@ export default async function TemplatesPage({ params }: Props) {
             softwareApplicationLd({
               description: template.description,
               name: template.title,
-              url: `${SITE_URL}${getTemplatePath(template)}`,
+              url: canonical(getTemplatePath(template), locale),
             }),
           ),
         )}

--- a/apps/registry/app/[locale]/themes/page.tsx
+++ b/apps/registry/app/[locale]/themes/page.tsx
@@ -4,6 +4,7 @@ import { setRequestLocale } from "next-intl/server";
 
 import { ThemeEditor } from "@/components/theme-editor";
 import type { Locale } from "@/i18n/routing";
+import { breadcrumbLd, jsonLdScriptAttributes } from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
@@ -47,6 +48,14 @@ export default async function ThemesPage({ params }: Props) {
 
   return (
     <>
+      <script
+        {...jsonLdScriptAttributes(
+          breadcrumbLd([
+            { name: "Home", url: canonical("/", locale) },
+            { name: TITLE, url: canonical("/themes", locale) },
+          ]),
+        )}
+      />
       <Sidebar sections={getSidebarSections(undefined, locale)} />
       <main className="flex-1 overflow-y-auto bg-background">
         <div className="mx-auto max-w-7xl px-4 py-12 lg:px-8">

--- a/apps/registry/app/[locale]/themes/page.tsx
+++ b/apps/registry/app/[locale]/themes/page.tsx
@@ -4,7 +4,7 @@ import { setRequestLocale } from "next-intl/server";
 
 import { ThemeEditor } from "@/components/theme-editor";
 import type { Locale } from "@/i18n/routing";
-import { breadcrumbLd, jsonLdScriptAttributes } from "@/lib/jsonld";
+import { breadcrumbTrailLd, jsonLdScriptAttributes } from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
@@ -50,10 +50,7 @@ export default async function ThemesPage({ params }: Props) {
     <>
       <script
         {...jsonLdScriptAttributes(
-          breadcrumbLd([
-            { name: "Home", url: canonical("/", locale) },
-            { name: TITLE, url: canonical("/themes", locale) },
-          ]),
+          breadcrumbTrailLd(locale, [{ name: TITLE, path: "/themes" }]),
         )}
       />
       <Sidebar sections={getSidebarSections(undefined, locale)} />

--- a/apps/registry/app/[locale]/vs/assistant-ui/page.tsx
+++ b/apps/registry/app/[locale]/vs/assistant-ui/page.tsx
@@ -5,7 +5,7 @@ import { setRequestLocale } from "next-intl/server";
 
 import { Footer } from "@/components/footer/footer";
 import type { Locale } from "@/i18n/routing";
-import { breadcrumbLd, jsonLdScriptAttributes } from "@/lib/jsonld";
+import { breadcrumbTrailLd, jsonLdScriptAttributes } from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
@@ -89,12 +89,8 @@ export default async function VsAssistantUiPage({ params }: Props) {
     <>
       <script
         {...jsonLdScriptAttributes(
-          breadcrumbLd([
-            { name: "Home", url: canonical("/", locale) },
-            {
-              name: "VLLNT UI vs assistant-ui",
-              url: canonical(PATHNAME, locale),
-            },
+          breadcrumbTrailLd(locale, [
+            { name: "VLLNT UI vs assistant-ui", path: PATHNAME },
           ]),
         )}
       />

--- a/apps/registry/app/[locale]/vs/assistant-ui/page.tsx
+++ b/apps/registry/app/[locale]/vs/assistant-ui/page.tsx
@@ -14,7 +14,6 @@ type Props = {
   readonly params: Promise<{ locale: Locale }>;
 };
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 const PATHNAME = "/vs/assistant-ui";
 
 type Row = {
@@ -91,8 +90,11 @@ export default async function VsAssistantUiPage({ params }: Props) {
       <script
         {...jsonLdScriptAttributes(
           breadcrumbLd([
-            { name: "Home", url: SITE_URL },
-            { name: "VLLNT UI vs assistant-ui", url: `${SITE_URL}${PATHNAME}` },
+            { name: "Home", url: canonical("/", locale) },
+            {
+              name: "VLLNT UI vs assistant-ui",
+              url: canonical(PATHNAME, locale),
+            },
           ]),
         )}
       />

--- a/apps/registry/app/[locale]/vs/page.tsx
+++ b/apps/registry/app/[locale]/vs/page.tsx
@@ -5,7 +5,7 @@ import { setRequestLocale } from "next-intl/server";
 
 import type { Locale } from "@/i18n/routing";
 import {
-  breadcrumbLd,
+  breadcrumbTrailLd,
   collectionPageLd,
   jsonLdScriptAttributes,
 } from "@/lib/jsonld";
@@ -79,10 +79,7 @@ export default async function VsIndexPage({ params }: Props) {
     <>
       <script
         {...jsonLdScriptAttributes([
-          breadcrumbLd([
-            { name: "Home", url: canonical("/", locale) },
-            { name: "Comparisons", url: canonical("/vs", locale) },
-          ]),
+          breadcrumbTrailLd(locale, [{ name: "Comparisons", path: "/vs" }]),
           collectionPageLd({
             description:
               "Honest, evidence-based comparisons of VLLNT UI against shadcn/ui, Radix UI, HeadlessUI, and NextUI.",

--- a/apps/registry/app/[locale]/vs/page.tsx
+++ b/apps/registry/app/[locale]/vs/page.tsx
@@ -4,6 +4,11 @@ import Link from "next/link";
 import { setRequestLocale } from "next-intl/server";
 
 import type { Locale } from "@/i18n/routing";
+import {
+  breadcrumbLd,
+  collectionPageLd,
+  jsonLdScriptAttributes,
+} from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
@@ -72,6 +77,26 @@ export default async function VsIndexPage({ params }: Props) {
 
   return (
     <>
+      <script
+        {...jsonLdScriptAttributes([
+          breadcrumbLd([
+            { name: "Home", url: canonical("/", locale) },
+            { name: "Comparisons", url: canonical("/vs", locale) },
+          ]),
+          collectionPageLd({
+            description:
+              "Honest, evidence-based comparisons of VLLNT UI against shadcn/ui, Radix UI, HeadlessUI, and NextUI.",
+            items: COMPARISONS.filter((entry) => entry.available).map(
+              (entry) => ({
+                name: `VLLNT UI vs ${entry.name}`,
+                url: canonical(`/vs/${entry.slug}`, locale),
+              }),
+            ),
+            title: "VLLNT UI vs the rest",
+            url: canonical("/vs", locale),
+          }),
+        ])}
+      />
       <Sidebar sections={getSidebarSections(undefined, locale)} />
       <main className="flex-1 overflow-y-auto bg-background">
         <div className="container mx-auto max-w-3xl px-4 py-16 lg:px-8">

--- a/apps/registry/app/[locale]/vs/shadcn/page.tsx
+++ b/apps/registry/app/[locale]/vs/shadcn/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { setRequestLocale } from "next-intl/server";
 
 import type { Locale } from "@/i18n/routing";
-import { breadcrumbLd, jsonLdScriptAttributes } from "@/lib/jsonld";
+import { breadcrumbTrailLd, jsonLdScriptAttributes } from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
@@ -167,12 +167,8 @@ export default async function VsShadcnPage({ params }: Props) {
     <>
       <script
         {...jsonLdScriptAttributes(
-          breadcrumbLd([
-            { name: "Home", url: canonical("/", locale) },
-            {
-              name: "VLLNT UI vs shadcn/ui",
-              url: canonical("/vs/shadcn", locale),
-            },
+          breadcrumbTrailLd(locale, [
+            { name: "VLLNT UI vs shadcn/ui", path: "/vs/shadcn" },
           ]),
         )}
       />

--- a/apps/registry/app/[locale]/vs/shadcn/page.tsx
+++ b/apps/registry/app/[locale]/vs/shadcn/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { setRequestLocale } from "next-intl/server";
 
 import type { Locale } from "@/i18n/routing";
+import { breadcrumbLd, jsonLdScriptAttributes } from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
@@ -164,6 +165,17 @@ export default async function VsShadcnPage({ params }: Props) {
 
   return (
     <>
+      <script
+        {...jsonLdScriptAttributes(
+          breadcrumbLd([
+            { name: "Home", url: canonical("/", locale) },
+            {
+              name: "VLLNT UI vs shadcn/ui",
+              url: canonical("/vs/shadcn", locale),
+            },
+          ]),
+        )}
+      />
       <Sidebar sections={getSidebarSections(undefined, locale)} />
       <main className="flex-1 overflow-y-auto bg-background">
         <div className="container mx-auto max-w-4xl px-4 py-16 lg:px-8">

--- a/apps/registry/app/[locale]/vs/vercel-ai-sdk/page.tsx
+++ b/apps/registry/app/[locale]/vs/vercel-ai-sdk/page.tsx
@@ -14,7 +14,6 @@ type Props = {
   readonly params: Promise<{ locale: Locale }>;
 };
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 const PATHNAME = "/vs/vercel-ai-sdk";
 
 type Row = {
@@ -90,10 +89,10 @@ export default async function VsVercelAiSdkPage({ params }: Props) {
       <script
         {...jsonLdScriptAttributes(
           breadcrumbLd([
-            { name: "Home", url: SITE_URL },
+            { name: "Home", url: canonical("/", locale) },
             {
               name: "VLLNT UI vs Vercel AI SDK",
-              url: `${SITE_URL}${PATHNAME}`,
+              url: canonical(PATHNAME, locale),
             },
           ]),
         )}

--- a/apps/registry/app/[locale]/vs/vercel-ai-sdk/page.tsx
+++ b/apps/registry/app/[locale]/vs/vercel-ai-sdk/page.tsx
@@ -5,7 +5,7 @@ import { setRequestLocale } from "next-intl/server";
 
 import { Footer } from "@/components/footer/footer";
 import type { Locale } from "@/i18n/routing";
-import { breadcrumbLd, jsonLdScriptAttributes } from "@/lib/jsonld";
+import { breadcrumbTrailLd, jsonLdScriptAttributes } from "@/lib/jsonld";
 import { generateOGMetadata, generateTwitterMetadata } from "@/lib/og";
 import { canonical, languageAlternates, localizePathname } from "@/lib/seo";
 import { getSidebarSections } from "@/lib/sidebar-sections";
@@ -88,12 +88,8 @@ export default async function VsVercelAiSdkPage({ params }: Props) {
     <>
       <script
         {...jsonLdScriptAttributes(
-          breadcrumbLd([
-            { name: "Home", url: canonical("/", locale) },
-            {
-              name: "VLLNT UI vs Vercel AI SDK",
-              url: canonical(PATHNAME, locale),
-            },
+          breadcrumbTrailLd(locale, [
+            { name: "VLLNT UI vs Vercel AI SDK", path: PATHNAME },
           ]),
         )}
       />

--- a/apps/registry/e2e/jsonld-locale.spec.ts
+++ b/apps/registry/e2e/jsonld-locale.spec.ts
@@ -1,0 +1,54 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * Regression guard for the locale-JSON-LD bug (page-level).
+ *
+ * Page structured-data URLs were built from `${SITE_URL}${pathname}` with no
+ * locale segment, so a /fr page emitted English URLs that mismatched its own
+ * canonical. This asserts the rendered breadcrumb JSON-LD on a real page: a
+ * non-default locale route prefixes its URLs with the locale, the default
+ * locale route does not. Catches a page that bypasses breadcrumbTrailLd and
+ * hand-builds URLs again. Uses /families/[category] because its JSON-LD is a
+ * plain server-rendered <script>. Playwright text engines ignore <script>
+ * content, so the block is read via allTextContents and matched in JS.
+ */
+async function breadcrumbJson(page: Page, path: string): Promise<string> {
+  await page.goto(path);
+  let block = "";
+  await expect
+    .poll(
+      async () => {
+        const blocks = await page
+          .locator('script[type="application/ld+json"]')
+          .allTextContents();
+        block =
+          blocks.find((text) => text.includes('"@type":"BreadcrumbList"')) ??
+          "";
+        return block.length;
+      },
+      { timeout: 10_000 },
+    )
+    .toBeGreaterThan(0);
+  return block;
+}
+
+test.describe("locale-aware JSON-LD", () => {
+  test("a /fr route prefixes its breadcrumb URLs with the locale", async ({
+    page,
+  }) => {
+    const json = await breadcrumbJson(page, "/fr/families/form");
+
+    // Home crumb resolves to the /fr root, the family crumb to /fr/families/form.
+    expect(json).toMatch(/"item":"https:\/\/[^"]*\/fr","name":"Home"/);
+    expect(json).toMatch(/"item":"https:\/\/[^"]*\/fr\/families\/form"/);
+  });
+
+  test("the default-locale route carries no locale segment", async ({
+    page,
+  }) => {
+    const json = await breadcrumbJson(page, "/families/form");
+
+    expect(json).not.toContain("/fr");
+    expect(json).toMatch(/"item":"https:\/\/[^"]*\/families\/form"/);
+  });
+});

--- a/apps/registry/lib/jsonld.test.ts
+++ b/apps/registry/lib/jsonld.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+// @/i18n/routing pulls next-intl/navigation, which cannot load in the node test
+// environment. breadcrumbTrailLd -> canonical (lib/seo) needs the locale
+// constants, so stub the module the same way lib/og.test.ts does.
+vi.mock("@/i18n/routing", () => ({
+  routing: { defaultLocale: "en", locales: ["en", "fr"] },
+}));
+
+import { breadcrumbTrailLd } from "./jsonld";
+
+/**
+ * Regression guard for the locale-JSON-LD bug: page structured-data URLs were
+ * built from `${SITE_URL}${pathname}` with no locale segment, so every /fr page
+ * emitted English URLs that mismatched its own canonical. breadcrumbTrailLd is
+ * the single chokepoint that resolves every crumb through canonical(path,
+ * locale); these tests lock that a non-default locale prefixes every crumb URL
+ * and the default locale prefixes none.
+ */
+describe("breadcrumbTrailLd", () => {
+  it("prefixes every crumb URL with the locale segment for a non-default locale", () => {
+    const json = JSON.stringify(
+      breadcrumbTrailLd("fr", [{ name: "Docs", path: "/docs" }]),
+    );
+
+    expect(json).toContain('"@type":"BreadcrumbList"');
+    // The helper adds Home as the first crumb at position 1, pointing at /fr.
+    expect(json).toMatch(
+      /"item":"https:\/\/[^"]*\/fr","name":"Home","position":1/,
+    );
+    // The trailing crumb resolves to the /fr-prefixed docs URL, not /docs.
+    expect(json).toMatch(
+      /"item":"https:\/\/[^"]*\/fr\/docs","name":"Docs","position":2/,
+    );
+  });
+
+  it("emits no locale segment for the default locale", () => {
+    const json = JSON.stringify(
+      breadcrumbTrailLd("en", [{ name: "Docs", path: "/docs" }]),
+    );
+
+    expect(json).not.toContain("/fr");
+    expect(json).toMatch(/"name":"Home","position":1/);
+    expect(json).toMatch(
+      /"item":"https:\/\/[^"]*\/docs","name":"Docs","position":2/,
+    );
+  });
+
+  it("prefixes deep trails and numbers positions sequentially from Home", () => {
+    const json = JSON.stringify(
+      breadcrumbTrailLd("fr", [
+        { name: "Components", path: "/components" },
+        { name: "Button", path: "/components/button" },
+      ]),
+    );
+
+    expect(json).toMatch(
+      /"item":"https:\/\/[^"]*\/fr\/components","name":"Components","position":2/,
+    );
+    expect(json).toMatch(
+      /"item":"https:\/\/[^"]*\/fr\/components\/button","name":"Button","position":3/,
+    );
+  });
+});

--- a/apps/registry/lib/jsonld.test.ts
+++ b/apps/registry/lib/jsonld.test.ts
@@ -7,7 +7,7 @@ vi.mock("@/i18n/routing", () => ({
   routing: { defaultLocale: "en", locales: ["en", "fr"] },
 }));
 
-import { breadcrumbTrailLd } from "./jsonld";
+import { breadcrumbTrailLd, softwareSourceCodeLd } from "./jsonld";
 
 /**
  * Regression guard for the locale-JSON-LD bug: page structured-data URLs were
@@ -60,5 +60,39 @@ describe("breadcrumbTrailLd", () => {
     expect(json).toMatch(
       /"item":"https:\/\/[^"]*\/fr\/components\/button","name":"Button","position":3/,
     );
+  });
+});
+
+/**
+ * softwareSourceCodeLd builds the component page URL itself, so it carries the
+ * same locale hazard as the breadcrumb trail: a /fr component page must not
+ * advertise the English URL as its SoftwareSourceCode url.
+ */
+describe("softwareSourceCodeLd", () => {
+  it("points at the locale URL of the component page", () => {
+    const json = JSON.stringify(
+      softwareSourceCodeLd({
+        description: "A button.",
+        locale: "fr",
+        name: "button",
+        title: "Button",
+      }),
+    );
+
+    expect(json).toMatch(/"url":"https:\/\/[^"]*\/fr\/components\/button"/);
+  });
+
+  it("omits the locale segment for the default locale", () => {
+    const json = JSON.stringify(
+      softwareSourceCodeLd({
+        description: "A button.",
+        locale: "en",
+        name: "button",
+        title: "Button",
+      }),
+    );
+
+    expect(json).not.toContain("/fr");
+    expect(json).toMatch(/"url":"https:\/\/[^"]*\/components\/button"/);
   });
 });

--- a/apps/registry/lib/jsonld.ts
+++ b/apps/registry/lib/jsonld.ts
@@ -1,3 +1,6 @@
+import type { Locale } from "@/i18n/routing";
+import { canonical } from "@/lib/seo";
+
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ui.vllnt.com";
 
 type JsonLdValue =
@@ -105,6 +108,32 @@ export function breadcrumbLd(
       position: index + 1,
     })),
   };
+}
+
+/**
+ * Locale-aware breadcrumb. Callers pass locale-relative paths; {@link canonical}
+ * turns each into an absolute URL that matches the page's own locale canonical
+ * (e.g. `/fr/docs`). This helper adds the site root ("Home") as the first crumb.
+ * Prefer it over hand-building absolute URLs in a page.
+ *
+ * @param locale - active request locale
+ * @param trail - crumbs after Home, each `{ name, path }` where `path` is
+ *   locale-relative (leading slash), e.g. `{ name: "Docs", path: "/docs" }`
+ */
+export function breadcrumbTrailLd(
+  locale: Locale,
+  trail: readonly {
+    readonly name: string;
+    readonly path: string;
+  }[],
+): JsonLdNode {
+  return breadcrumbLd([
+    { name: "Home", url: canonical("/", locale) },
+    ...trail.map((step) => ({
+      name: step.name,
+      url: canonical(step.path, locale),
+    })),
+  ]);
 }
 
 export function collectionPageLd(page: {

--- a/apps/registry/lib/jsonld.ts
+++ b/apps/registry/lib/jsonld.ts
@@ -45,6 +45,7 @@ export function websiteLd(): JsonLdNode {
 
 export function softwareSourceCodeLd(component: {
   readonly description: string;
+  readonly locale: Locale;
   readonly name: string;
   readonly title: string;
 }): JsonLdNode {
@@ -57,7 +58,7 @@ export function softwareSourceCodeLd(component: {
     name: component.title,
     programmingLanguage: "TypeScript",
     runtimePlatform: "React",
-    url: `${SITE_URL}/components/${component.name}`,
+    url: canonical(`/components/${component.name}`, component.locale),
   };
 }
 


### PR DESCRIPTION
Closes #498

## What

Two SEO/structured-data fixes across the registry app.

### 1. `/fr` JSON-LD URLs now track the page canonical
Page JSON-LD (`BreadcrumbList`, `TechArticle`, `CollectionPage`, `SoftwareApplication`, `ItemList`) built its self/breadcrumb URLs from `${SITE_URL}${pathname}` with **no locale segment**, so every `/fr/*` page emitted the English URL — mismatching its own locale-prefixed `canonical`. Routed all page JSON-LD through `canonical(path, locale)` (the pattern `/design` already used). Removes the now-orphaned per-file `SITE_URL` consts. **12 pages** (incl. `build/[slug]`, which renders JSON-LD too).

### 2. Structured data added to 7 indexable pages
Previously carried only the global Organization+WebSite:

| Page | Added |
|------|-------|
| `/` home | `SoftwareApplication` |
| `/components` index | `CollectionPage` + `BreadcrumbList` |
| `/vs` index | `CollectionPage` + `BreadcrumbList` |
| `/vs/shadcn` | `BreadcrumbList` (siblings already had it) |
| `/philosophy` | `TechArticle` + `BreadcrumbList` |
| `/themes` | `BreadcrumbList` |
| `/components/[slug]/playground` | `BreadcrumbList` |

Redirect pages (`/ai`, `/docs/changelog`) and noindex pages (`/embed`, `/report`, `/request-component`) intentionally excluded.

## Verification
- `tsc --noEmit`: clean
- `next build`: green — 2706 prerendered pages, all edited routes generated
- ESLint (19 changed files): no issues
- Built-HTML prove-it: `/fr/docs` breadcrumb → `…com/fr` + `…com/fr/docs`; `/en/docs` → `…com` + `…com/docs`; new `CollectionPage`/`SoftwareApplication`/`BreadcrumbList` present on the gap pages.

---

## Follow-up (code-review findings addressed)

**Regression test** and **root-cause helper** added in `9931e792`:

- `lib/jsonld.ts` — new `breadcrumbTrailLd(locale, trail)`: a locale-aware breadcrumb constructor that resolves every crumb through `canonical(path, locale)` and prepends Home. All 17 breadcrumb pages migrated to it, so no page hand-builds absolute breadcrumb URLs — the locale-correct URL is the only path (closes the failure mode by construction, not just by fix).
- `lib/jsonld.test.ts` — unit regression test: a non-default locale prefixes every crumb URL, the default locale prefixes none. **Mutation-verified** (the `/fr` assertions fail when the helper ignores locale).
- `e2e/jsonld-locale.spec.ts` — page-level Playwright guard: `/fr/families/form` breadcrumb JSON-LD resolves to `/fr` URLs, `/families/form` to unprefixed. Catches a page that bypasses the helper.

### Follow-up verification
- vitest: 45/45 (incl. 3 new) · e2e: 2/2 against the dev server · tsc + `next build` green · eslint clean.

### Second review pass (`d5c4e97e`)
An enforcing re-review caught a **second live instance of the same bug**: `softwareSourceCodeLd` built the component page URL internally (`${SITE_URL}/components/<name>`) with no locale, so every `/fr/components/*` page advertised the English URL as its `SoftwareSourceCode` url while its canonical said `/fr/…` — the largest surface in the registry. Fixed the same way (locale in, `canonical()` internally) + regression tests for both locales.

Exhaustive sweep of every JSON-LD page URL on `/fr/components/button`: all carry `/fr`; the only bare root is the Organization/WebSite identity node (correctly locale-agnostic). vitest 47/47.