### PR TITLE
fix(registry): remove vulnerable npm from runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,13 @@ RUN pnpm --filter @vllnt/ui-registry build
 FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS runtime
 WORKDIR /app
 
-RUN addgroup -S -g 65532 app && adduser -S -u 65532 -G app app
+# npm is build tooling only. Removing it from the final image also removes its
+# bundled tar package, so runtime admission cannot regress on CVE-2026-59873.
+RUN addgroup -S -g 65532 app \
+  && adduser -S -u 65532 -G app app \
+  && rm -rf /usr/local/lib/node_modules/npm \
+  && rm -f /usr/local/bin/npm /usr/local/bin/npx \
+  && test ! -e /usr/local/lib/node_modules/npm
 
 # Standalone monorepo layout: standalone dir contains workspace tree.
 # server.js lives at .next/standalone/apps/registry/server.js


### PR DESCRIPTION
## Summary
- remove build-only npm from the final `ui-registry` runtime image
- remove the `npm`/`npx` launchers that point into the deleted package
- retain npm/corepack in the builder stage
- assert during the image build that npm is absent from the runtime filesystem

## Incident / security rationale
The apps-cell admission policy rejected the prior production image after its pod was recreated. The attestor found CVE-2026-59873 in npm-bundled `tar@7.5.11` (fixed in 7.5.19). The registry runtime invokes only `node apps/registry/server.js`; it does not need npm or ingest/extract archives. Removing npm eliminates the vulnerable package from the merged runtime filesystem and reduces attack surface without weakening admission. The production deployer will run the actual Trivy + signed-attestation gate before apply and fail closed if OCI whiteout handling does not eliminate the finding.

## Validation
At commit `154e246`:
- `git diff --check` — passed
- `pnpm -F @vllnt/ui lint` — passed
- `pnpm -F @vllnt/ui exec tsc --noEmit --project tsconfig.build.json` — passed
- `pnpm build` — passed
- GitHub `Quality Gates` — passed (includes workspace build, drift/integrity checks, tests, story checks, Storybook build)
- GitHub `E2E (Playwright)` — passed
- GitHub CodeQL + react-doctor — passed
- Production rebuild, exact-digest attestation, rollout, rendered-path verification, and temporary-exception revocation follow merge.

Local `pnpm test:once` used unsupported Node 26: registry tests passed 47/47, while UI jsdom tests failed before assertions on Node 26's experimental unavailable `localStorage`. The canonical Node 22 Quality Gates passed the full suite.

## Design
No UI behavior or design-token change.

Fixes #501
